### PR TITLE
Feat/group fetch and cache

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeHotReload)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 kotlin {
@@ -80,7 +81,7 @@ kotlin {
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
-            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+            implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
             implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.1")
             
             implementation("io.ktor:ktor-client-core:3.0.0")

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/storage/SecureStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/storage/SecureStorage.android.kt
@@ -21,6 +21,7 @@ actual object SecureStorage {
     private const val MESSAGES_PREFIX = "messages_"
     private const val PENDING_EVENTS_PREFIX = "pending_events_"
     private const val RELAY_GROUPS_PREFIX = "relay_groups_"
+    private const val JOINED_GROUP_META_PREFIX = "joined_group_meta_"
     private const val RELAY_METADATA_KEY = "relay_metadata"
     private const val LIVE_CURSORS_PREFIX = "live_cursors_"
 
@@ -322,6 +323,34 @@ actual object SecureStorage {
         prefs.edit().remove(key).apply()
     }
 
+    actual fun saveJoinedGroupMetadata(pubkey: String, relayUrl: String, groupsJson: String) {
+        ensureInitialized()
+        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
+        prefs.edit().putString(key, groupsJson).apply()
+    }
+
+    actual fun getJoinedGroupMetadata(pubkey: String, relayUrl: String): String? {
+        ensureInitialized()
+        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
+        return prefs.getString(key, null)
+    }
+
+    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
+        ensureInitialized()
+        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
+        prefs.edit().remove(key).apply()
+    }
+
+    actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
+        ensureInitialized()
+        val accountPrefix = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_"
+        try {
+            val editor = prefs.edit()
+            prefs.all.keys.filter { it.startsWith(accountPrefix) }.forEach { editor.remove(it) }
+            editor.apply()
+        } catch (_: Exception) {}
+    }
+
     actual fun saveRelayMetadata(json: String) {
         ensureInitialized()
         prefs.edit().putString(RELAY_METADATA_KEY, json).apply()
@@ -359,4 +388,16 @@ actual object SecureStorage {
         ensureInitialized()
         return prefs.getBoolean(key, default)
     }
+
+    actual fun saveStringPref(key: String, value: String) {
+        ensureInitialized()
+        prefs.edit().putString(key, value).apply()
+    }
+
+    actual fun getStringPref(key: String, default: String): String {
+        ensureInitialized()
+        return prefs.getString(key, default) ?: default
+    }
+
+    actual suspend fun preloadMetadata() {}
 }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/storage/SecureStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/storage/SecureStorage.android.kt
@@ -335,12 +335,6 @@ actual object SecureStorage {
         return prefs.getString(key, null)
     }
 
-    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
-        ensureInitialized()
-        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
-        prefs.edit().remove(key).apply()
-    }
-
     actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
         ensureInitialized()
         val accountPrefix = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_"

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -58,6 +58,7 @@ import org.nostr.nostrord.ui.screens.login.NostrLoginScreen
 import org.nostr.nostrord.ui.screens.backup.BackupScreen
 import org.nostr.nostrord.ui.screens.onboarding.OnboardingScreen
 import org.nostr.nostrord.ui.screens.profile.EditProfileScreen
+import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.ui.theme.NostrordColors
 
 /**
@@ -772,6 +773,9 @@ private fun MobileDrawerContent(
     val unverifiedChildren = if (subgroupsEnabled) unverifiedChildrenRaw else emptySet()
 
     val orphanedJoinedByRelay by AppModule.nostrRepository.orphanedJoinedByRelay.collectAsState()
+    val fullGroupListFetchedRelays by AppModule.nostrRepository.fullGroupListFetchedRelays.collectAsState()
+    val connectionState by AppModule.nostrRepository.connectionState.collectAsState()
+    val isRelayConnected = connectionState is ConnectionManager.ConnectionState.Connected
     val sidebarScope = rememberCoroutineScope()
 
     val groupsForRelay = remember(activeRelayUrl, groupsByRelay) {
@@ -823,7 +827,15 @@ private fun MobileDrawerContent(
                     AppModule.nostrRepository.forgetGroup(groupId, activeRelayUrl)
                 }
             },
-            showRelayTitle = false
+            showRelayTitle = false,
+            isGroupFetchLazy = AppModule.nostrRepository.isGroupFetchLazy(activeRelayUrl),
+            hasFullGroupListBeenFetched = activeRelayUrl in fullGroupListFetchedRelays,
+            onRequestFullGroupList = {
+                sidebarScope.launch {
+                    AppModule.nostrRepository.requestFullGroupListForRelay(activeRelayUrl)
+                }
+            },
+            isRelayConnected = isRelayConnected
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.*
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.utils.epochMillis
 
@@ -42,7 +44,12 @@ data class GroupMetadata(
      * are invalid and MUST be ignored by the client.
      */
     val closedChildren: Boolean = false
-)
+) {
+    companion object
+}
+
+/** Explicit serializer — required on Kotlin/Wasm where runtime serializer lookup fails for user classes. */
+val groupMetadataListSerializer: KSerializer<List<GroupMetadata>> = ListSerializer(GroupMetadata.serializer())
 
 /**
  * A `["child", "<id>", "<order>", "<flags>"]` declaration inside a parent's `kind:39000`.
@@ -566,6 +573,26 @@ class NostrGroupClient(
      * Used by callers (e.g., EOSE handler) to identify the originating relay.
      */
     fun groupListSubscriptionId(): String = "group-list-${relayUrl.hashCode().toUInt()}"
+
+    /**
+     * Fetch kind:39000 metadata only for the given group IDs.
+     * Used in LAZY fetch mode: on connect we only pull metadata for joined groups,
+     * deferring the full list until the user opens "OTHER GROUPS".
+     * Reuses the same sub ID as requestGroups() so the EOSE handler works unchanged.
+     */
+    suspend fun requestGroupsForIds(groupIds: List<String>) {
+        if (groupIds.isEmpty()) return
+        val subId = groupListSubscriptionId()
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(buildJsonObject {
+                putJsonArray("kinds") { add(39000) }
+                putJsonArray("#d") { groupIds.forEach { add(it) } }
+            })
+        }
+        sendJson(req)
+    }
 
     /**
      * Subscribe for kind:39000 metadata for a specific group.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -848,22 +848,33 @@ class NostrRepository(
         // session has no data, silently blocking user-triggered fetches.
         if (groupManager.hasPendingFullFetch(relayUrl)) return
 
-        // Wait up to 30 s for the WebSocket to connect before giving up.
-        // This handles the race where the user opens OTHER GROUPS immediately after
-        // app startup, before the handshake completes.
-        val connected = withTimeoutOrNull(30_000L) {
-            connectionManager.connectionState.first {
-                it is ConnectionManager.ConnectionState.Connected
-            }
-        }
-        if (connected == null) return   // timed out
+        val normalizedTarget = relayUrl.normalizeRelayUrl()
 
-        // Re-check after waiting — connect() may have already sent a full REQ.
+        // Wait up to 30 s for a CONNECTED client whose relayUrl matches the target.
+        // We must NOT fall back to the current primary: the sidebar triggers this
+        // right after selectedRelayUrl changes, BEFORE switchRelay() has made the
+        // new relay primary. Falling back would send requestGroups() on the old
+        // primary's WebSocket, polluting that relay's _groupsByRelay cache with
+        // unrelated kind:39000 events — surfacing as OTHER GROUPS auto-populating
+        // on a collapsed relay the next time the user switches back to it.
+        val client = withTimeoutOrNull(30_000L) {
+            while (true) {
+                val c = connectionManager.getClientForRelay(normalizedTarget)
+                if (c != null &&
+                    c.isConnected() &&
+                    c.getRelayUrl().normalizeRelayUrl() == normalizedTarget
+                ) {
+                    return@withTimeoutOrNull c
+                }
+                delay(100)
+            }
+            @Suppress("UNREACHABLE_CODE") null
+        } ?: return
+
+        // Re-check after waiting — connect()/switchRelay may have already sent
+        // the full REQ for this relay.
         if (groupManager.hasPendingFullFetch(relayUrl)) return
 
-        val client = connectionManager.getClientForRelay(relayUrl)
-            ?: connectionManager.getPrimaryClient()
-            ?: return
         groupManager.markPendingFullFetch(relayUrl)
         groupManager.markRelayLoading(relayUrl)
         client.requestGroups()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -25,6 +25,8 @@ import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.isGroupFetchLazy
+import org.nostr.nostrord.storage.saveGroupFetchLazy
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
@@ -211,6 +213,18 @@ class NostrRepository(
         // Deep link relay from URL query params (web) — merge into relay list
         val deepLinkRelay = StartupResolver.deepLinkRelayUrl
 
+        // Populate IndexedDB-backed caches (relay_metadata, joined_group_meta) before any reads.
+        // No-op on Android/JVM where storage is synchronous.
+        SecureStorage.preloadMetadata()
+
+        // Now that the IDB cache is populated, prime the relay-metadata StateFlow so the sidebar
+        // shows icons/names immediately instead of waiting for NIP-11 HTTP fetches.
+        _relayMetadataManager.restoreFromCache()
+
+        // Seed the kind:10009 relay set from the persisted relay list so all joined relays appear
+        // in the sidebar immediately, instead of appearing one-by-one as network fetches complete.
+        outboxManager.seedFromCache()
+
         val restored = sessionManager.restoreSession()
         if (restored) {
             val pubkey = sessionManager.getPublicKey()
@@ -240,11 +254,11 @@ class NostrRepository(
                             connectionManager.loadSavedRelay()
 
                             groupManager.prePopulateRelayList(restoredRelays)
-                            groupManager.restoreAllGroupsFromStorage(restoredRelays)
                             _relayMetadataManager.fetchAll(restoredRelays)
                             liveCursorStore?.loadAll(restoredRelays)
                             groupManager.loadJoinedGroupsFromStorage(pubkey, primaryRelay)
                             groupManager.loadAllJoinedGroupsFromStorage(pubkey, restoredRelays)
+                            groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, restoredRelays)
                             connect(primaryRelay)
                         }
                     }
@@ -270,12 +284,14 @@ class NostrRepository(
             }
             liveCursorStore?.loadAll(allRelays)
             groupManager.prePopulateRelayList(allRelays)
-            groupManager.restoreAllGroupsFromStorage(allRelays)
             _relayMetadataManager.fetchAll(allRelays)
 
             if (pubkey != null) {
                 groupManager.loadJoinedGroupsFromStorage(pubkey, primaryRelay)
                 groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
+                // Restore only kind:10009 group metadata — fast, bounded dataset.
+                // Non-joined groups (OTHER GROUPS) are fetched on-demand from the network.
+                groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
                 unreadManager.initialize(pubkey)
             }
             initializeOutboxModel()
@@ -565,6 +581,41 @@ class NostrRepository(
         }
     }
 
+    /**
+     * Send the appropriate group-list REQ depending on the relay's fetch mode and whether
+     * the "OTHER GROUPS" section is currently expanded.
+     *
+     * Decision table:
+     * - EAGER mode → always full fetch (mark pending, send requestGroups())
+     * - LAZY mode + OTHER GROUPS open → full fetch (mark pending, send requestGroups())
+     * - LAZY mode + OTHER GROUPS closed + joined IDs present → partial fetch (joined only)
+     * - LAZY mode + OTHER GROUPS closed + no joined IDs → full fetch (relay would be silent)
+     */
+    private suspend fun requestGroupsForRelay(client: NostrGroupClient, relayUrl: String) {
+        if (SecureStorage.isGroupFetchLazy(relayUrl)) {
+            val otherGroupsOpen = SecureStorage.getBooleanPref(
+                "sidebar_other_expanded_$relayUrl", default = true
+            )
+            if (!otherGroupsOpen) {
+                // OTHER GROUPS is closed — only fetch joined group metadata.
+                val joinedIds = groupManager.joinedGroupsByRelay.value[relayUrl.normalizeRelayUrl()]
+                    .orEmpty().toList()
+                if (joinedIds.isNotEmpty()) {
+                    // Ensure any stale pending-full-fetch marker is cleared so EOSE for this
+                    // partial REQ doesn't incorrectly mark the relay as having a full list.
+                    groupManager.cancelPendingFullFetch(relayUrl)
+                    client.requestGroupsForIds(joinedIds)
+                    return
+                }
+                // No joined groups — fall through to full fetch so OTHER GROUPS populates
+            }
+            // OTHER GROUPS is open (or no joined groups) — full fetch
+        }
+        // EAGER mode or LAZY with OTHER GROUPS open: full unfiltered fetch
+        groupManager.markPendingFullFetch(relayUrl)
+        client.requestGroups()
+    }
+
     private suspend fun connect(relayUrl: String) {
         if (relayUrl.isBlank()) return
         _relayMetadataManager.fetch(relayUrl)
@@ -587,8 +638,18 @@ class NostrRepository(
                     if (!authHandled) {
                         lastRequestGroupsAt[relayUrl] = epochSeconds()
                         groupManager.markRelayLoading(relayUrl)
-                        client.requestGroups()
+                        requestGroupsForRelay(client, relayUrl)
                     }
+                } else if (
+                    SecureStorage.isGroupFetchLazy(relayUrl) &&
+                    !groupManager.hasFullGroupListBeenFetched(relayUrl) &&
+                    SecureStorage.getBooleanPref("sidebar_other_expanded_$relayUrl", default = true)
+                ) {
+                    // Cache is fresh (partial, joined-only) but OTHER GROUPS is open and the full
+                    // list was never fetched. Trigger a full fetch now so the sidebar populates.
+                    groupManager.markPendingFullFetch(relayUrl)
+                    groupManager.markRelayLoading(relayUrl)
+                    client.requestGroups()
                 }
                 // After AUTH (or if no AUTH needed), request metadata for private
                 // groups that are in the joined list (kind 10009) but not in the
@@ -691,7 +752,7 @@ class NostrRepository(
                 // promoted from the pool (e.g. connected by a link preview),
                 // AUTH happened while it was a pool client and requestGroups()
                 // was never sent.
-                client.requestGroups()
+                requestGroupsForRelay(client, newRelayUrl)
             } else {
                 // Cache was restored — no EOSE will arrive, so unmark loading now.
                 groupManager.markRelayLoaded(newRelayUrl)
@@ -764,6 +825,44 @@ class NostrRepository(
     override suspend fun disconnect() {
         connectionManager.disconnectPrimary()
         groupManager.clear()
+    }
+
+    override fun setGroupFetchLazy(relayUrl: String, lazy: Boolean) {
+        SecureStorage.saveGroupFetchLazy(relayUrl, lazy)
+    }
+
+    override fun isGroupFetchLazy(relayUrl: String): Boolean {
+        return SecureStorage.isGroupFetchLazy(relayUrl)
+    }
+
+    override val fullGroupListFetchedRelays: StateFlow<Set<String>> =
+        groupManager.fullGroupListFetchedRelays
+
+    override suspend fun requestFullGroupListForRelay(relayUrl: String) {
+        // Only guard against in-flight duplicates — hasFullGroupListBeenFetched is intentionally
+        // NOT checked here: a stale persisted timestamp can make it return true when the current
+        // session has no data, silently blocking user-triggered fetches.
+        if (groupManager.hasPendingFullFetch(relayUrl)) return
+
+        // Wait up to 30 s for the WebSocket to connect before giving up.
+        // This handles the race where the user opens OTHER GROUPS immediately after
+        // app startup, before the handshake completes.
+        val connected = withTimeoutOrNull(30_000L) {
+            connectionManager.connectionState.first {
+                it is ConnectionManager.ConnectionState.Connected
+            }
+        }
+        if (connected == null) return   // timed out
+
+        // Re-check after waiting — connect() may have already sent a full REQ.
+        if (groupManager.hasPendingFullFetch(relayUrl)) return
+
+        val client = connectionManager.getClientForRelay(relayUrl)
+            ?: connectionManager.getPrimaryClient()
+            ?: return
+        groupManager.markPendingFullFetch(relayUrl)
+        groupManager.markRelayLoading(relayUrl)
+        client.requestGroups()
     }
 
     override suspend fun addRelay(url: String) {
@@ -1891,6 +1990,16 @@ class NostrRepository(
         if (!groupManager.hasCachedGroupsForRelay(relayUrl)) {
             lastRequestGroupsAt[relayUrl] = epochSeconds()
             groupManager.markRelayLoading(relayUrl)
+            requestGroupsForRelay(client, relayUrl)
+        } else if (
+            SecureStorage.isGroupFetchLazy(relayUrl) &&
+            !groupManager.hasFullGroupListBeenFetched(relayUrl) &&
+            SecureStorage.getBooleanPref("sidebar_other_expanded_$relayUrl", default = true)
+        ) {
+            // Cache is fresh (partial, joined-only) but OTHER GROUPS is open and the full
+            // list was never fetched. Re-fetch on reconnect so OTHER GROUPS stays populated.
+            groupManager.markPendingFullFetch(relayUrl)
+            groupManager.markRelayLoading(relayUrl)
             client.requestGroups()
         }
 
@@ -1939,7 +2048,7 @@ class NostrRepository(
             if (now - lastAt > 10L) {
                 lastRequestGroupsAt[relayUrl] = now
                 groupManager.markRelayLoading(relayUrl)
-                client.requestGroups()
+                requestGroupsForRelay(client, relayUrl)
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -596,8 +596,13 @@ class NostrRepository(
             )
             if (!otherGroupsOpen) {
                 // OTHER GROUPS is closed — only fetch joined group metadata.
+                // Exclude groups already known to be restricted (the relay would
+                // CLOSE the entire batch if any single ID is denied).
+                val restricted = groupManager.restrictedGroups.value.keys
                 val joinedIds = groupManager.joinedGroupsByRelay.value[relayUrl.normalizeRelayUrl()]
-                    .orEmpty().toList()
+                    .orEmpty()
+                    .filter { it !in restricted }
+                    .toList()
                 if (joinedIds.isNotEmpty()) {
                     // Ensure any stale pending-full-fetch marker is cleared so EOSE for this
                     // partial REQ doesn't incorrectly mark the relay as having a full list.
@@ -605,7 +610,7 @@ class NostrRepository(
                     client.requestGroupsForIds(joinedIds)
                     return
                 }
-                // No joined groups — fall through to full fetch so OTHER GROUPS populates
+                // No (non-restricted) joined groups — fall through to full fetch so OTHER GROUPS populates
             }
             // OTHER GROUPS is open (or no joined groups) — full fetch
         }
@@ -681,6 +686,7 @@ class NostrRepository(
             groupManager.loadJoinedGroupsFromStorage(pubkey, primaryRelay)
             groupManager.loadAllJoinedGroupsFromStorage(pubkey, relays)
             groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, relays)
+            groupManager.loadRestrictedGroupsFromStorage(pubkey, relays)
         }
         connect(primaryRelay)
     }
@@ -1688,13 +1694,25 @@ class NostrRepository(
                 val isRestricted = reason.contains("restricted")
                 val isAuthRequired = reason.contains("auth-required")
 
-                // "restricted" on the group-list subscription means the relay
-                // actively denies access — stop loading, show error, disconnect.
+                // "restricted" on the group-list subscription: distinguish between
+                // (a) unfiltered requestGroups() failing — relay genuinely denies access,
+                // and (b) #d-filtered requestGroupsForIds() failing because one of the
+                // joined groups in the batch is restricted. Only (a) marks the whole
+                // relay. (b) is silent — OTHER GROUPS is collapsed by design, so no
+                // fallback unfiltered fetch (that would leak OTHER groups into the
+                // homescreen). Per-group meta_/msg_ CLOSEDs from requestPrivateGroupData
+                // and resubscribeAfterAuth identify the specific offender.
                 if (isRestricted && subId.startsWith("group-list")) {
                     val relayUrl = client.getRelayUrl()
-                    _restrictedRelays.value = _restrictedRelays.value + (relayUrl to reason)
-                    groupManager.markRelayLoaded(relayUrl)
-                    connectionManager.setError(reason)
+                    val wasFullFetch = groupManager.hasPendingFullFetch(relayUrl)
+                    if (wasFullFetch) {
+                        _restrictedRelays.value = _restrictedRelays.value + (relayUrl to reason)
+                        groupManager.cancelPendingFullFetch(relayUrl)
+                        groupManager.markRelayLoaded(relayUrl)
+                        connectionManager.setError(reason)
+                    } else {
+                        groupManager.markRelayLoaded(relayUrl)
+                    }
                     return
                 }
 
@@ -1707,14 +1725,24 @@ class NostrRepository(
                 }
 
                 // Track per-group "restricted" status so the UI can show a private
-                // group placeholder with invite code input. Extract the group ID
-                // from msg_ subscriptions (format: msg_<8-char-prefix>_<timestamp>).
-                if (isRestricted && subId.startsWith("msg_")) {
-                    val prefix = subId.removePrefix("msg_").substringBefore("_")
-                    val groupId = groupManager.getGroupIdByPrefix(prefix)
-                        ?: groupManager.activeGroupId?.takeIf { it.startsWith(prefix) }
-                    if (groupId != null) {
-                        groupManager.markGroupRestricted(groupId, reason)
+                // group placeholder with invite code input. Any per-group sub whose
+                // ID embeds an 8-char group prefix is a reliable signal when it
+                // closes with "restricted" — msg_, meta_, members_, admins_ all
+                // isolate exactly one group.
+                if (isRestricted) {
+                    val prefix = when {
+                        subId.startsWith("msg_") -> subId.removePrefix("msg_").substringBefore("_")
+                        subId.startsWith("meta_") -> subId.removePrefix("meta_")
+                        subId.startsWith("members_") -> subId.removePrefix("members_")
+                        subId.startsWith("admins_") -> subId.removePrefix("admins_")
+                        else -> null
+                    }
+                    if (prefix != null) {
+                        val groupId = groupManager.getGroupIdByPrefix(prefix)
+                            ?: groupManager.activeGroupId?.takeIf { it.startsWith(prefix) }
+                        if (groupId != null) {
+                            groupManager.markGroupRestricted(groupId, reason)
+                        }
                     }
                 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -289,8 +289,6 @@ class NostrRepository(
             if (pubkey != null) {
                 groupManager.loadJoinedGroupsFromStorage(pubkey, primaryRelay)
                 groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
-                // Restore only kind:10009 group metadata — fast, bounded dataset.
-                // Non-joined groups (OTHER GROUPS) are fetched on-demand from the network.
                 groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
                 unreadManager.initialize(pubkey)
             }
@@ -678,11 +676,11 @@ class NostrRepository(
         connectionManager.loadSavedRelay()
 
         val pubkey = sessionManager.getPublicKey()
-        groupManager.restoreAllGroupsFromStorage(relays)
         liveCursorStore?.loadAll(relays)
         if (pubkey != null) {
             groupManager.loadJoinedGroupsFromStorage(pubkey, primaryRelay)
             groupManager.loadAllJoinedGroupsFromStorage(pubkey, relays)
+            groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, relays)
         }
         connect(primaryRelay)
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -418,6 +418,10 @@ class NostrRepository(
 
         sessionManager.getPublicKey()?.let { pubKey ->
             groupManager.clearJoinedGroupsForAccount(pubKey)
+            // Drop persisted UI state for this account — otherwise the next login
+            // (same pubkey) would restore a group whose relay is no longer the
+            // primary, leaving the user on the wrong relay with a stale group open.
+            try { SecureStorage.clearLastViewedGroup(pubKey) } catch (_: Exception) {}
         }
         _isDiscoveringRelays.value = false
         outboxManager.clear()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -35,6 +35,8 @@ interface NostrRepositoryApi {
     val joinedGroups: StateFlow<Set<String>>
     val joinedGroupsByRelay: StateFlow<Map<String, Set<String>>>
     val loadingRelays: StateFlow<Set<String>>
+    /** Relays (in LAZY mode) whose full group list has been fetched this session. */
+    val fullGroupListFetchedRelays: StateFlow<Set<String>>
     /** Relays that returned CLOSED "restricted" — access permanently denied. */
     val restrictedRelays: StateFlow<Map<String, String>>
     val isLoadingMore: StateFlow<Map<String, Boolean>>
@@ -85,6 +87,13 @@ interface NostrRepositoryApi {
     suspend fun switchRelay(newRelayUrl: String)
     suspend fun removeRelay(url: String)
     suspend fun disconnect()
+
+    // --- Per-relay fetch mode ---
+    /** Set whether a relay uses lazy fetch mode (only joined-group metadata on connect). */
+    fun setGroupFetchLazy(relayUrl: String, lazy: Boolean)
+    fun isGroupFetchLazy(relayUrl: String): Boolean
+    /** Fetch the full group list for a relay — used when the user expands OTHER GROUPS on a lazy relay. */
+    suspend fun requestFullGroupListForRelay(relayUrl: String)
     /** Add a relay to the user's saved list and publish kind:10009. */
     suspend fun addRelay(url: String)
     /** Dismiss the deep link relay prompt without saving. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -30,7 +30,6 @@ import org.nostr.nostrord.storage.isFullGroupListCacheFresh
 import org.nostr.nostrord.storage.isGroupListCacheFresh
 import org.nostr.nostrord.storage.saveFullGroupListEoseTimestamp
 import org.nostr.nostrord.storage.saveGroupListEoseTimestamp
-import org.nostr.nostrord.storage.getGroupListEoseTimestamp
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochMillis
@@ -2020,14 +2019,7 @@ class GroupManager(
     }
 
     /**
-     * Handle incoming group metadata.
-     * Updates the live flow for the current relay AND stores in the per-relay cache
-     * so returning to this relay later is instant without a network re-fetch.
-     */
-    /**
      * Rebuild and persist the joined-group metadata snapshot for [relayUrl].
-     * Filters [_groupsByRelay] to only the groups the user has joined on that relay,
-     * then writes to the pubkey-scoped storage key used for fast startup restore.
      * No-op when [currentPubkey] is not set (unauthenticated state).
      */
     private fun persistJoinedGroupMetadataSnapshot(relayUrl: String) {
@@ -2037,11 +2029,14 @@ class GroupManager(
         val snapshot = (_groupsByRelay.value[normalized] ?: emptyList()).filter { it.id in joinedIds }
         try {
             SecureStorage.saveJoinedGroupMetadata(pubKey, normalized, json.encodeToString(groupMetadataListSerializer, snapshot))
-        } catch (e: Exception) {
-            println("[IDB] persistJoinedGroupMetadataSnapshot failed relay=$normalized: ${e.message}")
-        }
+        } catch (_: Exception) {}
     }
 
+    /**
+     * Handle incoming group metadata.
+     * Updates the live flow for the current relay AND persists the joined-group snapshot
+     * so returning to this relay later is instant without a network re-fetch.
+     */
     fun handleGroupMetadata(metadata: GroupMetadata, relayUrl: String) {
         if (metadata.id in deletedGroupIds) return
         val normalized = relayUrl.normalizeRelayUrl()
@@ -2065,8 +2060,6 @@ class GroupManager(
             }
             current + (normalized to updated)
         }
-        // Persist only joined-group metadata for fast startup restore.
-        // Non-joined groups are fetched on-demand and not cached.
         persistJoinedGroupMetadataSnapshot(relayUrl)
 
         // Recompute the full tree because a kind:39000 update can add/remove children,
@@ -2172,46 +2165,6 @@ class GroupManager(
         }.toSet()
         if (freshRelays.isNotEmpty()) {
             _completeGroupLoadRelays.update { it + freshRelays }
-        }
-        recomputeSubgroupTopology()
-    }
-
-    /**
-     * Restore group metadata for all known relays from SecureStorage.
-     * Called on startup before any WebSocket connects so relay switching is instant.
-     */
-    fun restoreAllGroupsFromStorage(relayUrls: List<String>) {
-        val now = epochSeconds()
-        _groupsByRelay.update { current ->
-            val updates = relayUrls.mapNotNull { url ->
-                val normalized = url.normalizeRelayUrl()
-                val jsonStr = SecureStorage.getGroupsForRelay(normalized) ?: return@mapNotNull null
-                try {
-                    val groups = json.decodeFromString(groupMetadataListSerializer, jsonStr)
-                    if (groups.isNotEmpty()) normalized to groups else null
-                } catch (_: Exception) { null }
-            }.toMap()
-            current + updates
-        }
-        // Restore session flags for relays with fresh enough caches.
-        val normalizedUrls = relayUrls.map { it.normalizeRelayUrl() }
-        val freshRelays = normalizedUrls
-            .filter { normalized ->
-                SecureStorage.isGroupListCacheFresh(normalized, now) &&
-                    _groupsByRelay.value[normalized]?.isNotEmpty() == true
-            }
-            .toSet()
-        if (freshRelays.isNotEmpty()) {
-            _completeGroupLoadRelays.update { it + freshRelays }
-        }
-        // Restore _fullGroupListFetchedRelays for relays whose full list is still fresh,
-        // so hasFullGroupListBeenFetched() returns true and the LaunchedEffect in the sidebar
-        // doesn't re-fetch when OTHER GROUPS was already open on the previous session.
-        val fullFreshRelays = normalizedUrls
-            .filter { SecureStorage.isFullGroupListCacheFresh(it, now) }
-            .toSet()
-        if (fullFreshRelays.isNotEmpty()) {
-            _fullGroupListFetchedRelays.update { it + fullFreshRelays }
         }
         recomputeSubgroupTopology()
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -26,8 +26,11 @@ import org.nostr.nostrord.network.RoleDefinition
 import org.nostr.nostrord.network.outbox.EventDeduplicator
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.addRestrictedGroupForRelay
+import org.nostr.nostrord.storage.getRestrictedGroupsForRelay
 import org.nostr.nostrord.storage.isFullGroupListCacheFresh
 import org.nostr.nostrord.storage.isGroupListCacheFresh
+import org.nostr.nostrord.storage.removeRestrictedGroupForRelay
 import org.nostr.nostrord.storage.saveFullGroupListEoseTimestamp
 import org.nostr.nostrord.storage.saveGroupListEoseTimestamp
 import org.nostr.nostrord.utils.AppError
@@ -325,16 +328,62 @@ class GroupManager(
     /**
      * Mark a group as restricted (relay denied access).
      * Called when a CLOSED "restricted" message arrives for a group subscription.
+     *
+     * Kicks off a debounced mux refresh so mux_meta / mux_del / mux_chat are
+     * re-sent with this group excluded from the #d/#h batch — otherwise the
+     * relay would keep CLOSE-ing the whole mux whenever this group is in it,
+     * starving the other joined groups of metadata/delete updates.
      */
     fun markGroupRestricted(groupId: String, reason: String) {
+        val wasAlreadyRestricted = groupId in _restrictedGroups.value
         _restrictedGroups.update { it + (groupId to reason) }
+        if (!wasAlreadyRestricted) {
+            val relayUrl = getRelayForGroup(groupId)
+            if (relayUrl != null) {
+                currentPubkey?.let { pk ->
+                    try {
+                        SecureStorage.addRestrictedGroupForRelay(pk, relayUrl, groupId, reason, epochSeconds())
+                    } catch (_: Exception) {}
+                }
+                refreshMuxDebounced(relayUrl)
+            }
+        }
     }
 
     /**
      * Clear restricted status for a group (e.g. after successful join).
      */
     fun clearGroupRestricted(groupId: String) {
+        if (groupId !in _restrictedGroups.value) return
         _restrictedGroups.update { it - groupId }
+        val relayUrl = getRelayForGroup(groupId)
+        if (relayUrl != null) {
+            currentPubkey?.let { pk ->
+                try {
+                    SecureStorage.removeRestrictedGroupForRelay(pk, relayUrl, groupId)
+                } catch (_: Exception) {}
+            }
+        }
+    }
+
+    /**
+     * Load persisted restricted groups for [relayUrls] into [_restrictedGroups].
+     * Called on startup before the first connect, so batched REQs exclude known
+     * restricted IDs from the start. Entries older than 7 days are auto-expired
+     * by [SecureStorage.getRestrictedGroupsForRelay].
+     */
+    fun loadRestrictedGroupsFromStorage(pubKey: String, relayUrls: List<String>) {
+        if (relayUrls.isEmpty()) return
+        val now = epochSeconds()
+        val loaded = mutableMapOf<String, String>()
+        for (url in relayUrls) {
+            try {
+                loaded.putAll(SecureStorage.getRestrictedGroupsForRelay(pubKey, url, now))
+            } catch (_: Exception) {}
+        }
+        if (loaded.isNotEmpty()) {
+            _restrictedGroups.update { it + loaded }
+        }
     }
 
     companion object {
@@ -522,7 +571,11 @@ class GroupManager(
     }
 
     private suspend fun refreshMuxSubscriptionsForRelayImpl(relayUrl: String) {
-        val allGroupIds = getGroupIdsForMux(relayUrl)
+        // Drop restricted groups from every batched filter — including a single
+        // restricted #d/#h value makes the relay CLOSE the entire subscription,
+        // silencing metadata/delete updates for the groups we DO belong to.
+        val restricted = _restrictedGroups.value.keys
+        val allGroupIds = getGroupIdsForMux(relayUrl).filter { it !in restricted }
         if (allGroupIds.isEmpty()) return
         val client = connectionManager.getClientForRelay(relayUrl) ?: return
         if (!client.isConnected()) return

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -1562,6 +1562,10 @@ class GroupManager(
             loadingRegistry.remove(groupId)
             // Reset opened tracking so setActiveGroupId() re-fetches on rejoin.
             _openedGroupIds.update { it - groupId }
+            // Drop any restricted-group marker — leaving is an explicit reset of intent,
+            // and a future rejoin should get a fresh access attempt instead of being
+            // silently excluded from batched REQs.
+            clearGroupRestricted(groupId)
 
             Result.Success(Unit)
         } catch (e: Throwable) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -14,9 +14,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.*
+import org.nostr.nostrord.network.groupMetadataListSerializer
 import org.nostr.nostrord.network.GroupAdmins
 import org.nostr.nostrord.network.GroupMembers
 import org.nostr.nostrord.network.DeclaredChild
@@ -27,9 +26,15 @@ import org.nostr.nostrord.network.RoleDefinition
 import org.nostr.nostrord.network.outbox.EventDeduplicator
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.isFullGroupListCacheFresh
+import org.nostr.nostrord.storage.isGroupListCacheFresh
+import org.nostr.nostrord.storage.saveFullGroupListEoseTimestamp
+import org.nostr.nostrord.storage.saveGroupListEoseTimestamp
+import org.nostr.nostrord.storage.getGroupListEoseTimestamp
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochMillis
+import org.nostr.nostrord.utils.epochSeconds
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
@@ -174,6 +179,44 @@ class GroupManager(
     // Used by the UI to show skeleton loaders while groups are being fetched.
     private val _loadingRelays = MutableStateFlow<Set<String>>(emptySet())
     val loadingRelays: StateFlow<Set<String>> = _loadingRelays.asStateFlow()
+
+    // Relays for which requestGroups() (unfiltered, no #d tag) was sent this session but
+    // EOSE hasn't arrived yet. Lets handleEoseSuspend() distinguish a full fetch from a
+    // lazy (joined-only) fetch when the same sub ID is reused.
+    private val pendingFullFetchRelays = mutableSetOf<String>()
+
+    fun markPendingFullFetch(relayUrl: String) {
+        pendingFullFetchRelays.add(relayUrl.normalizeRelayUrl())
+    }
+
+    /**
+     * Remove [relayUrl] from [pendingFullFetchRelays] without marking the full list as fetched.
+     * Call this when a partial (joined-only) REQ is sent after a full REQ was already marked
+     * pending, to prevent the partial EOSE from incorrectly setting fullGroupListFetchedRelays.
+     */
+    fun cancelPendingFullFetch(relayUrl: String) {
+        pendingFullFetchRelays.remove(relayUrl.normalizeRelayUrl())
+    }
+
+    /**
+     * Returns true if [relayUrl] has a pending full-fetch REQ that hasn't received EOSE yet.
+     * Used by [NostrRepository.requestFullGroupListForRelay] to skip a duplicate REQ when
+     * [requestGroupsForRelay] already scheduled a full fetch on connect.
+     */
+    fun hasPendingFullFetch(relayUrl: String): Boolean {
+        return relayUrl.normalizeRelayUrl() in pendingFullFetchRelays
+    }
+
+    // Relays whose FULL group list (unfiltered requestGroups()) EOSE was received this session.
+    // Updated by handleEoseSuspend when the relay is in pendingFullFetchRelays.
+    private val _fullGroupListFetchedRelays = MutableStateFlow<Set<String>>(emptySet())
+    val fullGroupListFetchedRelays: StateFlow<Set<String>> = _fullGroupListFetchedRelays.asStateFlow()
+
+    fun hasFullGroupListBeenFetched(relayUrl: String): Boolean {
+        val normalized = relayUrl.normalizeRelayUrl()
+        if (normalized in _fullGroupListFetchedRelays.value) return true
+        return SecureStorage.isFullGroupListCacheFresh(normalized, epochSeconds())
+    }
 
     fun markRelayLoading(relayUrl: String) {
         _loadingRelays.update { it + relayUrl.normalizeRelayUrl() }
@@ -587,6 +630,7 @@ class GroupManager(
      * Load joined groups from storage
      */
     fun loadJoinedGroupsFromStorage(pubKey: String, relayUrl: String) {
+        currentPubkey = pubKey
         val groups = SecureStorage.getJoinedGroupsForRelay(pubKey, relayUrl)
         _joinedGroupsByRelay.update { it + (relayUrl.normalizeRelayUrl() to groups) }
     }
@@ -1091,10 +1135,7 @@ class GroupManager(
                 val updated = (current[groupRelayUrl] ?: emptyList()).filter { it.id !in idsToRemove }
                 current + (groupRelayUrl to updated)
             }
-            try {
-                val updatedRelayGroups = _groupsByRelay.value[groupRelayUrl] ?: emptyList()
-                SecureStorage.saveGroupsForRelay(groupRelayUrl, json.encodeToString(updatedRelayGroups))
-            } catch (_: Exception) {}
+            persistJoinedGroupMetadataSnapshot(groupRelayUrl)
 
             _messages.update { it - idsToRemove }
             _isLoadingMore.update { it - idsToRemove }
@@ -1136,10 +1177,9 @@ class GroupManager(
             val updated = (current[relayUrl] ?: emptyList()).filter { it.id !in idsToRemove }
             current + (relayUrl to updated)
         }
-        try {
-            val updatedRelayGroups = _groupsByRelay.value[relayUrl] ?: emptyList()
-            SecureStorage.saveGroupsForRelay(relayUrl, json.encodeToString(updatedRelayGroups))
-        } catch (_: Exception) {}
+        // The group is intentionally kept in _joinedGroupsByRelay (shows as orphan in sidebar).
+        // Rebuild the snapshot so next startup sees it as an orphan (in joined but not in metadata).
+        persistJoinedGroupMetadataSnapshot(relayUrl)
 
         _messages.update { it - idsToRemove }
         _isLoadingMore.update { it - idsToRemove }
@@ -1458,6 +1498,7 @@ class GroupManager(
             val updatedAfterLeave = relayGroups - groupId
             SecureStorage.saveJoinedGroupsForRelay(pubKey, groupRelayUrl, updatedAfterLeave)
             _joinedGroupsByRelay.update { it + (groupRelayUrl to updatedAfterLeave) }
+            persistJoinedGroupMetadataSnapshot(groupRelayUrl)
 
             publishJoinedGroups()
 
@@ -1617,6 +1658,16 @@ class GroupManager(
                 val normalizedRelay = relay.normalizeRelayUrl()
                 _completeGroupLoadRelays.update { it + normalizedRelay }
                 _loadingRelays.update { it - normalizedRelay }
+                val now = epochSeconds()
+                val isFull = pendingFullFetchRelays.remove(normalizedRelay)
+                if (isFull) {
+                    // Full unfiltered fetch — save dedicated full-list timestamp so
+                    // hasFullGroupListBeenFetched() returns true after an app restart.
+                    _fullGroupListFetchedRelays.update { it + normalizedRelay }
+                    try { SecureStorage.saveFullGroupListEoseTimestamp(normalizedRelay, now) } catch (_: Exception) {}
+                }
+                // Always update the general cache timestamp (used by hasCachedGroupsForRelay).
+                try { SecureStorage.saveGroupListEoseTimestamp(normalizedRelay, now) } catch (_: Exception) {}
                 refreshMuxSubscriptionsForRelay(normalizedRelay)
             }
             return true
@@ -1973,6 +2024,24 @@ class GroupManager(
      * Updates the live flow for the current relay AND stores in the per-relay cache
      * so returning to this relay later is instant without a network re-fetch.
      */
+    /**
+     * Rebuild and persist the joined-group metadata snapshot for [relayUrl].
+     * Filters [_groupsByRelay] to only the groups the user has joined on that relay,
+     * then writes to the pubkey-scoped storage key used for fast startup restore.
+     * No-op when [currentPubkey] is not set (unauthenticated state).
+     */
+    private fun persistJoinedGroupMetadataSnapshot(relayUrl: String) {
+        val pubKey = currentPubkey ?: return
+        val normalized = relayUrl.normalizeRelayUrl()
+        val joinedIds = _joinedGroupsByRelay.value[normalized] ?: emptySet()
+        val snapshot = (_groupsByRelay.value[normalized] ?: emptyList()).filter { it.id in joinedIds }
+        try {
+            SecureStorage.saveJoinedGroupMetadata(pubKey, normalized, json.encodeToString(groupMetadataListSerializer, snapshot))
+        } catch (e: Exception) {
+            println("[IDB] persistJoinedGroupMetadataSnapshot failed relay=$normalized: ${e.message}")
+        }
+    }
+
     fun handleGroupMetadata(metadata: GroupMetadata, relayUrl: String) {
         if (metadata.id in deletedGroupIds) return
         val normalized = relayUrl.normalizeRelayUrl()
@@ -1996,11 +2065,9 @@ class GroupManager(
             }
             current + (normalized to updated)
         }
-        // Persist the updated group list for this relay so it survives app restarts
-        val relayGroups = _groupsByRelay.value[normalized] ?: emptyList()
-        try {
-            SecureStorage.saveGroupsForRelay(normalized, json.encodeToString(relayGroups))
-        } catch (_: Exception) {}
+        // Persist only joined-group metadata for fast startup restore.
+        // Non-joined groups are fetched on-demand and not cached.
+        persistJoinedGroupMetadataSnapshot(relayUrl)
 
         // Recompute the full tree because a kind:39000 update can add/remove children,
         // toggle `closed-children`, or carry new `child`/`parent` tags that change classification
@@ -2077,20 +2144,74 @@ class GroupManager(
     }
 
     /**
+     * Restore only the joined-group metadata snapshot for fast startup display.
+     * Reads from the pubkey-scoped cache written by [persistJoinedGroupMetadataSnapshot],
+     * which contains only the kind:10009 groups — a small, bounded dataset.
+     * Does NOT restore [_fullGroupListFetchedRelays]: a joined-only restore does not
+     * constitute a full list fetch, so OTHER GROUPS will trigger a network fetch when opened.
+     */
+    fun restoreJoinedGroupMetadataFromStorage(pubkey: String, relayUrls: List<String>) {
+        val now = epochSeconds()
+        _groupsByRelay.update { current ->
+            val updates = relayUrls.mapNotNull { url ->
+                val normalized = url.normalizeRelayUrl()
+                val jsonStr = SecureStorage.getJoinedGroupMetadata(pubkey, normalized) ?: return@mapNotNull null
+                try {
+                    val groups = json.decodeFromString(groupMetadataListSerializer, jsonStr)
+                    if (groups.isNotEmpty()) normalized to groups else null
+                } catch (_: Exception) { null }
+            }.toMap()
+            current + updates
+        }
+        // Restore general cache freshness flags so hasCachedGroupsForRelay() skips the
+        // network fetch when the joined-group snapshot is still within the TTL window.
+        val normalizedUrls = relayUrls.map { it.normalizeRelayUrl() }
+        val freshRelays = normalizedUrls.filter { normalized ->
+            SecureStorage.isGroupListCacheFresh(normalized, now) &&
+                _groupsByRelay.value[normalized]?.isNotEmpty() == true
+        }.toSet()
+        if (freshRelays.isNotEmpty()) {
+            _completeGroupLoadRelays.update { it + freshRelays }
+        }
+        recomputeSubgroupTopology()
+    }
+
+    /**
      * Restore group metadata for all known relays from SecureStorage.
      * Called on startup before any WebSocket connects so relay switching is instant.
      */
     fun restoreAllGroupsFromStorage(relayUrls: List<String>) {
+        val now = epochSeconds()
         _groupsByRelay.update { current ->
             val updates = relayUrls.mapNotNull { url ->
                 val normalized = url.normalizeRelayUrl()
                 val jsonStr = SecureStorage.getGroupsForRelay(normalized) ?: return@mapNotNull null
                 try {
-                    val groups = json.decodeFromString<List<GroupMetadata>>(jsonStr)
+                    val groups = json.decodeFromString(groupMetadataListSerializer, jsonStr)
                     if (groups.isNotEmpty()) normalized to groups else null
                 } catch (_: Exception) { null }
             }.toMap()
             current + updates
+        }
+        // Restore session flags for relays with fresh enough caches.
+        val normalizedUrls = relayUrls.map { it.normalizeRelayUrl() }
+        val freshRelays = normalizedUrls
+            .filter { normalized ->
+                SecureStorage.isGroupListCacheFresh(normalized, now) &&
+                    _groupsByRelay.value[normalized]?.isNotEmpty() == true
+            }
+            .toSet()
+        if (freshRelays.isNotEmpty()) {
+            _completeGroupLoadRelays.update { it + freshRelays }
+        }
+        // Restore _fullGroupListFetchedRelays for relays whose full list is still fresh,
+        // so hasFullGroupListBeenFetched() returns true and the LaunchedEffect in the sidebar
+        // doesn't re-fetch when OTHER GROUPS was already open on the previous session.
+        val fullFreshRelays = normalizedUrls
+            .filter { SecureStorage.isFullGroupListCacheFresh(it, now) }
+            .toSet()
+        if (fullFreshRelays.isNotEmpty()) {
+            _fullGroupListFetchedRelays.update { it + fullFreshRelays }
         }
         recomputeSubgroupTopology()
     }
@@ -2100,9 +2221,11 @@ class GroupManager(
      */
     fun hasCachedGroupsForRelay(relayUrl: String): Boolean {
         val normalized = relayUrl.normalizeRelayUrl()
-        // Only treat as cached if the initial load finished (EOSE received).
-        // A partial cache from an interrupted load must trigger a re-fetch.
-        return normalized in _completeGroupLoadRelays.value && _groupsByRelay.value[normalized]?.isNotEmpty() == true
+        if (_groupsByRelay.value[normalized]?.isNotEmpty() != true) return false
+        // Session flag set (EOSE received this session) — always valid.
+        if (normalized in _completeGroupLoadRelays.value) return true
+        // No session flag: check persisted timestamp so a fresh app restart can skip requestGroups().
+        return SecureStorage.isGroupListCacheFresh(normalized, epochSeconds())
     }
 
     /**
@@ -2603,6 +2726,7 @@ class GroupManager(
     fun removeRelayEntry(url: String) {
         val normalized = url.normalizeRelayUrl()
         _completeGroupLoadRelays.update { it - normalized }
+        _fullGroupListFetchedRelays.update { it - normalized }
         _groupsByRelay.update { current -> current - normalized }
     }
 
@@ -2613,6 +2737,7 @@ class GroupManager(
     suspend fun clear() {
         eventOrderingBuffer.flushAll()
         _completeGroupLoadRelays.value = emptySet()
+        _fullGroupListFetchedRelays.value = emptySet()
         _loadingRelays.value = emptySet()
         _groupsByRelay.value = emptyMap()
         _openedGroupIds.value = emptySet()
@@ -2624,7 +2749,9 @@ class GroupManager(
      */
     fun clearJoinedGroupsForAccount(pubKey: String) {
         SecureStorage.clearAllJoinedGroupsForAccount(pubKey)
+        SecureStorage.clearAllJoinedGroupMetadataForAccount(pubKey)
         _joinedGroupsByRelay.value = emptyMap()
+        currentPubkey = null
     }
 
     // ==========================================================================

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -62,6 +62,21 @@ class OutboxManager(
             .toSet()
     }
 
+    /**
+     * Seed [kind10009Relays] from the locally-persisted relay list so the sidebar
+     * shows all joined relays instantly on startup, without waiting for the kind:10009
+     * network fetch. The network fetch still runs and overwrites this with fresh data.
+     */
+    fun seedFromCache() {
+        val saved = SecureStorage.loadRelayList()
+            .map { it.normalizeRelayUrl() }
+            .filter { it.isNotBlank() }
+            .toSet()
+        if (saved.isNotEmpty()) {
+            _kind10009Relays.value = saved
+        }
+    }
+
     fun initialize(
         pubKey: String,
         messageHandler: (String, NostrGroupClient) -> Unit,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayMetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayMetadataManager.kt
@@ -117,8 +117,8 @@ class RelayMetadataManager(private val scope: CoroutineScope) {
                     _relayMetadata.value = updated
                     try {
                         SecureStorage.saveRelayMetadata(json.encodeToString(nip11RelayInfoMapSerializer, updated))
-                    } catch (e: Exception) {
-                        println("[IDB] saveRelayMetadata failed: ${e.message}")
+                    } catch (_: Exception) {
+                        // Non-critical — cache write failure doesn't break anything
                     }
                 } else {
                     if (attempt < MAX_RETRIES) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayMetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayMetadataManager.kt
@@ -10,9 +10,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.nostr.nostrord.nostr.Nip11RelayInfo
+import org.nostr.nostrord.nostr.nip11RelayInfoMapSerializer
 import org.nostr.nostrord.nostr.fetchNip11RelayInfo
 import org.nostr.nostrord.storage.SecureStorage
 
@@ -57,15 +57,19 @@ class RelayMetadataManager(private val scope: CoroutineScope) {
         private const val BACKOFF_CAP_MS = 5 * 60_000L // 5 minutes
     }
 
-    init {
-        // Pre-populate the StateFlow from storage so icons appear immediately on startup,
-        // without waiting for the network fetch. We intentionally do NOT add these URLs to
-        // `succeeded` so that fetch() still runs once per session and picks up any changes
-        // to relay metadata (e.g. updated icon URL, new name).
+    /**
+     * Pre-populates the StateFlow from storage so icons appear immediately on startup,
+     * without waiting for the network fetch. Must be called AFTER [SecureStorage.preloadMetadata]
+     * on web targets, since IndexedDB reads are async there and the cache would otherwise be empty.
+     *
+     * Intentionally does NOT add the URLs to `succeeded` so that fetch() still runs once per
+     * session and picks up any changes (updated icon URL, new name, etc.).
+     */
+    fun restoreFromCache() {
         try {
             val cached = SecureStorage.getRelayMetadata()
             if (!cached.isNullOrBlank()) {
-                val map = json.decodeFromString<Map<String, Nip11RelayInfo>>(cached)
+                val map = json.decodeFromString(nip11RelayInfoMapSerializer, cached)
                 if (map.isNotEmpty()) {
                     _relayMetadata.value = map
                 }
@@ -112,9 +116,9 @@ class RelayMetadataManager(private val scope: CoroutineScope) {
                     val updated = _relayMetadata.value + (relayUrl to info)
                     _relayMetadata.value = updated
                     try {
-                        SecureStorage.saveRelayMetadata(json.encodeToString(updated))
-                    } catch (_: Exception) {
-                        // Non-critical — cache write failure doesn't break anything
+                        SecureStorage.saveRelayMetadata(json.encodeToString(nip11RelayInfoMapSerializer, updated))
+                    } catch (e: Exception) {
+                        println("[IDB] saveRelayMetadata failed: ${e.message}")
                     }
                 } else {
                     if (attempt < MAX_RETRIES) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip11.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip11.kt
@@ -4,7 +4,10 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.HttpHeaders
 import io.ktor.http.isSuccess
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.intOrNull
@@ -33,7 +36,13 @@ data class Nip11RelayInfo(
     val version: String? = null,
     val authRequired: Boolean? = null,
     val paymentRequired: Boolean? = null,
-)
+) {
+    companion object
+}
+
+/** Explicit serializer — required on Kotlin/Wasm where runtime serializer lookup fails for user classes. */
+val nip11RelayInfoMapSerializer: KSerializer<Map<String, Nip11RelayInfo>> =
+    MapSerializer(String.serializer(), Nip11RelayInfo.serializer())
 
 /** Converts a WebSocket relay URL to its HTTPS equivalent for the NIP-11 fetch. */
 fun relayUrlToHttps(relayUrl: String): String =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -76,6 +76,14 @@ expect object SecureStorage {
     fun getGroupsForRelay(relayUrl: String): String?
     fun clearGroupsForRelay(relayUrl: String)
 
+    // Joined-group metadata cache — only the groups from kind:10009, scoped by pubkey.
+    // Written on every kind:39000 event for a joined group and on leave/create.
+    // Read on startup for instant sidebar display without waiting for the network.
+    fun saveJoinedGroupMetadata(pubkey: String, relayUrl: String, groupsJson: String)
+    fun getJoinedGroupMetadata(pubkey: String, relayUrl: String): String?
+    fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String)
+    fun clearAllJoinedGroupMetadataForAccount(pubkey: String)
+
     // NIP-11 relay metadata cache (persisted across restarts)
     fun saveRelayMetadata(json: String)
     fun getRelayMetadata(): String?
@@ -88,6 +96,55 @@ expect object SecureStorage {
     // Generic boolean preference — backs user-facing feature flags / settings.
     fun saveBooleanPref(key: String, value: Boolean)
     fun getBooleanPref(key: String, default: Boolean): Boolean
+
+    // Generic string preference — backs per-relay settings that aren't booleans (e.g. timestamps).
+    fun saveStringPref(key: String, value: String)
+    fun getStringPref(key: String, default: String): String
+
+    // Preload large metadata blobs from async storage (IndexedDB on web) into the in-memory cache.
+    // Must be called once before restoreJoinedGroupMetadataFromStorage to ensure synchronous reads work.
+    // No-op on Android and JVM (EncryptedSharedPreferences / Preferences are synchronous).
+    suspend fun preloadMetadata()
+}
+
+// Per-relay group-list EOSE timestamp — lets the app skip requestGroups() when the
+// cached group list is fresh enough (< GROUP_CACHE_TTL_S seconds old).
+private const val GROUP_CACHE_TTL_S = 3600L // 1 hour
+
+fun SecureStorage.saveGroupListEoseTimestamp(relayUrl: String, timestampSeconds: Long) {
+    saveStringPref("group_eose_ts_${relayUrl.hashCode()}", timestampSeconds.toString())
+}
+
+fun SecureStorage.getGroupListEoseTimestamp(relayUrl: String): Long {
+    return getStringPref("group_eose_ts_${relayUrl.hashCode()}", "0").toLongOrNull() ?: 0L
+}
+
+fun SecureStorage.isGroupListCacheFresh(relayUrl: String, nowSeconds: Long): Boolean {
+    val ts = getGroupListEoseTimestamp(relayUrl)
+    return ts > 0L && (nowSeconds - ts) < GROUP_CACHE_TTL_S
+}
+
+// Per-relay full group-list EOSE timestamp — set only when requestGroups() (unfiltered) EOSE
+// arrives, distinct from the joined-only timestamp saved by requestGroupsForIds().
+// Lets hasFullGroupListBeenFetched() return true after an app restart without re-fetching.
+fun SecureStorage.saveFullGroupListEoseTimestamp(relayUrl: String, timestampSeconds: Long) {
+    saveStringPref("group_full_eose_ts_${relayUrl.hashCode()}", timestampSeconds.toString())
+}
+
+fun SecureStorage.isFullGroupListCacheFresh(relayUrl: String, nowSeconds: Long): Boolean {
+    val ts = getStringPref("group_full_eose_ts_${relayUrl.hashCode()}", "0").toLongOrNull() ?: 0L
+    return ts > 0L && (nowSeconds - ts) < GROUP_CACHE_TTL_S
+}
+
+// Per-relay lazy fetch mode — when true (the default), only joined-group metadata is fetched on
+// connect; the full group list is deferred until the user expands "OTHER GROUPS".
+// Set to false on relays where you always want the full list loaded at startup (EAGER mode).
+fun SecureStorage.saveGroupFetchLazy(relayUrl: String, lazy: Boolean) {
+    saveBooleanPref("group_fetch_lazy_${relayUrl.hashCode()}", lazy)
+}
+
+fun SecureStorage.isGroupFetchLazy(relayUrl: String): Boolean {
+    return getBooleanPref("group_fetch_lazy_${relayUrl.hashCode()}", true)
 }
 
 // Legacy support functions (deprecated - use account-scoped versions)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -81,7 +81,6 @@ expect object SecureStorage {
     // Read on startup for instant sidebar display without waiting for the network.
     fun saveJoinedGroupMetadata(pubkey: String, relayUrl: String, groupsJson: String)
     fun getJoinedGroupMetadata(pubkey: String, relayUrl: String): String?
-    fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String)
     fun clearAllJoinedGroupMetadataForAccount(pubkey: String)
 
     // NIP-11 relay metadata cache (persisted across restarts)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.storage
 
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
@@ -144,6 +145,80 @@ fun SecureStorage.saveGroupFetchLazy(relayUrl: String, lazy: Boolean) {
 
 fun SecureStorage.isGroupFetchLazy(relayUrl: String): Boolean {
     return getBooleanPref("group_fetch_lazy_${relayUrl.hashCode()}", true)
+}
+
+// Per-relay restricted groups — groupIds the relay CLOSED with "restricted" for this
+// pubkey. Persisted so subsequent sessions exclude them from batched #d/#h REQs from
+// the start (otherwise pyramid-style relays CLOSE the whole batch on the first
+// connect, starving non-restricted groups of metadata until per-group CLOSEDs arrive).
+// Scoped by pubkey+relay so different accounts don't leak each other's state.
+// Entries auto-expire after RESTRICTED_GROUPS_TTL_S (7 days) — approval may have been
+// granted since the last session and we want to retry.
+private const val RESTRICTED_GROUPS_TTL_S = 7 * 24 * 3600L
+
+@Serializable
+private data class RestrictedGroupEntry(val reason: String, val ts: Long)
+
+private fun restrictedGroupsKey(pubkey: String, relayUrl: String): String =
+    "restricted_groups_${pubkey.hashCode()}_${relayUrl.hashCode()}"
+
+fun SecureStorage.getRestrictedGroupsForRelay(
+    pubkey: String,
+    relayUrl: String,
+    nowSeconds: Long
+): Map<String, String> {
+    val key = restrictedGroupsKey(pubkey, relayUrl)
+    val raw = getStringPref(key, "")
+    if (raw.isBlank()) return emptyMap()
+    val parsed: Map<String, RestrictedGroupEntry> = try {
+        Json.decodeFromString(raw)
+    } catch (_: Exception) {
+        return emptyMap()
+    }
+    val fresh = parsed.filterValues { nowSeconds - it.ts < RESTRICTED_GROUPS_TTL_S }
+    if (fresh.size != parsed.size) {
+        // Prune stale entries from storage so the blob doesn't grow unbounded.
+        try { saveStringPref(key, Json.encodeToString(fresh)) } catch (_: Exception) {}
+    }
+    return fresh.mapValues { it.value.reason }
+}
+
+fun SecureStorage.addRestrictedGroupForRelay(
+    pubkey: String,
+    relayUrl: String,
+    groupId: String,
+    reason: String,
+    nowSeconds: Long
+) {
+    val key = restrictedGroupsKey(pubkey, relayUrl)
+    val raw = getStringPref(key, "")
+    val current: MutableMap<String, RestrictedGroupEntry> = if (raw.isBlank()) {
+        mutableMapOf()
+    } else try {
+        Json.decodeFromString<Map<String, RestrictedGroupEntry>>(raw).toMutableMap()
+    } catch (_: Exception) {
+        mutableMapOf()
+    }
+    current[groupId] = RestrictedGroupEntry(reason, nowSeconds)
+    try { saveStringPref(key, Json.encodeToString<Map<String, RestrictedGroupEntry>>(current)) } catch (_: Exception) {}
+}
+
+fun SecureStorage.removeRestrictedGroupForRelay(
+    pubkey: String,
+    relayUrl: String,
+    groupId: String
+) {
+    val key = restrictedGroupsKey(pubkey, relayUrl)
+    val raw = getStringPref(key, "")
+    if (raw.isBlank()) return
+    val current: MutableMap<String, RestrictedGroupEntry> = try {
+        Json.decodeFromString<Map<String, RestrictedGroupEntry>>(raw).toMutableMap()
+    } catch (_: Exception) {
+        return
+    }
+    if (current.remove(groupId) != null) {
+        try { saveStringPref(key, Json.encodeToString<Map<String, RestrictedGroupEntry>>(current)) } catch (_: Exception) {}
+    }
 }
 
 // Legacy support functions (deprecated - use account-scoped versions)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/DesktopShell.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/DesktopShell.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.ui.components.navigation.ServerRail
 import org.nostr.nostrord.ui.components.sidebars.GroupsNavSidebar
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -69,6 +70,9 @@ fun DesktopShell(
     val relayMetadata by AppModule.nostrRepository.relayMetadata.collectAsState()
     val userMetadata by AppModule.nostrRepository.userMetadata.collectAsState()
     val orphanedJoinedByRelay by AppModule.nostrRepository.orphanedJoinedByRelay.collectAsState()
+    val fullGroupListFetchedRelays by AppModule.nostrRepository.fullGroupListFetchedRelays.collectAsState()
+    val connectionState by AppModule.nostrRepository.connectionState.collectAsState()
+    val isRelayConnected = connectionState is ConnectionManager.ConnectionState.Connected
     val sidebarScope = rememberCoroutineScope()
 
     val groupsForRelay = remember(activeRelayUrl, groupsByRelay) {
@@ -130,7 +134,15 @@ fun DesktopShell(
                         sidebarScope.launch {
                             AppModule.nostrRepository.forgetGroup(groupId, activeRelayUrl)
                         }
-                    }
+                    },
+                    isGroupFetchLazy = AppModule.nostrRepository.isGroupFetchLazy(activeRelayUrl),
+                    hasFullGroupListBeenFetched = activeRelayUrl in fullGroupListFetchedRelays,
+                    onRequestFullGroupList = {
+                        sidebarScope.launch {
+                            AppModule.nostrRepository.requestFullGroupListForRelay(activeRelayUrl)
+                        }
+                    },
+                    isRelayConnected = isRelayConnected
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/GroupsNavSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/GroupsNavSidebar.kt
@@ -100,6 +100,14 @@ fun GroupsNavSidebar(
     onAddRelay: (() -> Unit)? = null,
     onForgetOrphan: (groupId: String) -> Unit = {},
     showRelayTitle: Boolean = true,
+    /** True when this relay uses lazy fetch mode — full group list is fetched on-demand. */
+    isGroupFetchLazy: Boolean = false,
+    /** True when the full group list has already been fetched this session (LAZY mode only). */
+    hasFullGroupListBeenFetched: Boolean = true,
+    /** Called when OTHER GROUPS first expands on a lazy relay that hasn't fetched the full list yet. */
+    onRequestFullGroupList: () -> Unit = {},
+    /** True when the relay WebSocket is connected — used to re-trigger the fetch once connection is ready. */
+    isRelayConnected: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     // Reset when relay changes
@@ -143,6 +151,20 @@ fun GroupsNavSidebar(
     var myGroupsExpanded by remember(relayUrl) { mutableStateOf(true) }
     var otherGroupsExpanded by remember(relayUrl) {
         mutableStateOf(SecureStorage.getBooleanPref("sidebar_other_expanded_$relayUrl", default = true))
+    }
+
+    // A stale persisted full-list timestamp can make hasFullGroupListBeenFetched=true even when
+    // the current session has no data. Guard against that by also checking otherGroups.isEmpty()
+    // so an empty panel always triggers a fetch regardless of the cached timestamp.
+    val needsFullFetch = !hasFullGroupListBeenFetched || otherGroups.isEmpty()
+
+    // On a LAZY relay, trigger the full group list fetch when OTHER GROUPS is expanded and
+    // the connection is ready. isRelayConnected is included as a key so that if the sidebar
+    // renders before the WebSocket handshake completes, the effect re-fires once connected.
+    LaunchedEffect(otherGroupsExpanded, isGroupFetchLazy, needsFullFetch, isRelayConnected) {
+        if (otherGroupsExpanded && isGroupFetchLazy && needsFullFetch && isRelayConnected) {
+            onRequestFullGroupList()
+        }
     }
 
     Column(
@@ -245,7 +267,7 @@ fun GroupsNavSidebar(
                     modifier = Modifier.padding(horizontal = Spacing.lg, vertical = Spacing.sm)
                 )
             } else {
-                val hasOtherGroups = otherGroups.isNotEmpty() || searchQuery.isNotBlank()
+                val hasOtherGroups = otherGroups.isNotEmpty() || searchQuery.isNotBlank() || isGroupFetchLazy
                 Column(modifier = Modifier.fillMaxSize()) {
                 // MY GROUPS — weight gives verticalScroll a bounded viewport; OTHER GROUPS header always visible
                 if (myGroups.isNotEmpty() || orphanedJoinedIds.isNotEmpty()) {
@@ -305,7 +327,7 @@ fun GroupsNavSidebar(
                 }
 
                 // OTHER GROUPS — scrollable, fills remaining space
-                if (otherGroups.isNotEmpty() || searchQuery.isNotBlank()) {
+                if (otherGroups.isNotEmpty() || searchQuery.isNotBlank() || isGroupFetchLazy) {
                     Column(modifier = Modifier.padding(horizontal = Spacing.sm)) {
                         SectionToggleHeader(
                             text = "OTHER GROUPS",
@@ -315,6 +337,14 @@ fun GroupsNavSidebar(
                                 val next = !otherGroupsExpanded
                                 otherGroupsExpanded = next
                                 SecureStorage.saveBooleanPref("sidebar_other_expanded_$relayUrl", next)
+                                // Opening OTHER GROUPS on a lazy relay: trigger the download
+                                // immediately instead of relying on the LaunchedEffect.
+                                // needsFullFetch covers both the normal "not yet fetched" case and
+                                // the stale-timestamp case where hasFullGroupListBeenFetched=true
+                                // but the section is empty because no data arrived this session.
+                                if (next && isGroupFetchLazy && needsFullFetch) {
+                                    onRequestFullGroupList()
+                                }
                             }
                         )
                         if (otherGroupsExpanded) {
@@ -439,6 +469,17 @@ fun GroupsNavSidebar(
                                     item(key = "no_results") {
                                         Text(
                                             text = "No groups match \"$searchQuery\"",
+                                            color = NostrordColors.TextMuted,
+                                            fontSize = 12.sp,
+                                            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.xs)
+                                        )
+                                    }
+                                }
+
+                                if (otherGroups.isEmpty() && isGroupFetchLazy) {
+                                    item(key = "lazy_placeholder") {
+                                        Text(
+                                            text = if (isLoading) "Loading groups…" else "No other groups",
                                             color = NostrordColors.TextMuted,
                                             fontSize = 12.sp,
                                             modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.xs)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/GroupsNavSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/GroupsNavSidebar.kt
@@ -337,11 +337,8 @@ fun GroupsNavSidebar(
                                 val next = !otherGroupsExpanded
                                 otherGroupsExpanded = next
                                 SecureStorage.saveBooleanPref("sidebar_other_expanded_$relayUrl", next)
-                                // Opening OTHER GROUPS on a lazy relay: trigger the download
-                                // immediately instead of relying on the LaunchedEffect.
-                                // needsFullFetch covers both the normal "not yet fetched" case and
-                                // the stale-timestamp case where hasFullGroupListBeenFetched=true
-                                // but the section is empty because no data arrived this session.
+                                // Trigger immediately rather than waiting for the LaunchedEffect
+                                // below to recompose with the new otherGroupsExpanded value.
                                 if (next && isGroupFetchLazy && needsFullFetch) {
                                     onRequestFullGroupList()
                                 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/MemberSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/MemberSidebar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
@@ -40,6 +41,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.unit.dp
@@ -65,6 +67,8 @@ fun MemberSidebar(
     members: List<MemberInfo>,
     recentlyActiveMembers: Set<String> = emptySet(),
     isLoading: Boolean = false,
+    isPendingApproval: Boolean = false,
+    isGroupRestricted: Boolean = false,
     onMemberClick: (MemberInfo) -> Unit = {},
     isCurrentUserAdmin: Boolean = false,
     currentUserPubkey: String? = null,
@@ -264,6 +268,37 @@ fun MemberSidebar(
                                 text = "No members found",
                                 color = NostrordColors.TextMuted,
                                 style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+                }
+
+                // Locked empty state — pending approval or restricted group.
+                if (!isLoading && members.isEmpty() && searchQuery.isBlank() &&
+                    (isPendingApproval || isGroupRestricted)) {
+                    item {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 32.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Lock,
+                                contentDescription = null,
+                                tint = NostrordColors.TextMuted,
+                                modifier = Modifier.size(28.dp)
+                            )
+                            Spacer(modifier = Modifier.height(10.dp))
+                            Text(
+                                text = if (isPendingApproval)
+                                    "Members hidden until approved"
+                                else
+                                    "Members are private",
+                                color = NostrordColors.TextMuted,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                textAlign = TextAlign.Center
                             )
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -213,6 +213,19 @@ fun GroupScreen(
         }
     }
 
+    // Timestamp of the user's most recent pending join request (kind:9021),
+    // so the input banner can show "Requested Xh ago" — a quiet signal that
+    // the request has been seen by the relay.
+    val pendingRequestedAtSeconds by remember(groupId, currentUserPubkey) {
+        derivedStateOf {
+            val pubkey = currentUserPubkey ?: return@derivedStateOf null
+            (allMessages[groupId] ?: emptyList())
+                .asSequence()
+                .filter { it.kind == 9021 && it.pubkey == pubkey }
+                .maxOfOrNull { it.createdAt }
+        }
+    }
+
     // Refresh group data on join; poll while pending approval
     LaunchedEffect(isPendingApproval, isJoined, groupId) {
         if (!isJoined) return@LaunchedEffect
@@ -267,7 +280,10 @@ fun GroupScreen(
     }
 
     val isInitialLoading = isLoadingMoreMap[groupId] == true && chatItems.isEmpty()
-    val isMembersLoading = groupId in loadingMembersSet && groupMembers.isEmpty()
+    // Pending/restricted relays never deliver the member list, so the skeleton
+    // would spin forever — force-off so the sidebar can render its empty state.
+    val isMembersLoading = groupId in loadingMembersSet && groupMembers.isEmpty() &&
+            !isPendingApproval && !isGroupRestricted
 
     LaunchedEffect(groupId) {
         vm.requestGroupMessages(selectedChannel)
@@ -702,6 +718,10 @@ fun GroupScreen(
                 pendingJoinRequestCount = pendingJoinRequests.size,
                 onJoinRequestsClick = { showJoinRequestsModal = true },
                 isPendingApproval = isPendingApproval,
+                pendingRequestedAtSeconds = pendingRequestedAtSeconds,
+                onCancelJoinRequest = {
+                    vm.leaveGroup { onNavigateHome() }
+                },
                 onInviteCodesClick = { showInviteCodesModal = true },
                 isClosed = currentGroupMetadata?.isOpen == false,
                 isGroupRestricted = isGroupRestricted,
@@ -791,6 +811,10 @@ fun GroupScreen(
                 pendingJoinRequestCount = pendingJoinRequests.size,
                 onJoinRequestsClick = { showJoinRequestsModal = true },
                 isPendingApproval = isPendingApproval,
+                pendingRequestedAtSeconds = pendingRequestedAtSeconds,
+                onCancelJoinRequest = {
+                    vm.leaveGroup { onNavigateHome() }
+                },
                 onInviteCodesClick = { showInviteCodesModal = true },
                 isClosed = currentGroupMetadata?.isOpen == false,
                 isGroupRestricted = isGroupRestricted,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -105,6 +105,8 @@ fun GroupScreenDesktop(
     pendingJoinRequestCount: Int = 0,
     onJoinRequestsClick: () -> Unit = {},
     isPendingApproval: Boolean = false,
+    pendingRequestedAtSeconds: Long? = null,
+    onCancelJoinRequest: () -> Unit = {},
     onInviteCodesClick: () -> Unit = {},
     isClosed: Boolean = false,
     isGroupRestricted: Boolean = false,
@@ -178,6 +180,8 @@ fun GroupScreenDesktop(
                     currentUserPubkey = currentUserPubkey,
                     isJoined = isJoined,
                     isInitialLoading = isInitialLoading,
+                    isPendingApproval = isPendingApproval,
+                    isGroupRestricted = isGroupRestricted,
                     isLoadingMore = isLoadingMore,
                     hasMoreMessages = hasMoreMessages,
                     onLoadMore = onLoadMore,
@@ -194,6 +198,8 @@ fun GroupScreenDesktop(
 
             MessageInput(
                 isPendingApproval = isPendingApproval,
+                pendingRequestedAtSeconds = pendingRequestedAtSeconds,
+                onCancelJoinRequest = onCancelJoinRequest,
                 isJoined = isJoined,
                 selectedChannel = selectedChannel,
                 groupName = groupName,
@@ -218,6 +224,8 @@ fun GroupScreenDesktop(
                 members = groupMembers,
                 recentlyActiveMembers = recentlyActiveMembers,
                 isLoading = isMembersLoading,
+                isPendingApproval = isPendingApproval,
+                isGroupRestricted = isGroupRestricted,
                 onMemberClick = { member -> onUserClick(member.pubkey) },
                 isCurrentUserAdmin = isCurrentUserAdmin,
                 currentUserPubkey = currentUserPubkey,
@@ -239,6 +247,8 @@ fun GroupScreenDesktop(
                 members = groupMembers,
                 recentlyActiveMembers = recentlyActiveMembers,
                 isLoading = isMembersLoading,
+                isPendingApproval = isPendingApproval,
+                isGroupRestricted = isGroupRestricted,
                 onMemberClick = { member ->
                     onShowMemberSheet(false)
                     onUserClick(member.pubkey)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -134,6 +134,8 @@ fun GroupScreenMobile(
     pendingJoinRequestCount: Int = 0,
     onJoinRequestsClick: () -> Unit = {},
     isPendingApproval: Boolean = false,
+    pendingRequestedAtSeconds: Long? = null,
+    onCancelJoinRequest: () -> Unit = {},
     onInviteCodesClick: () -> Unit = {},
     isClosed: Boolean = false,
     isGroupRestricted: Boolean = false,
@@ -229,6 +231,8 @@ fun GroupScreenMobile(
                         currentUserPubkey = currentUserPubkey,
                         isJoined = isJoined,
                         isInitialLoading = isInitialLoading,
+                        isPendingApproval = isPendingApproval,
+                        isGroupRestricted = isGroupRestricted,
                         isLoadingMore = isLoadingMore,
                         hasMoreMessages = hasMoreMessages,
                         onLoadMore = onLoadMore,
@@ -245,6 +249,8 @@ fun GroupScreenMobile(
 
                 MessageInput(
                     isPendingApproval = isPendingApproval,
+                    pendingRequestedAtSeconds = pendingRequestedAtSeconds,
+                    onCancelJoinRequest = onCancelJoinRequest,
                     isJoined = isJoined,
                     selectedChannel = selectedChannel,
                     groupName = groupName,
@@ -279,6 +285,8 @@ fun GroupScreenMobile(
                 members = groupMembers,
                 recentlyActiveMembers = recentlyActiveMembers,
                 isLoading = isMembersLoading,
+                isPendingApproval = isPendingApproval,
+                isGroupRestricted = isGroupRestricted,
                 onMemberClick = { member ->
                     showMemberSheet = false
                     onUserClick(member.pubkey)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -44,6 +44,7 @@ import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
+import org.nostr.nostrord.utils.formatTimestamp
 
 /**
  * Message input field with Discord-style keyboard behavior.
@@ -64,6 +65,8 @@ import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 fun MessageInput(
     isJoined: Boolean,
     isPendingApproval: Boolean = false,
+    pendingRequestedAtSeconds: Long? = null,
+    onCancelJoinRequest: () -> Unit = {},
     selectedChannel: String,
     groupName: String?,
     messageInput: String,
@@ -227,18 +230,38 @@ fun MessageInput(
             modifier = Modifier
                 .fillMaxWidth()
                 .background(NostrordColors.SurfaceVariant)
-                .padding(Spacing.lg)
+                .padding(horizontal = Spacing.lg, vertical = Spacing.md)
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Text(
-                    text = "Your join request is pending admin approval",
-                    color = NostrordColors.TextMuted,
-                    style = NostrordTypography.MessageBody
-                )
+                Column(
+                    modifier = Modifier.weight(1f, fill = false),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "Your join request is pending admin approval",
+                        color = NostrordColors.TextMuted,
+                        style = NostrordTypography.MessageBody
+                    )
+                    if (pendingRequestedAtSeconds != null) {
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Text(
+                            text = "Requested ${formatTimestamp(pendingRequestedAtSeconds)}",
+                            color = NostrordColors.TextMuted,
+                            style = NostrordTypography.Caption
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.width(Spacing.sm))
+                TextButton(
+                    onClick = onCancelJoinRequest,
+                    colors = ButtonDefaults.textButtonColors(contentColor = NostrordColors.TextSecondary)
+                ) {
+                    Text("Cancel request", style = NostrordTypography.Button)
+                }
             }
         }
         return

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -11,7 +11,10 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import androidx.compose.ui.unit.dp
 import kotlinx.serialization.json.JsonPrimitive
@@ -73,6 +77,8 @@ fun MessagesList(
     currentUserPubkey: String? = null,
     isJoined: Boolean,
     isInitialLoading: Boolean = false,
+    isPendingApproval: Boolean = false,
+    isGroupRestricted: Boolean = false,
     isLoadingMore: Boolean = false,
     hasMoreMessages: Boolean = true,
     onLoadMore: () -> Unit = {},
@@ -201,17 +207,43 @@ fun MessagesList(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Text(
-                    "No messages yet",
-                    color = NostrordColors.TextSecondary,
-                    style = MaterialTheme.typography.bodyLarge
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                Text(
-                    if (isJoined) "Be the first to send a message!" else "Join the group to participate!",
-                    color = NostrordColors.TextMuted,
-                    style = MaterialTheme.typography.bodySmall
-                )
+                if (isPendingApproval || isGroupRestricted) {
+                    Icon(
+                        imageVector = Icons.Default.Lock,
+                        contentDescription = null,
+                        tint = NostrordColors.TextMuted,
+                        modifier = Modifier.size(40.dp)
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Text(
+                        if (isPendingApproval) "Awaiting admin approval" else "Private group",
+                        color = NostrordColors.TextSecondary,
+                        style = MaterialTheme.typography.bodyLarge,
+                        textAlign = TextAlign.Center
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        if (isPendingApproval)
+                            "Messages will appear once an admin approves your request."
+                        else
+                            "You need an invite code or admin approval to see messages.",
+                        color = NostrordColors.TextMuted,
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center
+                    )
+                } else {
+                    Text(
+                        "No messages yet",
+                        color = NostrordColors.TextSecondary,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        if (isJoined) "Be the first to send a message!" else "Join the group to participate!",
+                        color = NostrordColors.TextMuted,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
             }
         }
         else -> {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelaySettingsDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelaySettingsDesktop.kt
@@ -30,7 +30,9 @@ fun RelaySettingsDesktop(
     onNavigate: (Screen) -> Unit,
     onSelectRelay: (String) -> Unit,
     onAddRelay: () -> Unit,
-    onDeleteRelay: ((String) -> Unit)? = null
+    onDeleteRelay: ((String) -> Unit)? = null,
+    lazyFetchStates: Map<String, Boolean> = emptyMap(),
+    onToggleLazyFetch: ((String, Boolean) -> Unit)? = null
 ) {
     Column(
         modifier = Modifier
@@ -119,7 +121,9 @@ fun RelaySettingsDesktop(
                             relay = relay,
                             isCompact = false,
                             onSelectRelay = { onSelectRelay(relay.url) },
-                            onDeleteRelay = onDeleteRelay?.let { cb -> { cb(relay.url) } }
+                            onDeleteRelay = onDeleteRelay?.let { cb -> { cb(relay.url) } },
+                            isLazyFetch = lazyFetchStates[relay.url] ?: false,
+                            onToggleLazyFetch = onToggleLazyFetch?.let { cb -> { v -> cb(relay.url, v) } }
                         )
                     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelaySettingsMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelaySettingsMobile.kt
@@ -30,7 +30,9 @@ fun RelaySettingsMobile(
     onNavigate: (Screen) -> Unit,
     onSelectRelay: (String) -> Unit,
     onAddRelay: () -> Unit,
-    onDeleteRelay: ((String) -> Unit)? = null
+    onDeleteRelay: ((String) -> Unit)? = null,
+    lazyFetchStates: Map<String, Boolean> = emptyMap(),
+    onToggleLazyFetch: ((String, Boolean) -> Unit)? = null
 ) {
     Scaffold(
         topBar = {
@@ -100,7 +102,9 @@ fun RelaySettingsMobile(
                     relay = relay,
                     isCompact = true,
                     onSelectRelay = { onSelectRelay(relay.url) },
-                    onDeleteRelay = onDeleteRelay?.let { cb -> { cb(relay.url) } }
+                    onDeleteRelay = onDeleteRelay?.let { cb -> { cb(relay.url) } },
+                    isLazyFetch = lazyFetchStates[relay.url] ?: false,
+                    onToggleLazyFetch = onToggleLazyFetch?.let { cb -> { v -> cb(relay.url, v) } }
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelaySettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelaySettingsScreen.kt
@@ -14,6 +14,7 @@ import org.nostr.nostrord.ui.screens.relay.model.RelayInfo
 import org.nostr.nostrord.ui.screens.relay.model.RelayStatus
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.utils.isValidRelayUrl
+import androidx.compose.runtime.mutableStateMapOf
 
 @Composable
 fun RelaySettingsScreen(
@@ -38,6 +39,15 @@ fun RelaySettingsScreen(
 
     var newRelayUrl by remember { mutableStateOf("") }
     var showAddDialog by remember { mutableStateOf(false) }
+
+    // Per-relay lazy fetch state — initialised from SecureStorage, written back on toggle.
+    val lazyFetchStates = remember(relays) {
+        mutableStateMapOf<String, Boolean>().also { map ->
+            relays.forEach { relay ->
+                map[relay.url] = AppModule.nostrRepository.isGroupFetchLazy(relay.url)
+            }
+        }
+    }
 
     LaunchedEffect(currentRelay) {
         relays = relays.map { relay ->
@@ -116,7 +126,12 @@ fun RelaySettingsScreen(
                     onNavigate(Screen.Home)
                     vm.switchRelay(relayUrl)
                 },
-                onAddRelay = { showAddDialog = true }
+                onAddRelay = { showAddDialog = true },
+                lazyFetchStates = lazyFetchStates,
+                onToggleLazyFetch = { relayUrl, lazy ->
+                    lazyFetchStates[relayUrl] = lazy
+                    AppModule.nostrRepository.setGroupFetchLazy(relayUrl, lazy)
+                }
             )
         } else {
             RelaySettingsDesktop(
@@ -127,7 +142,12 @@ fun RelaySettingsScreen(
                     onNavigate(Screen.Home)
                     vm.switchRelay(relayUrl)
                 },
-                onAddRelay = { showAddDialog = true }
+                onAddRelay = { showAddDialog = true },
+                lazyFetchStates = lazyFetchStates,
+                onToggleLazyFetch = { relayUrl, lazy ->
+                    lazyFetchStates[relayUrl] = lazy
+                    AppModule.nostrRepository.setGroupFetchLazy(relayUrl, lazy)
+                }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/components/RelayCard.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/relay/components/RelayCard.kt
@@ -11,6 +11,10 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,7 +43,9 @@ fun RelayCard(
     relay: RelayInfo,
     isCompact: Boolean,
     onSelectRelay: () -> Unit,
-    onDeleteRelay: (() -> Unit)? = null
+    onDeleteRelay: (() -> Unit)? = null,
+    isLazyFetch: Boolean = false,
+    onToggleLazyFetch: ((Boolean) -> Unit)? = null
 ) {
     val statusColor = when (relay.status) {
         RelayStatus.CONNECTED -> NostrordColors.StatusOnline
@@ -154,6 +160,41 @@ fun RelayCard(
                         overflow = TextOverflow.Ellipsis,
                         lineHeight = 16.sp
                     )
+                }
+
+                // Fetch mode toggle
+                if (onToggleLazyFetch != null) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "Always fetch all groups",
+                                color = NostrordColors.TextPrimary,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.Medium
+                            )
+                            Text(
+                                text = "Load the full group list at startup instead of waiting until Other Groups is opened",
+                                color = NostrordColors.TextMuted,
+                                style = MaterialTheme.typography.bodySmall,
+                                lineHeight = 14.sp
+                            )
+                        }
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Switch(
+                            checked = !isLazyFetch,
+                            onCheckedChange = { onToggleLazyFetch(!it) },
+                            colors = SwitchDefaults.colors(
+                                checkedThumbColor = Color.White,
+                                checkedTrackColor = NostrordColors.Primary,
+                                uncheckedThumbColor = NostrordColors.TextMuted,
+                                uncheckedTrackColor = NostrordColors.SurfaceVariant
+                            )
+                        )
+                    }
                 }
             }
 

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.js.kt
@@ -1,6 +1,77 @@
 package org.nostr.nostrord.storage
 
 import kotlinx.browser.localStorage
+import kotlinx.browser.window
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+// In-memory caches for IndexedDB-backed data (synchronous read access after preloadMetadata).
+private var relayMetaIdbCache: String? = null
+private val joinedGroupMetaIdbCache = mutableMapOf<String, String>()
+
+// Single persistent DB connection — set once by preloadMetadata(), reused for all writes.
+private var _idbDb: dynamic = null
+
+private fun idbWrite(key: String, value: String) {
+    val db = _idbDb ?: run {
+        console.error("[IDB-JS] idbWrite skipped — DB not ready. key=$key")
+        return
+    }
+    try {
+        val tx: dynamic = db.transaction("kv", "readwrite")
+        val req: dynamic = tx.objectStore("kv").put(value, key)
+        req.onsuccess = { _: dynamic -> console.log("[IDB-JS] put ok: $key") }
+        req.onerror = { e: dynamic -> console.error("[IDB-JS] put error: $key — ${e.target.error}") }
+        tx.oncomplete = { _: dynamic -> console.log("[IDB-JS] tx committed: $key") }
+        tx.onerror = { e: dynamic -> console.error("[IDB-JS] tx error: $key — ${e.target.error}") }
+        tx.onabort = { e: dynamic -> console.error("[IDB-JS] tx aborted: $key — ${e.target.error}") }
+    } catch (e: Throwable) {
+        console.error("[IDB-JS] idbWrite threw: $key — ${e.message}")
+    }
+}
+
+private fun idbDelete(key: String) {
+    val db = _idbDb ?: run {
+        console.error("[IDB-JS] idbDelete skipped — DB not ready. key=$key")
+        return
+    }
+    try {
+        val tx: dynamic = db.transaction("kv", "readwrite")
+        val req: dynamic = tx.objectStore("kv").delete(key)
+        req.onerror = { e: dynamic -> console.error("[IDB-JS] delete error: $key — ${e.target.error}") }
+        tx.onerror = { e: dynamic -> console.error("[IDB-JS] delete tx error: $key — ${e.target.error}") }
+        tx.onabort = { e: dynamic -> console.error("[IDB-JS] delete tx aborted: $key — ${e.target.error}") }
+    } catch (e: Throwable) {
+        console.error("[IDB-JS] idbDelete threw: $key — ${e.message}")
+    }
+}
+
+private fun idbDeleteWithPrefix(prefix: String) {
+    val db = _idbDb ?: run {
+        console.error("[IDB-JS] idbDeleteWithPrefix skipped — DB not ready. prefix=$prefix")
+        return
+    }
+    try {
+        val tx: dynamic = db.transaction("kv", "readwrite")
+        val store: dynamic = tx.objectStore("kv")
+        val keysReq: dynamic = store.getAllKeys()
+        keysReq.onsuccess = { ke: dynamic ->
+            val keys = ke.target.result.unsafeCast<Array<String>>()
+            val toDelete = keys.filter { it.startsWith(prefix) }
+            if (toDelete.isNotEmpty()) {
+                console.log("[IDB-JS] deleteWithPrefix: deleting ${toDelete.size} keys for prefix=$prefix")
+                val tx2: dynamic = db.transaction("kv", "readwrite")
+                val store2: dynamic = tx2.objectStore("kv")
+                for (k in toDelete) store2.delete(k)
+                tx2.onerror = { e: dynamic -> console.error("[IDB-JS] deleteWithPrefix tx2 error: ${e.target.error}") }
+                tx2.onabort = { e: dynamic -> console.error("[IDB-JS] deleteWithPrefix tx2 aborted: ${e.target.error}") }
+            }
+        }
+        keysReq.onerror = { e: dynamic -> console.error("[IDB-JS] deleteWithPrefix getAllKeys error: ${e.target.error}") }
+    } catch (e: Throwable) {
+        console.error("[IDB-JS] idbDeleteWithPrefix threw: $prefix — ${e.message}")
+    }
+}
 
 actual object SecureStorage {
     private const val PRIVATE_KEY_PREF = "nostr_private_key"
@@ -16,33 +87,36 @@ actual object SecureStorage {
     private const val MESSAGES_PREFIX = "messages_"
     private const val PENDING_EVENTS_PREFIX = "pending_events_"
     private const val RELAY_GROUPS_PREFIX = "relay_groups_"
-    private const val RELAY_METADATA_KEY = "relay_metadata"
     private const val LIVE_CURSORS_PREFIX = "live_cursors_"
+
+    // IDB key constants
+    private const val IDB_RELAY_META_KEY = "relay_meta:relay_metadata"
+    private const val IDB_JOINED_GROUP_META_PREFIX = "joined_group_meta:"
 
     actual fun savePrivateKey(privateKeyHex: String) {
         localStorage.setItem(PRIVATE_KEY_PREF, privateKeyHex)
     }
-    
+
     actual fun getPrivateKey(): String? {
         return localStorage.getItem(PRIVATE_KEY_PREF)
     }
-    
+
     actual fun hasPrivateKey(): Boolean {
         return localStorage.getItem(PRIVATE_KEY_PREF) != null
     }
-    
+
     actual fun clearPrivateKey() {
         localStorage.removeItem(PRIVATE_KEY_PREF)
     }
-    
+
     actual fun saveCurrentRelayUrl(relayUrl: String) {
         localStorage.setItem(CURRENT_RELAY_URL, relayUrl)
     }
-    
+
     actual fun getCurrentRelayUrl(): String? {
         return localStorage.getItem(CURRENT_RELAY_URL)
     }
-    
+
     actual fun clearCurrentRelayUrl() {
         localStorage.removeItem(CURRENT_RELAY_URL)
     }
@@ -84,38 +158,35 @@ actual object SecureStorage {
         }
         keysToRemove.forEach { localStorage.removeItem(it) }
     }
-    
-    // NIP-46 Bunker URL support
+
     actual fun saveBunkerUrl(bunkerUrl: String) {
         localStorage.setItem(BUNKER_URL_PREF, bunkerUrl)
     }
-    
+
     actual fun getBunkerUrl(): String? {
         return localStorage.getItem(BUNKER_URL_PREF)
     }
-    
+
     actual fun hasBunkerUrl(): Boolean {
         return localStorage.getItem(BUNKER_URL_PREF) != null
     }
-    
+
     actual fun clearBunkerUrl() {
         localStorage.removeItem(BUNKER_URL_PREF)
     }
-    
-    // NIP-46 Bunker User Pubkey support
+
     actual fun saveBunkerUserPubkey(pubkey: String) {
         localStorage.setItem(BUNKER_USER_PUBKEY_PREF, pubkey)
     }
-    
+
     actual fun getBunkerUserPubkey(): String? {
         return localStorage.getItem(BUNKER_USER_PUBKEY_PREF)
     }
-    
+
     actual fun clearBunkerUserPubkey() {
         localStorage.removeItem(BUNKER_USER_PUBKEY_PREF)
     }
-    
-    // NIP-46 Bunker Client Private Key (for session persistence)
+
     actual fun saveBunkerClientPrivateKey(privateKey: String) {
         localStorage.setItem(BUNKER_CLIENT_PRIVATE_KEY_PREF, privateKey)
     }
@@ -128,7 +199,6 @@ actual object SecureStorage {
         localStorage.removeItem(BUNKER_CLIENT_PRIVATE_KEY_PREF)
     }
 
-    // NIP-07 Browser Extension
     actual fun saveNip07UserPubkey(pubkey: String) {
         localStorage.setItem(NIP07_USER_PUBKEY_PREF, pubkey)
     }
@@ -143,9 +213,10 @@ actual object SecureStorage {
 
     actual fun clearAll() {
         localStorage.clear()
+        relayMetaIdbCache = null
+        joinedGroupMetaIdbCache.clear()
     }
 
-    // Last read timestamp tracking
     actual fun saveLastReadTimestamp(pubkey: String, groupId: String, timestamp: Long) {
         val key = LAST_READ_PREFIX + pubkey.hashCode() + "_" + groupId.hashCode()
         localStorage.setItem(key, timestamp.toString())
@@ -176,10 +247,8 @@ actual object SecureStorage {
         return result
     }
 
-    // Last viewed group persistence
     actual fun saveLastViewedGroup(pubkey: String, groupId: String, groupName: String?) {
         val key = LAST_VIEWED_GROUP_PREFIX + pubkey.hashCode()
-        // Store as "groupId|groupName" (groupName can be empty)
         val value = "$groupId|${groupName ?: ""}"
         localStorage.setItem(key, value)
     }
@@ -199,7 +268,6 @@ actual object SecureStorage {
         localStorage.removeItem(key)
     }
 
-    // Message persistence
     actual fun saveMessagesForGroup(pubkey: String, groupId: String, messagesJson: String) {
         val key = MESSAGES_PREFIX + pubkey.hashCode() + "_" + groupId.hashCode()
         localStorage.setItem(key, messagesJson)
@@ -227,7 +295,6 @@ actual object SecureStorage {
         keysToRemove.forEach { localStorage.removeItem(it) }
     }
 
-    // Pending events persistence
     actual fun savePendingEvents(pubkey: String, eventsJson: String) {
         val key = PENDING_EVENTS_PREFIX + pubkey.hashCode()
         localStorage.setItem(key, eventsJson)
@@ -243,7 +310,6 @@ actual object SecureStorage {
         localStorage.removeItem(key)
     }
 
-    // Group metadata cache
     actual fun saveGroupsForRelay(relayUrl: String, groupsJson: String) {
         val key = RELAY_GROUPS_PREFIX + relayUrl.hashCode()
         localStorage.setItem(key, groupsJson)
@@ -259,13 +325,38 @@ actual object SecureStorage {
         localStorage.removeItem(key)
     }
 
-    actual fun saveRelayMetadata(json: String) {
-        localStorage.setItem(RELAY_METADATA_KEY, json)
+    // Joined-group metadata — backed by IndexedDB, read via in-memory cache.
+    actual fun saveJoinedGroupMetadata(pubkey: String, relayUrl: String, groupsJson: String) {
+        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
+        joinedGroupMetaIdbCache[cacheKey] = groupsJson
+        idbWrite(IDB_JOINED_GROUP_META_PREFIX + cacheKey, groupsJson)
     }
 
-    actual fun getRelayMetadata(): String? {
-        return localStorage.getItem(RELAY_METADATA_KEY)
+    actual fun getJoinedGroupMetadata(pubkey: String, relayUrl: String): String? {
+        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
+        return joinedGroupMetaIdbCache[cacheKey]
     }
+
+    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
+        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
+        joinedGroupMetaIdbCache.remove(cacheKey)
+        idbDelete(IDB_JOINED_GROUP_META_PREFIX + cacheKey)
+    }
+
+    actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
+        val accountPrefix = "${pubkey.hashCode()}_"
+        joinedGroupMetaIdbCache.keys.filter { it.startsWith(accountPrefix) }
+            .forEach { joinedGroupMetaIdbCache.remove(it) }
+        idbDeleteWithPrefix(IDB_JOINED_GROUP_META_PREFIX + accountPrefix)
+    }
+
+    // NIP-11 relay metadata — backed by IndexedDB, read via in-memory cache.
+    actual fun saveRelayMetadata(json: String) {
+        relayMetaIdbCache = json
+        idbWrite(IDB_RELAY_META_KEY, json)
+    }
+
+    actual fun getRelayMetadata(): String? = relayMetaIdbCache
 
     actual fun saveLiveCursors(relayUrl: String, json: String) {
         val key = LIVE_CURSORS_PREFIX + relayUrl.hashCode()
@@ -289,5 +380,116 @@ actual object SecureStorage {
     actual fun getBooleanPref(key: String, default: Boolean): Boolean {
         val raw = localStorage.getItem(key) ?: return default
         return raw == "1" || raw.equals("true", ignoreCase = true)
+    }
+
+    actual fun saveStringPref(key: String, value: String) {
+        localStorage.setItem(key, value)
+    }
+
+    actual fun getStringPref(key: String, default: String): String {
+        return localStorage.getItem(key) ?: default
+    }
+
+    // Open IndexedDB, read all kv entries, and populate in-memory caches.
+    // Stores the DB connection for subsequent writes — must be called before any reads or writes.
+    actual suspend fun preloadMetadata() {
+        console.log("[IDB-JS] preloadMetadata: starting")
+        try {
+            val loaded = mutableMapOf<String, String>()
+            suspendCoroutine<Unit> { cont ->
+                var resumed = false
+                fun safeResume() {
+                    if (!resumed) { resumed = true; cont.resume(Unit) }
+                }
+
+                val idb: dynamic = window.asDynamic().indexedDB
+                if (idb == null || idb == undefined) {
+                    console.error("[IDB-JS] preloadMetadata: indexedDB not available")
+                    safeResume()
+                    return@suspendCoroutine
+                }
+                val req: dynamic = idb.open("nostrord_meta_db", 1)
+                req.onupgradeneeded = { e: dynamic ->
+                    console.log("[IDB-JS] preloadMetadata: onupgradeneeded — creating kv store")
+                    val db: dynamic = e.target.result
+                    if (!(db.objectStoreNames.contains("kv").unsafeCast<Boolean>())) {
+                        db.createObjectStore("kv")
+                    }
+                }
+                req.onerror = { e: dynamic ->
+                    console.error("[IDB-JS] preloadMetadata: DB open error — ${e.target.error}")
+                    safeResume()
+                }
+                req.onsuccess = { e: dynamic ->
+                    console.log("[IDB-JS] preloadMetadata: DB opened successfully")
+                    _idbDb = e.target.result
+                    val db: dynamic = _idbDb
+                    // Re-open connection if the browser closes it (e.g. version change from another tab)
+                    db.onclose = { _: dynamic ->
+                        console.error("[IDB-JS] DB connection closed unexpectedly — clearing _idbDb")
+                        _idbDb = null
+                    }
+                    db.onversionchange = { _: dynamic ->
+                        console.error("[IDB-JS] DB versionchange — closing connection")
+                        db.close()
+                        _idbDb = null
+                    }
+
+                    val tx: dynamic = db.transaction("kv", "readonly")
+                    val store: dynamic = tx.objectStore("kv")
+                    val keysReq: dynamic = store.getAllKeys()
+                    val valsReq: dynamic = store.getAll()
+                    var dbKeys: Array<String>? = null
+                    var dbVals: Array<dynamic>? = null
+
+                    fun tryDone() {
+                        val k = dbKeys ?: return
+                        val v = dbVals ?: return
+                        console.log("[IDB-JS] preloadMetadata: loaded ${k.size} entries from IDB")
+                        for (i in k.indices) {
+                            val value = v[i]
+                            if (value != null) loaded[k[i]] = value.toString()
+                        }
+                        safeResume()
+                    }
+
+                    keysReq.onsuccess = { ke: dynamic ->
+                        dbKeys = ke.target.result.unsafeCast<Array<String>>()
+                        tryDone()
+                    }
+                    valsReq.onsuccess = { ve: dynamic ->
+                        dbVals = ve.target.result.unsafeCast<Array<dynamic>>()
+                        tryDone()
+                    }
+                    keysReq.onerror = { er: dynamic ->
+                        console.error("[IDB-JS] preloadMetadata: getAllKeys error — ${er.target.error}")
+                        safeResume()
+                    }
+                    valsReq.onerror = { er: dynamic ->
+                        console.error("[IDB-JS] preloadMetadata: getAll error — ${er.target.error}")
+                        safeResume()
+                    }
+                    tx.onerror = { er: dynamic ->
+                        console.error("[IDB-JS] preloadMetadata: read tx error — ${er.target.error}")
+                        safeResume()
+                    }
+                }
+            }
+
+            loaded[IDB_RELAY_META_KEY]?.let {
+                relayMetaIdbCache = it
+                console.log("[IDB-JS] preloadMetadata: restored relay metadata (${it.length} bytes)")
+            }
+            var groupCount = 0
+            loaded.forEach { (key, value) ->
+                if (key.startsWith(IDB_JOINED_GROUP_META_PREFIX)) {
+                    joinedGroupMetaIdbCache[key.removePrefix(IDB_JOINED_GROUP_META_PREFIX)] = value
+                    groupCount++
+                }
+            }
+            console.log("[IDB-JS] preloadMetadata: restored $groupCount joined-group-meta entries")
+        } catch (e: Throwable) {
+            console.error("[IDB-JS] preloadMetadata: uncaught exception — ${e.message}")
+        }
     }
 }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.js.kt
@@ -13,64 +13,26 @@ private val joinedGroupMetaIdbCache = mutableMapOf<String, String>()
 private var _idbDb: dynamic = null
 
 private fun idbWrite(key: String, value: String) {
-    val db = _idbDb ?: run {
-        console.error("[IDB-JS] idbWrite skipped — DB not ready. key=$key")
-        return
-    }
+    val db = _idbDb ?: return
     try {
-        val tx: dynamic = db.transaction("kv", "readwrite")
-        val req: dynamic = tx.objectStore("kv").put(value, key)
-        req.onsuccess = { _: dynamic -> console.log("[IDB-JS] put ok: $key") }
-        req.onerror = { e: dynamic -> console.error("[IDB-JS] put error: $key — ${e.target.error}") }
-        tx.oncomplete = { _: dynamic -> console.log("[IDB-JS] tx committed: $key") }
-        tx.onerror = { e: dynamic -> console.error("[IDB-JS] tx error: $key — ${e.target.error}") }
-        tx.onabort = { e: dynamic -> console.error("[IDB-JS] tx aborted: $key — ${e.target.error}") }
-    } catch (e: Throwable) {
-        console.error("[IDB-JS] idbWrite threw: $key — ${e.message}")
-    }
-}
-
-private fun idbDelete(key: String) {
-    val db = _idbDb ?: run {
-        console.error("[IDB-JS] idbDelete skipped — DB not ready. key=$key")
-        return
-    }
-    try {
-        val tx: dynamic = db.transaction("kv", "readwrite")
-        val req: dynamic = tx.objectStore("kv").delete(key)
-        req.onerror = { e: dynamic -> console.error("[IDB-JS] delete error: $key — ${e.target.error}") }
-        tx.onerror = { e: dynamic -> console.error("[IDB-JS] delete tx error: $key — ${e.target.error}") }
-        tx.onabort = { e: dynamic -> console.error("[IDB-JS] delete tx aborted: $key — ${e.target.error}") }
-    } catch (e: Throwable) {
-        console.error("[IDB-JS] idbDelete threw: $key — ${e.message}")
-    }
+        db.transaction("kv", "readwrite").objectStore("kv").put(value, key)
+    } catch (_: Throwable) {}
 }
 
 private fun idbDeleteWithPrefix(prefix: String) {
-    val db = _idbDb ?: run {
-        console.error("[IDB-JS] idbDeleteWithPrefix skipped — DB not ready. prefix=$prefix")
-        return
-    }
+    val db = _idbDb ?: return
     try {
-        val tx: dynamic = db.transaction("kv", "readwrite")
-        val store: dynamic = tx.objectStore("kv")
+        val store: dynamic = db.transaction("kv", "readwrite").objectStore("kv")
         val keysReq: dynamic = store.getAllKeys()
         keysReq.onsuccess = { ke: dynamic ->
             val keys = ke.target.result.unsafeCast<Array<String>>()
             val toDelete = keys.filter { it.startsWith(prefix) }
             if (toDelete.isNotEmpty()) {
-                console.log("[IDB-JS] deleteWithPrefix: deleting ${toDelete.size} keys for prefix=$prefix")
-                val tx2: dynamic = db.transaction("kv", "readwrite")
-                val store2: dynamic = tx2.objectStore("kv")
+                val store2: dynamic = db.transaction("kv", "readwrite").objectStore("kv")
                 for (k in toDelete) store2.delete(k)
-                tx2.onerror = { e: dynamic -> console.error("[IDB-JS] deleteWithPrefix tx2 error: ${e.target.error}") }
-                tx2.onabort = { e: dynamic -> console.error("[IDB-JS] deleteWithPrefix tx2 aborted: ${e.target.error}") }
             }
         }
-        keysReq.onerror = { e: dynamic -> console.error("[IDB-JS] deleteWithPrefix getAllKeys error: ${e.target.error}") }
-    } catch (e: Throwable) {
-        console.error("[IDB-JS] idbDeleteWithPrefix threw: $prefix — ${e.message}")
-    }
+    } catch (_: Throwable) {}
 }
 
 actual object SecureStorage {
@@ -337,12 +299,6 @@ actual object SecureStorage {
         return joinedGroupMetaIdbCache[cacheKey]
     }
 
-    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
-        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
-        joinedGroupMetaIdbCache.remove(cacheKey)
-        idbDelete(IDB_JOINED_GROUP_META_PREFIX + cacheKey)
-    }
-
     actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
         val accountPrefix = "${pubkey.hashCode()}_"
         joinedGroupMetaIdbCache.keys.filter { it.startsWith(accountPrefix) }
@@ -393,7 +349,6 @@ actual object SecureStorage {
     // Open IndexedDB, read all kv entries, and populate in-memory caches.
     // Stores the DB connection for subsequent writes — must be called before any reads or writes.
     actual suspend fun preloadMetadata() {
-        console.log("[IDB-JS] preloadMetadata: starting")
         try {
             val loaded = mutableMapOf<String, String>()
             suspendCoroutine<Unit> { cont ->
@@ -404,33 +359,23 @@ actual object SecureStorage {
 
                 val idb: dynamic = window.asDynamic().indexedDB
                 if (idb == null || idb == undefined) {
-                    console.error("[IDB-JS] preloadMetadata: indexedDB not available")
                     safeResume()
                     return@suspendCoroutine
                 }
                 val req: dynamic = idb.open("nostrord_meta_db", 1)
                 req.onupgradeneeded = { e: dynamic ->
-                    console.log("[IDB-JS] preloadMetadata: onupgradeneeded — creating kv store")
                     val db: dynamic = e.target.result
                     if (!(db.objectStoreNames.contains("kv").unsafeCast<Boolean>())) {
                         db.createObjectStore("kv")
                     }
                 }
-                req.onerror = { e: dynamic ->
-                    console.error("[IDB-JS] preloadMetadata: DB open error — ${e.target.error}")
-                    safeResume()
-                }
+                req.onerror = { _: dynamic -> safeResume() }
                 req.onsuccess = { e: dynamic ->
-                    console.log("[IDB-JS] preloadMetadata: DB opened successfully")
                     _idbDb = e.target.result
                     val db: dynamic = _idbDb
-                    // Re-open connection if the browser closes it (e.g. version change from another tab)
-                    db.onclose = { _: dynamic ->
-                        console.error("[IDB-JS] DB connection closed unexpectedly — clearing _idbDb")
-                        _idbDb = null
-                    }
+                    // Drop the handle if the browser closes it (e.g. version change from another tab).
+                    db.onclose = { _: dynamic -> _idbDb = null }
                     db.onversionchange = { _: dynamic ->
-                        console.error("[IDB-JS] DB versionchange — closing connection")
                         db.close()
                         _idbDb = null
                     }
@@ -445,7 +390,6 @@ actual object SecureStorage {
                     fun tryDone() {
                         val k = dbKeys ?: return
                         val v = dbVals ?: return
-                        console.log("[IDB-JS] preloadMetadata: loaded ${k.size} entries from IDB")
                         for (i in k.indices) {
                             val value = v[i]
                             if (value != null) loaded[k[i]] = value.toString()
@@ -461,35 +405,18 @@ actual object SecureStorage {
                         dbVals = ve.target.result.unsafeCast<Array<dynamic>>()
                         tryDone()
                     }
-                    keysReq.onerror = { er: dynamic ->
-                        console.error("[IDB-JS] preloadMetadata: getAllKeys error — ${er.target.error}")
-                        safeResume()
-                    }
-                    valsReq.onerror = { er: dynamic ->
-                        console.error("[IDB-JS] preloadMetadata: getAll error — ${er.target.error}")
-                        safeResume()
-                    }
-                    tx.onerror = { er: dynamic ->
-                        console.error("[IDB-JS] preloadMetadata: read tx error — ${er.target.error}")
-                        safeResume()
-                    }
+                    keysReq.onerror = { _: dynamic -> safeResume() }
+                    valsReq.onerror = { _: dynamic -> safeResume() }
+                    tx.onerror = { _: dynamic -> safeResume() }
                 }
             }
 
-            loaded[IDB_RELAY_META_KEY]?.let {
-                relayMetaIdbCache = it
-                console.log("[IDB-JS] preloadMetadata: restored relay metadata (${it.length} bytes)")
-            }
-            var groupCount = 0
+            loaded[IDB_RELAY_META_KEY]?.let { relayMetaIdbCache = it }
             loaded.forEach { (key, value) ->
                 if (key.startsWith(IDB_JOINED_GROUP_META_PREFIX)) {
                     joinedGroupMetaIdbCache[key.removePrefix(IDB_JOINED_GROUP_META_PREFIX)] = value
-                    groupCount++
                 }
             }
-            console.log("[IDB-JS] preloadMetadata: restored $groupCount joined-group-meta entries")
-        } catch (e: Throwable) {
-            console.error("[IDB-JS] preloadMetadata: uncaught exception — ${e.message}")
-        }
+        } catch (_: Throwable) {}
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
@@ -374,11 +374,6 @@ actual object SecureStorage {
         return getString(key)
     }
 
-    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
-        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
-        remove(key)
-    }
-
     actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
         try {
             val accountPrefix = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_"

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
@@ -26,6 +26,7 @@ actual object SecureStorage {
     private const val MESSAGES_PREFIX = "messages_"
     private const val PENDING_EVENTS_PREFIX = "pending_events_"
     private const val RELAY_GROUPS_PREFIX = "relay_groups_"
+    private const val JOINED_GROUP_META_PREFIX = "joined_group_meta_"
     private const val LIVE_CURSORS_PREFIX = "live_cursors_"
     private const val RELAY_METADATA_KEY = "relay_metadata"
 
@@ -363,6 +364,31 @@ actual object SecureStorage {
         remove(key)
     }
 
+    actual fun saveJoinedGroupMetadata(pubkey: String, relayUrl: String, groupsJson: String) {
+        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
+        saveString(key, groupsJson)
+    }
+
+    actual fun getJoinedGroupMetadata(pubkey: String, relayUrl: String): String? {
+        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
+        return getString(key)
+    }
+
+    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
+        val key = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
+        remove(key)
+    }
+
+    actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
+        try {
+            val accountPrefix = JOINED_GROUP_META_PREFIX + pubkey.hashCode() + "_"
+            prefs.keys().forEach { key ->
+                if (key.startsWith(accountPrefix)) prefs.remove(key)
+            }
+            prefs.flush()
+        } catch (_: Exception) {}
+    }
+
     // Relay metadata is NOT stored in Preferences because java.util.prefs.Preferences.put()
     // rejects values longer than MAX_VALUE_LENGTH (8192 chars). Encrypted+Base64 relay metadata
     // for even a handful of relays can exceed this limit, causing silent save failures and a
@@ -413,4 +439,14 @@ actual object SecureStorage {
     actual fun getBooleanPref(key: String, default: Boolean): Boolean {
         return prefs.getBoolean(key, default)
     }
+
+    actual fun saveStringPref(key: String, value: String) {
+        saveString(key, value)
+    }
+
+    actual fun getStringPref(key: String, default: String): String {
+        return getString(key) ?: default
+    }
+
+    actual suspend fun preloadMetadata() {}
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.wasmJs.kt
@@ -1,6 +1,11 @@
 @file:OptIn(ExperimentalWasmJsInterop::class)
 package org.nostr.nostrord.storage
 
+import kotlinx.coroutines.delay
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import kotlin.js.ExperimentalWasmJsInterop
 
 @JsFun("(key) => localStorage.getItem(key)")
@@ -18,6 +23,165 @@ private external fun jsClear()
 @JsFun("(prefix) => { const keys = []; for (let i = 0; i < localStorage.length; i++) { const key = localStorage.key(i); if (key && key.startsWith(prefix)) keys.push(key); } return keys; }")
 private external fun jsGetKeysWithPrefix(prefix: String): JsArray<JsString>
 
+// Opens IndexedDB, creates kv store if needed, stores the open DB in globalThis.__nostrordIdb,
+// reads all entries into globalThis.__nostrordIdbData (JSON string), and sets globalThis.__nostrordIdbReady.
+// Uses globalThis instead of window to work in all JS environments (Workers, bundlers, etc.).
+@JsFun("""
+() => {
+    globalThis.__nostrordIdbReady = false;
+    globalThis.__nostrordIdbData = '{}';
+    if (typeof indexedDB === 'undefined') {
+        console.error('[IDB-WASM] indexedDB not available in this context');
+        globalThis.__nostrordIdbData = '{}';
+        globalThis.__nostrordIdbReady = true;
+        return;
+    }
+    console.log('[IDB-WASM] opening nostrord_meta_db...');
+    var req = indexedDB.open('nostrord_meta_db', 1);
+    req.onupgradeneeded = function(e) {
+        console.log('[IDB-WASM] onupgradeneeded — creating kv store');
+        var db = e.target.result;
+        if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv');
+    };
+    req.onsuccess = function(e) {
+        console.log('[IDB-WASM] DB opened — reading all entries');
+        globalThis.__nostrordIdb = e.target.result;
+        globalThis.__nostrordIdb.onclose = function() {
+            console.error('[IDB-WASM] DB connection closed unexpectedly');
+            globalThis.__nostrordIdb = null;
+        };
+        globalThis.__nostrordIdb.onversionchange = function() {
+            console.error('[IDB-WASM] DB versionchange — closing connection');
+            globalThis.__nostrordIdb.close();
+            globalThis.__nostrordIdb = null;
+        };
+        var db = globalThis.__nostrordIdb;
+        var tx = db.transaction('kv', 'readonly');
+        var store = tx.objectStore('kv');
+        var keysReq = store.getAllKeys();
+        var valsReq = store.getAll();
+        var keys = null, vals = null;
+        function tryDone() {
+            if (keys !== null && vals !== null) {
+                var result = {};
+                for (var i = 0; i < keys.length; i++) {
+                    if (vals[i] !== null && vals[i] !== undefined) result[keys[i]] = vals[i];
+                }
+                var jsonStr = JSON.stringify(result);
+                console.log('[IDB-WASM] loaded ' + keys.length + ' entries from IDB');
+                globalThis.__nostrordIdbData = jsonStr;
+                globalThis.__nostrordIdbReady = true;
+            }
+        }
+        keysReq.onsuccess = function(e2) { keys = e2.target.result; tryDone(); };
+        valsReq.onsuccess = function(e2) { vals = e2.target.result; tryDone(); };
+        keysReq.onerror = function(e2) {
+            console.error('[IDB-WASM] getAllKeys error: ' + e2.target.error);
+            globalThis.__nostrordIdbData = '{}';
+            globalThis.__nostrordIdbReady = true;
+        };
+        valsReq.onerror = function(e2) {
+            console.error('[IDB-WASM] getAll error: ' + e2.target.error);
+            globalThis.__nostrordIdbData = '{}';
+            globalThis.__nostrordIdbReady = true;
+        };
+    };
+    req.onerror = function(e) {
+        console.error('[IDB-WASM] DB open error: ' + e.target.error);
+        globalThis.__nostrordIdbData = '{}';
+        globalThis.__nostrordIdbReady = true;
+    };
+}
+""")
+private external fun jsStartIdbPreload()
+
+// Returns true once jsStartIdbPreload() has finished and globalThis.__nostrordIdb is set.
+@JsFun("() => globalThis.__nostrordIdbReady === true")
+private external fun jsIsIdbReady(): Boolean
+
+// Returns the JSON string produced by jsStartIdbPreload().
+@JsFun("() => globalThis.__nostrordIdbData || '{}'")
+private external fun jsGetIdbData(): JsString
+
+// Write a value to the kv store using the already-open DB connection.
+@JsFun("""
+(key, value) => {
+    var db = globalThis.__nostrordIdb;
+    if (!db) {
+        console.error('[IDB-WASM] idbWrite skipped — DB not ready. key=' + key);
+        return;
+    }
+    try {
+        var tx = db.transaction('kv', 'readwrite');
+        var req = tx.objectStore('kv').put(value, key);
+        req.onsuccess = function() { console.log('[IDB-WASM] put ok: ' + key); };
+        req.onerror = function(e) { console.error('[IDB-WASM] put error: ' + key + ' — ' + e.target.error); };
+        tx.oncomplete = function() { console.log('[IDB-WASM] tx committed: ' + key); };
+        tx.onerror = function(e) { console.error('[IDB-WASM] tx error: ' + key + ' — ' + e.target.error); };
+        tx.onabort = function(e) { console.error('[IDB-WASM] tx aborted: ' + key + ' — ' + e.target.error); };
+    } catch(e) {
+        console.error('[IDB-WASM] idbWrite threw: ' + key + ' — ' + e);
+    }
+}
+""")
+private external fun jsIdbWrite(key: String, value: String)
+
+// Delete a single key from the kv store.
+@JsFun("""
+(key) => {
+    var db = globalThis.__nostrordIdb;
+    if (!db) {
+        console.error('[IDB-WASM] idbDelete skipped — DB not ready. key=' + key);
+        return;
+    }
+    try {
+        var tx = db.transaction('kv', 'readwrite');
+        var req = tx.objectStore('kv').delete(key);
+        req.onerror = function(e) { console.error('[IDB-WASM] delete error: ' + key + ' — ' + e.target.error); };
+        tx.onerror = function(e) { console.error('[IDB-WASM] delete tx error: ' + key + ' — ' + e.target.error); };
+        tx.onabort = function(e) { console.error('[IDB-WASM] delete tx aborted: ' + key + ' — ' + e.target.error); };
+    } catch(e) {
+        console.error('[IDB-WASM] idbDelete threw: ' + key + ' — ' + e);
+    }
+}
+""")
+private external fun jsIdbDelete(key: String)
+
+// Delete all keys that start with prefix.
+@JsFun("""
+(prefix) => {
+    var db = globalThis.__nostrordIdb;
+    if (!db) {
+        console.error('[IDB-WASM] idbDeleteWithPrefix skipped — DB not ready. prefix=' + prefix);
+        return;
+    }
+    try {
+        var tx = db.transaction('kv', 'readwrite');
+        var store = tx.objectStore('kv');
+        var req = store.getAllKeys();
+        req.onsuccess = function(e) {
+            var keys = e.target.result;
+            var toDelete = keys.filter(function(k) { return k.startsWith(prefix); });
+            if (toDelete.length === 0) return;
+            console.log('[IDB-WASM] deleteWithPrefix: ' + toDelete.length + ' keys for prefix=' + prefix);
+            var tx2 = db.transaction('kv', 'readwrite');
+            var store2 = tx2.objectStore('kv');
+            for (var i = 0; i < toDelete.length; i++) store2.delete(toDelete[i]);
+            tx2.onerror = function(e2) { console.error('[IDB-WASM] deleteWithPrefix tx2 error: ' + e2.target.error); };
+            tx2.onabort = function(e2) { console.error('[IDB-WASM] deleteWithPrefix tx2 aborted: ' + e2.target.error); };
+        };
+        req.onerror = function(e) { console.error('[IDB-WASM] deleteWithPrefix getAllKeys error: ' + e.target.error); };
+    } catch(e) {
+        console.error('[IDB-WASM] idbDeleteWithPrefix threw: ' + prefix + ' — ' + e);
+    }
+}
+""")
+private external fun jsIdbDeleteWithPrefix(prefix: String)
+
+// In-memory caches for IndexedDB-backed data (synchronous read access after preloadMetadata).
+private var relayMetaIdbCache: String? = null
+private val joinedGroupMetaIdbCache = mutableMapOf<String, String>()
+
 actual object SecureStorage {
     private const val PRIVATE_KEY_PREF = "nostr_private_key"
     private const val JOINED_GROUPS_PREFIX = "joined_groups_"
@@ -32,33 +196,36 @@ actual object SecureStorage {
     private const val MESSAGES_PREFIX = "messages_"
     private const val PENDING_EVENTS_PREFIX = "pending_events_"
     private const val RELAY_GROUPS_PREFIX = "relay_groups_"
-    private const val RELAY_METADATA_KEY = "relay_metadata"
     private const val LIVE_CURSORS_PREFIX = "live_cursors_"
+
+    // IDB key constants
+    private const val IDB_RELAY_META_KEY = "relay_meta:relay_metadata"
+    private const val IDB_JOINED_GROUP_META_PREFIX = "joined_group_meta:"
 
     actual fun savePrivateKey(privateKeyHex: String) {
         jsSetItem(PRIVATE_KEY_PREF, privateKeyHex)
     }
-    
+
     actual fun getPrivateKey(): String? {
         return jsGetItem(PRIVATE_KEY_PREF)
     }
-    
+
     actual fun hasPrivateKey(): Boolean {
         return jsGetItem(PRIVATE_KEY_PREF) != null
     }
-    
+
     actual fun clearPrivateKey() {
         jsRemoveItem(PRIVATE_KEY_PREF)
     }
-    
+
     actual fun saveCurrentRelayUrl(relayUrl: String) {
         jsSetItem(CURRENT_RELAY_URL, relayUrl)
     }
-    
+
     actual fun getCurrentRelayUrl(): String? {
         return jsGetItem(CURRENT_RELAY_URL)
     }
-    
+
     actual fun clearCurrentRelayUrl() {
         jsRemoveItem(CURRENT_RELAY_URL)
     }
@@ -96,51 +263,47 @@ actual object SecureStorage {
             jsRemoveItem(keys[i].toString())
         }
     }
-    
-    // NIP-46 Bunker URL support
+
     actual fun saveBunkerUrl(bunkerUrl: String) {
         jsSetItem(BUNKER_URL_PREF, bunkerUrl)
     }
-    
+
     actual fun getBunkerUrl(): String? {
         return jsGetItem(BUNKER_URL_PREF)
     }
-    
+
     actual fun hasBunkerUrl(): Boolean {
         return jsGetItem(BUNKER_URL_PREF) != null
     }
-    
+
     actual fun clearBunkerUrl() {
         jsRemoveItem(BUNKER_URL_PREF)
     }
-    
-    // NIP-46 Bunker User Pubkey support
+
     actual fun saveBunkerUserPubkey(pubkey: String) {
         jsSetItem(BUNKER_USER_PUBKEY_PREF, pubkey)
     }
-    
+
     actual fun getBunkerUserPubkey(): String? {
         return jsGetItem(BUNKER_USER_PUBKEY_PREF)
     }
-    
+
     actual fun clearBunkerUserPubkey() {
         jsRemoveItem(BUNKER_USER_PUBKEY_PREF)
     }
-    
-    // NIP-46 Bunker Client Private Key (for session persistence)
+
     actual fun saveBunkerClientPrivateKey(privateKey: String) {
         jsSetItem(BUNKER_CLIENT_PRIVATE_KEY_PREF, privateKey)
     }
-    
+
     actual fun getBunkerClientPrivateKey(): String? {
         return jsGetItem(BUNKER_CLIENT_PRIVATE_KEY_PREF)
     }
-    
+
     actual fun clearBunkerClientPrivateKey() {
         jsRemoveItem(BUNKER_CLIENT_PRIVATE_KEY_PREF)
     }
 
-    // NIP-07 Browser Extension
     actual fun saveNip07UserPubkey(pubkey: String) {
         jsSetItem(NIP07_USER_PUBKEY_PREF, pubkey)
     }
@@ -155,9 +318,10 @@ actual object SecureStorage {
 
     actual fun clearAll() {
         jsClear()
+        relayMetaIdbCache = null
+        joinedGroupMetaIdbCache.clear()
     }
 
-    // Last read timestamp tracking
     actual fun saveLastReadTimestamp(pubkey: String, groupId: String, timestamp: Long) {
         val key = LAST_READ_PREFIX + pubkey.hashCode() + "_" + groupId.hashCode()
         jsSetItem(key, timestamp.toString())
@@ -187,10 +351,8 @@ actual object SecureStorage {
         return result
     }
 
-    // Last viewed group persistence
     actual fun saveLastViewedGroup(pubkey: String, groupId: String, groupName: String?) {
         val key = LAST_VIEWED_GROUP_PREFIX + pubkey.hashCode()
-        // Store as "groupId|groupName" (groupName can be empty)
         val value = "$groupId|${groupName ?: ""}"
         jsSetItem(key, value)
     }
@@ -210,7 +372,6 @@ actual object SecureStorage {
         jsRemoveItem(key)
     }
 
-    // Message persistence
     actual fun saveMessagesForGroup(pubkey: String, groupId: String, messagesJson: String) {
         val key = MESSAGES_PREFIX + pubkey.hashCode() + "_" + groupId.hashCode()
         jsSetItem(key, messagesJson)
@@ -234,7 +395,6 @@ actual object SecureStorage {
         }
     }
 
-    // Pending events persistence
     actual fun savePendingEvents(pubkey: String, eventsJson: String) {
         val key = PENDING_EVENTS_PREFIX + pubkey.hashCode()
         jsSetItem(key, eventsJson)
@@ -250,7 +410,6 @@ actual object SecureStorage {
         jsRemoveItem(key)
     }
 
-    // Group metadata cache
     actual fun saveGroupsForRelay(relayUrl: String, groupsJson: String) {
         val key = RELAY_GROUPS_PREFIX + relayUrl.hashCode()
         jsSetItem(key, groupsJson)
@@ -266,13 +425,38 @@ actual object SecureStorage {
         jsRemoveItem(key)
     }
 
-    actual fun saveRelayMetadata(json: String) {
-        jsSetItem(RELAY_METADATA_KEY, json)
+    // Joined-group metadata — backed by IndexedDB, read via in-memory cache.
+    actual fun saveJoinedGroupMetadata(pubkey: String, relayUrl: String, groupsJson: String) {
+        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
+        joinedGroupMetaIdbCache[cacheKey] = groupsJson
+        jsIdbWrite(IDB_JOINED_GROUP_META_PREFIX + cacheKey, groupsJson)
     }
 
-    actual fun getRelayMetadata(): String? {
-        return jsGetItem(RELAY_METADATA_KEY)
+    actual fun getJoinedGroupMetadata(pubkey: String, relayUrl: String): String? {
+        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
+        return joinedGroupMetaIdbCache[cacheKey]
     }
+
+    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
+        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
+        joinedGroupMetaIdbCache.remove(cacheKey)
+        jsIdbDelete(IDB_JOINED_GROUP_META_PREFIX + cacheKey)
+    }
+
+    actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
+        val accountPrefix = "${pubkey.hashCode()}_"
+        joinedGroupMetaIdbCache.keys.filter { it.startsWith(accountPrefix) }
+            .forEach { joinedGroupMetaIdbCache.remove(it) }
+        jsIdbDeleteWithPrefix(IDB_JOINED_GROUP_META_PREFIX + accountPrefix)
+    }
+
+    // NIP-11 relay metadata — backed by IndexedDB, read via in-memory cache.
+    actual fun saveRelayMetadata(json: String) {
+        relayMetaIdbCache = json
+        jsIdbWrite(IDB_RELAY_META_KEY, json)
+    }
+
+    actual fun getRelayMetadata(): String? = relayMetaIdbCache
 
     actual fun saveLiveCursors(relayUrl: String, json: String) {
         val key = LIVE_CURSORS_PREFIX + relayUrl.hashCode()
@@ -296,5 +480,58 @@ actual object SecureStorage {
     actual fun getBooleanPref(key: String, default: Boolean): Boolean {
         val raw = jsGetItem(key) ?: return default
         return raw == "1" || raw.equals("true", ignoreCase = true)
+    }
+
+    actual fun saveStringPref(key: String, value: String) {
+        jsSetItem(key, value)
+    }
+
+    actual fun getStringPref(key: String, default: String): String {
+        return jsGetItem(key) ?: default
+    }
+
+    // Opens IndexedDB (storing the connection in globalThis.__nostrordIdb) and reads all kv entries
+    // into globalThis.__nostrordIdbData. Polls until ready, then populates in-memory caches.
+    // Avoids passing Kotlin lambdas to JS — uses a global ready-flag instead.
+    actual suspend fun preloadMetadata() {
+        println("[IDB-WASM] preloadMetadata: starting")
+        try {
+            jsStartIdbPreload()
+            // Yield to the JS event loop until the IDB open + read completes (max 3s).
+            var attempts = 0
+            while (!jsIsIdbReady() && attempts < 600) {
+                delay(5)
+                attempts++
+            }
+            if (!jsIsIdbReady()) {
+                println("[IDB-WASM] preloadMetadata: timed out after ${attempts * 5}ms — continuing without cache")
+                return
+            }
+            println("[IDB-WASM] preloadMetadata: IDB ready after ${attempts * 5}ms")
+
+            val json = jsGetIdbData().toString()
+            if (json == "{}") {
+                println("[IDB-WASM] preloadMetadata: IDB empty — nothing to restore")
+                return
+            }
+
+            val parsed = Json.parseToJsonElement(json).jsonObject
+            parsed[IDB_RELAY_META_KEY]?.jsonPrimitive?.contentOrNull?.let {
+                relayMetaIdbCache = it
+                println("[IDB-WASM] preloadMetadata: restored relay metadata (${it.length} bytes)")
+            }
+            var groupCount = 0
+            parsed.forEach { (key, value) ->
+                if (key.startsWith(IDB_JOINED_GROUP_META_PREFIX)) {
+                    value.jsonPrimitive.contentOrNull?.let { v ->
+                        joinedGroupMetaIdbCache[key.removePrefix(IDB_JOINED_GROUP_META_PREFIX)] = v
+                        groupCount++
+                    }
+                }
+            }
+            println("[IDB-WASM] preloadMetadata: restored $groupCount joined-group-meta entries")
+        } catch (e: Throwable) {
+            println("[IDB-WASM] preloadMetadata: uncaught exception — ${e.message}")
+        }
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/storage/SecureStorage.wasmJs.kt
@@ -31,27 +31,18 @@ private external fun jsGetKeysWithPrefix(prefix: String): JsArray<JsString>
     globalThis.__nostrordIdbReady = false;
     globalThis.__nostrordIdbData = '{}';
     if (typeof indexedDB === 'undefined') {
-        console.error('[IDB-WASM] indexedDB not available in this context');
-        globalThis.__nostrordIdbData = '{}';
         globalThis.__nostrordIdbReady = true;
         return;
     }
-    console.log('[IDB-WASM] opening nostrord_meta_db...');
     var req = indexedDB.open('nostrord_meta_db', 1);
     req.onupgradeneeded = function(e) {
-        console.log('[IDB-WASM] onupgradeneeded — creating kv store');
         var db = e.target.result;
         if (!db.objectStoreNames.contains('kv')) db.createObjectStore('kv');
     };
     req.onsuccess = function(e) {
-        console.log('[IDB-WASM] DB opened — reading all entries');
         globalThis.__nostrordIdb = e.target.result;
-        globalThis.__nostrordIdb.onclose = function() {
-            console.error('[IDB-WASM] DB connection closed unexpectedly');
-            globalThis.__nostrordIdb = null;
-        };
+        globalThis.__nostrordIdb.onclose = function() { globalThis.__nostrordIdb = null; };
         globalThis.__nostrordIdb.onversionchange = function() {
-            console.error('[IDB-WASM] DB versionchange — closing connection');
             globalThis.__nostrordIdb.close();
             globalThis.__nostrordIdb = null;
         };
@@ -67,30 +58,16 @@ private external fun jsGetKeysWithPrefix(prefix: String): JsArray<JsString>
                 for (var i = 0; i < keys.length; i++) {
                     if (vals[i] !== null && vals[i] !== undefined) result[keys[i]] = vals[i];
                 }
-                var jsonStr = JSON.stringify(result);
-                console.log('[IDB-WASM] loaded ' + keys.length + ' entries from IDB');
-                globalThis.__nostrordIdbData = jsonStr;
+                globalThis.__nostrordIdbData = JSON.stringify(result);
                 globalThis.__nostrordIdbReady = true;
             }
         }
         keysReq.onsuccess = function(e2) { keys = e2.target.result; tryDone(); };
         valsReq.onsuccess = function(e2) { vals = e2.target.result; tryDone(); };
-        keysReq.onerror = function(e2) {
-            console.error('[IDB-WASM] getAllKeys error: ' + e2.target.error);
-            globalThis.__nostrordIdbData = '{}';
-            globalThis.__nostrordIdbReady = true;
-        };
-        valsReq.onerror = function(e2) {
-            console.error('[IDB-WASM] getAll error: ' + e2.target.error);
-            globalThis.__nostrordIdbData = '{}';
-            globalThis.__nostrordIdbReady = true;
-        };
+        keysReq.onerror = function() { globalThis.__nostrordIdbReady = true; };
+        valsReq.onerror = function() { globalThis.__nostrordIdbReady = true; };
     };
-    req.onerror = function(e) {
-        console.error('[IDB-WASM] DB open error: ' + e.target.error);
-        globalThis.__nostrordIdbData = '{}';
-        globalThis.__nostrordIdbReady = true;
-    };
+    req.onerror = function() { globalThis.__nostrordIdbReady = true; };
 }
 """)
 private external fun jsStartIdbPreload()
@@ -107,73 +84,30 @@ private external fun jsGetIdbData(): JsString
 @JsFun("""
 (key, value) => {
     var db = globalThis.__nostrordIdb;
-    if (!db) {
-        console.error('[IDB-WASM] idbWrite skipped — DB not ready. key=' + key);
-        return;
-    }
+    if (!db) return;
     try {
-        var tx = db.transaction('kv', 'readwrite');
-        var req = tx.objectStore('kv').put(value, key);
-        req.onsuccess = function() { console.log('[IDB-WASM] put ok: ' + key); };
-        req.onerror = function(e) { console.error('[IDB-WASM] put error: ' + key + ' — ' + e.target.error); };
-        tx.oncomplete = function() { console.log('[IDB-WASM] tx committed: ' + key); };
-        tx.onerror = function(e) { console.error('[IDB-WASM] tx error: ' + key + ' — ' + e.target.error); };
-        tx.onabort = function(e) { console.error('[IDB-WASM] tx aborted: ' + key + ' — ' + e.target.error); };
-    } catch(e) {
-        console.error('[IDB-WASM] idbWrite threw: ' + key + ' — ' + e);
-    }
+        db.transaction('kv', 'readwrite').objectStore('kv').put(value, key);
+    } catch(e) {}
 }
 """)
 private external fun jsIdbWrite(key: String, value: String)
-
-// Delete a single key from the kv store.
-@JsFun("""
-(key) => {
-    var db = globalThis.__nostrordIdb;
-    if (!db) {
-        console.error('[IDB-WASM] idbDelete skipped — DB not ready. key=' + key);
-        return;
-    }
-    try {
-        var tx = db.transaction('kv', 'readwrite');
-        var req = tx.objectStore('kv').delete(key);
-        req.onerror = function(e) { console.error('[IDB-WASM] delete error: ' + key + ' — ' + e.target.error); };
-        tx.onerror = function(e) { console.error('[IDB-WASM] delete tx error: ' + key + ' — ' + e.target.error); };
-        tx.onabort = function(e) { console.error('[IDB-WASM] delete tx aborted: ' + key + ' — ' + e.target.error); };
-    } catch(e) {
-        console.error('[IDB-WASM] idbDelete threw: ' + key + ' — ' + e);
-    }
-}
-""")
-private external fun jsIdbDelete(key: String)
 
 // Delete all keys that start with prefix.
 @JsFun("""
 (prefix) => {
     var db = globalThis.__nostrordIdb;
-    if (!db) {
-        console.error('[IDB-WASM] idbDeleteWithPrefix skipped — DB not ready. prefix=' + prefix);
-        return;
-    }
+    if (!db) return;
     try {
-        var tx = db.transaction('kv', 'readwrite');
-        var store = tx.objectStore('kv');
+        var store = db.transaction('kv', 'readwrite').objectStore('kv');
         var req = store.getAllKeys();
         req.onsuccess = function(e) {
             var keys = e.target.result;
             var toDelete = keys.filter(function(k) { return k.startsWith(prefix); });
             if (toDelete.length === 0) return;
-            console.log('[IDB-WASM] deleteWithPrefix: ' + toDelete.length + ' keys for prefix=' + prefix);
-            var tx2 = db.transaction('kv', 'readwrite');
-            var store2 = tx2.objectStore('kv');
+            var store2 = db.transaction('kv', 'readwrite').objectStore('kv');
             for (var i = 0; i < toDelete.length; i++) store2.delete(toDelete[i]);
-            tx2.onerror = function(e2) { console.error('[IDB-WASM] deleteWithPrefix tx2 error: ' + e2.target.error); };
-            tx2.onabort = function(e2) { console.error('[IDB-WASM] deleteWithPrefix tx2 aborted: ' + e2.target.error); };
         };
-        req.onerror = function(e) { console.error('[IDB-WASM] deleteWithPrefix getAllKeys error: ' + e.target.error); };
-    } catch(e) {
-        console.error('[IDB-WASM] idbDeleteWithPrefix threw: ' + prefix + ' — ' + e);
-    }
+    } catch(e) {}
 }
 """)
 private external fun jsIdbDeleteWithPrefix(prefix: String)
@@ -437,12 +371,6 @@ actual object SecureStorage {
         return joinedGroupMetaIdbCache[cacheKey]
     }
 
-    actual fun clearJoinedGroupMetadata(pubkey: String, relayUrl: String) {
-        val cacheKey = "${pubkey.hashCode()}_${relayUrl.hashCode()}"
-        joinedGroupMetaIdbCache.remove(cacheKey)
-        jsIdbDelete(IDB_JOINED_GROUP_META_PREFIX + cacheKey)
-    }
-
     actual fun clearAllJoinedGroupMetadataForAccount(pubkey: String) {
         val accountPrefix = "${pubkey.hashCode()}_"
         joinedGroupMetaIdbCache.keys.filter { it.startsWith(accountPrefix) }
@@ -494,7 +422,6 @@ actual object SecureStorage {
     // into globalThis.__nostrordIdbData. Polls until ready, then populates in-memory caches.
     // Avoids passing Kotlin lambdas to JS — uses a global ready-flag instead.
     actual suspend fun preloadMetadata() {
-        println("[IDB-WASM] preloadMetadata: starting")
         try {
             jsStartIdbPreload()
             // Yield to the JS event loop until the IDB open + read completes (max 3s).
@@ -503,35 +430,22 @@ actual object SecureStorage {
                 delay(5)
                 attempts++
             }
-            if (!jsIsIdbReady()) {
-                println("[IDB-WASM] preloadMetadata: timed out after ${attempts * 5}ms — continuing without cache")
-                return
-            }
-            println("[IDB-WASM] preloadMetadata: IDB ready after ${attempts * 5}ms")
+            if (!jsIsIdbReady()) return
 
             val json = jsGetIdbData().toString()
-            if (json == "{}") {
-                println("[IDB-WASM] preloadMetadata: IDB empty — nothing to restore")
-                return
-            }
+            if (json == "{}") return
 
             val parsed = Json.parseToJsonElement(json).jsonObject
             parsed[IDB_RELAY_META_KEY]?.jsonPrimitive?.contentOrNull?.let {
                 relayMetaIdbCache = it
-                println("[IDB-WASM] preloadMetadata: restored relay metadata (${it.length} bytes)")
             }
-            var groupCount = 0
             parsed.forEach { (key, value) ->
                 if (key.startsWith(IDB_JOINED_GROUP_META_PREFIX)) {
                     value.jsonPrimitive.contentOrNull?.let { v ->
                         joinedGroupMetaIdbCache[key.removePrefix(IDB_JOINED_GROUP_META_PREFIX)] = v
-                        groupCount++
                     }
                 }
             }
-            println("[IDB-WASM] preloadMetadata: restored $groupCount joined-group-meta entries")
-        } catch (e: Throwable) {
-            println("[IDB-WASM] preloadMetadata: uncaught exception — ${e.message}")
-        }
+        } catch (_: Throwable) {}
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,3 +35,4 @@ composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "com
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Relay/group cache + UX for pending-approval groups

### Summary

The original goal was to **cache relay and group metadata to disk** so the sidebar shows up fully painted the instant the app opens, without waiting for the network round-trip. Along the way three bugs surfaced that were blocking the very path the cache was trying to speed up, so the scope grew — it felt wrong to ship the cache and leave the jams for later.

### What's included

**Cache (the original motivation)**
- `saveJoinedGroupMetadata` / `restoreJoinedGroupMetadataFromStorage` for kind:39000 of the groups the user belongs to, scoped by pubkey + relay.
- `saveRelayMetadata` / `getRelayMetadata` for NIP-11 (relay name/icon).
- Restore runs before any REQ, so the sidebar is painted from the first frame and each network update simply overwrites.

**Batched `#d`/`#h` subs choking on a restricted group**
Pyramid-style relays (e.g. `pyramid.fiatjaf.com`) CLOSE the whole subscription with `restricted` when **one** ID in the filter is denied. A single pending-approval group was starving every other joined group on that relay of metadata and delete updates, and it also popped "Access denied by relay" on the homescreen as if the whole relay were off-limits.
- `group-list-*` CLOSED `restricted` now distinguishes a full-fetch REQ (marks the relay) from a `#d`-filtered REQ (doesn't — OTHER GROUPS is collapsed by design, no unfiltered fallback that would leak other groups into the homescreen).
- `meta_` / `members_` / `admins_` CLOSEDs also mark the per-group restriction; previously only `msg_` did.
- Restricted IDs are stripped from every batch (`requestGroupsForIds`, `mux_meta`, `mux_del`, `mux_chat`) before it goes out.
- `markGroupRestricted` kicks off `refreshMuxDebounced`, so the mux is re-sent without the offender and the other groups unblock.
- State persisted in `SecureStorage` by `(pubkey, relayUrl)` with a 7-day TTL, so subsequent sessions skip those IDs from the start.
- `leaveGroup` clears the marker — cancel = fresh intent on the next join.

**Honest empty states for pending-approval groups**
A group awaiting admin approval used to show "Be the first to send a message!" in chat and a never-ending skeleton on the member list — only the input banner told the truth. Now all three panels tell the same story:
- Chat: locked card with "Awaiting admin approval" + "Messages will appear once an admin approves your request."
- Members: "Members hidden until approved" (skeleton is force-off when pending/restricted).
- Input: keeps "Your join request is pending admin approval" and gains a "Cancel request" button (publishes kind:9022 and navigates home).

**`switchRelay` disconnect race**
`requestFullGroupListForRelay` now picks the specific client for the target relay instead of the primary. Closed a window where a quick switch could send `requestGroups()` to a relay that was no longer current.

**Logout leaving a ghost group**
`logout()` did not clear `lastViewedGroup`. On re-login (same pubkey), `StartupResolver` restored the group — but the active relay was now the first one in the list, not the group's actual relay. Since `saveLastViewedGroup` doesn't store the source relay, there was no way to recover. Clearing on logout fixes it: the next session lands on Home.
