### PR TITLE
fix(navigation): persist last group under correct relay on cross-relay naddr click

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -358,6 +358,20 @@ private fun AuthenticatedApp(
         }
     }
 
+    // Cross-relay group navigation (e.g. clicking a NIP-29 group naddr that points
+    // to a different relay). selectedRelayUrl must be updated synchronously before
+    // persistScreenState runs, otherwise the new group is saved under the previous
+    // relay's lastGroupForRelay entry and the sidebar serves the wrong group when
+    // the user later switches back to that relay.
+    val onNavigateToGroupWithRelay: (String, String?, String?) -> Unit =
+        { groupId, groupName, relayUrl ->
+            if (relayUrl != null && relayUrl != selectedRelayUrl) {
+                selectedRelayUrl = relayUrl
+                scope.launch { AppModule.nostrRepository.switchRelay(relayUrl) }
+            }
+            onNavigate(Screen.Group(groupId, groupName))
+        }
+
     // Direct history navigation — called by native platforms and by BrowserNavigationHandler.
     // Restores the relay that was active when the entry was pushed.
     val onDirectHistoryBack: () -> Unit = {
@@ -590,6 +604,7 @@ private fun AuthenticatedApp(
                             selectedRelayUrl = selectedRelayUrl,
                             homeGridState = homeGridState,
                             onNavigate = onNavigate,
+                            onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
                             hasNoRelays = hasNoRelays,
                             onAddRelay = { addRelayInitialTab = 0; showAddRelayModal = true },
                             onAddRelayCustomUrl = { addRelayInitialTab = 1; showAddRelayModal = true },
@@ -663,6 +678,7 @@ private fun AuthenticatedApp(
                         selectedRelayUrl = selectedRelayUrl,
                         homeGridState = homeGridState,
                         onNavigate = onNavigate,
+                        onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
                         onCreateGroupClick = { showCreateGroupModal = true },
                         hasNoRelays = hasNoRelays,
                         onAddRelay = { addRelayInitialTab = 0; showAddRelayModal = true },
@@ -709,6 +725,7 @@ private fun DesktopContent(
     selectedRelayUrl: String,
     homeGridState: androidx.compose.foundation.lazy.grid.LazyGridState,
     onNavigate: (Screen) -> Unit,
+    onNavigateToGroupWithRelay: (String, String?, String?) -> Unit = { _, _, _ -> },
     hasNoRelays: Boolean = false,
     onAddRelay: () -> Unit = {},
     onAddRelayCustomUrl: () -> Unit = {},
@@ -736,9 +753,7 @@ private fun DesktopContent(
                 groupId = screen.groupId,
                 groupName = screen.groupName,
                 onNavigateHome = { onNavigate(Screen.Home) },
-                onNavigateToGroup = { newGroupId, newGroupName ->
-                    onNavigate(Screen.Group(newGroupId, newGroupName))
-                },
+                onNavigateToGroup = onNavigateToGroupWithRelay,
                 showServerRail = false,
                 forceDesktop = true,
                 pendingInviteCode = pendingInviteCode,
@@ -770,6 +785,7 @@ private fun MobileContent(
     selectedRelayUrl: String,
     homeGridState: androidx.compose.foundation.lazy.grid.LazyGridState,
     onNavigate: (Screen) -> Unit,
+    onNavigateToGroupWithRelay: (String, String?, String?) -> Unit = { _, _, _ -> },
     onCreateGroupClick: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
     hasNoRelays: Boolean = false,
@@ -800,9 +816,7 @@ private fun MobileContent(
                 groupId = screen.groupId,
                 groupName = screen.groupName,
                 onNavigateHome = { onNavigate(Screen.Home) },
-                onNavigateToGroup = { newGroupId, newGroupName ->
-                    onNavigate(Screen.Group(newGroupId, newGroupName))
-                },
+                onNavigateToGroup = onNavigateToGroupWithRelay,
                 onOpenDrawer = onOpenDrawer,
                 pendingInviteCode = pendingInviteCode,
                 onInviteCodeConsumed = onInviteCodeConsumed

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -40,7 +40,7 @@ fun GroupScreen(
     groupId: String,
     groupName: String?,
     onNavigateHome: () -> Unit = {},
-    onNavigateToGroup: (groupId: String, groupName: String?) -> Unit = { _, _ -> },
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     showServerRail: Boolean = true, // When false, server rail is handled by parent shell
     onOpenDrawer: () -> Unit = {},
     forceDesktop: Boolean = false,
@@ -332,7 +332,7 @@ fun GroupScreen(
             onDismiss = { showCreateSubgroupModal = false },
             onGroupCreated = { newId, newName ->
                 showCreateSubgroupModal = false
-                onNavigateToGroup(newId, newName)
+                onNavigateToGroup(newId, newName, null)
             }
         )
     }
@@ -686,7 +686,7 @@ fun GroupScreen(
                 onParentClick = {
                     val parentId = currentGroupMetadata?.parent
                     if (!parentId.isNullOrBlank()) {
-                        onNavigateToGroup(parentId, parentGroupName)
+                        onNavigateToGroup(parentId, parentGroupName, null)
                     }
                 },
                 subgroupCount = childrenByParent[groupId]?.size ?: 0,
@@ -712,7 +712,6 @@ fun GroupScreen(
                 joinedGroups = joinedGroups,
                 groups = groups,
                 onNavigateToGroup = onNavigateToGroup,
-                onSwitchRelay = { vm.switchRelay(it) },
                 onUserClick = { pubkey -> selectedUserPubkey = pubkey },
                 onReconnect = { vm.reconnect() },
                 isSending = isSending,
@@ -777,7 +776,7 @@ fun GroupScreen(
                 onParentClick = {
                     val parentId = currentGroupMetadata?.parent
                     if (!parentId.isNullOrBlank()) {
-                        onNavigateToGroup(parentId, parentGroupName)
+                        onNavigateToGroup(parentId, parentGroupName, null)
                     }
                 },
                 subgroupCount = childrenByParent[groupId]?.size ?: 0,
@@ -803,7 +802,6 @@ fun GroupScreen(
                 joinedGroups = joinedGroups,
                 groups = groups,
                 onNavigateToGroup = onNavigateToGroup,
-                onSwitchRelay = { vm.switchRelay(it) },
                 onUserClick = { pubkey -> selectedUserPubkey = pubkey },
                 onReconnect = { vm.reconnect() },
                 isSending = isSending,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -91,8 +91,7 @@ fun GroupScreenDesktop(
     onLoadMore: () -> Unit = {},
     joinedGroups: Set<String> = emptySet(),
     groups: List<GroupMetadata> = emptyList(),
-    onNavigateToGroup: (groupId: String, groupName: String?) -> Unit = { _, _ -> },
-    onSwitchRelay: (String) -> Unit = {},
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     onUserClick: (String) -> Unit = {},
     onReconnect: () -> Unit = {},
     isSending: Boolean = false,
@@ -190,10 +189,7 @@ fun GroupScreenDesktop(
                     onReplyClick = onReplyClick,
                     onDeleteMessage = onDeleteMessage,
                     onReactionBadgeClick = onReactionBadgeClick,
-                    onNavigateToGroup = { targetGroupId, targetGroupName, targetRelayUrl ->
-                        if (targetRelayUrl != null) onSwitchRelay(targetRelayUrl)
-                        onNavigateToGroup(targetGroupId, targetGroupName)
-                    },
+                    onNavigateToGroup = onNavigateToGroup,
                     onReachedBottom = onReachedBottom
                 )
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -123,8 +123,7 @@ fun GroupScreenMobile(
     onLoadMore: () -> Unit = {},
     joinedGroups: Set<String> = emptySet(),
     groups: List<GroupMetadata> = emptyList(),
-    onNavigateToGroup: (groupId: String, groupName: String?) -> Unit = { _, _ -> },
-    onSwitchRelay: (String) -> Unit = {},
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     onUserClick: (String) -> Unit = {},
     onReconnect: () -> Unit = {},
     isSending: Boolean = false,
@@ -241,10 +240,7 @@ fun GroupScreenMobile(
                         onReplyClick = onReplyClick,
                         onDeleteMessage = onDeleteMessage,
                         onReactionBadgeClick = onReactionBadgeClick,
-                        onNavigateToGroup = { targetGroupId, targetGroupName, targetRelayUrl ->
-                            if (targetRelayUrl != null) onSwitchRelay(targetRelayUrl)
-                            onNavigateToGroup(targetGroupId, targetGroupName)
-                        },
+                        onNavigateToGroup = onNavigateToGroup,
                         onReachedBottom = onReachedBottom
                     )
                 }


### PR DESCRIPTION
The relay switch from MessagesList ran async via vm.switchRelay, so persistScreenState read the previous relay from selectedRelayUrl and saved the new group under the wrong lastGroupForRelay entry. Route the target relay up to App.kt and update selectedRelayUrl synchronously before navigation, mirroring the onUrlNavigation pattern.