### PR TITLE
feat: direct message deep link with scroll, highlight and share

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -46,7 +46,7 @@ class MainActivity : ComponentActivity() {
         val relayUrl = relay.toRelayUrl().takeIf { it.isNotBlank() } ?: return
         val groupId = uri.getQueryParameter("group")?.takeIf { it.isNotBlank() }
         val inviteCode = uri.getQueryParameter("code")?.takeIf { it.isNotBlank() }
-        val messageId = uri.getQueryParameter("message")?.takeIf { it.isNotBlank() }
+        val messageId = uri.getQueryParameter("e")?.takeIf { it.isNotBlank() }
 
         val context = if (groupId != null) {
             ExternalLaunchContext.OpenGroup(

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -46,13 +46,15 @@ class MainActivity : ComponentActivity() {
         val relayUrl = relay.toRelayUrl().takeIf { it.isNotBlank() } ?: return
         val groupId = uri.getQueryParameter("group")?.takeIf { it.isNotBlank() }
         val inviteCode = uri.getQueryParameter("code")?.takeIf { it.isNotBlank() }
+        val messageId = uri.getQueryParameter("message")?.takeIf { it.isNotBlank() }
 
         val context = if (groupId != null) {
             ExternalLaunchContext.OpenGroup(
                 groupId = groupId,
                 groupName = null,
                 relayUrl = relayUrl,
-                inviteCode = inviteCode
+                inviteCode = inviteCode,
+                messageId = messageId
             )
         } else {
             ExternalLaunchContext.OpenRelay(relayUrl)

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.android.kt
@@ -1,12 +1,10 @@
 package org.nostr.nostrord.ui.components.chat
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 
-/**
- * Android implementation: No-op, context menu is accessed via "More" button.
- * Touch devices don't have a secondary button.
- */
-actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier {
-    // No-op on Android - users access context menu via the "More" button
-    return Modifier
-}
+actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier =
+    Modifier.pointerInput(onRightClick) {
+        detectTapGestures(onLongPress = { onRightClick() })
+    }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/utils/ShareUtils.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/utils/ShareUtils.android.kt
@@ -1,0 +1,19 @@
+package org.nostr.nostrord.utils
+
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+actual val supportsNativeShare: Boolean = true
+
+@Composable
+actual fun rememberTextSharer(): (String) -> Unit {
+    val context = LocalContext.current
+    return { text ->
+        val intent = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, text)
+        }
+        context.startActivity(Intent.createChooser(intent, null))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -142,7 +142,8 @@ fun App() {
                         initialScreen = startupState.initialScreen,
                         restoredFromPersistence = startupState.restoredFromPersistence,
                         deepLinkRelayUrl = startupState.deepLinkRelayUrl,
-                        deepLinkInviteCode = startupState.deepLinkInviteCode
+                        deepLinkInviteCode = startupState.deepLinkInviteCode,
+                        deepLinkMessageId = startupState.deepLinkMessageId
                     )
                 }
             }
@@ -199,7 +200,8 @@ private fun AuthenticatedApp(
     initialScreen: Screen,
     restoredFromPersistence: Boolean,
     deepLinkRelayUrl: String? = null,
-    deepLinkInviteCode: String? = null
+    deepLinkInviteCode: String? = null,
+    deepLinkMessageId: String? = null
 ) {
     // Initialize navigation history with the resolved initial screen
     val navHistory = remember {
@@ -293,6 +295,7 @@ private fun AuthenticatedApp(
     // Pending invite code from deep link or browser navigation.
     // Passed to GroupScreen which handles auto-join and consumption.
     var pendingInviteCode by remember { mutableStateOf(deepLinkInviteCode) }
+    var pendingMessageId by remember { mutableStateOf(deepLinkMessageId) }
 
     var showCreateGroupModal by remember { mutableStateOf(false) }
     var showJoinGroupModal by remember { mutableStateOf(false) }
@@ -611,7 +614,9 @@ private fun AuthenticatedApp(
                             onAddRelay = { addRelayInitialTab = 0; showAddRelayModal = true },
                             onAddRelayCustomUrl = { addRelayInitialTab = 1; showAddRelayModal = true },
                             pendingInviteCode = pendingInviteCode,
-                            onInviteCodeConsumed = { pendingInviteCode = null }
+                            onInviteCodeConsumed = { pendingInviteCode = null },
+                            pendingMessageId = pendingMessageId,
+                            onMessageIdConsumed = { pendingMessageId = null }
                         )
                     }
                 }
@@ -687,7 +692,9 @@ private fun AuthenticatedApp(
                         onAddRelayCustomUrl = { addRelayInitialTab = 1; showAddRelayModal = true },
                         onOpenDrawer = onOpenDrawer,
                         pendingInviteCode = pendingInviteCode,
-                        onInviteCodeConsumed = { pendingInviteCode = null }
+                        onInviteCodeConsumed = { pendingInviteCode = null },
+                        pendingMessageId = pendingMessageId,
+                        onMessageIdConsumed = { pendingMessageId = null }
                     )
                 }
             }
@@ -732,7 +739,9 @@ private fun DesktopContent(
     onAddRelay: () -> Unit = {},
     onAddRelayCustomUrl: () -> Unit = {},
     pendingInviteCode: String? = null,
-    onInviteCodeConsumed: () -> Unit = {}
+    onInviteCodeConsumed: () -> Unit = {},
+    pendingMessageId: String? = null,
+    onMessageIdConsumed: () -> Unit = {}
 ) {
     when (val screen = currentScreen) {
         is Screen.Home -> {
@@ -759,7 +768,9 @@ private fun DesktopContent(
                 showServerRail = false,
                 forceDesktop = true,
                 pendingInviteCode = pendingInviteCode,
-                onInviteCodeConsumed = onInviteCodeConsumed
+                onInviteCodeConsumed = onInviteCodeConsumed,
+                targetMessageId = pendingMessageId,
+                onTargetMessageConsumed = onMessageIdConsumed
             )
         }
         is Screen.EditProfile -> {
@@ -794,7 +805,9 @@ private fun MobileContent(
     onAddRelay: () -> Unit = {},
     onAddRelayCustomUrl: () -> Unit = {},
     pendingInviteCode: String? = null,
-    onInviteCodeConsumed: () -> Unit = {}
+    onInviteCodeConsumed: () -> Unit = {},
+    pendingMessageId: String? = null,
+    onMessageIdConsumed: () -> Unit = {}
 ) {
     when (val screen = currentScreen) {
         is Screen.Home -> {
@@ -821,7 +834,9 @@ private fun MobileContent(
                 onNavigateToGroup = onNavigateToGroupWithRelay,
                 onOpenDrawer = onOpenDrawer,
                 pendingInviteCode = pendingInviteCode,
-                onInviteCodeConsumed = onInviteCodeConsumed
+                onInviteCodeConsumed = onInviteCodeConsumed,
+                targetMessageId = pendingMessageId,
+                onTargetMessageConsumed = onMessageIdConsumed
             )
         }
         is Screen.EditProfile -> {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -1281,6 +1281,20 @@ suspend fun sendLiveSubscription(groupId: String, sinceSeconds: Long? = null) {
         sendJson(req)
     }
 
+    // #h filter included because some NIP-29 relays require it even for ID lookups.
+    suspend fun requestGroupMessageById(groupId: String, messageId: String) {
+        val subId = "e_${epochMillis()}"
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(buildJsonObject {
+                putJsonArray("ids") { add(messageId) }
+                putJsonArray("#h") { add(groupId) }
+            })
+        }
+        sendJson(req)
+    }
+
     /**
      * Request an addressable event by its coordinates (kind, pubkey, d-tag).
      * Addressable events are parameterized replaceable events (kinds 30000-39999).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1243,6 +1243,10 @@ class NostrRepository(
         return groupManager.loadMoreMessages(groupId, channel)
     }
 
+    override suspend fun fetchGroupMessageById(groupId: String, messageId: String) {
+        groupManager.fetchGroupMessageById(groupId, messageId)
+    }
+
     override suspend fun sendMessage(groupId: String, content: String, channel: String?, mentions: Map<String, String>, replyToMessageId: String?, extraTags: List<List<String>>): Result<Unit> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -202,6 +202,7 @@ interface NostrRepositoryApi {
     /** Connect to a relay in the background and fetch kind 39000 metadata for a group preview. */
     suspend fun fetchGroupPreview(groupId: String, relayUrl: String)
     suspend fun loadMoreMessages(groupId: String, channel: String? = null): Boolean
+    suspend fun fetchGroupMessageById(groupId: String, messageId: String)
     suspend fun sendMessage(groupId: String, content: String, channel: String? = null, mentions: Map<String, String> = emptyMap(), replyToMessageId: String? = null, extraTags: List<List<String>> = emptyList()): Result<Unit>
     suspend fun addUser(groupId: String, targetPubkey: String, roles: List<String> = emptyList()): Result<Unit>
     suspend fun removeUser(groupId: String, targetPubkey: String): Result<Unit>

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupLoadingController.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupLoadingController.kt
@@ -254,9 +254,13 @@ class GroupLoadingController(
                 return@withLock true // Wait for more relays
             }
 
-            // Determine next state based on message count
+            // Determine next state based on message count.
+            // For the initial load, never mark Exhausted here: messages may arrive via other
+            // subscriptions (mux/live) before EOSE and not be counted by this tracker, causing
+            // a false Exhausted when there is still more history. The next (empty) pagination
+            // page will correctly transition to Exhausted.
             val messagesReceived = tracker.messageCount
-            val isExhausted = messagesReceived < pageSize
+            val isExhausted = !tracker.isInitialLoad && messagesReceived < pageSize
 
             val newCursor = if (tracker.oldestEventId != null) {
                 (getCurrentCursor() ?: PaginationCursor.initial()).advance(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3,7 +3,7 @@ package org.nostr.nostrord.network.managers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -1728,11 +1728,24 @@ class GroupManager(
         // Update legacy flags
         updateLegacyFlags(groupId, controller.state.value)
 
+        // When cursor.untilTimestamp == Long.MAX_VALUE the tracker counted 0 messages
+        // (all were deduplicated because mux delivered them before the pagination sub).
+        // Fall back to the actual oldest message in the store so page 2 doesn't repeat
+        // the same window as the initial load and return nothing.
+        val effectiveUntil = if (cursor.untilTimestamp == Long.MAX_VALUE) {
+            val minCreatedAt = _messages.value[groupId]
+                ?.filter { it.createdAt > 1_000_000_000L } // guard against epoch-0 outliers
+                ?.minOfOrNull { it.createdAt }
+            if (minCreatedAt != null) minCreatedAt - 1L else cursor.untilTimestamp
+        } else {
+            cursor.untilTimestamp
+        }
+
         return try {
             currentClient.requestGroupMessages(
                 groupId = groupId,
                 channel = channel,
-                until = cursor.untilTimestamp,
+                until = effectiveUntil,
                 limit = PAGE_SIZE,
                 subscriptionId = subscriptionId
             )
@@ -1743,6 +1756,10 @@ class GroupManager(
             updateLegacyFlags(groupId, controller.state.value)
             false
         }
+    }
+
+    suspend fun fetchGroupMessageById(groupId: String, messageId: String) {
+        clientForGroup(groupId)?.requestGroupMessageById(groupId, messageId)
     }
 
     /**
@@ -1806,41 +1823,27 @@ class GroupManager(
         return true
     }
 
-    // [trackMessageForSubscription] runs each track on a separate scope.launch
-    // (handleMessage is non-suspend). Without this bookkeeping, EOSE can read
-    // messageCount while N tracks are still queued and a full page lands as
-    // Exhausted.
-    private val pendingTrackJobs = mutableMapOf<String, MutableList<Job>>()
-    private val pendingTracksLock = Mutex()
+    // Incremented synchronously (before scope.launch) so EOSE always sees the full count.
+    private val pendingTrackCounts = MutableStateFlow<Map<String, Int>>(emptyMap())
 
     fun trackMessageForSubscription(subscriptionId: String, timestamp: Long, eventId: String) {
-        val job = scope.launch {
-            loadingRegistry.trackMessage(subscriptionId, timestamp, eventId)
+        pendingTrackCounts.update { map ->
+            map + (subscriptionId to ((map[subscriptionId] ?: 0) + 1))
         }
         scope.launch {
-            pendingTracksLock.withLock {
-                pendingTrackJobs.getOrPut(subscriptionId) { mutableListOf() }.add(job)
-            }
             try {
-                job.join()
+                loadingRegistry.trackMessage(subscriptionId, timestamp, eventId)
             } finally {
-                pendingTracksLock.withLock {
-                    val list = pendingTrackJobs[subscriptionId]
-                    list?.remove(job)
-                    if (list?.isEmpty() == true) pendingTrackJobs.remove(subscriptionId)
+                pendingTrackCounts.update { map ->
+                    val n = map[subscriptionId] ?: return@update map
+                    if (n <= 1) map - subscriptionId else map + (subscriptionId to (n - 1))
                 }
             }
         }
     }
 
     private suspend fun awaitTrackingForSubscription(subscriptionId: String) {
-        repeat(3) {
-            val snapshot = pendingTracksLock.withLock {
-                pendingTrackJobs[subscriptionId]?.toList().orEmpty()
-            }
-            if (snapshot.isEmpty()) return
-            snapshot.joinAll()
-        }
+        pendingTrackCounts.first { (it[subscriptionId] ?: 0) == 0 }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/AppStartState.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/AppStartState.kt
@@ -38,6 +38,7 @@ sealed class AppStartState {
         val initialScreen: Screen,
         val restoredFromPersistence: Boolean = false,
         val deepLinkRelayUrl: String? = null,
-        val deepLinkInviteCode: String? = null
+        val deepLinkInviteCode: String? = null,
+        val deepLinkMessageId: String? = null
     ) : AppStartState()
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/StartupResolver.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/StartupResolver.kt
@@ -69,7 +69,8 @@ object StartupResolver {
                 is ExternalLaunchContext.OpenGroup -> ResolvedScreen(
                     screen = Screen.Group(external.groupId, external.groupName),
                     relayUrl = external.relayUrl,
-                    inviteCode = external.inviteCode
+                    inviteCode = external.inviteCode,
+                    messageId = external.messageId
                 )
                 is ExternalLaunchContext.OpenRelay -> ResolvedScreen(
                     screen = Screen.Home,
@@ -135,7 +136,8 @@ object StartupResolver {
             initialScreen = resolved.screen,
             restoredFromPersistence = resolved.restoredFromPersistence,
             deepLinkRelayUrl = resolved.relayUrl,
-            deepLinkInviteCode = resolved.inviteCode
+            deepLinkInviteCode = resolved.inviteCode,
+            deepLinkMessageId = resolved.messageId
         )
     }
 }
@@ -147,7 +149,8 @@ data class ResolvedScreen(
     val screen: Screen,
     val restoredFromPersistence: Boolean = false,
     val relayUrl: String? = null,
-    val inviteCode: String? = null
+    val inviteCode: String? = null,
+    val messageId: String? = null
 )
 
 sealed class ExternalLaunchContext {
@@ -155,7 +158,8 @@ sealed class ExternalLaunchContext {
         val groupId: String,
         val groupName: String?,
         val relayUrl: String? = null,
-        val inviteCode: String? = null
+        val inviteCode: String? = null,
+        val messageId: String? = null
     ) : ExternalLaunchContext()
     data class OpenRelay(val relayUrl: String) : ExternalLaunchContext()
     data object OpenHome : ExternalLaunchContext()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.PushPin
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -47,6 +48,7 @@ import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.utils.supportsNativeShare
 
 /**
  * Context menu actions for messages.
@@ -64,6 +66,7 @@ sealed class MessageContextAction {
     data object Reply : MessageContextAction()
     data object CopyText : MessageContextAction()
     data object CopyMessageLink : MessageContextAction()
+    data object ShareMessageLink : MessageContextAction()
     data object CopyEventJson : MessageContextAction()
     data object PinMessage : MessageContextAction()
     data object DeleteMessage : MessageContextAction()
@@ -195,15 +198,27 @@ private fun ContextMenuContent(
             }
         )
 
-        // Copy Message Link
-        ContextMenuItem(
-            icon = Icons.Outlined.Link,
-            label = "Copy Message Link",
-            onClick = {
-                onAction(MessageContextAction.CopyMessageLink)
-                onDismiss()
-            }
-        )
+        if (!supportsNativeShare) {
+            ContextMenuItem(
+                icon = Icons.Outlined.Link,
+                label = "Copy Message Link",
+                onClick = {
+                    onAction(MessageContextAction.CopyMessageLink)
+                    onDismiss()
+                }
+            )
+        }
+
+        if (supportsNativeShare) {
+            ContextMenuItem(
+                icon = Icons.Outlined.Share,
+                label = "Share Message Link",
+                onClick = {
+                    onAction(MessageContextAction.ShareMessageLink)
+                    onDismiss()
+                }
+            )
+        }
 
         // Copy Event JSON
         ContextMenuItem(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -1,6 +1,8 @@
 package org.nostr.nostrord.ui.components.chat
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -94,7 +96,8 @@ fun MessageItem(
     onDeleteMessage: () -> Unit = {},
     onUsernameClick: (String) -> Unit = {},
     onScrollToMessage: (String) -> Unit = {},
-    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> }
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
+    isHighlighted: Boolean = false
 ) {
     // Use rememberUpdatedState to avoid recomposition when callbacks change reference
     val currentOnUsernameClick by rememberUpdatedState(onUsernameClick)
@@ -188,6 +191,19 @@ fun MessageItem(
     // Context menu state
     var showContextMenu by remember { mutableStateOf(false) }
 
+    var highlightActive by remember(isHighlighted) { mutableStateOf(isHighlighted) }
+    LaunchedEffect(isHighlighted) {
+        if (isHighlighted) {
+            highlightActive = true
+            delay(2500)
+            highlightActive = false
+        }
+    }
+    val highlightColor by animateColorAsState(
+        targetValue = if (highlightActive) NostrordColors.Primary.copy(alpha = 0.18f) else Color.Transparent,
+        animationSpec = if (highlightActive) snap() else tween(durationMillis = 1200)
+    )
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -198,7 +214,7 @@ fun MessageItem(
                 showContextMenu = true
             })
             .background(
-                if (isHovered || isPressed) NostrordColors.MessageHover else Color.Transparent
+                if (isHovered || isPressed) NostrordColors.MessageHover else highlightColor
             )
     ) {
         // Main message content - this defines the Box size

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -56,15 +56,8 @@ import org.nostr.nostrord.utils.formatTime
  * Enhanced message item with grouping support and hover actions.
  *
  * Interaction behavior:
- * - Hover: Shows subtle background highlight after 50ms
- * - Actions toolbar appears at top-right with 100ms fade in
- * - Actions disappear immediately (50ms fade out) on mouse leave
- * - Right-click (desktop) or tap "More" button: Shows context menu
- *
- * TEXT SELECTION: This component is designed to NOT interfere with text selection.
- * - NO long-press handler (conflicts with selection start gesture)
- * - Context menu triggered via right-click (desktop) or "More" button (mobile)
- * - All text content is selectable via parent SelectionContainer
+ * - Desktop: hover shows action toolbar; right-click opens context menu
+ * - Android: long-press opens context menu directly
  *
  * Spacing:
  * - 72dp total left column (16dp padding + 40dp avatar + 16dp gap)
@@ -91,6 +84,7 @@ fun MessageItem(
     onMoreClick: () -> Unit = {},
     onCopyText: () -> Unit = {},
     onCopyLink: () -> Unit = {},
+    onShareLink: () -> Unit = {},
     onCopyJson: () -> Unit = {},
     onPinMessage: () -> Unit = {},
     onDeleteMessage: () -> Unit = {},
@@ -105,6 +99,7 @@ fun MessageItem(
     val currentOnReactionClick by rememberUpdatedState(onReactionClick)
     val currentOnCopyText by rememberUpdatedState(onCopyText)
     val currentOnCopyLink by rememberUpdatedState(onCopyLink)
+    val currentOnShareLink by rememberUpdatedState(onShareLink)
     val currentOnCopyJson by rememberUpdatedState(onCopyJson)
     val currentOnPinMessage by rememberUpdatedState(onPinMessage)
     val currentOnDeleteMessage by rememberUpdatedState(onDeleteMessage)
@@ -214,7 +209,11 @@ fun MessageItem(
                 showContextMenu = true
             })
             .background(
-                if (isHovered || isPressed) NostrordColors.MessageHover else highlightColor
+                when {
+                    showContextMenu -> NostrordColors.SurfaceVariant
+                    isHovered || isPressed -> NostrordColors.MessageHover
+                    else -> highlightColor
+                }
             )
     ) {
         // Main message content - this defines the Box size
@@ -356,6 +355,7 @@ fun MessageItem(
                     MessageContextAction.Reply -> currentOnReplyClick()
                     MessageContextAction.CopyText -> currentOnCopyText()
                     MessageContextAction.CopyMessageLink -> currentOnCopyLink()
+                    MessageContextAction.ShareMessageLink -> currentOnShareLink()
                     MessageContextAction.CopyEventJson -> currentOnCopyJson()
                     MessageContextAction.PinMessage -> currentOnPinMessage()
                     MessageContextAction.DeleteMessage -> currentOnDeleteMessage()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.kt
@@ -3,14 +3,12 @@ package org.nostr.nostrord.ui.components.chat
 import androidx.compose.ui.Modifier
 
 /**
- * Returns a Modifier that detects right-click (secondary button) and triggers the callback.
+ * Returns a Modifier that opens the context menu via the platform's secondary interaction.
  *
  * Platform behavior:
- * - Desktop (JVM): Detects right-click via PointerEvent.button
- * - Mobile (Android/iOS): No-op, context menu accessed via "More" button
- * - Web (JS/WasmJS): Detects right-click via contextmenu event
- *
- * This modifier does NOT interfere with text selection as it only responds to
- * secondary button presses, not primary button or touch gestures.
+ * - Desktop (JVM): right-click via PointerEvent secondary button
+ * - Android: long-press via detectTapGestures
+ * - iOS: no-op (context menu accessed via "More" button)
+ * - Web (JS/WasmJS): contextmenu event
  */
 expect fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -47,7 +47,9 @@ fun GroupScreen(
     onOpenDrawer: () -> Unit = {},
     forceDesktop: Boolean = false,
     pendingInviteCode: String? = null,
-    onInviteCodeConsumed: () -> Unit = {}
+    onInviteCodeConsumed: () -> Unit = {},
+    targetMessageId: String? = null,
+    onTargetMessageConsumed: () -> Unit = {}
 ) {
     val vm = viewModel(key = groupId) { GroupViewModel(AppModule.nostrRepository, groupId) }
 
@@ -757,7 +759,10 @@ fun GroupScreen(
                 isClosed = currentGroupMetadata?.isOpen == false,
                 isGroupRestricted = isGroupRestricted,
                 initialInviteCode = effectiveInviteCode,
-                onReachedBottom = { vm.markAsRead() }
+                onReachedBottom = { vm.markAsRead() },
+                targetMessageId = targetMessageId,
+                onTargetConsumed = onTargetMessageConsumed,
+                onFetchTargetById = { id -> vm.fetchMessageById(id) }
             )
         } else {
             GroupScreenDesktop(
@@ -860,7 +865,10 @@ fun GroupScreen(
                 isClosed = currentGroupMetadata?.isOpen == false,
                 isGroupRestricted = isGroupRestricted,
                 initialInviteCode = effectiveInviteCode,
-                onReachedBottom = { vm.markAsRead() }
+                onReachedBottom = { vm.markAsRead() },
+                targetMessageId = targetMessageId,
+                onTargetConsumed = onTargetMessageConsumed,
+                onFetchTargetById = { id -> vm.fetchMessageById(id) }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -114,7 +114,10 @@ fun GroupScreenDesktop(
     onInviteCodesClick: () -> Unit = {},
     isClosed: Boolean = false,
     isGroupRestricted: Boolean = false,
-    initialInviteCode: String? = null
+    initialInviteCode: String? = null,
+    targetMessageId: String? = null,
+    onTargetConsumed: () -> Unit = {},
+    onFetchTargetById: (String) -> Unit = {}
 ) {
 
     Row(modifier = Modifier.fillMaxSize()) {
@@ -194,7 +197,10 @@ fun GroupScreenDesktop(
                     onDeleteMessage = onDeleteMessage,
                     onReactionBadgeClick = onReactionBadgeClick,
                     onNavigateToGroup = onNavigateToGroup,
-                    onReachedBottom = onReachedBottom
+                    onReachedBottom = onReachedBottom,
+                    targetMessageId = targetMessageId,
+                    onTargetConsumed = onTargetConsumed,
+                    onFetchTargetById = onFetchTargetById
                 )
             }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -143,7 +143,10 @@ fun GroupScreenMobile(
     onInviteCodesClick: () -> Unit = {},
     isClosed: Boolean = false,
     isGroupRestricted: Boolean = false,
-    initialInviteCode: String? = null
+    initialInviteCode: String? = null,
+    targetMessageId: String? = null,
+    onTargetConsumed: () -> Unit = {},
+    onFetchTargetById: (String) -> Unit = {}
 ) {
     val scope = rememberCoroutineScope()
     var showMemberSheet by remember { mutableStateOf(false) }
@@ -245,7 +248,10 @@ fun GroupScreenMobile(
                         onDeleteMessage = onDeleteMessage,
                         onReactionBadgeClick = onReactionBadgeClick,
                         onNavigateToGroup = onNavigateToGroup,
-                        onReachedBottom = onReachedBottom
+                        onReachedBottom = onReachedBottom,
+                        targetMessageId = targetMessageId,
+                        onTargetConsumed = onTargetConsumed,
+                        onFetchTargetById = onFetchTargetById
                     )
                 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -239,6 +239,10 @@ class GroupViewModel(
         viewModelScope.launch { repo.loadMoreMessages(groupId, channel) }
     }
 
+    fun fetchMessageById(messageId: String) {
+        viewModelScope.launch { repo.fetchGroupMessageById(groupId, messageId) }
+    }
+
     fun switchRelay(relayUrl: String) {
         viewModelScope.launch { repo.switchRelay(relayUrl) }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import org.nostr.nostrord.utils.rememberClipboardWriter
+import org.nostr.nostrord.utils.rememberTextSharer
 import androidx.compose.ui.unit.dp
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonArray
@@ -106,6 +107,7 @@ fun MessagesList(
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
     val currentRelayUrl by AppModule.nostrRepository.currentRelayUrl.collectAsState()
     val copyToClipboard = rememberClipboardWriter()
+    val shareText = rememberTextSharer()
 
     // Hide ALL animated HTML overlays when the image viewer modal is open
     val parentHidden = LocalAnimatedImageHidden.current
@@ -393,6 +395,10 @@ fun MessagesList(
                                     onCopyLink = {
                                         val relay = currentRelayUrl ?: return@MessageItem
                                         copyToClipboard(buildShareMessageLink(relay, groupId, item.message.id))
+                                    },
+                                    onShareLink = {
+                                        val relay = currentRelayUrl ?: return@MessageItem
+                                        shareText(buildShareMessageLink(relay, groupId, item.message.id))
                                     },
                                     onCopyJson = {
                                         val msg = item.message

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -56,6 +56,7 @@ import org.nostr.nostrord.ui.components.chat.MessageItem
 import org.nostr.nostrord.ui.components.chat.NewMessagesDivider
 import org.nostr.nostrord.ui.components.chat.SystemEventItem
 import org.nostr.nostrord.ui.components.chat.ZapEventItem
+import org.nostr.nostrord.ui.util.buildShareMessageLink
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import androidx.compose.ui.unit.sp
 import org.nostr.nostrord.ui.components.scrollbar.VerticalScrollbarWrapper
@@ -89,12 +90,17 @@ fun MessagesList(
     onReactionBadgeClick: (messageId: String, emoji: String) -> Unit = { _, _ -> },
     onScrollToMessage: (String) -> Unit = {},
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
-    onReachedBottom: () -> Unit = {}
+    onReachedBottom: () -> Unit = {},
+    targetMessageId: String? = null,
+    onTargetConsumed: () -> Unit = {},
+    onFetchTargetById: (String) -> Unit = {}
 ) {
     val currentOnUsernameClick by rememberUpdatedState(onUsernameClick)
     val currentOnReplyClick by rememberUpdatedState(onReplyClick)
     val currentOnLoadMore by rememberUpdatedState(onLoadMore)
     val currentOnReachedBottom by rememberUpdatedState(onReachedBottom)
+    val currentOnFetchTargetById by rememberUpdatedState(onFetchTargetById)
+    val currentChatItems by rememberUpdatedState(chatItems)
 
     var reactingToMessageId by remember { mutableStateOf<String?>(null) }
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
@@ -124,25 +130,76 @@ fun MessagesList(
         is ChatItem.ZapEvent -> "zap_${item.id}"
     }
 
+    val isSeekingTarget = targetMessageId != null
+    val currentOnTargetConsumed by rememberUpdatedState(onTargetConsumed)
+
+    // Correct scroll position after pagination prepends items.
+    val currentHasMore by rememberUpdatedState(hasMoreMessages)
+    val currentIsLoadingMore by rememberUpdatedState(isLoadingMore)
+
     ScrollPositionEffect(
         groupId = groupId,
         listState = listState,
         items = chatItems,
         stateHolder = scrollStateHolder,
         getItemKey = ::getItemKey,
-        initialScrollToEnd = true
+        initialScrollToEnd = !isSeekingTarget
     )
 
     AutoScrollEffect(
         listState = listState,
         items = chatItems,
         getItemKey = ::getItemKey,
-        enabled = scrollStateHolder.isRestored || !scrollStateHolder.isRestorationPending
+        enabled = (scrollStateHolder.isRestored || !scrollStateHolder.isRestorationPending) && !isSeekingTarget
     )
 
+    // Fetch by ID immediately — covers cursor-drift misses independently of pagination.
+    LaunchedEffect(groupId, targetMessageId) {
+        val id = targetMessageId ?: return@LaunchedEffect
+        currentOnFetchTargetById(id)
+    }
+
+    var seekScrollApplied by remember(groupId) { mutableStateOf(false) }
+    var highlightedMessageId by remember(groupId) { mutableStateOf<String?>(null) }
+
+    // hasMoreMessages and isLoadingMore are keys so the effect re-fires on the
+    // InitialLoading→HasMore transition (state change without chatItems.size changing).
+    LaunchedEffect(chatItems.size, targetMessageId, hasMoreMessages, isLoadingMore) {
+        val id = targetMessageId ?: run { seekScrollApplied = false; return@LaunchedEffect }
+        val idx = chatItems.indexOfFirst { it is ChatItem.Message && it.message.id == id }
+        when {
+            idx >= 0 -> {
+                seekScrollApplied = true
+                highlightedMessageId = id
+                listState.scrollToItem(idx)
+                currentOnTargetConsumed()
+            }
+            chatItems.isNotEmpty() && hasMoreMessages && !isLoadingMore -> currentOnLoadMore()
+        }
+    }
+
+    // Fallback after exhaustion: delay 500ms to let the eventOrderingBuffer (300ms debounce)
+    // flush the last page, then check once more before giving up.
+    // Empty snapshot means the relay served nothing (relay switch in progress) — preserve target.
+    LaunchedEffect(targetMessageId, hasMoreMessages, isLoadingMore) {
+        val id = targetMessageId ?: return@LaunchedEffect
+        if (hasMoreMessages || isLoadingMore) return@LaunchedEffect
+        kotlinx.coroutines.delay(500)
+        val snapshot = currentChatItems
+        val idx = snapshot.indexOfFirst { it is ChatItem.Message && it.message.id == id }
+        if (idx >= 0) {
+            seekScrollApplied = true
+            highlightedMessageId = id
+            listState.scrollToItem(idx)
+            currentOnTargetConsumed()
+            return@LaunchedEffect
+        }
+        if (snapshot.isEmpty()) return@LaunchedEffect
+        listState.scrollToItem(snapshot.lastIndex)
+        currentOnTargetConsumed()
+    }
+
     // Correct scroll position after pagination prepends items.
-    val currentHasMore by rememberUpdatedState(hasMoreMessages)
-    val currentIsLoadingMore by rememberUpdatedState(isLoadingMore)
     var previousFirstKey by remember(groupId) { mutableStateOf<String?>(null) }
     LaunchedEffect(groupId, chatItems.size) {
         if (chatItems.isEmpty()) return@LaunchedEffect
@@ -150,11 +207,16 @@ fun MessagesList(
         val prevKey = previousFirstKey
         previousFirstKey = currentFirstKey
 
+        if (seekScrollApplied) {
+            seekScrollApplied = false
+            return@LaunchedEffect
+        }
+
         if (prevKey != null && currentFirstKey != prevKey) {
-            val saved = scrollStateHolder.savedPosition ?: return@LaunchedEffect
-            val newIndex = chatItems.indexOfFirst { getItemKey(it) == saved.anchorKey }
+            val saved = scrollStateHolder.savedPosition
+            val newIndex = saved?.let { chatItems.indexOfFirst { getItemKey(it) == saved.anchorKey } } ?: -1
             if (newIndex >= 0) {
-                listState.scrollToItem(newIndex, saved.offset)
+                listState.scrollToItem(newIndex, saved!!.offset)
             }
         }
     }
@@ -327,6 +389,11 @@ fun MessagesList(
                                     },
                                     onScrollToMessage = onScrollToMessage,
                                     onNavigateToGroup = onNavigateToGroup,
+                                    isHighlighted = item.message.id == highlightedMessageId,
+                                    onCopyLink = {
+                                        val relay = currentRelayUrl ?: return@MessageItem
+                                        copyToClipboard(buildShareMessageLink(relay, groupId, item.message.id))
+                                    },
                                     onCopyJson = {
                                         val msg = item.message
                                         val json = buildJsonObject {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
@@ -31,3 +31,14 @@ fun buildShareGroupLink(relayUrl: String, groupId: String): String {
     return if (origin != null) "$origin/?relay=$host&group=$groupId"
     else "https://nostrord.com/open/?relay=$host&group=$groupId"
 }
+
+/**
+ * Builds a shareable link pointing to a specific message within a group.
+ * On web uses the current origin, on native uses https://nostrord.com/open/.
+ */
+fun buildShareMessageLink(relayUrl: String, groupId: String, messageId: String): String {
+    val host = relayHost(relayUrl)
+    val origin = platformAppOrigin()
+    return if (origin != null) "$origin/?relay=$host&group=$groupId&message=$messageId"
+    else "https://nostrord.com/open/?relay=$host&group=$groupId&message=$messageId"
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
@@ -1,6 +1,6 @@
 package org.nostr.nostrord.ui.util
 
-import org.nostr.nostrord.ui.navigation.platformAppOrigin
+private const val OPEN_BASE = "https://nostrord.com/open/"
 
 private fun relayHost(relayUrl: String): String =
     relayUrl
@@ -10,35 +10,17 @@ private fun relayHost(relayUrl: String): String =
         .removePrefix("http://")
         .trimEnd('/')
 
-/**
- * Builds a shareable relay link.
- * On web uses the current origin, on native uses https://nostrord.com/open/.
- */
 fun buildShareRelayLink(relayUrl: String): String {
     val host = relayHost(relayUrl)
-    val origin = platformAppOrigin()
-    return if (origin != null) "$origin/?relay=$host"
-    else "https://nostrord.com/open/?relay=$host"
+    return "${OPEN_BASE}?relay=$host"
 }
 
-/**
- * Builds a shareable group link.
- * On web uses the current origin, on native uses https://nostrord.com/open/.
- */
 fun buildShareGroupLink(relayUrl: String, groupId: String): String {
     val host = relayHost(relayUrl)
-    val origin = platformAppOrigin()
-    return if (origin != null) "$origin/?relay=$host&group=$groupId"
-    else "https://nostrord.com/open/?relay=$host&group=$groupId"
+    return "${OPEN_BASE}?relay=$host&group=$groupId"
 }
 
-/**
- * Builds a shareable link pointing to a specific message within a group.
- * On web uses the current origin, on native uses https://nostrord.com/open/.
- */
 fun buildShareMessageLink(relayUrl: String, groupId: String, messageId: String): String {
     val host = relayHost(relayUrl)
-    val origin = platformAppOrigin()
-    return if (origin != null) "$origin/?relay=$host&group=$groupId&message=$messageId"
-    else "https://nostrord.com/open/?relay=$host&group=$groupId&message=$messageId"
+    return "${OPEN_BASE}?relay=$host&group=$groupId&e=$messageId"
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/ShareUtils.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/ShareUtils.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+
+expect val supportsNativeShare: Boolean
+
+@Composable
+expect fun rememberTextSharer(): (String) -> Unit

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/utils/ShareUtils.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/utils/ShareUtils.ios.kt
@@ -1,0 +1,20 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import kotlinx.coroutines.launch
+
+actual val supportsNativeShare: Boolean = false
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+actual fun rememberTextSharer(): (String) -> Unit {
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    return { text ->
+        scope.launch { clipboard.setClipEntry(ClipEntry.withPlainText(text)) }
+    }
+}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/utils/ShareUtils.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/utils/ShareUtils.js.kt
@@ -1,0 +1,20 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import kotlinx.coroutines.launch
+
+actual val supportsNativeShare: Boolean = false
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+actual fun rememberTextSharer(): (String) -> Unit {
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    return { text ->
+        scope.launch { clipboard.setClipEntry(ClipEntry.withPlainText(text)) }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
@@ -53,9 +53,10 @@ private fun parseDeepLinkUrl(url: String): ExternalLaunchContext? {
     val relayUrl = relay.toRelayUrl().takeIf { it.isNotBlank() } ?: return null
     val groupId = params["group"]?.takeIf { it.isNotBlank() }
     val inviteCode = params["code"]?.takeIf { it.isNotBlank() }
+    val messageId = params["e"]?.takeIf { it.isNotBlank() }
 
     return if (groupId != null) {
-        ExternalLaunchContext.OpenGroup(groupId = groupId, groupName = null, relayUrl = relayUrl, inviteCode = inviteCode)
+        ExternalLaunchContext.OpenGroup(groupId = groupId, groupName = null, relayUrl = relayUrl, inviteCode = inviteCode, messageId = messageId)
     } else {
         ExternalLaunchContext.OpenRelay(relayUrl)
     }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/ShareUtils.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/ShareUtils.jvm.kt
@@ -1,0 +1,13 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+
+actual val supportsNativeShare: Boolean = false
+
+@Composable
+actual fun rememberTextSharer(): (String) -> Unit = { text ->
+    val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+    clipboard.setContents(StringSelection(text), null)
+}

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/utils/ShareUtils.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/utils/ShareUtils.wasmJs.kt
@@ -1,0 +1,20 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import androidx.compose.ui.platform.LocalClipboard
+import kotlinx.coroutines.launch
+
+actual val supportsNativeShare: Boolean = false
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+actual fun rememberTextSharer(): (String) -> Unit {
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
+    return { text ->
+        scope.launch { clipboard.setClipEntry(ClipEntry.withPlainText(text)) }
+    }
+}

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
@@ -47,9 +47,10 @@ private fun parseDeepLinkFromUrl() {
     val relayUrl = relay.toRelayUrl().takeIf { it.isNotBlank() } ?: return
     val groupId = params["group"]?.takeIf { it.isNotBlank() }
     val inviteCode = params["code"]?.takeIf { it.isNotBlank() }
+    val messageId = params["message"]?.takeIf { it.isNotBlank() }
 
     val context = if (groupId != null) {
-        ExternalLaunchContext.OpenGroup(groupId = groupId, groupName = null, relayUrl = relayUrl, inviteCode = inviteCode)
+        ExternalLaunchContext.OpenGroup(groupId = groupId, groupName = null, relayUrl = relayUrl, inviteCode = inviteCode, messageId = messageId)
     } else {
         ExternalLaunchContext.OpenRelay(relayUrl)
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
@@ -47,7 +47,7 @@ private fun parseDeepLinkFromUrl() {
     val relayUrl = relay.toRelayUrl().takeIf { it.isNotBlank() } ?: return
     val groupId = params["group"]?.takeIf { it.isNotBlank() }
     val inviteCode = params["code"]?.takeIf { it.isNotBlank() }
-    val messageId = params["message"]?.takeIf { it.isNotBlank() }
+    val messageId = params["e"]?.takeIf { it.isNotBlank() }
 
     val context = if (groupId != null) {
         ExternalLaunchContext.OpenGroup(groupId = groupId, groupName = null, relayUrl = relayUrl, inviteCode = inviteCode, messageId = messageId)


### PR DESCRIPTION
## Summary

- Adds `?e=<eventId>` deep-link that opens the app and scrolls to a specific message in any group, paginating backwards until found
- Long-press on Android now opens the context menu directly (was inaccessible — hover toolbar never showed without a mouse)
- Context menu highlights the active message with `SurfaceVariant` while open
- Android gets a native share sheet for message links; desktop/web keeps "Copy Message Link"
- All copy/share actions now generate `https://nostrord.com/open/` links so recipients land on the universal entry page regardless of their platform
- Group image fallback to Jdenticon on load error in chat naddr embeds (was broken on Android)

## Bug fixes

- `awaitTrackingForSubscription` race: tracking coroutines were registered asynchronously so EOSE could read an empty map and set `Exhausted` instead of `HasMore`, cutting pagination short. Fixed with a synchronous `MutableStateFlow` counter incremented before `scope.launch`.
- Premature seek target consumption for non-joined groups: `switchRelay` is async so the first page loaded against the old relay returned 0 events, triggering the exhaustion fallback which cleared the seek target before the correct relay connected. Fixed by skipping consumption when the message list is empty.

Closes https://github.com/nostrord/nostrord/issues/34