### PR TITLE
feat(arch): add AUR PKGBUILD for nostrord-bin

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: Anderson Juhasc <anjhc@proton.me>
+pkgname=nostrord-bin
+pkgver=1.0.0
+pkgrel=1
+pkgdesc="Nostr NIP-29 group messaging client"
+arch=('x86_64')
+url="https://github.com/Nostrord/nostrord"
+license=('MIT')
+provides=('nostrord')
+conflicts=('nostrord')
+depends=('libxtst' 'libxrender' 'fontconfig' 'freetype2')
+install=nostrord-bin.install
+source=("nostrord-${pkgver}.deb::https://github.com/Nostrord/nostrord/releases/download/v${pkgver}/nostrord-${pkgver}-linux-amd64.deb")
+sha256sums=('SKIP')
+
+package() {
+    cd "${srcdir}"
+
+    # Extract .deb data archive
+    bsdtar -xf "nostrord-${pkgver}.deb" data.tar.xz 2>/dev/null \
+        || bsdtar -xf "nostrord-${pkgver}.deb" data.tar.gz 2>/dev/null \
+        || bsdtar -xf "nostrord-${pkgver}.deb" data.tar.zst
+    bsdtar -xf data.tar.* -C "${pkgdir}"
+
+    # Move .desktop to the standard location (deb puts it in /opt via xdg-desktop-menu)
+    local desktop_src="${pkgdir}/opt/nostrord/lib/nostrord-Nostrord.desktop"
+    if [[ -f "${desktop_src}" ]]; then
+        install -Dm644 "${desktop_src}" \
+            "${pkgdir}/usr/share/applications/nostrord.desktop"
+    fi
+
+    # Launcher wrapper at /usr/bin
+    install -Dm755 /dev/stdin "${pkgdir}/usr/bin/nostrord" <<'EOF'
+#!/bin/sh
+exec /opt/nostrord/bin/Nostrord "$@"
+EOF
+}

--- a/aur/nostrord-bin.install
+++ b/aur/nostrord-bin.install
@@ -1,0 +1,14 @@
+post_install() {
+    update-desktop-database -q
+    xdg-mime default nostrord.desktop x-scheme-handler/nostrord 2>/dev/null || true
+    gtk-update-icon-cache -q -f -t /usr/share/icons/hicolor 2>/dev/null || true
+}
+
+post_upgrade() {
+    post_install
+}
+
+post_remove() {
+    update-desktop-database -q
+    gtk-update-icon-cache -q -f -t /usr/share/icons/hicolor 2>/dev/null || true
+}


### PR DESCRIPTION
## Summary

- Add `aur/PKGBUILD` for `nostrord-bin` AUR package
- Add `aur/nostrord-bin.install` with post-install hooks

## How it works

The PKGBUILD downloads the prebuilt `.deb` from GitHub Releases, extracts it with `bsdtar`, and installs:

- `/opt/nostrord/` — JVM runtime + app (bundled, no Java required)
- `/usr/bin/nostrord` — launcher wrapper
- `/usr/share/applications/nostrord.desktop` — app menu entry with `nostrord://` deep link handler
- `/usr/share/icons/hicolor/{16..512}/` — icons at all sizes

After publishing to AUR, Arch Linux users can install with:

```
yay -S nostrord-bin
```
