### PR TITLE
feat(chat): add jump-to-latest button when scrolled up

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -12,10 +12,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -24,9 +26,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.launch
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -103,6 +107,7 @@ fun MessagesList(
     val currentOnFetchTargetById by rememberUpdatedState(onFetchTargetById)
     val currentChatItems by rememberUpdatedState(chatItems)
 
+    val coroutineScope = rememberCoroutineScope()
     var reactingToMessageId by remember { mutableStateOf<String?>(null) }
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
     val currentRelayUrl by AppModule.nostrRepository.currentRelayUrl.collectAsState()
@@ -462,6 +467,34 @@ fun MessagesList(
                                 text = "Loading messages…",
                                 color = NostrordColors.TextMuted,
                                 fontSize = 11.sp
+                            )
+                        }
+                    }
+
+                    AnimatedVisibility(
+                        visible = scrollStateHolder.isScrolledAway,
+                        enter = fadeIn(),
+                        exit = fadeOut(),
+                        modifier = Modifier.align(Alignment.BottomEnd).padding(end = 12.dp, bottom = 12.dp)
+                    ) {
+                        SmallFloatingActionButton(
+                            onClick = {
+                                coroutineScope.launch {
+                                    val lastIndex = chatItems.lastIndex
+                                    val distance = lastIndex - listState.firstVisibleItemIndex
+                                    if (distance <= 30) {
+                                        listState.animateScrollToItem(lastIndex)
+                                    } else {
+                                        listState.scrollToItem(lastIndex, Int.MAX_VALUE)
+                                    }
+                                }
+                            },
+                            containerColor = NostrordColors.Primary,
+                            contentColor = MaterialTheme.colorScheme.onPrimary
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.KeyboardArrowDown,
+                                contentDescription = "Jump to latest message"
                             )
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ScrollPositionCache.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ScrollPositionCache.kt
@@ -64,6 +64,9 @@ class ScrollStateHolder(
     var isRestorationPending by mutableStateOf(initialPosition != null)
         private set
 
+    var isScrolledAway by mutableStateOf(false)
+        internal set
+
     fun savePosition(anchorKey: String, offset: Int) {
         val position = ScrollPosition(anchorKey, offset)
         savedPosition = position
@@ -129,7 +132,6 @@ fun <T> ScrollPositionEffect(
     initialScrollToEnd: Boolean = true
 ) {
     val currentItems by rememberUpdatedState(items)
-    var userScrolledAway by remember(groupId) { mutableStateOf(false) }
 
     // Scroll to bottom once items appear, keep scrolling while load delivers more.
     LaunchedEffect(groupId) {
@@ -144,7 +146,7 @@ fun <T> ScrollPositionEffect(
         }
         stateHolder.markRestored()
 
-        snapshotFlow { currentItems.size to userScrolledAway }
+        snapshotFlow { currentItems.size to stateHolder.isScrolledAway }
             .distinctUntilChanged()
             .collect { (_, scrolledAway) ->
                 if (!scrolledAway) {
@@ -159,12 +161,27 @@ fun <T> ScrollPositionEffect(
     // Track when user scrolls away from bottom.
     LaunchedEffect(groupId, listState) {
         if (!initialScrollToEnd) return@LaunchedEffect
-        snapshotFlow { listState.firstVisibleItemIndex to currentItems.size }
+        var prevFirstVisible = listState.firstVisibleItemIndex
+        snapshotFlow {
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+            lastVisible to listState.firstVisibleItemIndex
+        }
             .distinctUntilChanged()
-            .collect { (firstVisible, size) ->
-                if (size > 0) {
-                    val nearBottom = firstVisible >= size - 5
-                    userScrolledAway = !nearBottom
+            .collect { (lastVisible, firstVisible) ->
+                val size = currentItems.size
+                if (size > 0 && lastVisible >= 0) {
+                    val atBottom = lastVisible >= size - 1
+                    if (atBottom) {
+                        stateHolder.isScrolledAway = false
+                    } else {
+                        when {
+                            firstVisible > prevFirstVisible -> stateHolder.isScrolledAway = true
+                            firstVisible < prevFirstVisible -> stateHolder.isScrolledAway = false
+                        }
+                    }
+                    prevFirstVisible = firstVisible
+                } else {
+                    stateHolder.isScrolledAway = false
                 }
             }
     }
@@ -177,7 +194,7 @@ fun <T> ScrollPositionEffect(
             .collect { (canScrollFwd, firstVisible) ->
                 val curItems = currentItems
                 val nearBottom = curItems.isNotEmpty() && firstVisible >= curItems.size - 5
-                if (canScrollFwd && nearBottom && !userScrolledAway) {
+                if (canScrollFwd && nearBottom && !stateHolder.isScrolledAway) {
                     listState.scrollToItem(curItems.lastIndex, Int.MAX_VALUE)
                 }
             }


### PR DESCRIPTION
## Summary

- Adds a floating action button (down arrow) that appears when the user reverses scroll direction toward the latest messages
- Button is hidden while reading history (scrolling up) and disappears when reaching the bottom
- Tapping animates smoothly if within 30 items of the bottom, jumps instantly otherwise

## Changes

- `ScrollPositionCache.kt` — exposes `isScrolledAway` on `ScrollStateHolder`; scroll-away detection now uses last visible item index and scroll direction instead of first visible item index
- `MessagesList.kt` — renders `SmallFloatingActionButton` with `AnimatedVisibility` inside the existing message list `Box`

Closes nostrord/nostrord#37
