### PR TITLE
fix(notifications): clicking a notification from a different relay now switches relays correctly

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/notifications/NotificationService.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/notifications/NotificationService.android.kt
@@ -11,8 +11,8 @@ actual class NotificationService actual constructor() {
     private val _permission = MutableStateFlow(NotificationPermission.Denied)
     actual val permission: StateFlow<NotificationPermission> = _permission.asStateFlow()
 
-    private val _clicks = MutableSharedFlow<String>(extraBufferCapacity = 8)
-    actual val notificationClicks: SharedFlow<String> = _clicks.asSharedFlow()
+    private val _clicks = MutableSharedFlow<NotificationClick>(extraBufferCapacity = 8)
+    actual val notificationClicks: SharedFlow<NotificationClick> = _clicks.asSharedFlow()
 
     actual fun isSupported(): Boolean = false
     actual fun requestPermission() {}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -358,6 +358,20 @@ private fun AuthenticatedApp(
         }
     }
 
+    // Cross-relay group navigation (e.g. clicking a NIP-29 group naddr that points
+    // to a different relay). selectedRelayUrl must be updated synchronously before
+    // persistScreenState runs, otherwise the new group is saved under the previous
+    // relay's lastGroupForRelay entry and the sidebar serves the wrong group when
+    // the user later switches back to that relay.
+    val onNavigateToGroupWithRelay: (String, String?, String?) -> Unit =
+        { groupId, groupName, relayUrl ->
+            if (relayUrl != null && relayUrl != selectedRelayUrl) {
+                selectedRelayUrl = relayUrl
+                scope.launch { AppModule.nostrRepository.switchRelay(relayUrl) }
+            }
+            onNavigate(Screen.Group(groupId, groupName))
+        }
+
     // Direct history navigation — called by native platforms and by BrowserNavigationHandler.
     // Restores the relay that was active when the entry was pushed.
     val onDirectHistoryBack: () -> Unit = {
@@ -406,12 +420,14 @@ private fun AuthenticatedApp(
         }
     }
 
-    // Route notification clicks to navigation. Only the web NotificationService actual
-    // emits here (other platforms' SharedFlow never fires), so this is a no-op elsewhere.
+    // rememberUpdatedState so the LaunchedEffect(Unit) closure always calls the
+    // latest lambda — selectedRelayUrl is re-keyed whenever currentRelayUrl changes,
+    // so the backing MutableState instance can change between recompositions.
+    val latestNavigateToGroupWithRelay by rememberUpdatedState(onNavigateToGroupWithRelay)
     LaunchedEffect(Unit) {
-        AppModule.notificationService.notificationClicks.collect { clickedGroupId ->
-            val name = AppModule.nostrRepository.groups.value.firstOrNull { it.id == clickedGroupId }?.name
-            onNavigate(Screen.Group(clickedGroupId, name))
+        AppModule.notificationService.notificationClicks.collect { click ->
+            val name = AppModule.nostrRepository.groups.value.firstOrNull { it.id == click.groupId }?.name
+            latestNavigateToGroupWithRelay(click.groupId, name, click.relayUrl.takeIf { it.isNotBlank() })
         }
     }
 
@@ -590,6 +606,7 @@ private fun AuthenticatedApp(
                             selectedRelayUrl = selectedRelayUrl,
                             homeGridState = homeGridState,
                             onNavigate = onNavigate,
+                            onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
                             hasNoRelays = hasNoRelays,
                             onAddRelay = { addRelayInitialTab = 0; showAddRelayModal = true },
                             onAddRelayCustomUrl = { addRelayInitialTab = 1; showAddRelayModal = true },
@@ -663,6 +680,7 @@ private fun AuthenticatedApp(
                         selectedRelayUrl = selectedRelayUrl,
                         homeGridState = homeGridState,
                         onNavigate = onNavigate,
+                        onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
                         onCreateGroupClick = { showCreateGroupModal = true },
                         hasNoRelays = hasNoRelays,
                         onAddRelay = { addRelayInitialTab = 0; showAddRelayModal = true },
@@ -709,6 +727,7 @@ private fun DesktopContent(
     selectedRelayUrl: String,
     homeGridState: androidx.compose.foundation.lazy.grid.LazyGridState,
     onNavigate: (Screen) -> Unit,
+    onNavigateToGroupWithRelay: (String, String?, String?) -> Unit = { _, _, _ -> },
     hasNoRelays: Boolean = false,
     onAddRelay: () -> Unit = {},
     onAddRelayCustomUrl: () -> Unit = {},
@@ -736,9 +755,7 @@ private fun DesktopContent(
                 groupId = screen.groupId,
                 groupName = screen.groupName,
                 onNavigateHome = { onNavigate(Screen.Home) },
-                onNavigateToGroup = { newGroupId, newGroupName ->
-                    onNavigate(Screen.Group(newGroupId, newGroupName))
-                },
+                onNavigateToGroup = onNavigateToGroupWithRelay,
                 showServerRail = false,
                 forceDesktop = true,
                 pendingInviteCode = pendingInviteCode,
@@ -770,6 +787,7 @@ private fun MobileContent(
     selectedRelayUrl: String,
     homeGridState: androidx.compose.foundation.lazy.grid.LazyGridState,
     onNavigate: (Screen) -> Unit,
+    onNavigateToGroupWithRelay: (String, String?, String?) -> Unit = { _, _, _ -> },
     onCreateGroupClick: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
     hasNoRelays: Boolean = false,
@@ -800,9 +818,7 @@ private fun MobileContent(
                 groupId = screen.groupId,
                 groupName = screen.groupName,
                 onNavigateHome = { onNavigate(Screen.Home) },
-                onNavigateToGroup = { newGroupId, newGroupName ->
-                    onNavigate(Screen.Group(newGroupId, newGroupName))
-                },
+                onNavigateToGroup = onNavigateToGroupWithRelay,
                 onOpenDrawer = onOpenDrawer,
                 pendingInviteCode = pendingInviteCode,
                 onInviteCodeConsumed = onInviteCodeConsumed

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -155,8 +155,12 @@ object AppModule {
                         ?: (message.pubkey.take(8) + "…")
                     val preview = resolveMentionsForNotification(message.content).take(120)
 
+                    val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
+                        ?: groupManager.getRelayForGroup(groupId)
+                        ?: ""
                     notificationService.notify(
                         NotificationRequest(
+                            relayUrl = relayUrl,
                             groupId = groupId,
                             title = groupName,
                             body = "$authorName: $preview",

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -337,6 +337,13 @@ class GroupManager(
     private val recentlyLeftAt = mutableMapOf<String, Long>()
     private val LEFT_GROUP_GRACE_MS = 5_000L
 
+    // Relay-of-origin per groupId, recorded from the WebSocket that delivered
+    // each event. Used by notifications to route clicks to the correct relay
+    // when getRelayForGroup would be ambiguous.
+    private val _latestMessageRelayByGroup = MutableStateFlow<Map<String, String>>(emptyMap())
+    fun getLatestMessageRelayForGroup(groupId: String): String? =
+        _latestMessageRelayByGroup.value[groupId]
+
     private fun isRecentlyLeft(groupId: String): Boolean {
         val at = recentlyLeftAt[groupId] ?: return false
         if (epochMillis() - at < LEFT_GROUP_GRACE_MS) return true
@@ -1600,6 +1607,7 @@ class GroupManager(
             roleEventTimestamps.remove(groupId)
             pendingApprovalSince.remove(groupId)
             messageIdIndex.remove(groupId)
+            _latestMessageRelayByGroup.update { it - groupId }
             observedGroupsMutex.withLock { observedGroups.remove(groupId) }
             loadingRegistry.remove(groupId)
             _openedGroupIds.update { it - groupId }
@@ -2534,6 +2542,10 @@ class GroupManager(
         val groupId = extractGroupIdFromMessage(rawMsg) ?: return null
 
         if (isRecentlyLeft(groupId)) return null
+
+        if (relayUrl != null) {
+            _latestMessageRelayByGroup.update { it + (groupId to relayUrl) }
+        }
 
         // Populate global emoji cache from message emoji tags and backfill
         // any existing reactions that are missing their image URL.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationService.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationService.kt
@@ -13,12 +13,18 @@ enum class NotificationPermission {
 }
 
 data class NotificationRequest(
+    val relayUrl: String,
     val groupId: String,
     val title: String,
     val body: String,
     /** Tag used by the browser to coalesce notifications from the same conversation. */
     val tag: String = groupId,
     val iconUrl: String? = null,
+)
+
+data class NotificationClick(
+    val relayUrl: String,
+    val groupId: String,
 )
 
 /**
@@ -30,8 +36,8 @@ data class NotificationRequest(
 expect class NotificationService() {
     val permission: StateFlow<NotificationPermission>
 
-    /** Emits the groupId of the notification the user clicked. */
-    val notificationClicks: SharedFlow<String>
+    /** Emits the relay+group of the notification the user clicked. */
+    val notificationClicks: SharedFlow<NotificationClick>
 
     fun isSupported(): Boolean
     fun requestPermission()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -40,7 +40,7 @@ fun GroupScreen(
     groupId: String,
     groupName: String?,
     onNavigateHome: () -> Unit = {},
-    onNavigateToGroup: (groupId: String, groupName: String?) -> Unit = { _, _ -> },
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     showServerRail: Boolean = true, // When false, server rail is handled by parent shell
     onOpenDrawer: () -> Unit = {},
     forceDesktop: Boolean = false,
@@ -332,7 +332,7 @@ fun GroupScreen(
             onDismiss = { showCreateSubgroupModal = false },
             onGroupCreated = { newId, newName ->
                 showCreateSubgroupModal = false
-                onNavigateToGroup(newId, newName)
+                onNavigateToGroup(newId, newName, null)
             }
         )
     }
@@ -686,7 +686,7 @@ fun GroupScreen(
                 onParentClick = {
                     val parentId = currentGroupMetadata?.parent
                     if (!parentId.isNullOrBlank()) {
-                        onNavigateToGroup(parentId, parentGroupName)
+                        onNavigateToGroup(parentId, parentGroupName, null)
                     }
                 },
                 subgroupCount = childrenByParent[groupId]?.size ?: 0,
@@ -712,7 +712,6 @@ fun GroupScreen(
                 joinedGroups = joinedGroups,
                 groups = groups,
                 onNavigateToGroup = onNavigateToGroup,
-                onSwitchRelay = { vm.switchRelay(it) },
                 onUserClick = { pubkey -> selectedUserPubkey = pubkey },
                 onReconnect = { vm.reconnect() },
                 isSending = isSending,
@@ -777,7 +776,7 @@ fun GroupScreen(
                 onParentClick = {
                     val parentId = currentGroupMetadata?.parent
                     if (!parentId.isNullOrBlank()) {
-                        onNavigateToGroup(parentId, parentGroupName)
+                        onNavigateToGroup(parentId, parentGroupName, null)
                     }
                 },
                 subgroupCount = childrenByParent[groupId]?.size ?: 0,
@@ -803,7 +802,6 @@ fun GroupScreen(
                 joinedGroups = joinedGroups,
                 groups = groups,
                 onNavigateToGroup = onNavigateToGroup,
-                onSwitchRelay = { vm.switchRelay(it) },
                 onUserClick = { pubkey -> selectedUserPubkey = pubkey },
                 onReconnect = { vm.reconnect() },
                 isSending = isSending,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -91,8 +91,7 @@ fun GroupScreenDesktop(
     onLoadMore: () -> Unit = {},
     joinedGroups: Set<String> = emptySet(),
     groups: List<GroupMetadata> = emptyList(),
-    onNavigateToGroup: (groupId: String, groupName: String?) -> Unit = { _, _ -> },
-    onSwitchRelay: (String) -> Unit = {},
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     onUserClick: (String) -> Unit = {},
     onReconnect: () -> Unit = {},
     isSending: Boolean = false,
@@ -190,10 +189,7 @@ fun GroupScreenDesktop(
                     onReplyClick = onReplyClick,
                     onDeleteMessage = onDeleteMessage,
                     onReactionBadgeClick = onReactionBadgeClick,
-                    onNavigateToGroup = { targetGroupId, targetGroupName, targetRelayUrl ->
-                        if (targetRelayUrl != null) onSwitchRelay(targetRelayUrl)
-                        onNavigateToGroup(targetGroupId, targetGroupName)
-                    },
+                    onNavigateToGroup = onNavigateToGroup,
                     onReachedBottom = onReachedBottom
                 )
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -123,8 +123,7 @@ fun GroupScreenMobile(
     onLoadMore: () -> Unit = {},
     joinedGroups: Set<String> = emptySet(),
     groups: List<GroupMetadata> = emptyList(),
-    onNavigateToGroup: (groupId: String, groupName: String?) -> Unit = { _, _ -> },
-    onSwitchRelay: (String) -> Unit = {},
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     onUserClick: (String) -> Unit = {},
     onReconnect: () -> Unit = {},
     isSending: Boolean = false,
@@ -241,10 +240,7 @@ fun GroupScreenMobile(
                         onReplyClick = onReplyClick,
                         onDeleteMessage = onDeleteMessage,
                         onReactionBadgeClick = onReactionBadgeClick,
-                        onNavigateToGroup = { targetGroupId, targetGroupName, targetRelayUrl ->
-                            if (targetRelayUrl != null) onSwitchRelay(targetRelayUrl)
-                            onNavigateToGroup(targetGroupId, targetGroupName)
-                        },
+                        onNavigateToGroup = onNavigateToGroup,
                         onReachedBottom = onReachedBottom
                     )
                 }

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/notifications/NotificationService.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/notifications/NotificationService.ios.kt
@@ -11,8 +11,8 @@ actual class NotificationService actual constructor() {
     private val _permission = MutableStateFlow(NotificationPermission.Denied)
     actual val permission: StateFlow<NotificationPermission> = _permission.asStateFlow()
 
-    private val _clicks = MutableSharedFlow<String>(extraBufferCapacity = 8)
-    actual val notificationClicks: SharedFlow<String> = _clicks.asSharedFlow()
+    private val _clicks = MutableSharedFlow<NotificationClick>(extraBufferCapacity = 8)
+    actual val notificationClicks: SharedFlow<NotificationClick> = _clicks.asSharedFlow()
 
     actual fun isSupported(): Boolean = false
     actual fun requestPermission() {}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.js.kt
@@ -59,8 +59,8 @@ actual class NotificationService actual constructor() {
     private val _permission = MutableStateFlow(readPermission())
     actual val permission: StateFlow<NotificationPermission> = _permission.asStateFlow()
 
-    private val _clicks = MutableSharedFlow<String>(extraBufferCapacity = 8)
-    actual val notificationClicks: SharedFlow<String> = _clicks.asSharedFlow()
+    private val _clicks = MutableSharedFlow<NotificationClick>(extraBufferCapacity = 8)
+    actual val notificationClicks: SharedFlow<NotificationClick> = _clicks.asSharedFlow()
 
     init {
         if (jsSupported()) {
@@ -88,7 +88,7 @@ actual class NotificationService actual constructor() {
             request.body,
             request.tag,
             request.iconUrl ?: "",
-        ) { _clicks.tryEmit(request.groupId) }
+        ) { _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId)) }
     }
 
     private fun readPermission(): NotificationPermission {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/notifications/NotificationService.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/notifications/NotificationService.jvm.kt
@@ -11,8 +11,8 @@ actual class NotificationService actual constructor() {
     private val _permission = MutableStateFlow(NotificationPermission.Denied)
     actual val permission: StateFlow<NotificationPermission> = _permission.asStateFlow()
 
-    private val _clicks = MutableSharedFlow<String>(extraBufferCapacity = 8)
-    actual val notificationClicks: SharedFlow<String> = _clicks.asSharedFlow()
+    private val _clicks = MutableSharedFlow<NotificationClick>(extraBufferCapacity = 8)
+    actual val notificationClicks: SharedFlow<NotificationClick> = _clicks.asSharedFlow()
 
     actual fun isSupported(): Boolean = false
     actual fun requestPermission() {}

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.wasmJs.kt
@@ -60,8 +60,8 @@ actual class NotificationService actual constructor() {
     private val _permission = MutableStateFlow(readPermission())
     actual val permission: StateFlow<NotificationPermission> = _permission.asStateFlow()
 
-    private val _clicks = MutableSharedFlow<String>(extraBufferCapacity = 8)
-    actual val notificationClicks: SharedFlow<String> = _clicks.asSharedFlow()
+    private val _clicks = MutableSharedFlow<NotificationClick>(extraBufferCapacity = 8)
+    actual val notificationClicks: SharedFlow<NotificationClick> = _clicks.asSharedFlow()
 
     init {
         if (jsSupported()) {
@@ -89,7 +89,7 @@ actual class NotificationService actual constructor() {
             request.body,
             request.tag,
             request.iconUrl ?: "",
-        ) { _clicks.tryEmit(request.groupId) }
+        ) { _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId)) }
     }
 
     private fun readPermission(): NotificationPermission {


### PR DESCRIPTION
Before this fix, tapping a web push notification for a group on relay B while already viewing relay A would open the right group but keep relay A selected. The relay switch ran async so persistScreenState saved the group under relay A in lastGroupForRelay — poisoning the sidebar: next time the user switched back to relay A, it restored the wrong group.

Fix: NotificationClick now carries the source relayUrl. The click handler updates selectedRelayUrl synchronously before navigating, the same pattern already used for URL-based navigation (onUrlNavigation).