### PR TITLE
fix(mention): normalize stylized Unicode names in autocomplete search

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MentionPopup.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MentionPopup.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.dp
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.utils.normalizeForSearch
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
@@ -33,8 +34,9 @@ fun getFilteredMembers(members: List<MemberInfo>, query: String): List<MemberInf
     return if (query.isEmpty()) {
         members.take(8)
     } else {
+        val normalizedQuery = query.normalizeForSearch()
         members.filter { member ->
-            member.displayName.contains(query, ignoreCase = true) ||
+            member.displayName.normalizeForSearch().contains(normalizedQuery) ||
             member.pubkey.contains(query, ignoreCase = true)
         }.take(8)
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
@@ -41,8 +41,19 @@ private val mathLowSurrogateToAscii: Map<Char, Char> by lazy {
     map
 }
 
-// Maps decorative Unicode letter variants (mathematical styles, full-width) to plain ASCII
-// lowercase. Callers do not need ignoreCase = true after this.
+// Small-capital letters from IPA / Latin Extended blocks used as decorative text.
+// These are BMP code points (no surrogate pairs), so a plain map suffices.
+private val smallCapsToAscii: Map<Char, Char> = mapOf(
+    'ᴀ' to 'a', 'ʙ' to 'b', 'ᴄ' to 'c', 'ᴅ' to 'd',
+    'ᴇ' to 'e', 'ꜰ' to 'f', 'ɢ' to 'g', 'ʜ' to 'h',
+    'ɪ' to 'i', 'ᴊ' to 'j', 'ᴋ' to 'k', 'ʟ' to 'l',
+    'ᴍ' to 'm', 'ɴ' to 'n', 'ᴏ' to 'o', 'ᴘ' to 'p',
+    'ʀ' to 'r', 'ꜱ' to 's', 'ᴛ' to 't', 'ᴜ' to 'u',
+    'ᴠ' to 'v', 'ᴡ' to 'w', 'ʏ' to 'y', 'ᴢ' to 'z',
+)
+
+// Maps decorative Unicode letter variants (mathematical styles, full-width, small caps) to
+// plain ASCII lowercase. Callers do not need ignoreCase = true after this.
 fun String.normalizeForSearch(): String {
     val sb = StringBuilder(length)
     var i = 0
@@ -57,7 +68,7 @@ fun String.normalizeForSearch(): String {
             }
             c.code in 0xFF21..0xFF3A -> { sb.append(('A'.code + c.code - 0xFF21).toChar()); i++ }
             c.code in 0xFF41..0xFF5A -> { sb.append(('a'.code + c.code - 0xFF41).toChar()); i++ }
-            else -> { sb.append(c); i++ }
+            else -> { sb.append(smallCapsToAscii[c] ?: c); i++ }
         }
     }
     return sb.toString().lowercase()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
@@ -1,5 +1,68 @@
 package org.nostr.nostrord.utils
 
+// Maps the low surrogate of U+1D400-U+1D7FF (Mathematical Alphanumeric Symbols, all sharing
+// high surrogate \uD835) to plain ASCII. Ranges: (startOffset, endOffset, baseAsciiCode)
+// where offset is relative to \uDC00. Gaps in Script/Fraktur/Double-Struck blocks exist
+// because those letters pre-date the math block and live at separate code points.
+private val mathLowSurrogateToAscii: Map<Char, Char> by lazy {
+    val map = HashMap<Char, Char>(512)
+    val ranges = arrayOf(
+        intArrayOf(0x000, 0x019, 'A'.code), intArrayOf(0x01A, 0x033, 'a'.code), // Bold
+        intArrayOf(0x034, 0x04D, 'A'.code), intArrayOf(0x04E, 0x054, 'a'.code), // Italic
+        intArrayOf(0x056, 0x067, 'i'.code),                                       // Italic small i-z (h gap)
+        intArrayOf(0x068, 0x081, 'A'.code), intArrayOf(0x082, 0x09B, 'a'.code), // Bold Italic
+        intArrayOf(0x09C, 0x09C, 'A'.code), intArrayOf(0x09E, 0x09F, 'C'.code), // Script Capital
+        intArrayOf(0x0A2, 0x0A2, 'G'.code), intArrayOf(0x0A5, 0x0A6, 'J'.code),
+        intArrayOf(0x0A9, 0x0AC, 'N'.code), intArrayOf(0x0AE, 0x0B5, 'S'.code),
+        intArrayOf(0x0B6, 0x0B9, 'a'.code), intArrayOf(0x0BB, 0x0BB, 'f'.code), // Script Small
+        intArrayOf(0x0BD, 0x0C3, 'h'.code), intArrayOf(0x0C5, 0x0CF, 'p'.code),
+        intArrayOf(0x0D0, 0x0E9, 'A'.code), intArrayOf(0x0EA, 0x103, 'a'.code), // Bold Script
+        intArrayOf(0x104, 0x105, 'A'.code), intArrayOf(0x107, 0x10A, 'D'.code), // Fraktur Capital
+        intArrayOf(0x10D, 0x114, 'J'.code), intArrayOf(0x116, 0x11C, 'S'.code),
+        intArrayOf(0x11E, 0x137, 'a'.code),                                       // Fraktur Small
+        intArrayOf(0x138, 0x139, 'A'.code), intArrayOf(0x13B, 0x13E, 'D'.code), // Double-Struck Capital
+        intArrayOf(0x140, 0x144, 'I'.code), intArrayOf(0x146, 0x146, 'O'.code),
+        intArrayOf(0x14A, 0x150, 'S'.code),
+        intArrayOf(0x152, 0x16B, 'a'.code),                                       // Double-Struck Small
+        intArrayOf(0x16C, 0x185, 'A'.code), intArrayOf(0x186, 0x19F, 'a'.code), // Bold Fraktur
+        intArrayOf(0x1A0, 0x1B9, 'A'.code), intArrayOf(0x1BA, 0x1D3, 'a'.code), // Sans-Serif
+        intArrayOf(0x1D4, 0x1ED, 'A'.code), intArrayOf(0x1EE, 0x207, 'a'.code), // Sans-Serif Bold
+        intArrayOf(0x208, 0x221, 'A'.code), intArrayOf(0x222, 0x23B, 'a'.code), // Sans-Serif Italic
+        intArrayOf(0x23C, 0x255, 'A'.code), intArrayOf(0x256, 0x26F, 'a'.code), // Sans-Serif Bold Italic
+        intArrayOf(0x270, 0x289, 'A'.code), intArrayOf(0x28A, 0x2A3, 'a'.code), // Monospace
+    )
+    for (r in ranges) {
+        val startLow = 0xDC00 + r[0]
+        val baseCode = r[2]
+        for (low in startLow..0xDC00 + r[1]) {
+            map[low.toChar()] = (baseCode + (low - startLow)).toChar()
+        }
+    }
+    map
+}
+
+// Maps decorative Unicode letter variants (mathematical styles, full-width) to plain ASCII
+// lowercase. Callers do not need ignoreCase = true after this.
+fun String.normalizeForSearch(): String {
+    val sb = StringBuilder(length)
+    var i = 0
+    while (i < length) {
+        val c = this[i]
+        when {
+            c == '\uD835' && i + 1 < length -> {
+                val low = this[i + 1]
+                val ascii = mathLowSurrogateToAscii[low]
+                if (ascii != null) sb.append(ascii) else { sb.append(c); sb.append(low) }
+                i += 2
+            }
+            c.code in 0xFF21..0xFF3A -> { sb.append(('A'.code + c.code - 0xFF21).toChar()); i++ }
+            c.code in 0xFF41..0xFF5A -> { sb.append(('a'.code + c.code - 0xFF41).toChar()); i++ }
+            else -> { sb.append(c); i++ }
+        }
+    }
+    return sb.toString().lowercase()
+}
+
 /**
  * URL decode a percent-encoded string.
  *

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -209,4 +209,8 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val kind10009Relays: StateFlow<Set<String>> = MutableStateFlow(emptySet())
     override val groupTagRelays: StateFlow<Set<String>> = MutableStateFlow(emptySet())
     override suspend fun fetchGroupPreview(groupId: String, relayUrl: String) {}
+    override val fullGroupListFetchedRelays: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+    override fun setGroupFetchLazy(relayUrl: String, lazy: Boolean) {}
+    override fun isGroupFetchLazy(relayUrl: String): Boolean = false
+    override suspend fun requestFullGroupListForRelay(relayUrl: String) {}
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/components/MentionPopupTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/components/MentionPopupTest.kt
@@ -1,0 +1,79 @@
+package org.nostr.nostrord.ui.screens.group.components
+
+import org.nostr.nostrord.ui.screens.group.model.MemberInfo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MentionPopupTest {
+
+    private fun member(displayName: String, pubkey: String = "aabbccdd") =
+        MemberInfo(pubkey = pubkey, displayName = displayName, picture = null)
+
+    @Test
+    fun `bold fraktur name found by plain query`() {
+        val result = getFilteredMembers(listOf(member("𝖘𝖊𝖙𝖙𝖔𝖘𝖍𝖎 𝖙𝖔𝖓𝖆𝖒𝖎")), "settoshi")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `mathematical bold name found by plain query`() {
+        val result = getFilteredMembers(listOf(member("𝐬𝐚𝐭𝐨𝐬𝐡𝐢")), "satoshi")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `mathematical italic name found by plain query`() {
+        val result = getFilteredMembers(listOf(member("𝑎𝑙𝑖𝑐𝑒")), "alice")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `sans-serif bold name found by plain query`() {
+        val result = getFilteredMembers(listOf(member("𝗯𝗼𝗯")), "bob")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `full-width name found by plain query`() {
+        val result = getFilteredMembers(listOf(member("ｃａｒｏｌ")), "carol")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `plain ascii query matches styled name partially`() {
+        val result = getFilteredMembers(listOf(member("𝑎𝑙𝑖𝑐𝑒")), "lic")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `styled query finds plain ascii name`() {
+        val result = getFilteredMembers(listOf(member("carol")), "ｃａｒｏｌ")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `non-matching query returns empty`() {
+        val result = getFilteredMembers(listOf(member("𝗯𝗼𝗯")), "carol")
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `empty query returns up to 8 members`() {
+        val members = (1..10).map { member("user$it", "pk$it") }
+        assertEquals(8, getFilteredMembers(members, "").size)
+    }
+
+    @Test
+    fun `pubkey prefix still matches`() {
+        val result = getFilteredMembers(listOf(member("Alice", pubkey = "deadbeef1234")), "deadbeef")
+        assertEquals(1, result.size)
+    }
+
+    @Test
+    fun `case-insensitive plain ascii match`() {
+        val members = listOf(member("Alice"))
+        assertEquals(1, getFilteredMembers(members, "alice").size)
+        assertEquals(1, getFilteredMembers(members, "ALICE").size)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/StringUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/StringUtilsTest.kt
@@ -1,0 +1,54 @@
+package org.nostr.nostrord.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringUtilsTest {
+
+    @Test
+    fun `bold fraktur normalizes to ascii`() {
+        assertEquals("settoshi", "𝖘𝖊𝖙𝖙𝖔𝖘𝖍𝖎".normalizeForSearch())
+        assertEquals("abc", "𝕬𝕭𝕮".normalizeForSearch())
+    }
+
+    @Test
+    fun `mathematical bold lowercase normalizes to ascii`() {
+        assertEquals("hello", "𝐡𝐞𝐥𝐥𝐨".normalizeForSearch())
+    }
+
+    @Test
+    fun `mathematical italic lowercase normalizes to ascii`() {
+        assertEquals("world", "𝑤𝑜𝑟𝑙𝑑".normalizeForSearch())
+    }
+
+    @Test
+    fun `mathematical sans-serif bold normalizes to ascii`() {
+        assertEquals("nostr", "𝗻𝗼𝘀𝘁𝗿".normalizeForSearch())
+    }
+
+    @Test
+    fun `mathematical monospace normalizes to ascii`() {
+        assertEquals("code", "𝚌𝚘𝚍𝚎".normalizeForSearch())
+    }
+
+    @Test
+    fun `full-width latin normalizes to ascii`() {
+        assertEquals("hello", "ＨＥＬＬＯ".normalizeForSearch())
+        assertEquals("hello", "ｈｅｌｌｏ".normalizeForSearch())
+    }
+
+    @Test
+    fun `plain ascii is returned unchanged and lowercased`() {
+        assertEquals("nostr", "Nostr".normalizeForSearch())
+    }
+
+    @Test
+    fun `empty string returns empty`() {
+        assertEquals("", "".normalizeForSearch())
+    }
+
+    @Test
+    fun `mixed plain and styled normalizes correctly`() {
+        assertEquals("hello world", "𝐡𝐞𝐥𝐥𝐨 world".normalizeForSearch())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/StringUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/StringUtilsTest.kt
@@ -38,6 +38,13 @@ class StringUtilsTest {
     }
 
     @Test
+    fun `small caps normalizes to ascii`() {
+        assertEquals("holder", "ʜᴏʟᴅᴇʀ".normalizeForSearch())
+        assertEquals("perfil", "ᴘᴇʀꜰɪʟ".normalizeForSearch())
+        assertEquals("secundario", "ꜱᴇᴄᴜɴᴅᴀʀɪᴏ".normalizeForSearch())
+    }
+
+    @Test
     fun `plain ascii is returned unchanged and lowercased`() {
         assertEquals("nostr", "Nostr".normalizeForSearch())
     }


### PR DESCRIPTION
Users with decorative Unicode names were invisible to mention autocomplete
because the search compared raw code points. Typing plain ASCII never matched
stylized characters.

## What changed

`normalizeForSearch()` added to `StringUtils.kt` — maps decorative Unicode
letter variants to plain ASCII lowercase before comparison. Covers:

- **Mathematical Alphanumeric Symbols** (U+1D400–U+1D7FF): all 13 style
  variants — Bold, Italic, Bold Italic, Script, Bold Script, Fraktur,
  Bold Fraktur, Double-Struck, Sans-Serif (4 variants), Monospace
- **Full-Width Latin** (U+FF21–U+FF5A)
- **IPA small capitals** (ʜᴏʟᴅᴇʀ, ᴘᴇʀꜰɪʟ ꜱᴇᴄᴜɴᴅáʀɪᴏ, etc.)

`getFilteredMembers` in `MentionPopup.kt` now normalizes both the member
name and the query before comparison, so the search is bidirectional:
plain query finds stylized name, and stylized query finds plain name.

## Examples that now work

| Name | Query |
|------|-------|
| `𝖘𝖊𝖙𝖙𝖔𝖘𝖍𝖎 𝖙𝖔𝖓𝖆𝖒𝖎` | `settoshi` |
| `𝑪𝒂𝒏𝒊𝒔 𝒍𝒖𝒑𝒖𝒍𝒖𝒔` | `canis` |
| `ʜᴏʟᴅᴇʀ` | `holder` |
| `𝙰𝚂𝙲𝙾𝚃` | `ascot` |

Closes #36