### PR TITLE
feat(group): share modal with nostr:naddr and link

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -55,7 +55,7 @@ import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.theme.NostrordColors
-import org.nostr.nostrord.ui.util.buildShareGroupLink
+import org.nostr.nostrord.ui.screens.group.components.ShareGroupModal
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
@@ -475,6 +475,7 @@ private fun MobileGroupTopBar(
             } else {
                 // Dropdown menu for members
                 var menuExpanded by remember { mutableStateOf(false) }
+                var showShareModal by remember { mutableStateOf(false) }
                 val copyToClipboard = rememberClipboardWriter()
 
                 Box {
@@ -595,7 +596,7 @@ private fun MobileGroupTopBar(
                                 text = { Text("Share", color = NostrordColors.TextPrimary) },
                                 onClick = {
                                     menuExpanded = false
-                                    copyToClipboard(buildShareGroupLink(relayUrl, groupId))
+                                    showShareModal = true
                                 },
                                 leadingIcon = {
                                     Icon(
@@ -628,6 +629,14 @@ private fun MobileGroupTopBar(
                             }
                         )
                     }
+                }
+
+                if (showShareModal && relayUrl.isNotBlank() && groupId.isNotBlank()) {
+                    ShareGroupModal(
+                        relayUrl = relayUrl,
+                        groupId = groupId,
+                        onDismiss = { showShareModal = false }
+                    )
                 }
             }
         },

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupHeader.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupHeader.kt
@@ -42,7 +42,6 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.ui.theme.NostrordColors
-import org.nostr.nostrord.ui.util.buildShareGroupLink
 import org.nostr.nostrord.ui.util.generateColorFromString
 import org.nostr.nostrord.utils.rememberClipboardWriter
 
@@ -246,6 +245,7 @@ fun GroupHeader(
                     }
                 } else {
                     var menuExpanded by remember { mutableStateOf(false) }
+                    var showShareModal by remember { mutableStateOf(false) }
                     val copyToClipboard = rememberClipboardWriter()
 
                     Box {
@@ -367,7 +367,7 @@ fun GroupHeader(
                                     text = { Text("Share", color = NostrordColors.TextPrimary) },
                                     onClick = {
                                         menuExpanded = false
-                                        copyToClipboard(buildShareGroupLink(relayUrl, groupId))
+                                        showShareModal = true
                                     },
                                     leadingIcon = {
                                         Icon(
@@ -400,6 +400,14 @@ fun GroupHeader(
                                 }
                             )
                         }
+                    }
+
+                    if (showShareModal && relayUrl.isNotBlank() && groupId.isNotBlank()) {
+                        ShareGroupModal(
+                            relayUrl = relayUrl,
+                            groupId = groupId,
+                            onDismiss = { showShareModal = false }
+                        )
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
@@ -1,0 +1,115 @@
+package org.nostr.nostrord.ui.screens.group.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.util.buildGroupNaddr
+import org.nostr.nostrord.ui.util.buildShareGroupLink
+import org.nostr.nostrord.utils.rememberClipboardWriter
+import org.nostr.nostrord.utils.rememberTextSharer
+import org.nostr.nostrord.utils.supportsNativeShare
+
+@Composable
+fun ShareGroupModal(
+    relayUrl: String,
+    groupId: String,
+    onDismiss: () -> Unit
+) {
+    val link = buildShareGroupLink(relayUrl, groupId)
+    val naddr = buildGroupNaddr(relayUrl, groupId)
+    val copyToClipboard = rememberClipboardWriter()
+    val shareText = rememberTextSharer()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = NostrordColors.Surface,
+        title = {
+            Text(
+                "Share Group",
+                color = Color.White,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                ShareRow(
+                    label = "Link",
+                    value = link,
+                    actionIcon = if (supportsNativeShare) Icons.Default.Share else Icons.Default.ContentCopy,
+                    actionLabel = if (supportsNativeShare) "Share" else "Copy",
+                    onAction = { if (supportsNativeShare) shareText(link) else copyToClipboard(link) }
+                )
+                ShareRow(
+                    label = "Nostr Address (naddr)",
+                    value = naddr,
+                    actionIcon = if (supportsNativeShare) Icons.Default.Share else Icons.Default.ContentCopy,
+                    actionLabel = if (supportsNativeShare) "Share" else "Copy",
+                    onAction = { if (supportsNativeShare) shareText(naddr) else copyToClipboard(naddr) }
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Close", color = NostrordColors.TextSecondary)
+            }
+        }
+    )
+}
+
+@Composable
+private fun ShareRow(
+    label: String,
+    value: String,
+    actionIcon: androidx.compose.ui.graphics.vector.ImageVector,
+    actionLabel: String,
+    onAction: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        Text(
+            text = label,
+            color = NostrordColors.TextSecondary,
+            style = MaterialTheme.typography.labelSmall
+        )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(NostrordColors.SurfaceVariant, RoundedCornerShape(8.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = value,
+                color = NostrordColors.TextPrimary,
+                style = MaterialTheme.typography.bodySmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            IconButton(
+                onClick = onAction,
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = actionIcon,
+                    contentDescription = actionLabel,
+                    tint = NostrordColors.Primary,
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
@@ -1,5 +1,7 @@
 package org.nostr.nostrord.ui.util
 
+import org.nostr.nostrord.nostr.Nip19
+
 private const val OPEN_BASE = "https://nostrord.com/open/"
 
 private fun relayHost(relayUrl: String): String =
@@ -24,3 +26,6 @@ fun buildShareMessageLink(relayUrl: String, groupId: String, messageId: String):
     val host = relayHost(relayUrl)
     return "${OPEN_BASE}?relay=$host&group=$groupId&e=$messageId"
 }
+
+fun buildGroupNaddr(relayUrl: String, groupId: String): String =
+    "nostr:" + Nip19.encodeNaddr(identifier = groupId, relay = relayUrl, kind = 39000)


### PR DESCRIPTION
## Summary

- Replaces the single "Share" dropdown item with a modal showing two sharing options
- **Link** — `https://nostrord.com/open/?relay=...&group=...` (web-friendly URL)    
- **Nostr Address** — `nostr:naddr1...` (NIP-19 + NIP-21 URI, kind 39000)       
- On Android both options open the native share sheet; on desktop/web both copy to clipboard                                                                                                                                   
                                                                                              
Closes #48