### PR TITLE
feat: remember last group viewed per relay

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -34,6 +34,9 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.startup.AppStartState
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.clearLastGroupForRelay
+import org.nostr.nostrord.storage.getLastGroupForRelay
+import org.nostr.nostrord.storage.saveLastGroupForRelay
 import org.nostr.nostrord.ui.Screen
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.components.layout.DesktopShell
@@ -206,12 +209,53 @@ private fun AuthenticatedApp(
 
     var selectedRelayUrl by remember(currentRelayUrl) { mutableStateOf(currentRelayUrl) }
 
+    // [previousRelayUrl] must be captured before [selectedRelayUrl] is mutated by
+    // the caller — reading it inside this fn would always see the new value and
+    // break the same-relay toggle.
+    fun resolveScreenForRelay(clickedUrl: String, previousRelayUrl: String): Screen {
+        if (clickedUrl.isBlank() || clickedUrl == previousRelayUrl) return Screen.Home
+        val pk = pubKey ?: return Screen.Home
+        val (groupId, groupName) = SecureStorage.getLastGroupForRelay(pk, clickedUrl) ?: return Screen.Home
+        return Screen.Group(groupId, groupName)
+    }
+
+    fun persistScreenState(screen: Screen) {
+        pubKey?.let { pk ->
+            when (screen) {
+                is Screen.Group -> {
+                    SecureStorage.saveLastViewedGroup(pk, screen.groupId, screen.groupName)
+                    if (selectedRelayUrl.isNotBlank()) {
+                        SecureStorage.saveLastGroupForRelay(
+                            pk, selectedRelayUrl, screen.groupId, screen.groupName
+                        )
+                    }
+                }
+                is Screen.Home -> {
+                    SecureStorage.clearLastViewedGroup(pk)
+                    // A null per-relay entry means "user last on Home" — see resolveScreenForRelay.
+                    if (selectedRelayUrl.isNotBlank()) {
+                        SecureStorage.clearLastGroupForRelay(pk, selectedRelayUrl)
+                    }
+                }
+                else -> {
+                    // Other screens don't affect persisted group state
+                }
+            }
+        }
+    }
+
     // Connect to deep link relay if provided (e.g. login via /?relay=X&group=Y).
     // initialize() may have skipped the deep link because the user wasn't logged in yet.
     LaunchedEffect(deepLinkRelayUrl) {
         if (deepLinkRelayUrl != null && deepLinkRelayUrl != currentRelayUrl) {
             selectedRelayUrl = deepLinkRelayUrl
             AppModule.nostrRepository.switchRelay(deepLinkRelayUrl)
+        }
+        // navHistory skips onNavigate for the initial entry, so deep links never
+        // hit persistScreenState. Mirror it so the URL is authoritative — a
+        // group URL saves it, a relay-only URL clears the per-relay entry.
+        if (deepLinkRelayUrl != null) {
+            persistScreenState(initialScreen)
         }
     }
 
@@ -274,23 +318,6 @@ private fun AuthenticatedApp(
 
     val loadingRelays by AppModule.nostrRepository.loadingRelays.collectAsState()
     val isGroupsLoading = selectedRelayUrl in loadingRelays || selectedRelayUrl.isBlank()
-
-    // Persist screen state for next app launch
-    fun persistScreenState(screen: Screen) {
-        pubKey?.let { pk ->
-            when (screen) {
-                is Screen.Group -> {
-                    SecureStorage.saveLastViewedGroup(pk, screen.groupId, screen.groupName)
-                }
-                is Screen.Home -> {
-                    SecureStorage.clearLastViewedGroup(pk)
-                }
-                else -> {
-                    // Other screens don't affect persisted group state
-                }
-            }
-        }
-    }
 
     // Navigation handler that records history and persists state.
     // Screen.RelaySettings is intercepted here and shown as a modal instead of navigating.
@@ -408,11 +435,14 @@ private fun AuthenticatedApp(
                 }
                 if (targetScreen != currentScreen) {
                     navHistory.navigate(targetScreen, relayUrl)
-                    persistScreenState(targetScreen)
                     AppModule.nostrRepository.setActiveGroup(
                         if (targetScreen is Screen.Group) targetScreen.groupId else null
                     )
                 }
+                // Outside the guard: a URL change can swap the relay without
+                // changing the screen kind (Home → Home on another relay), and
+                // we still need per-relay state to track the new URL.
+                persistScreenState(targetScreen)
             }
         }
     )
@@ -516,10 +546,12 @@ private fun AuthenticatedApp(
                     activeGroupId = activeGroupId,
                     isGroupsLoading = isGroupsLoading,
                     onRelayClick = { url ->
+                        val previousRelayUrl = selectedRelayUrl
                         selectedRelayUrl = url
                         scope.launch { AppModule.nostrRepository.switchRelay(url) }
-                        onNavigate(Screen.Home)
+                        onNavigate(resolveScreenForRelay(url, previousRelayUrl))
                     },
+                    onRelayTitleClick = { onNavigate(Screen.Home) },
                     onAddRelayClick = { onNavigate(Screen.RelaySettings) },
                     onGroupClick = { groupId, groupName ->
                         onNavigate(Screen.Group(groupId, groupName))
@@ -564,11 +596,16 @@ private fun AuthenticatedApp(
                             hasNoRelays = hasNoRelays,
                             isProfileActive = showSettings,
                             onRelayClick = { url ->
+                                val previousRelayUrl = selectedRelayUrl
                                 selectedRelayUrl = url
                                 scope.launch {
                                     drawerState.close()
                                     AppModule.nostrRepository.switchRelay(url)
                                 }
+                                onNavigate(resolveScreenForRelay(url, previousRelayUrl))
+                            },
+                            onRelayTitleClick = {
+                                scope.launch { drawerState.close() }
                                 onNavigate(Screen.Home)
                             },
                             onAddRelayClick = {
@@ -785,6 +822,7 @@ private fun MobileDrawerContent(
     hasNoRelays: Boolean,
     isProfileActive: Boolean,
     onRelayClick: (String) -> Unit,
+    onRelayTitleClick: () -> Unit,
     onAddRelayClick: () -> Unit,
     onGroupClick: (groupId: String, groupName: String?) -> Unit,
     onCreateGroupClick: () -> Unit,
@@ -855,6 +893,7 @@ private fun MobileDrawerContent(
             childrenByParent = childrenByParent,
             unverifiedChildren = unverifiedChildren,
             orphanedJoinedIds = orphanedJoinedIds,
+            onRelayTitleClick = onRelayTitleClick,
             onGroupClick = onGroupClick,
             onCreateGroupClick = onCreateGroupClick,
             onJoinGroupClick = onJoinGroupClick,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -107,6 +107,47 @@ expect object SecureStorage {
     suspend fun preloadMetadata()
 }
 
+// Per-relay last-viewed group. Stored as "groupId|groupName" with `|` and `%`
+// percent-escaped so the pipe stays unambiguous as the field separator.
+private fun lastGroupForRelayKey(pubkey: String, relayUrl: String): String =
+    "last_group_${pubkey.hashCode()}_${relayUrl.hashCode()}"
+
+private fun encodeLastGroupValue(groupId: String, groupName: String?): String {
+    fun esc(s: String) = s.replace("%", "%25").replace("|", "%7C")
+    return if (groupName == null) esc(groupId) else "${esc(groupId)}|${esc(groupName)}"
+}
+
+private fun decodeLastGroupValue(raw: String): Pair<String, String?>? {
+    if (raw.isBlank()) return null
+    fun unesc(s: String) = s.replace("%7C", "|").replace("%25", "%")
+    val parts = raw.split("|", limit = 2)
+    val id = unesc(parts[0])
+    if (id.isBlank()) return null
+    val name = parts.getOrNull(1)?.let(::unesc)?.takeIf { it.isNotBlank() }
+    return id to name
+}
+
+fun SecureStorage.saveLastGroupForRelay(
+    pubkey: String,
+    relayUrl: String,
+    groupId: String,
+    groupName: String?
+) {
+    if (pubkey.isBlank() || relayUrl.isBlank() || groupId.isBlank()) return
+    saveStringPref(lastGroupForRelayKey(pubkey, relayUrl), encodeLastGroupValue(groupId, groupName))
+}
+
+fun SecureStorage.getLastGroupForRelay(pubkey: String, relayUrl: String): Pair<String, String?>? {
+    if (pubkey.isBlank() || relayUrl.isBlank()) return null
+    val raw = getStringPref(lastGroupForRelayKey(pubkey, relayUrl), "")
+    return decodeLastGroupValue(raw)
+}
+
+fun SecureStorage.clearLastGroupForRelay(pubkey: String, relayUrl: String) {
+    if (pubkey.isBlank() || relayUrl.isBlank()) return
+    saveStringPref(lastGroupForRelayKey(pubkey, relayUrl), "")
+}
+
 // Per-relay group-list EOSE timestamp — lets the app skip requestGroups() when the
 // cached group list is fresh enough (< GROUP_CACHE_TTL_S seconds old).
 private const val GROUP_CACHE_TTL_S = 3600L // 1 hour

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/DesktopShell.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/DesktopShell.kt
@@ -43,6 +43,7 @@ fun DesktopShell(
     activeGroupId: String?,
     isGroupsLoading: Boolean = false,
     onRelayClick: (String) -> Unit,
+    onRelayTitleClick: () -> Unit = {},
     onAddRelayClick: () -> Unit,
     onGroupClick: (groupId: String, groupName: String?) -> Unit,
     onCreateGroupClick: () -> Unit,
@@ -133,6 +134,7 @@ fun DesktopShell(
                     onCreateGroupClick = onCreateGroupClick,
                     onJoinGroupClick = onJoinGroupClick,
                     onAddRelay = onAddRelayFromSidebar,
+                    onRelayTitleClick = onRelayTitleClick,
                     orphanedJoinedIds = orphanedJoinedIds,
                     onForgetOrphan = { groupId ->
                         sidebarScope.launch {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/GroupsNavSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/sidebars/GroupsNavSidebar.kt
@@ -105,6 +105,7 @@ fun GroupsNavSidebar(
     onJoinGroupClick: () -> Unit = {},
     onAddRelay: (() -> Unit)? = null,
     onForgetOrphan: (groupId: String) -> Unit = {},
+    onRelayTitleClick: (() -> Unit)? = null,
     showRelayTitle: Boolean = true,
     /** True when this relay uses lazy fetch mode — full group list is fetched on-demand. */
     isGroupFetchLazy: Boolean = false,
@@ -186,17 +187,30 @@ fun GroupsNavSidebar(
             .background(NostrordColors.Surface)
     ) {
         if (showRelayTitle) {
+            val titleClickEnabled = onRelayTitleClick != null && relayUrl.isNotBlank()
+            val titleInteractionSource = remember { MutableInteractionSource() }
+            val titleHovered by titleInteractionSource.collectIsHoveredAsState()
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(Spacing.headerHeight)
-                    .background(NostrordColors.Surface)
+                    .background(
+                        if (titleClickEnabled && titleHovered) NostrordColors.HoverBackground
+                        else NostrordColors.Surface
+                    )
+                    .then(
+                        if (titleClickEnabled) Modifier
+                            .hoverable(titleInteractionSource)
+                            .clickable(onClick = onRelayTitleClick!!)
+                            .pointerHoverIcon(PointerIcon.Hand)
+                        else Modifier
+                    )
                     .padding(horizontal = Spacing.lg),
                 contentAlignment = Alignment.CenterStart
             ) {
                 Text(
                     text = if (relayUrl.isBlank()) "No Relay" else (relayName?.takeIf { it.isNotBlank() } ?: relayUrl).uppercase(),
-                    color = NostrordColors.TextSecondary,
+                    color = if (titleClickEnabled && titleHovered) NostrordColors.TextPrimary else NostrordColors.TextSecondary,
                     fontSize = 13.sp,
                     fontWeight = FontWeight.Bold,
                     letterSpacing = 0.02.sp,


### PR DESCRIPTION
## Summary
- Each relay now persists whether the user was last on a group or on Home; rail clicks restore that state instead of always going to Home.
- Clicking the active relay (or the new clickable relay title in the groups sidebar header) navigates to Home — two ways to step out of a group.
- URL deep links stay authoritative: `?relay=X&group=Y` opens the group and saves it as the last for X; `?relay=X` (no group) opens Home and clears any saved group for X. Same logic on app startup and on browser back/forward.
- Storage keyed by `(pubkey, relayUrl)` via small `SecureStorage` extensions; no membership validation on restore — invalid ids fall through to the existing `GroupScreen` placeholder, same as the app-startup restore path.
