### PR TITLE
feat: group mentions via % autocomplete

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
@@ -44,6 +44,26 @@ object Nip19 {
         return Bech32.encode("npub", pubkeyHex.hexToByteArray())
     }
 
+    // Zero pubkey per convention — NIP-29 groups have no author.
+    fun encodeNaddr(identifier: String, relay: String, kind: Int = 39000): String {
+        val tlv = mutableListOf<Byte>()
+        fun addTLV(type: Int, value: ByteArray) {
+            tlv.add(type.toByte())
+            tlv.add(value.size.toByte())
+            tlv.addAll(value.toList())
+        }
+        addTLV(TLV_SPECIAL, identifier.encodeToByteArray())
+        addTLV(TLV_RELAY, relay.encodeToByteArray())
+        addTLV(TLV_AUTHOR, ByteArray(32))
+        addTLV(TLV_KIND, byteArrayOf(
+            (kind shr 24).toByte(),
+            (kind shr 16).toByte(),
+            (kind shr 8).toByte(),
+            kind.toByte()
+        ))
+        return Bech32.encode("naddr", tlv.toByteArray())
+    }
+
     /**
      * Encode a private key to nsec
      */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
@@ -44,17 +44,18 @@ object Nip19 {
         return Bech32.encode("npub", pubkeyHex.hexToByteArray())
     }
 
-    // Zero pubkey per convention — NIP-29 groups have no author.
-    fun encodeNaddr(identifier: String, relay: String, kind: Int = 39000): String {
+    // pubkeyHex: relay's own pubkey from NIP-11; falls back to 32 zero bytes if unknown.
+    fun encodeNaddr(identifier: String, relay: String, kind: Int = 39000, pubkeyHex: String? = null): String {
         val tlv = mutableListOf<Byte>()
         fun addTLV(type: Int, value: ByteArray) {
             tlv.add(type.toByte())
             tlv.add(value.size.toByte())
             tlv.addAll(value.toList())
         }
+        val authorBytes = pubkeyHex?.runCatching { hexToByteArray() }?.getOrNull()?.takeIf { it.size == 32 } ?: ByteArray(32)
         addTLV(TLV_SPECIAL, identifier.encodeToByteArray())
         addTLV(TLV_RELAY, relay.encodeToByteArray())
-        addTLV(TLV_AUTHOR, ByteArray(32))
+        addTLV(TLV_AUTHOR, authorBytes)
         addTLV(TLV_KIND, byteArrayOf(
             (kind shr 24).toByte(),
             (kind shr 16).toByte(),

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -72,6 +72,8 @@ import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
+import androidx.compose.ui.graphics.Color
+import org.nostr.nostrord.ui.util.generateColorFromString
 
 // Type alias to bridge new parser to existing rendering code
 private typealias ContentPart = MessageContentParser.ParsedPart
@@ -2236,6 +2238,11 @@ private fun GroupLinkCard(
 
     val displayName = groupMeta?.name ?: groupId
     val relayDisplay = relayUrl?.removePrefix("wss://")?.removePrefix("ws://")
+    var imageState by remember(groupMeta?.picture) {
+        mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty)
+    }
+    val pictureUrl = groupMeta?.picture
+    val showImage = !pictureUrl.isNullOrBlank() && imageState !is AsyncImagePainter.State.Error
 
     DisableSelection {
         Row(
@@ -2253,22 +2260,31 @@ private fun GroupLinkCard(
                 modifier = Modifier
                     .size(36.dp)
                     .clip(RoundedCornerShape(8.dp))
+                    .background(if (!showImage) generateColorFromString(groupId) else NostrordColors.BackgroundDark),
+                contentAlignment = Alignment.Center
             ) {
-                if (groupMeta?.picture != null) {
+                if (!showImage) {
+                    Text(
+                        text = displayName.take(1).uppercase(),
+                        color = Color.White,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+                if (!pictureUrl.isNullOrBlank()) {
                     val context = LocalPlatformContext.current
                     AsyncImage(
                         model = ImageRequest.Builder(context)
-                            .data(getImageUrl(groupMeta.picture))
+                            .data(getImageUrl(pictureUrl))
                             .crossfade(true)
                             .memoryCachePolicy(CachePolicy.ENABLED)
                             .diskCachePolicy(CachePolicy.ENABLED)
                             .build(),
                         contentDescription = displayName,
                         modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop
+                        contentScale = ContentScale.Crop,
+                        onState = { imageState = it }
                     )
-                } else {
-                    Jdenticon(value = groupId, size = 36.dp)
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -797,7 +797,7 @@ fun processMentionsInContent(
                 }
                 is Nip19.Entity.Note -> "[note]"
                 is Nip19.Entity.Nevent -> "[event]"
-                is Nip19.Entity.Naddr -> "[article]"
+                is Nip19.Entity.Naddr -> if (entity.kind == 39000) "%${entity.identifier}" else "[article]"
                 else -> uri
             }
         } catch (_: Exception) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -81,6 +81,7 @@ fun GroupScreen(
     val joinedGroups by vm.joinedGroups.collectAsState()
     val groups by vm.groups.collectAsState()
     val groupsByRelay by vm.groupsByRelay.collectAsState()
+    val relayMetadata by vm.relayMetadata.collectAsState()
     val userMetadata by vm.userMetadata.collectAsState()
     val allReactions by vm.reactions.collectAsState()
     val allGroupMembers by vm.groupMembers.collectAsState()
@@ -681,7 +682,8 @@ fun GroupScreen(
                     val imetaTags = pendingUploads.map { it.toImetaTag() }
                     var content = messageInput
                     groupMentions.forEach { (name, group) ->
-                        val naddr = Nip19.encodeNaddr(group.id, group.relay)
+                        val relayPubkey = relayMetadata[group.relay]?.pubkey
+                        val naddr = Nip19.encodeNaddr(group.id, group.relay, pubkeyHex = relayPubkey)
                         content = content.replace("%$name", "nostr:$naddr")
                     }
                     vm.sendMessage(content, selectedChannel, mentions, replyingToMessage?.id, imetaTags)
@@ -780,7 +782,8 @@ fun GroupScreen(
                     val imetaTags = pendingUploads.map { it.toImetaTag() }
                     var content = messageInput
                     groupMentions.forEach { (name, group) ->
-                        val naddr = Nip19.encodeNaddr(group.id, group.relay)
+                        val relayPubkey = relayMetadata[group.relay]?.pubkey
+                        val naddr = Nip19.encodeNaddr(group.id, group.relay, pubkeyHex = relayPubkey)
                         content = content.replace("%$name", "nostr:$naddr")
                     }
                     vm.sendMessage(content, selectedChannel, mentions, replyingToMessage?.id, imetaTags)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -32,7 +32,9 @@ import org.nostr.nostrord.ui.screens.group.components.JoinRequestsModal
 import org.nostr.nostrord.ui.screens.group.components.MemberManagementModal
 import org.nostr.nostrord.ui.screens.group.components.UserProfileModal
 import org.nostr.nostrord.ui.screens.group.model.buildChatItems
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.theme.NostrordColors
 
 @Composable
@@ -78,6 +80,7 @@ fun GroupScreen(
     val connectionState by vm.connectionState.collectAsState()
     val joinedGroups by vm.joinedGroups.collectAsState()
     val groups by vm.groups.collectAsState()
+    val groupsByRelay by vm.groupsByRelay.collectAsState()
     val userMetadata by vm.userMetadata.collectAsState()
     val allReactions by vm.reactions.collectAsState()
     val allGroupMembers by vm.groupMembers.collectAsState()
@@ -91,6 +94,14 @@ fun GroupScreen(
 
     val currentGroupMetadata = remember(groups, groupId) {
         groups.find { it.id == groupId }
+    }
+
+    val availableGroups = remember(groupsByRelay) {
+        groupsByRelay.flatMap { (relay, relayGroups) ->
+            relayGroups.map { g ->
+                GroupInfo(id = g.id, name = g.name ?: g.id, picture = g.picture, relay = relay)
+            }
+        }.distinctBy { it.id }
     }
 
     val isGroupRestricted = allRestrictedGroups.containsKey(groupId)
@@ -113,7 +124,8 @@ fun GroupScreen(
     val hasMoreMessages = hasMoreMessagesMap[groupId] ?: true
 
     var messageInput by remember { mutableStateOf("") }
-    var mentions by remember { mutableStateOf<Map<String, String>>(emptyMap()) } // displayName -> pubkey
+    var mentions by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var groupMentions by remember { mutableStateOf<Map<String, GroupInfo>>(emptyMap()) }
     var replyingToMessage by remember { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
     var pendingUploads by remember { mutableStateOf<List<UploadResult>>(emptyList()) }
     var showLeaveDialog by remember { mutableStateOf(false) }
@@ -667,9 +679,15 @@ fun GroupScreen(
                 onMessageInputChange = { messageInput = it },
                 onSendMessage = {
                     val imetaTags = pendingUploads.map { it.toImetaTag() }
-                    vm.sendMessage(messageInput, selectedChannel, mentions, replyingToMessage?.id, imetaTags)
+                    var content = messageInput
+                    groupMentions.forEach { (name, group) ->
+                        val naddr = Nip19.encodeNaddr(group.id, group.relay)
+                        content = content.replace("%$name", "nostr:$naddr")
+                    }
+                    vm.sendMessage(content, selectedChannel, mentions, replyingToMessage?.id, imetaTags)
                     messageInput = ""
                     mentions = emptyMap()
+                    groupMentions = emptyMap()
                     replyingToMessage = null
                     pendingUploads = emptyList()
                 },
@@ -694,6 +712,9 @@ fun GroupScreen(
                 recentlyActiveMembers = recentlyActiveMembers,
                 mentions = mentions,
                 onMentionsChange = { mentions = it },
+                availableGroups = availableGroups,
+                groupMentions = groupMentions,
+                onGroupMentionsChange = { groupMentions = it },
                 replyingToMessage = replyingToMessage,
                 onReplyClick = { message -> replyingToMessage = message },
                 onDeleteMessage = { message -> messageToDelete = message },
@@ -757,9 +778,15 @@ fun GroupScreen(
                 onMessageInputChange = { messageInput = it },
                 onSendMessage = {
                     val imetaTags = pendingUploads.map { it.toImetaTag() }
-                    vm.sendMessage(messageInput, selectedChannel, mentions, replyingToMessage?.id, imetaTags)
+                    var content = messageInput
+                    groupMentions.forEach { (name, group) ->
+                        val naddr = Nip19.encodeNaddr(group.id, group.relay)
+                        content = content.replace("%$name", "nostr:$naddr")
+                    }
+                    vm.sendMessage(content, selectedChannel, mentions, replyingToMessage?.id, imetaTags)
                     messageInput = ""
                     mentions = emptyMap()
+                    groupMentions = emptyMap()
                     replyingToMessage = null
                     pendingUploads = emptyList()
                 },
@@ -784,6 +811,9 @@ fun GroupScreen(
                 recentlyActiveMembers = recentlyActiveMembers,
                 mentions = mentions,
                 onMentionsChange = { mentions = it },
+                availableGroups = availableGroups,
+                groupMentions = groupMentions,
+                onGroupMentionsChange = { groupMentions = it },
                 replyingToMessage = replyingToMessage,
                 onReplyClick = { message -> replyingToMessage = message },
                 onDeleteMessage = { message -> messageToDelete = message },

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -26,6 +26,7 @@ import org.nostr.nostrord.ui.screens.group.components.GroupHeader
 import org.nostr.nostrord.ui.screens.group.components.MessageInput
 import org.nostr.nostrord.ui.screens.group.components.MessagesList
 import org.nostr.nostrord.ui.screens.group.model.ChatItem
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
 
@@ -78,6 +79,9 @@ fun GroupScreenDesktop(
     recentlyActiveMembers: Set<String> = emptySet(),
     mentions: Map<String, String> = emptyMap(),
     onMentionsChange: (Map<String, String>) -> Unit = {},
+    availableGroups: List<GroupInfo> = emptyList(),
+    groupMentions: Map<String, GroupInfo> = emptyMap(),
+    onGroupMentionsChange: (Map<String, GroupInfo>) -> Unit = {},
     replyingToMessage: NostrMessage? = null,
     onReplyClick: (NostrMessage) -> Unit = {},
     onDeleteMessage: (NostrMessage) -> Unit = {},
@@ -208,6 +212,9 @@ fun GroupScreenDesktop(
                 groupMembers = groupMembers,
                 mentions = mentions,
                 onMentionsChange = onMentionsChange,
+                availableGroups = availableGroups,
+                groupMentions = groupMentions,
+                onGroupMentionsChange = onGroupMentionsChange,
                 replyingToMessage = replyingToMessage,
                 replyingToMetadata = replyingToMessage?.let { userMetadata[it.pubkey] },
                 userMetadata = userMetadata,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -51,6 +51,7 @@ import org.nostr.nostrord.ui.components.sidebars.MemberSidebar
 import org.nostr.nostrord.ui.screens.group.components.MessageInput
 import org.nostr.nostrord.ui.screens.group.components.MessagesList
 import org.nostr.nostrord.ui.screens.group.model.ChatItem
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -110,6 +111,9 @@ fun GroupScreenMobile(
     recentlyActiveMembers: Set<String> = emptySet(),
     mentions: Map<String, String> = emptyMap(),
     onMentionsChange: (Map<String, String>) -> Unit = {},
+    availableGroups: List<GroupInfo> = emptyList(),
+    groupMentions: Map<String, GroupInfo> = emptyMap(),
+    onGroupMentionsChange: (Map<String, GroupInfo>) -> Unit = {},
     replyingToMessage: NostrMessage? = null,
     onReplyClick: (NostrMessage) -> Unit = {},
     onDeleteMessage: (NostrMessage) -> Unit = {},
@@ -259,6 +263,9 @@ fun GroupScreenMobile(
                     groupMembers = groupMembers,
                     mentions = mentions,
                     onMentionsChange = onMentionsChange,
+                    availableGroups = availableGroups,
+                    groupMentions = groupMentions,
+                    onGroupMentionsChange = onGroupMentionsChange,
                     replyingToMessage = replyingToMessage,
                     replyingToMetadata = replyingToMessage?.let { userMetadata[it.pubkey] },
                     userMetadata = userMetadata,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -17,6 +17,7 @@ class GroupViewModel(
     val connectionState = repo.connectionState
     val joinedGroups = repo.joinedGroups
     val groups = repo.groups
+    val groupsByRelay = repo.groupsByRelay
     val userMetadata = repo.userMetadata
     val reactions = repo.reactions
     val groupMembers = repo.groupMembers

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -28,6 +28,7 @@ class GroupViewModel(
     val isLoadingMore = repo.isLoadingMore
     val hasMoreMessages = repo.hasMoreMessages
     val currentRelayUrl = repo.currentRelayUrl
+    val relayMetadata = repo.relayMetadata
     val childrenByParent = repo.childrenByParent
 
     private val _isSending = MutableStateFlow(false)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupMentionPopup.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupMentionPopup.kt
@@ -1,0 +1,215 @@
+package org.nostr.nostrord.ui.screens.group.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.ui.theme.NostrordTypography
+import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.ui.util.generateColorFromString
+import org.nostr.nostrord.utils.normalizeForSearch
+
+fun getFilteredGroups(groups: List<GroupInfo>, query: String): List<GroupInfo> {
+    return if (query.isEmpty()) {
+        groups.take(8)
+    } else {
+        val normalizedQuery = query.normalizeForSearch()
+        groups.filter { group ->
+            group.name.normalizeForSearch().contains(normalizedQuery) ||
+            group.id.contains(query, ignoreCase = true)
+        }.take(8)
+    }
+}
+
+@Composable
+fun GroupMentionPopup(
+    groups: List<GroupInfo>,
+    query: String,
+    selectedIndex: Int = 0,
+    onGroupSelect: (GroupInfo) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val filteredGroups = getFilteredGroups(groups, query)
+
+    if (filteredGroups.isEmpty()) return
+
+    val safeSelectedIndex = selectedIndex.coerceIn(0, filteredGroups.size - 1)
+
+    Surface(
+        modifier = modifier
+            .width(300.dp)
+            .heightIn(max = 320.dp),
+        shape = NostrordShapes.menuShape,
+        color = NostrordColors.Surface,
+        shadowElevation = 16.dp,
+        tonalElevation = 0.dp
+    ) {
+        Column {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.inputPadding, vertical = Spacing.sm)
+            ) {
+                Text(
+                    text = "GROUPS",
+                    style = NostrordTypography.SectionHeader,
+                    color = NostrordColors.TextMuted
+                )
+            }
+
+            HorizontalDivider(
+                color = NostrordColors.BackgroundDark,
+                thickness = Spacing.dividerThickness
+            )
+
+            LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                itemsIndexed(filteredGroups) { index, group ->
+                    GroupMentionItem(
+                        group = group,
+                        isSelected = index == safeSelectedIndex,
+                        onClick = { onGroupSelect(group) }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupMentionItem(
+    group: GroupInfo,
+    isSelected: Boolean = false,
+    onClick: () -> Unit
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val isPressed by interactionSource.collectIsPressedAsState()
+
+    val backgroundColor = when {
+        isPressed -> NostrordColors.SurfaceVariant
+        isSelected -> NostrordColors.Primary.copy(alpha = 0.2f)
+        isHovered -> NostrordColors.HoverBackground
+        else -> Color.Transparent
+    }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .hoverable(interactionSource = interactionSource)
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                onClick = onClick
+            )
+            .pointerHoverIcon(PointerIcon.Hand)
+            .background(backgroundColor)
+            .padding(horizontal = Spacing.inputPadding, vertical = Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        GroupIcon(
+            groupId = group.id,
+            name = group.name,
+            pictureUrl = group.picture,
+            size = Spacing.avatarSizeSmall
+        )
+
+        Spacer(modifier = Modifier.width(Spacing.inputPadding))
+
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = group.name,
+                style = NostrordTypography.MemberName,
+                color = NostrordColors.TextContent,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Text(
+                text = group.relay
+                    .removePrefix("wss://")
+                    .removePrefix("ws://"),
+                style = NostrordTypography.Tiny,
+                color = NostrordColors.TextMuted,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun GroupIcon(
+    groupId: String,
+    name: String,
+    pictureUrl: String?,
+    size: Dp
+) {
+    val context = LocalPlatformContext.current
+    val shape = RoundedCornerShape(8.dp)
+    var imageState by remember(pictureUrl) {
+        mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty)
+    }
+    val showImage = !pictureUrl.isNullOrBlank() && imageState !is AsyncImagePainter.State.Error
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(shape)
+            .background(if (!showImage) generateColorFromString(groupId) else NostrordColors.BackgroundDark),
+        contentAlignment = Alignment.Center
+    ) {
+        if (!showImage) {
+            Text(
+                text = name.take(1).uppercase(),
+                color = Color.White,
+                fontSize = (size.value * 0.5f).sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+        if (!pictureUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(pictureUrl)
+                    .crossfade(true)
+                    .memoryCachePolicy(CachePolicy.ENABLED)
+                    .diskCachePolicy(CachePolicy.ENABLED)
+                    .build(),
+                contentDescription = name,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(shape),
+                contentScale = ContentScale.Crop,
+                onState = { imageState = it }
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -37,6 +37,7 @@ import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.ui.components.upload.MessageUploadButton
 import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import androidx.compose.ui.text.font.FontFamily
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -49,17 +50,10 @@ import org.nostr.nostrord.utils.formatTimestamp
 /**
  * Message input field with Discord-style keyboard behavior.
  *
- * Keyboard behavior:
- * - Enter: Send message (or select mention if popup open)
- * - Shift+Enter: Insert newline at cursor (manually handled for reliability)
- * - Escape: Close mention popup
- * - Tab: Select highlighted mention
- *
- * Features:
- * - Send button (disabled when empty, shows spinner when sending)
- * - @mention autocomplete popup
- * - Multi-line text input (up to 4 lines visible)
- * - Join prompt when not a group member
+ * - Enter: send (or confirm mention/group popup)
+ * - Shift+Enter: insert newline
+ * - Escape: close active popup
+ * - Tab: confirm highlighted suggestion
  */
 @Composable
 fun MessageInput(
@@ -76,6 +70,9 @@ fun MessageInput(
     groupMembers: List<MemberInfo> = emptyList(),
     mentions: Map<String, String> = emptyMap(), // displayName -> pubkey
     onMentionsChange: (Map<String, String>) -> Unit = {},
+    availableGroups: List<GroupInfo> = emptyList(),
+    groupMentions: Map<String, GroupInfo> = emptyMap(), // name -> GroupInfo
+    onGroupMentionsChange: (Map<String, GroupInfo>) -> Unit = {},
     replyingToMessage: NostrGroupClient.NostrMessage? = null,
     replyingToMetadata: UserMetadata? = null,
     userMetadata: Map<String, UserMetadata> = emptyMap(),
@@ -87,6 +84,10 @@ fun MessageInput(
     var mentionStartIndex by remember { mutableStateOf(-1) }
     var mentionQuery by remember { mutableStateOf("") }
     var mentionSelectedIndex by remember { mutableStateOf(0) }
+    var showGroupMentionPopup by remember { mutableStateOf(false) }
+    var groupMentionStartIndex by remember { mutableStateOf(-1) }
+    var groupMentionQuery by remember { mutableStateOf("") }
+    var groupMentionSelectedIndex by remember { mutableStateOf(0) }
     var showEmojiPicker by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
     val showEmojiButton = remember {
@@ -108,7 +109,6 @@ fun MessageInput(
         }
     }
 
-    // Local TextFieldValue state for cursor position control
     var textFieldValue by remember { mutableStateOf(TextFieldValue(messageInput)) }
 
     // Sync with external messageInput when it changes (e.g., cleared after send)
@@ -122,59 +122,25 @@ fun MessageInput(
         }
     }
 
-    /**
-     * Finds the mention context at the given cursor position.
-     * Returns the start index of '@' if cursor is in a valid mention context, -1 otherwise.
-     * A valid mention context is: cursor is after '@' with no space between '@' and cursor,
-     * and '@' is at start of text or preceded by whitespace.
-     */
-    fun findMentionContext(text: String, cursorPosition: Int): Pair<Int, String> {
-        if (cursorPosition <= 0 || cursorPosition > text.length) {
-            return Pair(-1, "")
-        }
-
-        // Search backwards from cursor to find '@'
-        val textBeforeCursor = text.substring(0, cursorPosition)
-        val lastAtIndex = textBeforeCursor.lastIndexOf('@')
-
-        if (lastAtIndex == -1) {
-            return Pair(-1, "")
-        }
-
-        // Check if '@' is at start or after whitespace
-        val charBeforeAt = text.getOrNull(lastAtIndex - 1)
-        if (charBeforeAt != null && !charBeforeAt.isWhitespace()) {
-            return Pair(-1, "")
-        }
-
-        // Get the text between '@' and cursor
-        val queryPart = text.substring(lastAtIndex + 1, cursorPosition)
-
-        // If there's a space in the query, it's not a valid mention context
-        if (queryPart.contains(' ') || queryPart.contains('\n')) {
-            return Pair(-1, "")
-        }
-
-        return Pair(lastAtIndex, queryPart)
+    fun findMentionContext(text: String, cursorPosition: Int, trigger: Char): Pair<Int, String> {
+        if (cursorPosition <= 0 || cursorPosition > text.length) return Pair(-1, "")
+        val triggerIndex = text.substring(0, cursorPosition).lastIndexOf(trigger)
+        if (triggerIndex == -1) return Pair(-1, "")
+        val charBefore = text.getOrNull(triggerIndex - 1)
+        if (charBefore != null && !charBefore.isWhitespace()) return Pair(-1, "")
+        val queryPart = text.substring(triggerIndex + 1, cursorPosition)
+        if (queryPart.contains(' ') || queryPart.contains('\n')) return Pair(-1, "")
+        return Pair(triggerIndex, queryPart)
     }
 
-    /**
-     * Updates mention popup state based on current cursor position.
-     * Called on every text/cursor change to handle typing, backspace, clicks, arrow keys, etc.
-     */
     fun updateMentionState(value: TextFieldValue) {
-        val cursorPosition = value.selection.start
-        val (atIndex, query) = findMentionContext(value.text, cursorPosition)
-
-        if (atIndex >= 0) {
-            val queryChanged = mentionQuery != query
+        val (index, query) = findMentionContext(value.text, value.selection.start, '@')
+        if (index >= 0) {
+            if (mentionQuery != query) mentionSelectedIndex = 0
             showMentionPopup = true
             showEmojiPicker = false
-            mentionStartIndex = atIndex
+            mentionStartIndex = index
             mentionQuery = query
-            if (queryChanged) {
-                mentionSelectedIndex = 0 // Reset selection when query changes
-            }
         } else {
             showMentionPopup = false
             mentionStartIndex = -1
@@ -182,15 +148,29 @@ fun MessageInput(
         }
     }
 
-    // Handle text field value changes (text or cursor position)
+    fun updateGroupMentionState(value: TextFieldValue) {
+        val (index, query) = findMentionContext(value.text, value.selection.start, '%')
+        if (index >= 0) {
+            if (groupMentionQuery != query) groupMentionSelectedIndex = 0
+            showGroupMentionPopup = true
+            showEmojiPicker = false
+            groupMentionStartIndex = index
+            groupMentionQuery = query
+        } else {
+            showGroupMentionPopup = false
+            groupMentionStartIndex = -1
+            groupMentionQuery = ""
+        }
+    }
+
     fun handleTextFieldValueChange(newValue: TextFieldValue) {
         textFieldValue = newValue
         onMessageInputChange(newValue.text)
         updateMentionState(newValue)
+        updateGroupMentionState(newValue)
     }
 
     fun handleMemberSelect(member: MemberInfo) {
-        // Replace "@query" with "@displayName " (exactly one space after)
         val currentText = textFieldValue.text
         val beforeMention = currentText.substring(0, mentionStartIndex)
         val afterMention = if (mentionStartIndex + 1 + mentionQuery.length < currentText.length) {
@@ -199,29 +179,40 @@ fun MessageInput(
             ""
         }
         val mentionPart = "@${member.displayName} "
-        val newText = if (afterMention.isEmpty()) {
-            "$beforeMention$mentionPart"
-        } else {
-            "$beforeMention$mentionPart$afterMention"
-        }
-
-        // Calculate cursor position: right after the mention and space
+        val newText = if (afterMention.isEmpty()) "$beforeMention$mentionPart"
+                      else "$beforeMention$mentionPart$afterMention"
         val cursorPosition = beforeMention.length + mentionPart.length
-
-        // Update with new text and cursor position
         textFieldValue = TextFieldValue(newText, TextRange(cursorPosition))
         onMessageInputChange(newText)
-
-        // Add displayName -> pubkey mapping
         if (!mentions.containsKey(member.displayName)) {
             onMentionsChange(mentions + (member.displayName to member.pubkey))
         }
-
         showMentionPopup = false
         mentionStartIndex = -1
         mentionQuery = ""
+        focusRequester.requestFocus()
+    }
 
-        // Focus the input field after selection
+    fun handleGroupSelect(group: GroupInfo) {
+        val currentText = textFieldValue.text
+        val beforeMention = currentText.substring(0, groupMentionStartIndex)
+        val afterMention = if (groupMentionStartIndex + 1 + groupMentionQuery.length < currentText.length) {
+            currentText.substring(groupMentionStartIndex + 1 + groupMentionQuery.length).trimStart()
+        } else {
+            ""
+        }
+        val mentionPart = "%${group.name} "
+        val newText = if (afterMention.isEmpty()) "$beforeMention$mentionPart"
+                      else "$beforeMention$mentionPart$afterMention"
+        val cursorPosition = beforeMention.length + mentionPart.length
+        textFieldValue = TextFieldValue(newText, TextRange(cursorPosition))
+        onMessageInputChange(newText)
+        if (!groupMentions.containsKey(group.name)) {
+            onGroupMentionsChange(groupMentions + (group.name to group))
+        }
+        showGroupMentionPopup = false
+        groupMentionStartIndex = -1
+        groupMentionQuery = ""
         focusRequester.requestFocus()
     }
 
@@ -299,7 +290,6 @@ fun MessageInput(
         Column(
             modifier = Modifier.fillMaxWidth()
         ) {
-            // Reply preview bar (shown when replying to a message)
             if (replyingToMessage != null) {
                 ReplyingToBar(
                     message = replyingToMessage,
@@ -312,7 +302,6 @@ fun MessageInput(
             Box(
                 modifier = Modifier.fillMaxWidth()
             ) {
-                // Input row
                 Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -350,19 +339,19 @@ fun MessageInput(
                         .onFocusChanged { focusState ->
                             if (!focusState.isFocused) {
                                 showMentionPopup = false
+                                showGroupMentionPopup = false
                             }
                         }
                         .onPreviewKeyEvent { event ->
                             val filteredMembers = getFilteredMembers(groupMembers, mentionQuery)
+                            val filteredGroups = getFilteredGroups(availableGroups, groupMentionQuery)
                             when {
-                                // Escape closes the emoji picker first, then mention popup
                                 event.type == KeyEventType.KeyDown &&
                                 event.key == Key.Escape &&
                                 showEmojiPicker -> {
                                     showEmojiPicker = false
                                     true
                                 }
-                                // Escape closes the mention popup
                                 event.type == KeyEventType.KeyDown &&
                                 event.key == Key.Escape &&
                                 showMentionPopup -> {
@@ -371,7 +360,14 @@ fun MessageInput(
                                     mentionQuery = ""
                                     true
                                 }
-                                // Arrow Up - navigate up in mention popup
+                                event.type == KeyEventType.KeyDown &&
+                                event.key == Key.Escape &&
+                                showGroupMentionPopup -> {
+                                    showGroupMentionPopup = false
+                                    groupMentionStartIndex = -1
+                                    groupMentionQuery = ""
+                                    true
+                                }
                                 event.type == KeyEventType.KeyDown &&
                                 event.key == Key.DirectionUp &&
                                 showMentionPopup &&
@@ -379,12 +375,25 @@ fun MessageInput(
                                     mentionSelectedIndex = (mentionSelectedIndex - 1).coerceAtLeast(0)
                                     true
                                 }
-                                // Arrow Down - navigate down in mention popup
                                 event.type == KeyEventType.KeyDown &&
                                 event.key == Key.DirectionDown &&
                                 showMentionPopup &&
                                 filteredMembers.isNotEmpty() -> {
                                     mentionSelectedIndex = (mentionSelectedIndex + 1).coerceAtMost(filteredMembers.size - 1)
+                                    true
+                                }
+                                event.type == KeyEventType.KeyDown &&
+                                event.key == Key.DirectionUp &&
+                                showGroupMentionPopup &&
+                                filteredGroups.isNotEmpty() -> {
+                                    groupMentionSelectedIndex = (groupMentionSelectedIndex - 1).coerceAtLeast(0)
+                                    true
+                                }
+                                event.type == KeyEventType.KeyDown &&
+                                event.key == Key.DirectionDown &&
+                                showGroupMentionPopup &&
+                                filteredGroups.isNotEmpty() -> {
+                                    groupMentionSelectedIndex = (groupMentionSelectedIndex + 1).coerceAtMost(filteredGroups.size - 1)
                                     true
                                 }
                                 // Shift+Enter: manually insert newline at cursor (Discord-style)
@@ -399,35 +408,42 @@ fun MessageInput(
                                     textFieldValue = newValue
                                     onMessageInputChange(newText)
                                     updateMentionState(newValue)
+                                    updateGroupMentionState(newValue)
                                     true
                                 }
-                                // Enter selects mention if popup is open, otherwise sends message
                                 event.type == KeyEventType.KeyDown &&
                                 event.key == Key.Enter &&
                                 !event.isShiftPressed -> {
                                     if (showMentionPopup && filteredMembers.isNotEmpty()) {
                                         val selectedMember = filteredMembers.getOrNull(mentionSelectedIndex)
-                                        if (selectedMember != null) {
-                                            handleMemberSelect(selectedMember)
-                                        }
+                                        if (selectedMember != null) handleMemberSelect(selectedMember)
+                                        true
+                                    } else if (showGroupMentionPopup && filteredGroups.isNotEmpty()) {
+                                        val selectedGroup = filteredGroups.getOrNull(groupMentionSelectedIndex)
+                                        if (selectedGroup != null) handleGroupSelect(selectedGroup)
                                         true
                                     } else if (textFieldValue.text.isNotBlank()) {
                                         showEmojiPicker = false
                                         onSendMessage()
                                         true
                                     } else {
-                                        true // Consume to prevent accidental newline on empty field
+                                        true
                                     }
                                 }
-                                // Tab also selects mention if popup is open
                                 event.type == KeyEventType.KeyDown &&
                                 event.key == Key.Tab &&
                                 showMentionPopup &&
                                 filteredMembers.isNotEmpty() -> {
                                     val selectedMember = filteredMembers.getOrNull(mentionSelectedIndex)
-                                    if (selectedMember != null) {
-                                        handleMemberSelect(selectedMember)
-                                    }
+                                    if (selectedMember != null) handleMemberSelect(selectedMember)
+                                    true
+                                }
+                                event.type == KeyEventType.KeyDown &&
+                                event.key == Key.Tab &&
+                                showGroupMentionPopup &&
+                                filteredGroups.isNotEmpty() -> {
+                                    val selectedGroup = filteredGroups.getOrNull(groupMentionSelectedIndex)
+                                    if (selectedGroup != null) handleGroupSelect(selectedGroup)
                                     true
                                 }
                                 else -> false
@@ -455,11 +471,11 @@ fun MessageInput(
                     visualTransformation = MentionVisualTransformation(
                         mentionedNames = mentions.keys,
                         mentionColor = NostrordColors.MentionText,
-                        emojiFontFamily = rememberEmojiFontFamily()
+                        emojiFontFamily = rememberEmojiFontFamily(),
+                        groupMentionedNames = groupMentions.keys
                     )
                 )
 
-                // Emoji picker button — desktop/web only
                 if (showEmojiButton) {
                     IconButton(
                         onClick = {
@@ -478,7 +494,6 @@ fun MessageInput(
                     }
                 }
 
-                // Send button — disabled when empty, shows spinner while sending
                 IconButton(
                     onClick = {
                         if (textFieldValue.text.isNotBlank() && !isSending) {
@@ -507,20 +522,14 @@ fun MessageInput(
                 }
             }
 
-            // Mention popup floating above the input
             if (showMentionPopup && groupMembers.isNotEmpty()) {
                 val density = LocalDensity.current
                 val filteredCount = getFilteredMembers(groupMembers, mentionQuery).size
-                // Calculate popup height in dp: header (~28dp) + divider + items (each ~36dp), max 8 items
                 val popupHeightDp = 28 + 2 + (filteredCount.coerceAtMost(8) * 36)
                 val popupHeightPx = with(density) { popupHeightDp.dp.roundToPx() }
                 val offsetXPx = with(density) { Spacing.lg.roundToPx() }
 
-                // Fullscreen scrim to capture clicks outside popup and TextField
-                Popup(
-                    alignment = Alignment.Center,
-                    onDismissRequest = { showMentionPopup = false }
-                ) {
+                Popup(alignment = Alignment.Center, onDismissRequest = { showMentionPopup = false }) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -533,19 +542,11 @@ fun MessageInput(
                     )
                 }
 
-                // The actual mention popup
                 Popup(
                     alignment = Alignment.TopStart,
-                    offset = IntOffset(
-                        x = offsetXPx,
-                        y = -popupHeightPx
-                    ),
+                    offset = IntOffset(x = offsetXPx, y = -popupHeightPx),
                     onDismissRequest = { showMentionPopup = false },
-                    properties = PopupProperties(
-                        focusable = false,
-                        dismissOnClickOutside = false,
-                        dismissOnBackPress = true
-                    )
+                    properties = PopupProperties(focusable = false, dismissOnClickOutside = false, dismissOnBackPress = true)
                 ) {
                     MentionPopup(
                         members = groupMembers,
@@ -556,7 +557,41 @@ fun MessageInput(
                 }
             }
 
-            // Emoji picker popup — single fullscreen popup with scrim + positioned picker
+            if (showGroupMentionPopup && availableGroups.isNotEmpty()) {
+                val density = LocalDensity.current
+                val filteredCount = getFilteredGroups(availableGroups, groupMentionQuery).size
+                val popupHeightDp = 28 + 2 + (filteredCount.coerceAtMost(8) * 36)
+                val popupHeightPx = with(density) { popupHeightDp.dp.roundToPx() }
+                val offsetXPx = with(density) { Spacing.lg.roundToPx() }
+
+                Popup(alignment = Alignment.Center, onDismissRequest = { showGroupMentionPopup = false }) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color.Transparent)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = { showGroupMentionPopup = false }
+                            )
+                    )
+                }
+
+                Popup(
+                    alignment = Alignment.TopStart,
+                    offset = IntOffset(x = offsetXPx, y = -popupHeightPx),
+                    onDismissRequest = { showGroupMentionPopup = false },
+                    properties = PopupProperties(focusable = false, dismissOnClickOutside = false, dismissOnBackPress = true)
+                ) {
+                    GroupMentionPopup(
+                        groups = availableGroups,
+                        query = groupMentionQuery,
+                        selectedIndex = groupMentionSelectedIndex,
+                        onGroupSelect = { handleGroupSelect(it) }
+                    )
+                }
+            }
+
             if (showEmojiPicker) {
                 Popup(
                     alignment = Alignment.Center,
@@ -570,7 +605,6 @@ fun MessageInput(
                         dismissOnBackPress = true
                     )
                 ) {
-                    // Fullscreen container: transparent scrim catches clicks outside picker
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -583,7 +617,6 @@ fun MessageInput(
                                 }
                             )
                     ) {
-                        // Picker anchored to bottom-end, above the input bar
                         EmojiPicker(
                             onEmojiSelect = { emoji ->
                                 val text = textFieldValue.text
@@ -604,14 +637,11 @@ fun MessageInput(
                     }
                 }
             }
-            } // End Box
-        } // End Column
+            }
+        }
     }
 }
 
-/**
- * Compact bar shown above input when replying to a message.
- */
 @Composable
 private fun ReplyingToBar(
     message: NostrGroupClient.NostrMessage,
@@ -623,7 +653,6 @@ private fun ReplyingToBar(
         ?: metadata?.name
         ?: message.pubkey.take(8) + "..."
 
-    // Request metadata for any pubkeys mentioned in the content
     LaunchedEffect(message.content) {
         val pubkeysToFetch = org.nostr.nostrord.ui.components.chat.extractPubkeysFromContent(message.content)
             .filter { !userMetadata.containsKey(it) }
@@ -633,7 +662,6 @@ private fun ReplyingToBar(
         }
     }
 
-    // Process mentions in content to show @name instead of nostr:npub...
     val processedContent = remember(message.content, userMetadata) {
         org.nostr.nostrord.ui.components.chat.processMentionsInContent(message.content, userMetadata)
             .replace('\n', ' ')
@@ -646,7 +674,6 @@ private fun ReplyingToBar(
             .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        // Left accent bar
         Box(
             modifier = Modifier
                 .width(3.dp)
@@ -659,7 +686,6 @@ private fun ReplyingToBar(
 
         Spacer(modifier = Modifier.width(Spacing.sm))
 
-        // Reply info
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = "Replying to $authorName",
@@ -674,7 +700,6 @@ private fun ReplyingToBar(
             )
         }
 
-        // Cancel button
         IconButton(
             onClick = onCancelReply,
             modifier = Modifier.size(32.dp)
@@ -689,9 +714,6 @@ private fun ReplyingToBar(
     }
 }
 
-/**
- * Regex matching emoji codepoints — same pattern used in MessageContent for display.
- */
 private val emojiRegex = Regex(
     "[" +
         "\u00A9\u00AE" +
@@ -717,35 +739,29 @@ private val emojiRegex = Regex(
         "]+"
 )
 
-/**
- * Visual transformation that highlights @mentions and applies
- * NotoColorEmoji font selectively to emoji segments.
- */
 private class MentionVisualTransformation(
     private val mentionedNames: Set<String>,
     private val mentionColor: Color,
-    private val emojiFontFamily: FontFamily? = null
+    private val emojiFontFamily: FontFamily? = null,
+    private val groupMentionedNames: Set<String> = emptySet()
 ) : VisualTransformation {
     override fun filter(text: AnnotatedString): TransformedText {
         val builder = AnnotatedString.Builder(text)
 
-        // Find and highlight @mentions
-        mentionedNames.forEach { displayName ->
-            val mentionText = "@$displayName"
+        fun highlight(prefix: String, name: String) {
+            val mentionText = "$prefix$name"
             var startIndex = 0
             while (true) {
                 val index = text.text.indexOf(mentionText, startIndex)
                 if (index == -1) break
-                builder.addStyle(
-                    SpanStyle(color = mentionColor),
-                    index,
-                    index + mentionText.length
-                )
+                builder.addStyle(SpanStyle(color = mentionColor), index, index + mentionText.length)
                 startIndex = index + mentionText.length
             }
         }
 
-        // Apply emoji font only to emoji segments
+        mentionedNames.forEach { highlight("@", it) }
+        groupMentionedNames.forEach { highlight("%", it) }
+
         if (emojiFontFamily != null) {
             emojiRegex.findAll(text.text).forEach { match ->
                 builder.addStyle(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/model/GroupInfo.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/model/GroupInfo.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.ui.screens.group.model
+
+data class GroupInfo(
+    val id: String,
+    val name: String,
+    val picture: String?,
+    val relay: String
+)

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,9 @@
+# feat: group mentions via % autocomplete
+
+Typing `%` in the message input opens a group picker (mirroring the existing `@` user mention system). Selecting a group inserts `%GroupName` into the text, which is encoded as `nostr:naddr1...` on send. Received `naddr` kind:39000 entities are decoded back to `%GroupName` for display in chat.
+
+- `Nip19.encodeNaddr` — new function to encode NIP-29 group references; uses the relay's own pubkey from the cached NIP-11 metadata (`relayMetadata`), falling back to 32 zero bytes if not yet available
+- `GroupMentionPopup` — new autocomplete popup with group icon, name and relay, filtered by name/id
+- `GroupLinkCard` — fixed fallback to use group icon pattern (rounded square + color + initial) instead of Jdenticon; added image error-state tracking
+- `MessageInput` — unified `findMentionContext` handles both `@` and `%` triggers; `MentionVisualTransformation` highlights group mentions alongside user mentions
+- `GroupScreen` — derives `availableGroups` from `groupsByRelay` (relay-accurate) and encodes mentions on send


### PR DESCRIPTION
Typing `%` in the message input opens a group picker (mirroring the existing `@` user mention system). Selecting a group inserts `%GroupName` into the text, which is encoded as `nostr:naddr1...` on send. Received `naddr` kind:39000 entities are decoded back to `%GroupName` for display in chat.

- `Nip19.encodeNaddr` — new function to encode NIP-29 group references; uses the relay's own pubkey from the cached NIP-11 metadata (`relayMetadata`), falling back to 32 zero bytes if not yet available
- `GroupMentionPopup` — new autocomplete popup with group icon, name and relay, filtered by name/id
- `GroupLinkCard` — fixed fallback to use group icon pattern (rounded square + color + initial) instead of Jdenticon; added image error-state tracking
- `MessageInput` — unified `findMentionContext` handles both `@` and `%` triggers; `MentionVisualTransformation` highlights group mentions alongside user mentions
- `GroupScreen` — derives `availableGroups` from `groupsByRelay` (relay-accurate) and encodes mentions on send
- 
Closes https://github.com/nostrord/nostrord/issues/31