### PR TITLE
feat: paste images and share media for upload

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -37,6 +37,40 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" android:host="nostrord.com" android:pathPrefix="/open" />
             </intent-filter>
+
+            <!-- Share a single media file from another app -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+
+            <!-- Share multiple media files from another app -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="video/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -2,6 +2,8 @@ package org.nostr.nostrord
 
 import android.content.Intent
 import android.graphics.Color
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -14,6 +16,7 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import org.nostr.nostrord.network.upload.ShareMediaQueue
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -26,6 +29,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
         super.onCreate(savedInstanceState)
         handleDeepLink(intent)
+        handleShareIntent(intent)
         setContent {
             Box(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
                 Box(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
@@ -38,6 +42,28 @@ class MainActivity : ComponentActivity() {
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleDeepLink(intent)
+        handleShareIntent(intent)
+    }
+
+    private fun handleShareIntent(intent: Intent?) {
+        if (intent == null) return
+        @Suppress("DEPRECATION")
+        val uris: List<Uri> = when (intent.action) {
+            Intent.ACTION_SEND -> listOfNotNull(
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                    intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java)
+                else
+                    intent.getParcelableExtra(Intent.EXTRA_STREAM)
+            )
+            Intent.ACTION_SEND_MULTIPLE -> (
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
+                    intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM, Uri::class.java)
+                else
+                    intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM)
+            )?.toList() ?: emptyList()
+            else -> emptyList()
+        }
+        if (uris.isNotEmpty()) ShareMediaQueue.offer(uris)
     }
 
     private fun handleDeepLink(intent: Intent?) {

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.android.kt
@@ -1,0 +1,61 @@
+package org.nostr.nostrord.network.upload
+
+import android.content.ClipboardManager
+import android.content.Context
+import android.provider.OpenableColumns
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+actual class ClipboardImageReader(private val context: Context) {
+    private val cm = context.getSystemService(ClipboardManager::class.java)
+
+    actual fun hasImage(): Boolean {
+        val desc = cm?.primaryClipDescription ?: return false
+        return desc.hasMimeType("image/*") ||
+               desc.hasMimeType("video/*") ||
+               desc.hasMimeType("audio/*")
+    }
+
+    actual suspend fun read(): Pair<ByteArray, String>? = withContext(Dispatchers.IO) {
+        val clip = cm?.primaryClip ?: return@withContext null
+        val item = clip.getItemAt(0) ?: return@withContext null
+        val uri = item.uri ?: return@withContext null
+        val mimeType = context.contentResolver.getType(uri) ?: return@withContext null
+        if (!isSupportedMediaMime(mimeType)) return@withContext null
+        val fileSize = context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)
+            ?.use { c -> if (c.moveToFirst()) c.getLong(0) else null }
+        if (fileSize != null && fileSize > MAX_UPLOAD_BYTES) throw FileTooLargeException()
+        val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            ?: return@withContext null
+        val ext = mimeToExtension(mimeType)
+        bytes to "clipboard.$ext"
+    }
+}
+
+private fun mimeToExtension(mime: String): String = when (mime) {
+    "image/jpeg"      -> "jpg"
+    "image/png"       -> "png"
+    "image/gif"       -> "gif"
+    "image/webp"      -> "webp"
+    "video/mp4"       -> "mp4"
+    "video/quicktime" -> "mov"
+    "audio/mpeg"      -> "mp3"
+    "audio/ogg"       -> "ogg"
+    "audio/wav"       -> "wav"
+    "audio/flac"      -> "flac"
+    "audio/mp4"       -> "m4a"
+    "audio/aac"       -> "aac"
+    else              -> mime.substringAfterLast('/')
+}
+
+@Composable
+actual fun rememberClipboardImageReader(): ClipboardImageReader {
+    val context = LocalContext.current
+    return remember(context) { ClipboardImageReader(context) }
+}
+
+@Composable
+actual fun PasteMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {}

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.android.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
+import org.nostr.nostrord.network.upload.MAX_UPLOAD_BYTES
 
 actual class MediaPickerLauncher(private val doLaunch: () -> Unit) {
     actual fun launch() = doLaunch()
@@ -15,18 +16,36 @@ actual class MediaPickerLauncher(private val doLaunch: () -> Unit) {
 @Composable
 actual fun rememberMediaPickerLauncher(
     accept: MediaAccept,
+    onPickStart: () -> Unit,
+    onError: (String) -> Unit,
     onFilePicked: (ByteArray, String) -> Unit
 ): MediaPickerLauncher {
     val context = LocalContext.current
     val currentCallback = rememberUpdatedState(onFilePicked)
+    val currentErrorCallback = rememberUpdatedState(onError)
+    val currentPickStart = rememberUpdatedState(onPickStart)
     val mimeTypes = when (accept) {
         MediaAccept.Images            -> arrayOf("image/*")
-        MediaAccept.ImagesVideosAudio -> arrayOf("image/*", "video/mp4", "video/quicktime", "audio/*")
+        MediaAccept.ImagesVideosAudio -> arrayOf("image/*", "video/mp4", "video/quicktime", "video/webm", "audio/*")
     }
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri != null) {
+            currentPickStart.value()
+            val size = context.contentResolver
+                .query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)
+                ?.use { cursor ->
+                    if (cursor.moveToFirst()) {
+                        val idx = cursor.getColumnIndex(OpenableColumns.SIZE)
+                        if (idx >= 0) cursor.getLong(idx) else null
+                    } else null
+                }
+            if (size != null && size > MAX_UPLOAD_BYTES) {
+                currentErrorCallback.value("File is too large. The maximum upload size is 20 MB.")
+                return@rememberLauncherForActivityResult
+            }
+
             val name = context.contentResolver
                 .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
                 ?.use { cursor ->

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.android.kt
@@ -32,6 +32,11 @@ actual fun rememberMediaPickerLauncher(
         contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         if (uri != null) {
+            val mimeType = context.contentResolver.getType(uri)
+            if (mimeType == null || !isSupportedUploadMime(mimeType)) {
+                currentErrorCallback.value("This file type is not supported.\n\n$SUPPORTED_FORMATS_MESSAGE")
+                return@rememberLauncherForActivityResult
+            }
             currentPickStart.value()
             val size = context.contentResolver
                 .query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.android.kt
@@ -1,0 +1,55 @@
+package org.nostr.nostrord.network.upload
+
+import android.net.Uri
+import android.provider.OpenableColumns
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.flow.MutableStateFlow
+
+internal object ShareMediaQueue {
+    val pending = MutableStateFlow<List<Uri>>(emptyList())
+    fun offer(uris: List<Uri>) { pending.value = uris }
+    fun consume(): List<Uri> = pending.value.also { pending.value = emptyList() }
+}
+
+@Composable
+actual fun ShareMediaEffect(
+    onMediaPasted: (ByteArray, String) -> Unit,
+    onError: (String) -> Unit
+) {
+    val context = LocalContext.current
+    val currentCallback = rememberUpdatedState(onMediaPasted)
+    val currentOnError  = rememberUpdatedState(onError)
+
+    LaunchedEffect(Unit) {
+        ShareMediaQueue.pending.collect { uris ->
+            if (uris.isEmpty()) return@collect
+            val toProcess = ShareMediaQueue.consume()
+            for (uri in toProcess) {
+                try {
+                    val mimeType = context.contentResolver.getType(uri) ?: continue
+                    if (!isSupportedUploadMime(mimeType)) {
+                        currentOnError.value("This file type is not supported.\n\n$SUPPORTED_FORMATS_MESSAGE")
+                        continue
+                    }
+                    val size = context.contentResolver
+                        .query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)
+                        ?.use { c -> if (c.moveToFirst()) c.getLong(0) else null }
+                    if (size != null && size > MAX_UPLOAD_BYTES) {
+                        currentOnError.value("This file is too large. The maximum upload size is 20 MB.")
+                        continue
+                    }
+                    val name = context.contentResolver
+                        .query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)
+                        ?.use { c -> if (c.moveToFirst()) c.getString(0) else null }
+                        ?: "shared_media"
+                    val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                        ?: continue
+                    currentCallback.value(bytes, name)
+                } catch (_: Throwable) {}
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.android.kt
@@ -1,0 +1,5 @@
+package org.nostr.nostrord.network.upload
+
+internal actual suspend fun executeUpload(
+    url: String, bytes: ByteArray, filename: String, mimeType: String, authHeader: String
+): Pair<Int, String> = ktorExecuteUpload(NostrBuildUploader.client, url, bytes, filename, mimeType, authHeader)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.kt
@@ -1,0 +1,31 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+
+fun isSupportedMediaMime(mime: String): Boolean =
+    mime.startsWith("image/") || mime.startsWith("video/") || mime.startsWith("audio/")
+
+internal class FileTooLargeException :
+    Exception("This file is too large. The maximum upload size is 20 MB.")
+
+internal class UnsupportedFileTypeException(ext: String) :
+    Exception("\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE")
+
+expect class ClipboardImageReader {
+    fun hasImage(): Boolean
+    suspend fun read(): Pair<ByteArray, String>?
+}
+
+@Composable
+expect fun rememberClipboardImageReader(): ClipboardImageReader
+
+/**
+ * Side-effect composable that listens for paste events containing media (image/video/audio).
+ * On desktop/Android this is a no-op (handled via onPreviewKeyEvent + ClipboardImageReader).
+ * On web it registers a DOM paste listener for the lifetime of the composition.
+ */
+@Composable
+expect fun PasteMediaEffect(
+    onMediaPasted: (ByteArray, String) -> Unit,
+    onError: (String) -> Unit = {}
+)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.kt
@@ -3,9 +3,9 @@ package org.nostr.nostrord.network.upload
 import androidx.compose.runtime.Composable
 
 enum class MediaAccept {
-    /** Only still images: jpg, png, gif, webp */
+    /** Only still images: jpg, png, gif, webp, avif */
     Images,
-    /** Images + video + audio */
+    /** Images + video (mp4, mov, webm) + audio (mp3, ogg, wav, flac, m4a, aac, opus) */
     ImagesVideosAudio,
 }
 
@@ -21,5 +21,7 @@ expect class MediaPickerLauncher {
 @Composable
 expect fun rememberMediaPickerLauncher(
     accept: MediaAccept = MediaAccept.Images,
+    onPickStart: () -> Unit = {},
+    onError: (String) -> Unit = {},
     onFilePicked: (ByteArray, String) -> Unit
 ): MediaPickerLauncher

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
@@ -1,14 +1,30 @@
 package org.nostr.nostrord.network.upload
 
-import io.ktor.client.request.forms.*
-import io.ktor.client.statement.*
-import io.ktor.http.*
+import kotlinx.coroutines.delay
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.createHttpClient
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 
 private const val UPLOAD_URL = "https://nostr.build/api/v2/upload/files"
+
+const val MAX_UPLOAD_BYTES: Long = 20L * 1024 * 1024
+
+const val SUPPORTED_FORMATS_MESSAGE =
+    "Supported formats:\n" +
+    "Images: jpg, png, gif, webp, avif\n" +
+    "Video: mp4, mov, webm\n" +
+    "Audio: mp3, ogg, wav, flac, m4a, aac, opus"
+
+internal fun isBlobRef(s: String) = s.startsWith("nostrord-blob|")
+
+internal val SUPPORTED_UPLOAD_MIMES = setOf(
+    "image/jpeg", "image/png", "image/gif", "image/webp", "image/avif",
+    "video/mp4", "video/quicktime", "video/webm",
+    "audio/mpeg", "audio/ogg", "audio/wav", "audio/flac", "audio/mp4", "audio/aac", "audio/opus"
+)
+
+internal fun isSupportedUploadMime(mime: String) = mime in SUPPORTED_UPLOAD_MIMES
 
 private val responseJson = Json { ignoreUnknownKeys = true }
 
@@ -38,7 +54,7 @@ data class UploadResult(
 }
 
 object NostrBuildUploader {
-    private val client by lazy { createHttpClient() }
+    internal val client by lazy { createHttpClient() }
 
     /**
      * Upload a file to nostr.build with NIP-98 auth.
@@ -51,88 +67,122 @@ object NostrBuildUploader {
         mimeType: String,
         buildAuthHeader: suspend (url: String, method: String) -> String?
     ): Result<UploadResult> {
-        return try {
-            val authHeader = buildAuthHeader(UPLOAD_URL, "POST")
-                ?: return Result.Error(AppError.Auth.NotAuthenticated)
-
-            val response = client.submitFormWithBinaryData(
-                url = UPLOAD_URL,
-                formData = formData {
-                    append(
-                        key = "fileToUpload",
-                        value = bytes,
-                        headers = Headers.build {
-                            append(HttpHeaders.ContentDisposition,
-                                "form-data; name=\"fileToUpload\"; filename=\"$filename\"")
-                            append(HttpHeaders.ContentType, mimeType)
-                        }
-                    )
-                }
-            ) {
-                headers.append(HttpHeaders.Authorization, authHeader)
-            }
-
-            val text = response.bodyAsText()
-
-            if (!response.status.isSuccess()) {
-                val msg = runCatching {
-                    responseJson.parseToJsonElement(text).jsonObject["message"]
-                        ?.jsonPrimitive?.contentOrNull
-                }.getOrNull() ?: "HTTP ${response.status.value}"
-                return Result.Error(AppError.Unknown("Upload failed: $msg"))
-            }
-
-            val json = responseJson.parseToJsonElement(text).jsonObject
-
-            val status = json["status"]?.jsonPrimitive?.contentOrNull
-            if (status != "success") {
-                val msg = json["message"]?.jsonPrimitive?.contentOrNull ?: text
-                return Result.Error(AppError.Unknown("Upload failed: $msg"))
-            }
-
-            // nostr.build v2 returns data as array; handle object shape defensively
-            val data = json["data"]
-            val entry = when {
-                data is JsonArray -> data.firstOrNull()?.jsonObject
-                data is JsonObject -> data
-                else -> null
-            }
-            val url = entry?.get("url")?.jsonPrimitive?.contentOrNull
-                ?: return Result.Error(AppError.Unknown("Upload failed: no URL in response"))
-
-            // Extract NIP-68 metadata from the response
-            val dimensions = entry["dimensions"]?.jsonObject
-            val result = UploadResult(
-                url = url,
-                mimeType = entry["mime"]?.jsonPrimitive?.contentOrNull
-                    ?: entry["type"]?.jsonPrimitive?.contentOrNull,
-                sha256 = entry["original_sha256"]?.jsonPrimitive?.contentOrNull
-                    ?: entry["sha256"]?.jsonPrimitive?.contentOrNull,
-                width = dimensions?.get("width")?.jsonPrimitive?.intOrNull,
-                height = dimensions?.get("height")?.jsonPrimitive?.intOrNull,
-                size = entry["size"]?.jsonPrimitive?.longOrNull
-            )
-
-            Result.Success(result)
-        } catch (e: Throwable) {
-            Result.Error(AppError.Unknown("Upload failed: ${e.message}", e))
+        val isCached = isBlobRef(filename)
+        val displayName = if (isCached) filename.split("|").getOrNull(2) ?: filename else filename
+        val sizeDesc = if (isCached) "clipboard cache" else {
+            val kb = bytes.size / 1024
+            "${bytes.size}B (${kb / 1024}.${((kb % 1024) * 100 / 1024).toString().padStart(2, '0')}MB)"
         }
+        println("[Upload] START  file=$displayName  size=$sizeDesc  mime=$mimeType  url=$UPLOAD_URL")
+
+        val authHeader = buildAuthHeader(UPLOAD_URL, "POST")
+        if (authHeader == null) {
+            println("[Upload] ERROR  auth header is null – not authenticated")
+            return Result.Error(AppError.Auth.NotAuthenticated)
+        }
+        println("[Upload] AUTH   header obtained (length=${authHeader.length})")
+
+        // Blob-ref uploads can't be retried — the JS cache entry is consumed on first use
+        val maxAttempts = if (isCached) 1 else 3
+        var lastException: Throwable? = null
+        repeat(maxAttempts) { attempt ->
+            println("[Upload] ATTEMPT ${attempt + 1}/$maxAttempts  file=$displayName")
+            try {
+                val result = doUpload(bytes, filename, mimeType, authHeader)
+                println("[Upload] DONE   file=$displayName  result=${
+                    when (result) {
+                        is Result.Success -> "SUCCESS url=${result.data.url}"
+                        is Result.Error   -> "SERVER_ERROR ${result.error.message}"
+                    }
+                }")
+                return result
+            } catch (e: Throwable) {
+                println("[Upload] EXCEPTION attempt=${attempt + 1}  type=${e::class.simpleName}  msg=${e.message}")
+                e.cause?.let { println("[Upload]   cause: ${it::class.simpleName}: ${it.message}") }
+                lastException = e
+                if (attempt < maxAttempts - 1) {
+                    println("[Upload] RETRY in 500ms…")
+                    delay(500)
+                }
+            }
+        }
+        println("[Upload] FAILED after $maxAttempts attempts  file=$displayName  lastError=${lastException?.message}")
+        return Result.Error(AppError.Unknown("Upload failed: ${lastException?.message}", lastException))
     }
 
-    fun mimeTypeForFilename(filename: String): String =
-        when (filename.substringAfterLast('.').lowercase()) {
+    // Throws on IO/connection errors so the caller can retry.
+    // Returns Result.Error for server-side errors (no retry needed).
+    private suspend fun doUpload(
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        authHeader: String
+    ): Result<UploadResult> {
+        println("[Upload] SEND   submitting multipart to $UPLOAD_URL")
+        val (statusCode, text) = executeUpload(UPLOAD_URL, bytes, filename, mimeType, authHeader)
+
+        println("[Upload] RESPONSE  status=$statusCode")
+        println("[Upload] BODY  (${text.length} chars): ${text.take(500)}${if (text.length > 500) "…" else ""}")
+
+        if (statusCode !in 200..299) {
+            val msg = runCatching {
+                responseJson.parseToJsonElement(text).jsonObject["message"]
+                    ?.jsonPrimitive?.contentOrNull
+            }.getOrNull() ?: "HTTP $statusCode"
+            return Result.Error(AppError.Unknown("Upload failed: $msg"))
+        }
+
+        val json = responseJson.parseToJsonElement(text).jsonObject
+
+        val status = json["status"]?.jsonPrimitive?.contentOrNull
+        if (status != "success") {
+            val msg = json["message"]?.jsonPrimitive?.contentOrNull ?: text
+            return Result.Error(AppError.Unknown("Upload failed: $msg"))
+        }
+
+        // nostr.build v2 returns data as array; handle object shape defensively
+        val data = json["data"]
+        val entry = when {
+            data is JsonArray -> data.firstOrNull()?.jsonObject
+            data is JsonObject -> data
+            else -> null
+        }
+        val url = entry?.get("url")?.jsonPrimitive?.contentOrNull
+            ?: return Result.Error(AppError.Unknown("Upload failed: no URL in response"))
+
+        // Extract NIP-68 metadata from the response
+        val dimensions = entry["dimensions"]?.jsonObject
+        return Result.Success(UploadResult(
+            url = url,
+            mimeType = entry["mime"]?.jsonPrimitive?.contentOrNull
+                ?: entry["type"]?.jsonPrimitive?.contentOrNull,
+            sha256 = entry["original_sha256"]?.jsonPrimitive?.contentOrNull
+                ?: entry["sha256"]?.jsonPrimitive?.contentOrNull,
+            width = dimensions?.get("width")?.jsonPrimitive?.intOrNull,
+            height = dimensions?.get("height")?.jsonPrimitive?.intOrNull,
+            size = entry["size"]?.jsonPrimitive?.longOrNull
+        ))
+    }
+
+    fun mimeTypeForFilename(filename: String): String {
+        if (isBlobRef(filename)) return filename.split("|").getOrNull(1) ?: "application/octet-stream"
+        return when (filename.substringAfterLast('.').lowercase()) {
             "jpg", "jpeg" -> "image/jpeg"
             "png"         -> "image/png"
             "gif"         -> "image/gif"
             "webp"        -> "image/webp"
             "mp4"         -> "video/mp4"
             "mov"         -> "video/quicktime"
+            "webm"        -> "video/webm"
             "mp3"         -> "audio/mpeg"
             "ogg"         -> "audio/ogg"
             "wav"         -> "audio/wav"
             "flac"        -> "audio/flac"
             "m4a"         -> "audio/mp4"
             "aac"         -> "audio/aac"
+            "opus"        -> "audio/opus"
+            "avif"        -> "image/avif"
             else          -> "application/octet-stream"
         }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.kt
@@ -1,0 +1,9 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+
+@Composable
+expect fun ShareMediaEffect(
+    onMediaPasted: (ByteArray, String) -> Unit,
+    onError: (String) -> Unit = {}
+)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.kt
@@ -1,0 +1,46 @@
+package org.nostr.nostrord.network.upload
+
+import io.ktor.client.*
+import io.ktor.client.plugins.timeout
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+
+internal expect suspend fun executeUpload(
+    url: String,
+    bytes: ByteArray,
+    filename: String,
+    mimeType: String,
+    authHeader: String
+): Pair<Int, String>
+
+internal suspend fun ktorExecuteUpload(
+    client: HttpClient,
+    url: String,
+    bytes: ByteArray,
+    filename: String,
+    mimeType: String,
+    authHeader: String
+): Pair<Int, String> {
+    val response = client.submitFormWithBinaryData(
+        url = url,
+        formData = formData {
+            append(
+                key = "fileToUpload",
+                value = bytes,
+                headers = Headers.build {
+                    append(HttpHeaders.ContentDisposition,
+                        "form-data; name=\"fileToUpload\"; filename=\"$filename\"")
+                    append(HttpHeaders.ContentType, mimeType)
+                }
+            )
+        }
+    ) {
+        headers.append(HttpHeaders.Authorization, authHeader)
+        timeout {
+            requestTimeoutMillis = 120_000
+            socketTimeoutMillis  = 60_000
+        }
+    }
+    return Pair(response.status.value, response.bodyAsText())
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
@@ -3,9 +3,13 @@ package org.nostr.nostrord.ui.components.upload
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerIcon
@@ -32,9 +36,13 @@ fun MessageUploadButton(
 ) {
     val scope = rememberCoroutineScope()
     var isUploading by remember { mutableStateOf(false) }
+    var uploadError by remember { mutableStateOf<String?>(null) }
 
-    val picker = rememberMediaPickerLauncher(accept = MediaAccept.ImagesVideosAudio) { bytes, filename ->
-        isUploading = true
+    val picker = rememberMediaPickerLauncher(
+        accept = MediaAccept.ImagesVideosAudio,
+        onPickStart = { isUploading = true },
+        onError = { isUploading = false; uploadError = it }
+    ) { bytes, filename ->
         scope.launch {
             try {
                 val mime = NostrBuildUploader.mimeTypeForFilename(filename)
@@ -42,11 +50,28 @@ fun MessageUploadButton(
                     bytes, filename, mime,
                     AppModule.nostrRepository::buildNip98AuthHeader
                 )
-                if (result is Result.Success) onUploadComplete(result.data)
+                when (result) {
+                    is Result.Success -> onUploadComplete(result.data)
+                    is Result.Error -> uploadError = result.error.message
+                }
             } finally {
                 isUploading = false
             }
         }
+    }
+
+    uploadError?.let { error ->
+        AlertDialog(
+            onDismissRequest = { uploadError = null },
+            title = { Text("Upload Failed") },
+            text = { Text(error) },
+            confirmButton = {
+                TextButton(
+                    onClick = { uploadError = null },
+                    colors = ButtonDefaults.textButtonColors(contentColor = NostrordColors.Primary)
+                ) { Text("OK") }
+            }
+        )
     }
 
     IconButton(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -35,7 +35,17 @@ import androidx.compose.material.icons.outlined.EmojiEmotions
 import org.nostr.nostrord.getPlatform
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.network.NostrGroupClient
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.upload.FileTooLargeException
+import org.nostr.nostrord.network.upload.UnsupportedFileTypeException
+import org.nostr.nostrord.network.upload.MAX_UPLOAD_BYTES
+import org.nostr.nostrord.network.upload.NostrBuildUploader
+import org.nostr.nostrord.network.upload.UploadResult
+import org.nostr.nostrord.network.upload.PasteMediaEffect
+import org.nostr.nostrord.network.upload.rememberClipboardImageReader
 import org.nostr.nostrord.ui.components.upload.MessageUploadButton
+import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
@@ -78,8 +88,13 @@ fun MessageInput(
     userMetadata: Map<String, UserMetadata> = emptyMap(),
     onCancelReply: () -> Unit = {},
     isSending: Boolean = false,
-    onMediaUploaded: (org.nostr.nostrord.network.upload.UploadResult) -> Unit = {}
+    onMediaUploaded: (UploadResult) -> Unit = {}
 ) {
+    val scope = rememberCoroutineScope()
+    val clipboardReader = rememberClipboardImageReader()
+    var isUploadingPaste by remember { mutableStateOf(false) }
+    var pasteError by remember { mutableStateOf<String?>(null) }
+
     var showMentionPopup by remember { mutableStateOf(false) }
     var mentionStartIndex by remember { mutableStateOf(-1) }
     var mentionQuery by remember { mutableStateOf("") }
@@ -110,6 +125,35 @@ fun MessageInput(
     }
 
     var textFieldValue by remember { mutableStateOf(TextFieldValue(messageInput)) }
+
+    suspend fun handlePastedMedia(bytes: ByteArray, filename: String) {
+        if (bytes.size.toLong() > MAX_UPLOAD_BYTES) {
+            isUploadingPaste = false
+            pasteError = "This file is too large. The maximum upload size is 20 MB."
+            return
+        }
+        try {
+            val mime = NostrBuildUploader.mimeTypeForFilename(filename)
+            val result = NostrBuildUploader.upload(
+                bytes, filename, mime,
+                AppModule.nostrRepository::buildNip98AuthHeader
+            )
+            when (result) {
+                is Result.Success -> {
+                    val url = result.data.url
+                    val current = textFieldValue.text
+                    val sep = if (current.isNotEmpty() && !current.endsWith(" ") && !current.endsWith("\n")) " " else ""
+                    val newText = current + sep + url
+                    textFieldValue = TextFieldValue(newText, TextRange(newText.length))
+                    onMessageInputChange(newText)
+                    onMediaUploaded(result.data)
+                }
+                is Result.Error -> pasteError = result.error.message
+            }
+        } finally {
+            isUploadingPaste = false
+        }
+    }
 
     // Sync with external messageInput when it changes (e.g., cleared after send)
     LaunchedEffect(messageInput) {
@@ -396,6 +440,33 @@ fun MessageInput(
                                     groupMentionSelectedIndex = (groupMentionSelectedIndex + 1).coerceAtMost(filteredGroups.size - 1)
                                     true
                                 }
+                                event.type == KeyEventType.KeyDown &&
+                                event.key == Key.V &&
+                                event.isCtrlPressed &&
+                                !isUploadingPaste -> {
+                                    val hasMedia = runCatching { clipboardReader.hasImage() }.getOrDefault(false)
+                                    if (hasMedia) {
+                                        isUploadingPaste = true
+                                        scope.launch {
+                                            val image = try {
+                                                clipboardReader.read()
+                                            } catch (e: FileTooLargeException) {
+                                                isUploadingPaste = false
+                                                pasteError = e.message
+                                                return@launch
+                                            } catch (e: UnsupportedFileTypeException) {
+                                                isUploadingPaste = false
+                                                pasteError = e.message
+                                                return@launch
+                                            }
+                                            if (image == null) { isUploadingPaste = false; return@launch }
+                                            handlePastedMedia(image.first, image.second)
+                                        }
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                }
                                 // Shift+Enter: manually insert newline at cursor (Discord-style)
                                 // Returning false here is unreliable in Compose Desktop — insert explicitly.
                                 event.type == KeyEventType.KeyDown &&
@@ -496,15 +567,15 @@ fun MessageInput(
 
                 IconButton(
                     onClick = {
-                        if (textFieldValue.text.isNotBlank() && !isSending) {
+                        if (textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste) {
                             showEmojiPicker = false
                             onSendMessage()
                         }
                     },
-                    enabled = textFieldValue.text.isNotBlank() && !isSending,
+                    enabled = textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste,
                     modifier = Modifier.size(40.dp)
                 ) {
-                    if (isSending) {
+                    if (isSending || isUploadingPaste) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(Spacing.iconMd),
                             color = NostrordColors.Primary,
@@ -638,6 +709,27 @@ fun MessageInput(
                 }
             }
             }
+        }
+
+        PasteMediaEffect(
+            onMediaPasted = { bytes, filename ->
+                if (!isUploadingPaste) {
+                    isUploadingPaste = true
+                    scope.launch { handlePastedMedia(bytes, filename) }
+                }
+            },
+            onError = { pasteError = it }
+        )
+
+        pasteError?.let { error ->
+            AlertDialog(
+                onDismissRequest = { pasteError = null },
+                title = { Text("Upload Failed") },
+                text = { Text(error) },
+                confirmButton = {
+                    TextButton(onClick = { pasteError = null }) { Text("OK") }
+                }
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -43,6 +43,7 @@ import org.nostr.nostrord.network.upload.MAX_UPLOAD_BYTES
 import org.nostr.nostrord.network.upload.NostrBuildUploader
 import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.network.upload.PasteMediaEffect
+import org.nostr.nostrord.network.upload.ShareMediaEffect
 import org.nostr.nostrord.network.upload.rememberClipboardImageReader
 import org.nostr.nostrord.ui.components.upload.MessageUploadButton
 import org.nostr.nostrord.utils.Result
@@ -712,6 +713,16 @@ fun MessageInput(
         }
 
         PasteMediaEffect(
+            onMediaPasted = { bytes, filename ->
+                if (!isUploadingPaste) {
+                    isUploadingPaste = true
+                    scope.launch { handlePastedMedia(bytes, filename) }
+                }
+            },
+            onError = { pasteError = it }
+        )
+
+        ShareMediaEffect(
             onMediaPasted = { bytes, filename ->
                 if (!isUploadingPaste) {
                     isUploadingPaste = true

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.ios.kt
@@ -1,0 +1,15 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+actual class ClipboardImageReader {
+    actual fun hasImage(): Boolean = false
+    actual suspend fun read(): Pair<ByteArray, String>? = null
+}
+
+@Composable
+actual fun rememberClipboardImageReader(): ClipboardImageReader = remember { ClipboardImageReader() }
+
+@Composable
+actual fun PasteMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.ios.kt
@@ -11,6 +11,8 @@ actual class MediaPickerLauncher(private val doLaunch: () -> Unit) {
 @Composable
 actual fun rememberMediaPickerLauncher(
     accept: MediaAccept,
+    onPickStart: () -> Unit,
+    onError: (String) -> Unit,
     onFilePicked: (ByteArray, String) -> Unit
 ): MediaPickerLauncher {
     return remember { MediaPickerLauncher { } }

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.ios.kt
@@ -1,0 +1,6 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun ShareMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.ios.kt
@@ -1,0 +1,5 @@
+package org.nostr.nostrord.network.upload
+
+internal actual suspend fun executeUpload(
+    url: String, bytes: ByteArray, filename: String, mimeType: String, authHeader: String
+): Pair<Int, String> = ktorExecuteUpload(NostrBuildUploader.client, url, bytes, filename, mimeType, authHeader)

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.js.kt
@@ -1,0 +1,67 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.browser.document
+import org.khronos.webgl.ArrayBuffer
+import org.khronos.webgl.Int8Array
+import org.w3c.dom.events.Event
+import org.w3c.files.FileReader
+
+actual class ClipboardImageReader {
+    actual fun hasImage(): Boolean = false
+    actual suspend fun read(): Pair<ByteArray, String>? = null
+}
+
+@Composable
+actual fun rememberClipboardImageReader(): ClipboardImageReader = remember { ClipboardImageReader() }
+
+@Composable
+actual fun PasteMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {
+    val currentCallback = rememberUpdatedState(onMediaPasted)
+    val currentOnError = rememberUpdatedState(onError)
+    DisposableEffect(Unit) {
+        val handler: (Event) -> Unit = handler@{ event ->
+            val items = event.asDynamic().clipboardData?.items ?: return@handler
+            val len = items.length as? Int ?: return@handler
+            for (i in 0 until len) {
+                val item = items[i] ?: continue
+                if (item.kind as? String != "file") continue
+                val type = item.type as? String ?: continue
+                if (!isSupportedMediaMime(type)) continue
+                val jsFile = item.getAsFile() ?: continue
+                event.preventDefault()
+                if (!isSupportedUploadMime(type)) {
+                    currentOnError.value("This file type is not supported.\n\n$SUPPORTED_FORMATS_MESSAGE")
+                    return@handler
+                }
+                val fileSize = jsFile.asDynamic().size as? Double ?: 0.0
+                if (fileSize > MAX_UPLOAD_BYTES) {
+                    currentOnError.value("This file is too large. The maximum upload size is 20 MB.")
+                    return@handler
+                }
+                val reader = FileReader()
+                reader.onload = {
+                    runCatching {
+                        val buffer = reader.result as ArrayBuffer
+                        val int8 = Int8Array(buffer)
+                        val bytes = ByteArray(int8.length).also { arr ->
+                            for (j in arr.indices) arr[j] = int8.asDynamic()[j]
+                        }
+                        val ext = type.substringAfterLast('/')
+                        val name = jsFile.asDynamic().name as? String ?: "clipboard.$ext"
+                        currentCallback.value(bytes, name)
+                    }
+                }
+                reader.asDynamic().readAsArrayBuffer(jsFile)
+                return@handler
+            }
+        }
+        document.addEventListener("paste", handler)
+        onDispose {
+            document.removeEventListener("paste", handler)
+        }
+    }
+}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.js.kt
@@ -17,12 +17,16 @@ actual class MediaPickerLauncher(private val doLaunch: () -> Unit) {
 @Composable
 actual fun rememberMediaPickerLauncher(
     accept: MediaAccept,
+    onPickStart: () -> Unit,
+    onError: (String) -> Unit,
     onFilePicked: (ByteArray, String) -> Unit
 ): MediaPickerLauncher {
     val currentCallback = rememberUpdatedState(onFilePicked)
+    val currentErrorCallback = rememberUpdatedState(onError)
+    val currentPickStart = rememberUpdatedState(onPickStart)
     val acceptAttr = when (accept) {
         MediaAccept.Images            -> "image/*"
-        MediaAccept.ImagesVideosAudio -> "image/*,video/mp4,video/quicktime,audio/*"
+        MediaAccept.ImagesVideosAudio -> "image/*,video/mp4,video/quicktime,video/webm,audio/*"
     }
     return remember(acceptAttr) {
         MediaPickerLauncher {
@@ -40,21 +44,27 @@ actual fun rememberMediaPickerLauncher(
             input.onchange = {
                 val file = input.files?.get(0)
                 if (file != null) {
-                    val reader = FileReader()
-                    reader.onload = {
-                        val buffer = reader.result as ArrayBuffer
-                        val int8 = Int8Array(buffer)
-                        // Copy via asDynamic() — Int8Array.get(index) operator resolution
-                        // is unreliable across Kotlin/JS versions; unsafeCast<ByteArray>()
-                        // may produce a raw JS object that Ktor's multipart writer rejects.
-                        val bytes = ByteArray(int8.length).also { arr ->
-                            for (i in arr.indices) arr[i] = int8.asDynamic()[i]
-                        }
-                        currentCallback.value(bytes, file.name)
+                    currentPickStart.value()
+                    if ((file.asDynamic().size as Double) > MAX_UPLOAD_BYTES.toDouble()) {
+                        currentErrorCallback.value("File is too large. The maximum upload size is 20 MB.")
                         cleanup()
+                    } else {
+                        val reader = FileReader()
+                        reader.onload = {
+                            val buffer = reader.result as ArrayBuffer
+                            val int8 = Int8Array(buffer)
+                            // Copy via asDynamic() — Int8Array.get(index) operator resolution
+                            // is unreliable across Kotlin/JS versions; unsafeCast<ByteArray>()
+                            // may produce a raw JS object that Ktor's multipart writer rejects.
+                            val bytes = ByteArray(int8.length).also { arr ->
+                                for (i in arr.indices) arr[i] = int8.asDynamic()[i]
+                            }
+                            currentCallback.value(bytes, file.name)
+                            cleanup()
+                        }
+                        reader.onerror = { cleanup() }
+                        reader.readAsArrayBuffer(file)
                     }
-                    reader.onerror = { cleanup() }
-                    reader.readAsArrayBuffer(file)
                 } else {
                     cleanup()
                 }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.js.kt
@@ -44,11 +44,14 @@ actual fun rememberMediaPickerLauncher(
             input.onchange = {
                 val file = input.files?.get(0)
                 if (file != null) {
-                    currentPickStart.value()
-                    if ((file.asDynamic().size as Double) > MAX_UPLOAD_BYTES.toDouble()) {
+                    if (!isSupportedUploadMime(file.type)) {
+                        currentErrorCallback.value("This file type is not supported.\n\n$SUPPORTED_FORMATS_MESSAGE")
+                        cleanup()
+                    } else if ((file.asDynamic().size as Double) > MAX_UPLOAD_BYTES.toDouble()) {
                         currentErrorCallback.value("File is too large. The maximum upload size is 20 MB.")
                         cleanup()
                     } else {
+                        currentPickStart.value()
                         val reader = FileReader()
                         reader.onload = {
                             val buffer = reader.result as ArrayBuffer

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.js.kt
@@ -1,0 +1,6 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun ShareMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.js.kt
@@ -1,0 +1,5 @@
+package org.nostr.nostrord.network.upload
+
+internal actual suspend fun executeUpload(
+    url: String, bytes: ByteArray, filename: String, mimeType: String, authHeader: String
+): Pair<Int, String> = ktorExecuteUpload(NostrBuildUploader.client, url, bytes, filename, mimeType, authHeader)

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.jvm.kt
@@ -1,0 +1,60 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.awt.datatransfer.DataFlavor
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import javax.imageio.ImageIO
+
+actual class ClipboardImageReader {
+    private val clipboard = java.awt.Toolkit.getDefaultToolkit().systemClipboard
+
+    actual fun hasImage(): Boolean =
+        runCatching {
+            clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor) ||
+            clipboard.isDataFlavorAvailable(DataFlavor.javaFileListFlavor)
+        }.getOrDefault(false)
+
+    actual suspend fun read(): Pair<ByteArray, String>? = withContext(Dispatchers.IO) {
+        when {
+            runCatching { clipboard.isDataFlavorAvailable(DataFlavor.imageFlavor) }.getOrDefault(false) -> {
+                val image = runCatching {
+                    clipboard.getData(DataFlavor.imageFlavor) as? java.awt.Image
+                }.getOrNull() ?: return@withContext null
+                val buffered = if (image is BufferedImage) image
+                else BufferedImage(
+                    image.getWidth(null), image.getHeight(null),
+                    BufferedImage.TYPE_INT_ARGB
+                ).also {
+                    val g = it.createGraphics()
+                    g.drawImage(image, 0, 0, null)
+                    g.dispose()
+                }
+                val baos = ByteArrayOutputStream()
+                ImageIO.write(buffered, "png", baos)
+                baos.toByteArray() to "clipboard.png"
+            }
+            runCatching { clipboard.isDataFlavorAvailable(DataFlavor.javaFileListFlavor) }.getOrDefault(false) -> {
+                @Suppress("UNCHECKED_CAST")
+                val files = runCatching {
+                    clipboard.getData(DataFlavor.javaFileListFlavor) as? List<java.io.File>
+                }.getOrNull()
+                val file = files?.firstOrNull() ?: return@withContext null
+                val mime = NostrBuildUploader.mimeTypeForFilename(file.name)
+                if (!isSupportedMediaMime(mime)) throw UnsupportedFileTypeException(file.extension)
+                if (file.length() > MAX_UPLOAD_BYTES) throw FileTooLargeException()
+                file.readBytes() to file.name
+            }
+            else -> null
+        }
+    }
+}
+
+@Composable
+actual fun rememberClipboardImageReader(): ClipboardImageReader = remember { ClipboardImageReader() }
+
+@Composable
+actual fun PasteMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -23,9 +23,9 @@ actual class MediaPickerLauncher(private val doLaunch: () -> Unit) {
     actual fun launch() = doLaunch()
 }
 
-private val IMAGE_EXTENSIONS     = arrayOf("jpg", "jpeg", "png", "gif", "webp")
-private val AUDIO_EXTENSIONS     = arrayOf("mp3", "ogg", "wav", "flac", "m4a", "aac")
-private val ALL_EXTENSIONS       = IMAGE_EXTENSIONS + arrayOf("mp4", "mov") + AUDIO_EXTENSIONS
+private val IMAGE_EXTENSIONS     = arrayOf("jpg", "jpeg", "png", "gif", "webp", "avif")
+private val AUDIO_EXTENSIONS     = arrayOf("mp3", "ogg", "wav", "flac", "m4a", "aac", "opus")
+private val ALL_EXTENSIONS       = IMAGE_EXTENSIONS + arrayOf("mp4", "mov", "webm") + AUDIO_EXTENSIONS
 private val ALL_EXTENSIONS_SET   = ALL_EXTENSIONS.toSet()
 private val IMAGE_EXTENSIONS_SET = IMAGE_EXTENSIONS.toSet()
 
@@ -39,6 +39,8 @@ private var systemLafApplied = false
 @Composable
 actual fun rememberMediaPickerLauncher(
     accept: MediaAccept,
+    onPickStart: () -> Unit,
+    onError: (String) -> Unit,
     onFilePicked: (ByteArray, String) -> Unit
 ): MediaPickerLauncher {
     val scope = rememberCoroutineScope()
@@ -77,9 +79,9 @@ actual fun rememberMediaPickerLauncher(
 
                 val (filterDesc, extensions, allowedSet) = when (accept) {
                     MediaAccept.Images ->
-                        Triple("Images (jpg, png, gif, webp)", IMAGE_EXTENSIONS, IMAGE_EXTENSIONS_SET)
+                        Triple("Images (jpg, png, gif, webp, avif)", IMAGE_EXTENSIONS, IMAGE_EXTENSIONS_SET)
                     MediaAccept.ImagesVideosAudio ->
-                        Triple("Images, Videos & Audio", ALL_EXTENSIONS, ALL_EXTENSIONS_SET)
+                        Triple("Images, Videos & Audio (jpg, png, gif, webp, avif, mp4, mov, webm, mp3, ogg, wav, flac, m4a, aac, opus)", ALL_EXTENSIONS, ALL_EXTENSIONS_SET)
                 }
 
                 val chooser = JFileChooser().apply {
@@ -125,11 +127,21 @@ actual fun rememberMediaPickerLauncher(
 
                     val selected = chooser.selectedFile
                     if (selected != null && selected.extension.lowercase() in allowedSet) {
-                        scope.launch(Dispatchers.IO) {
-                            deferred.complete(selected.readBytes() to selected.name)
+                        scope.launch { onPickStart() }
+                        if (selected.length() > MAX_UPLOAD_BYTES) {
+                            deferred.complete(null)
+                            scope.launch { onError("File is too large. The maximum upload size is 20 MB.") }
+                        } else {
+                            scope.launch(Dispatchers.IO) {
+                                deferred.complete(selected.readBytes() to selected.name)
+                            }
                         }
                     } else {
                         deferred.complete(null)
+                        if (selected != null) {
+                            val ext = selected.extension.ifEmpty { "unknown" }
+                            scope.launch { onError("\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE") }
+                        }
                     }
                 } finally {
                     anchor.dispose()

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.jvm.kt
@@ -1,0 +1,6 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun ShareMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.jvm.kt
@@ -1,0 +1,5 @@
+package org.nostr.nostrord.network.upload
+
+internal actual suspend fun executeUpload(
+    url: String, bytes: ByteArray, filename: String, mimeType: String, authHeader: String
+): Pair<Int, String> = ktorExecuteUpload(NostrBuildUploader.client, url, bytes, filename, mimeType, authHeader)

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/ClipboardImage.wasmJs.kt
@@ -1,0 +1,99 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlinx.coroutines.await
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+actual class ClipboardImageReader {
+    actual fun hasImage(): Boolean = false
+    actual suspend fun read(): Pair<ByteArray, String>? = null
+}
+
+@Composable
+actual fun rememberClipboardImageReader(): ClipboardImageReader = remember { ClipboardImageReader() }
+
+// Stores the pasted File in the JS-side cache (__nc) and returns just a key.
+// Avoids reading clipboard data into Kotlin/Wasm memory, preventing the 6-8x
+// memory amplification of the base64 round-trip.
+@JsFun("""() => new Promise((resolve) => {
+    const SUPPORTED = new Set([
+        'image/jpeg','image/png','image/gif','image/webp','image/avif',
+        'video/mp4','video/quicktime','video/webm',
+        'audio/mpeg','audio/ogg','audio/wav','audio/flac','audio/mp4','audio/aac','audio/opus'
+    ]);
+    document.addEventListener('paste', function handler(event) {
+        const items = event.clipboardData && event.clipboardData.items;
+        if (!items) return;
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (item.kind !== 'file') continue;
+            const type = item.type;
+            if (!type.startsWith('image/') && !type.startsWith('video/') && !type.startsWith('audio/')) continue;
+            const file = item.getAsFile();
+            if (!file) continue;
+            event.preventDefault();
+            document.removeEventListener('paste', handler);
+            if (!SUPPORTED.has(type)) {
+                resolve(JSON.stringify({ error: 'unsupported_type' }));
+                return;
+            }
+            if (file.size > 20971520) {
+                resolve(JSON.stringify({ error: 'too_large' }));
+                return;
+            }
+            if (!globalThis.__nc) { globalThis.__nc = new Map(); globalThis.__ncSeq = 0; }
+            const key = '__nc_' + (++globalThis.__ncSeq);
+            globalThis.__nc.set(key, file);
+            resolve(JSON.stringify({ name: file.name || 'paste.png', mime: type, key: key }));
+            return;
+        }
+    });
+})""")
+private external fun jsAwaitNextPaste(): kotlin.js.Promise<JsString?>
+
+@Composable
+actual fun PasteMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {
+    val currentCallback = rememberUpdatedState(onMediaPasted)
+    val currentOnError  = rememberUpdatedState(onError)
+    val scope = rememberCoroutineScope()
+    DisposableEffect(Unit) {
+        var active = true
+        val job = scope.launch {
+            while (active) {
+                val result: JsString? = jsAwaitNextPaste().await()
+                if (!active) break
+                val jsonStr = result?.toString() ?: continue
+                try {
+                    val json = Json.parseToJsonElement(jsonStr).jsonObject
+                    val error = json["error"]?.jsonPrimitive?.contentOrNull
+                    if (error != null) {
+                        when (error) {
+                            "too_large"        -> currentOnError.value("This file is too large. The maximum upload size is 20 MB.")
+                            "unsupported_type" -> currentOnError.value("This file type is not supported.\n\n$SUPPORTED_FORMATS_MESSAGE")
+                        }
+                        continue
+                    }
+                    val name = json["name"]?.jsonPrimitive?.contentOrNull ?: continue
+                    val mime = json["mime"]?.jsonPrimitive?.contentOrNull ?: "application/octet-stream"
+                    val key  = json["key"]?.jsonPrimitive?.contentOrNull ?: continue
+                    currentCallback.value(ByteArray(0), blobRef(mime, name, key))
+                } catch (_: Throwable) {}
+            }
+        }
+        onDispose {
+            active = false
+            job.cancel()
+        }
+    }
+}

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.wasmJs.kt
@@ -19,6 +19,11 @@ import kotlinx.serialization.json.jsonPrimitive
 // the 6-8x memory amplification that occurs with the base64 round-trip.
 @JsFun("""(accept) => new Promise((resolve) => {
     if (!globalThis.__nc) { globalThis.__nc = new Map(); globalThis.__ncSeq = 0; }
+    const SUPPORTED = new Set([
+        'image/jpeg','image/png','image/gif','image/webp','image/avif',
+        'video/mp4','video/quicktime','video/webm',
+        'audio/mpeg','audio/ogg','audio/wav','audio/flac','audio/mp4','audio/aac','audio/opus'
+    ]);
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = accept;
@@ -31,11 +36,13 @@ import kotlinx.serialization.json.jsonPrimitive
     input.onchange = () => {
         const file = input.files && input.files[0];
         if (!file) { cleanup(); resolve(null); return; }
-        if (file.size > 20971520) { cleanup(); resolve(null); return; }
+        const type = file.type || '';
+        if (!SUPPORTED.has(type)) { cleanup(); resolve(JSON.stringify({ error: 'unsupported_type' })); return; }
+        if (file.size > 20971520) { cleanup(); resolve(JSON.stringify({ error: 'too_large' })); return; }
         const key = '__nc_' + (++globalThis.__ncSeq);
         globalThis.__nc.set(key, file);
         cleanup();
-        resolve(JSON.stringify({ name: file.name, mime: file.type || 'application/octet-stream', key: key }));
+        resolve(JSON.stringify({ name: file.name, mime: type, key: key }));
     };
 
     document.body.appendChild(input);
@@ -57,6 +64,7 @@ actual fun rememberMediaPickerLauncher(
     val scope = rememberCoroutineScope()
     val currentCallback = rememberUpdatedState(onFilePicked)
     val currentPickStart = rememberUpdatedState(onPickStart)
+    val currentOnError = rememberUpdatedState(onError)
     val acceptAttr = when (accept) {
         MediaAccept.Images            -> "image/*"
         MediaAccept.ImagesVideosAudio -> "image/*,video/mp4,video/quicktime,video/webm,audio/*"
@@ -67,8 +75,16 @@ actual fun rememberMediaPickerLauncher(
                 try {
                     val result: JsString? = jsPickFile(acceptAttr).await()
                     val jsonStr = result?.toString() ?: return@launch
-                    currentPickStart.value()
                     val json = Json.parseToJsonElement(jsonStr).jsonObject
+                    val error = json["error"]?.jsonPrimitive?.contentOrNull
+                    if (error != null) {
+                        when (error) {
+                            "unsupported_type" -> currentOnError.value("This file type is not supported.\n\n$SUPPORTED_FORMATS_MESSAGE")
+                            "too_large"        -> currentOnError.value("This file is too large. The maximum upload size is 20 MB.")
+                        }
+                        return@launch
+                    }
+                    currentPickStart.value()
                     val name = json["name"]?.jsonPrimitive?.contentOrNull ?: return@launch
                     val mime = json["mime"]?.jsonPrimitive?.contentOrNull ?: "application/octet-stream"
                     val key  = json["key"]?.jsonPrimitive?.contentOrNull ?: return@launch

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.wasmJs.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.js.ExperimentalWasmJsInterop
 import kotlinx.coroutines.await
 import kotlinx.coroutines.launch
@@ -16,15 +14,11 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
-/**
- * Opens a native browser file picker, reads the selected file as base64 JSON, and
- * returns it to Kotlin via a Promise.  The base64 round-trip is the only way to pass
- * arbitrary binary data from Wasm-JS interop without resorting to unsafe memory tricks.
- *
- * Large files are encoded in 8 kB chunks to avoid call-stack overflow in String.fromCharCode.
- * The [accept] parameter maps directly to the HTML input accept attribute.
- */
+// Stores the File object in a JS-side cache (__nc) and returns just a key.
+// This avoids reading the file into Kotlin/Wasm memory entirely, preventing
+// the 6-8x memory amplification that occurs with the base64 round-trip.
 @JsFun("""(accept) => new Promise((resolve) => {
+    if (!globalThis.__nc) { globalThis.__nc = new Map(); globalThis.__ncSeq = 0; }
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = accept;
@@ -37,19 +31,11 @@ import kotlinx.serialization.json.jsonPrimitive
     input.onchange = () => {
         const file = input.files && input.files[0];
         if (!file) { cleanup(); resolve(null); return; }
-        const reader = new FileReader();
-        reader.onload = () => {
-            const bytes = new Uint8Array(reader.result);
-            let bin = '';
-            const chunk = 8192;
-            for (let i = 0; i < bytes.length; i += chunk) {
-                bin += String.fromCharCode.apply(null, bytes.subarray(i, i + chunk));
-            }
-            cleanup();
-            resolve(JSON.stringify({ name: file.name, data: btoa(bin) }));
-        };
-        reader.onerror = () => { cleanup(); resolve(null); };
-        reader.readAsArrayBuffer(file);
+        if (file.size > 20971520) { cleanup(); resolve(null); return; }
+        const key = '__nc_' + (++globalThis.__ncSeq);
+        globalThis.__nc.set(key, file);
+        cleanup();
+        resolve(JSON.stringify({ name: file.name, mime: file.type || 'application/octet-stream', key: key }));
     };
 
     document.body.appendChild(input);
@@ -61,17 +47,19 @@ actual class MediaPickerLauncher(private val doLaunch: () -> Unit) {
     actual fun launch() = doLaunch()
 }
 
-@OptIn(ExperimentalEncodingApi::class)
 @Composable
 actual fun rememberMediaPickerLauncher(
     accept: MediaAccept,
+    onPickStart: () -> Unit,
+    onError: (String) -> Unit,
     onFilePicked: (ByteArray, String) -> Unit
 ): MediaPickerLauncher {
     val scope = rememberCoroutineScope()
     val currentCallback = rememberUpdatedState(onFilePicked)
+    val currentPickStart = rememberUpdatedState(onPickStart)
     val acceptAttr = when (accept) {
         MediaAccept.Images            -> "image/*"
-        MediaAccept.ImagesVideosAudio -> "image/*,video/mp4,video/quicktime,audio/*"
+        MediaAccept.ImagesVideosAudio -> "image/*,video/mp4,video/quicktime,video/webm,audio/*"
     }.toJsString()
     return remember(acceptAttr) {
         MediaPickerLauncher {
@@ -79,13 +67,16 @@ actual fun rememberMediaPickerLauncher(
                 try {
                     val result: JsString? = jsPickFile(acceptAttr).await()
                     val jsonStr = result?.toString() ?: return@launch
+                    currentPickStart.value()
                     val json = Json.parseToJsonElement(jsonStr).jsonObject
                     val name = json["name"]?.jsonPrimitive?.contentOrNull ?: return@launch
-                    val data = json["data"]?.jsonPrimitive?.contentOrNull ?: return@launch
-                    val bytes = Base64.decode(data)
-                    currentCallback.value(bytes, name)
+                    val mime = json["mime"]?.jsonPrimitive?.contentOrNull ?: "application/octet-stream"
+                    val key  = json["key"]?.jsonPrimitive?.contentOrNull ?: return@launch
+                    currentCallback.value(ByteArray(0), blobRef(mime, name, key))
                 } catch (_: Throwable) {}
             }
         }
     }
 }
+
+internal fun blobRef(mime: String, name: String, key: String) = "nostrord-blob|$mime|$name|$key"

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/ShareMedia.wasmJs.kt
@@ -1,0 +1,6 @@
+package org.nostr.nostrord.network.upload
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun ShareMediaEffect(onMediaPasted: (ByteArray, String) -> Unit, onError: (String) -> Unit) {}

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/upload/UploadEngine.wasmJs.kt
@@ -1,0 +1,102 @@
+@file:OptIn(ExperimentalWasmJsInterop::class, ExperimentalEncodingApi::class)
+
+package org.nostr.nostrord.network.upload
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.js.ExperimentalWasmJsInterop
+import kotlinx.coroutines.await
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+// Retrieves a File/Blob from the JS-side cache (__nc) and uploads it directly
+// as FormData, keeping the data entirely in JS memory with no Kotlin/Wasm copy.
+@JsFun("""(url, key, filename, mimeType, authHeader) =>
+    new Promise((resolve) => {
+        const file = globalThis.__nc && globalThis.__nc.get(key);
+        if (!file) { resolve(JSON.stringify({ status: 0, body: 'blob not in cache: ' + key })); return; }
+        globalThis.__nc.delete(key);
+        const form = new FormData();
+        form.append('fileToUpload', file, filename);
+        fetch(url, {
+            method: 'POST',
+            headers: { 'Authorization': authHeader },
+            body: form
+        })
+        .then(r => r.text().then(b => resolve(JSON.stringify({ status: r.status, body: b }))))
+        .catch(e => resolve(JSON.stringify({ status: 0, body: String(e) })));
+    })
+""")
+private external fun jsFetchFromCache(
+    url: JsString,
+    key: JsString,
+    filename: JsString,
+    mimeType: JsString,
+    authHeader: JsString
+): kotlin.js.Promise<JsString?>
+
+// Passes bytes as base64 (single string interop call) so JS can reconstruct a
+// Uint8Array without triggering Ktor's byte-by-byte Wasm→JS conversion, which
+// would stall on files larger than a few hundred KB.
+@JsFun("""(url, base64data, filename, mimeType, authHeader) =>
+    new Promise((resolve) => {
+        const bin = atob(base64data);
+        const arr = new Uint8Array(bin.length);
+        for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+        const blob = new Blob([arr], { type: mimeType });
+        const form = new FormData();
+        form.append('fileToUpload', blob, filename);
+        fetch(url, {
+            method: 'POST',
+            headers: { 'Authorization': authHeader },
+            body: form
+        })
+        .then(r => r.text().then(b => resolve(JSON.stringify({ status: r.status, body: b }))))
+        .catch(e => resolve(JSON.stringify({ status: 0, body: String(e) })));
+    })
+""")
+private external fun jsFetch(
+    url: JsString,
+    base64data: JsString,
+    filename: JsString,
+    mimeType: JsString,
+    authHeader: JsString
+): kotlin.js.Promise<JsString?>
+
+internal actual suspend fun executeUpload(
+    url: String,
+    bytes: ByteArray,
+    filename: String,
+    mimeType: String,
+    authHeader: String
+): Pair<Int, String> {
+    val result: JsString? = if (isBlobRef(filename)) {
+        val parts = filename.split("|")
+        val realMime = parts.getOrNull(1) ?: mimeType
+        val realName = parts.getOrNull(2) ?: "file"
+        val key      = parts.getOrNull(3) ?: return Pair(0, "invalid blob ref: missing key")
+        jsFetchFromCache(
+            url.toJsString(),
+            key.toJsString(),
+            realName.toJsString(),
+            realMime.toJsString(),
+            authHeader.toJsString()
+        ).await()
+    } else {
+        val base64 = Base64.encode(bytes)
+        jsFetch(
+            url.toJsString(),
+            base64.toJsString(),
+            filename.toJsString(),
+            mimeType.toJsString(),
+            authHeader.toJsString()
+        ).await()
+    }
+    val json = Json.parseToJsonElement(result?.toString() ?: """{"status":0,"body":"no response"}""").jsonObject
+    val status = json["status"]?.jsonPrimitive?.intOrNull ?: 0
+    val body   = json["body"]?.jsonPrimitive?.contentOrNull ?: ""
+    return Pair(status, body)
+}


### PR DESCRIPTION
## What's new

**Paste from clipboard (all platforms)**
Ctrl+V / Cmd+V in the message input detects image or media in the clipboard and uploads it directly. Supported on Android, JVM desktop, JS, and WasmJS. iOS stub is present; full clipboard access requires native UIKit bridging not yet wired.

**Share from other apps (Android)**
The app now appears in the Android share sheet when sharing images, videos, or audio from a gallery, file manager, or browser. `ACTION_SEND` and `ACTION_SEND_MULTIPLE` intent filters are registered in the manifest; `ShareMediaQueue` (a `MutableStateFlow<List<Uri>>`) bridges the Activity lifecycle to Compose, and `ShareMediaEffect` consumes the queue using the same upload path as paste and the file picker.

**Format and size validation everywhere**
All entry points — paste, file picker button, and share intent — now validate MIME type and file size before upload starts, with a consistent error dialog showing the accepted formats list. Format is checked before size so an unsupported file always gets the format error regardless of its size. Previously, unsupported types and oversized files failed silently on several platforms.

**WasmJS: zero-copy blob upload**
Pasted and picked files on WasmJS are stored in a JS-side `Map` (`globalThis.__nc`) and uploaded via native `fetch` + `FormData` without ever copying bytes into Kotlin/Wasm linear memory. This eliminates the 6-8x memory amplification that previously caused OOM crashes when uploading from the browser (WasmJS target).

**JVM: guard against huge files**
The desktop picker and clipboard reader now check `File.length()` before calling `readBytes()`, so pasting or picking a multi-gigabyte file shows an error dialog instead of crashing the JVM process with an OOM.

**New accepted formats**
Added `webm` (video), `avif` (image), and `opus` (audio) to the supported upload set across all platforms.

Closes https://github.com/nostrord/nostrord/issues/22