### PR TITLE
feat(desktop/security): harden local key storage with OS keychain + passphrase fallback

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -131,6 +131,7 @@ kotlin {
             // Pure-Java MP3 decoder for notification chime — avoids the GStreamer
             // native-library matrix that JavaFX Media relies on.
             implementation("javazoom:jlayer:1.0.1")
+            implementation("com.github.javakeyring:java-keyring:1.0.3")
         }
         
         jsMain.dependencies {

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.android.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.storage
+
+actual object PassphraseSettings {
+    actual val isApplicable: Boolean = false
+    actual fun usesKeychain(): Boolean = false
+    actual fun usesPassphrase(): Boolean = false
+    actual fun changePassphrase(current: String, new: String): Boolean = false
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.storage
+
+expect object PassphraseSettings {
+    val isApplicable: Boolean
+    fun usesKeychain(): Boolean
+    fun usesPassphrase(): Boolean
+    fun changePassphrase(current: String, new: String): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.delay
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
+import org.nostr.nostrord.storage.PassphraseSettings
 import org.nostr.nostrord.ui.Screen
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.cards.InfoCard
@@ -72,6 +73,7 @@ enum class SettingsSection(val label: String) {
     BackupKeys("Backup Keys"),
     RelaysNip65("Relays (NIP-65)"),
     Notifications("Notifications"),
+    Security("Security"),
     Experimental("Experimental")
 }
 
@@ -228,6 +230,10 @@ fun SettingsScreen(
         )
     }
 
+    val securityContent: @Composable () -> Unit = {
+        SecurityPanelContent()
+    }
+
     var activeSection by remember { mutableStateOf(SettingsSection.Profile) }
     var showMobilePanel by remember { mutableStateOf(false) }
 
@@ -267,6 +273,7 @@ fun SettingsScreen(
                 backupContent = backupContent,
                 relaysContent = relaysContent,
                 notificationsContent = notificationsContent,
+                securityContent = securityContent,
                 experimentalContent = experimentalContent
             )
         } else {
@@ -279,6 +286,7 @@ fun SettingsScreen(
                 backupContent = backupContent,
                 relaysContent = relaysContent,
                 notificationsContent = notificationsContent,
+                securityContent = securityContent,
                 experimentalContent = experimentalContent,
                 showToolbar = showToolbar,
                 canGoBack = canGoBack,
@@ -302,6 +310,7 @@ private fun DesktopSettings(
     backupContent: @Composable () -> Unit,
     relaysContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    securityContent: @Composable () -> Unit,
     experimentalContent: @Composable () -> Unit,
     showToolbar: Boolean = false,
     canGoBack: Boolean = false,
@@ -363,7 +372,7 @@ private fun DesktopSettings(
                         .padding(top = 24.dp, start = 40.dp, end = 20.dp, bottom = 80.dp)
                 ) {
                     Box(modifier = Modifier.widthIn(max = 660.dp)) {
-                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, notificationsContent, experimentalContent)
+                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, notificationsContent, securityContent, experimentalContent)
                     }
                 }
 
@@ -389,6 +398,7 @@ private fun MobileSettings(
     backupContent: @Composable () -> Unit,
     relaysContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    securityContent: @Composable () -> Unit,
     experimentalContent: @Composable () -> Unit
 ) {
     if (!showPanel) {
@@ -430,7 +440,7 @@ private fun MobileSettings(
                     .verticalScroll(rememberScrollState())
                     .padding(horizontal = 20.dp, vertical = 24.dp)
             ) {
-                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, notificationsContent, experimentalContent)
+                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, notificationsContent, securityContent, experimentalContent)
             }
         }
     }
@@ -482,6 +492,11 @@ private fun SettingsSidebar(
     }
     SettingsNavItem("Notifications", activeSection == SettingsSection.Notifications, compact = compact) {
         onSelectSection(SettingsSection.Notifications)
+    }
+    if (PassphraseSettings.isApplicable) {
+        SettingsNavItem("Security", activeSection == SettingsSection.Security, compact = compact) {
+            onSelectSection(SettingsSection.Security)
+        }
     }
     SettingsNavItem("Experimental", activeSection == SettingsSection.Experimental, compact = compact) {
         onSelectSection(SettingsSection.Experimental)
@@ -586,6 +601,7 @@ private fun SettingsPanel(
     backupContent: @Composable () -> Unit,
     relaysContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    securityContent: @Composable () -> Unit,
     experimentalContent: @Composable () -> Unit
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -604,6 +620,7 @@ private fun SettingsPanel(
             SettingsSection.BackupKeys -> backupContent()
             SettingsSection.RelaysNip65 -> relaysContent()
             SettingsSection.Notifications -> notificationsContent()
+            SettingsSection.Security -> securityContent()
             SettingsSection.Experimental -> experimentalContent()
         }
     }
@@ -1103,6 +1120,166 @@ private fun ExperimentalToggleRow(
                 uncheckedTrackColor = NostrordColors.InputBackground
             ),
             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand)
+        )
+    }
+}
+
+// ── Security panel content ───────────────────────────────────────────────────
+
+@Composable
+private fun SecurityPanelContent() {
+    when {
+        !PassphraseSettings.isApplicable -> {
+            InfoCard(
+                title = "Not applicable",
+                titleColor = NostrordColors.TextSecondary,
+                icon = Icons.Default.Lightbulb,
+                content = "This setting is only relevant on the desktop app.",
+                isCompact = false
+            )
+        }
+        PassphraseSettings.usesKeychain() -> {
+            InfoCard(
+                title = "Protected by your OS keychain",
+                titleColor = NostrordColors.Success,
+                icon = Icons.Default.Check,
+                content = "Your private key, bunker credentials and cached messages " +
+                        "are encrypted with a key held in your operating system " +
+                        "credential store (macOS Keychain, Windows Credential Manager " +
+                        "or Linux Secret Service). No passphrase is needed.",
+                isCompact = false
+            )
+        }
+        PassphraseSettings.usesPassphrase() -> {
+            ChangePassphraseForm()
+        }
+        else -> {
+            InfoCard(
+                title = "No passphrase set",
+                titleColor = NostrordColors.Warning,
+                icon = Icons.Default.Warning,
+                content = "Your OS keychain is not available. Nostrord is using an " +
+                        "in-memory key for this session. Save a credential (private " +
+                        "key or bunker URL) and you will be prompted to set a " +
+                        "passphrase to persist your data securely.",
+                isCompact = false
+            )
+        }
+    }
+}
+
+@Composable
+private fun ChangePassphraseForm() {
+    var current by remember { mutableStateOf("") }
+    var new by remember { mutableStateOf("") }
+    var confirm by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+    var success by remember { mutableStateOf(false) }
+
+    LaunchedEffect(success) {
+        if (success) { delay(2000); success = false }
+    }
+
+    val canSubmit = current.isNotEmpty() && new.length >= 8 && new == confirm
+
+    fun submit() {
+        if (!canSubmit) return
+        val ok = PassphraseSettings.changePassphrase(current, new)
+        if (ok) {
+            current = ""; new = ""; confirm = ""
+            success = true; error = null
+        } else {
+            error = "Current passphrase is incorrect."
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.lg)
+    ) {
+        InfoCard(
+            title = "Passphrase-protected",
+            titleColor = NostrordColors.TextSecondary,
+            icon = Icons.Default.Key,
+            content = "Your data is encrypted with a key derived from your passphrase. " +
+                    "Choose a new passphrase below to rotate it. The passphrase cannot " +
+                    "be recovered if you forget it.",
+            isCompact = false
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = NostrordShapes.cardShape,
+            colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface)
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(Spacing.xl),
+                verticalArrangement = Arrangement.spacedBy(Spacing.lg)
+            ) {
+                PassphraseField("Current passphrase", current) { current = it; error = null }
+                PassphraseField("New passphrase", new) { new = it; error = null }
+                PassphraseField("Confirm new passphrase", confirm) { confirm = it; error = null }
+
+                Text(
+                    text = "At least 8 characters. Must match.",
+                    style = NostrordTypography.Caption,
+                    color = NostrordColors.TextSecondary
+                )
+
+                error?.let {
+                    Text(text = it, style = NostrordTypography.MessageBody, color = NostrordColors.Error)
+                }
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = ::submit, enabled = canSubmit) {
+                        Text("Change passphrase", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                    }
+                }
+            }
+        }
+
+        if (success) {
+            Card(
+                colors = CardDefaults.cardColors(containerColor = NostrordColors.Success),
+                shape = RoundedCornerShape(8.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Check, contentDescription = null,
+                        tint = Color.White, modifier = Modifier.size(16.dp))
+                    Spacer(Modifier.width(8.dp))
+                    Text("Passphrase updated", color = Color.White, fontWeight = FontWeight.Bold)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PassphraseField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit
+) {
+    Column {
+        Text(text = label, style = NostrordTypography.SectionHeader, color = NostrordColors.TextMuted)
+        Spacer(Modifier.height(Spacing.sm))
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            visualTransformation = androidx.compose.ui.text.input.PasswordVisualTransformation(),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = NostrordColors.Primary,
+                unfocusedBorderColor = NostrordColors.Divider,
+                focusedContainerColor = NostrordColors.InputBackground,
+                unfocusedContainerColor = NostrordColors.InputBackground,
+                cursorColor = NostrordColors.Primary,
+                focusedTextColor = Color.White,
+                unfocusedTextColor = Color.White
+            ),
+            shape = NostrordShapes.shapeSmall
         )
     }
 }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.js.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.storage
+
+actual object PassphraseSettings {
+    actual val isApplicable: Boolean = false
+    actual fun usesKeychain(): Boolean = false
+    actual fun usesPassphrase(): Boolean = false
+    actual fun changePassphrase(current: String, new: String): Boolean = false
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
@@ -30,6 +30,8 @@ import io.ktor.client.plugins.HttpTimeout
 import okio.Path.Companion.toOkioPath
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.UnlockState
 import org.nostr.nostrord.ui.PassphraseGate
 import org.nostr.nostrord.ui.window.DesktopWindowControls
 import org.nostr.nostrord.ui.window.LocalAwtWindow
@@ -113,7 +115,8 @@ fun main(args: Array<String> = emptyArray()) {
     // brief window, then halts — Runtime.halt skips shutdown hooks (which is what we
     // want: java-keyring's DBus close hook deadlocks on shutdown). Safe here because
     // every save*() in SecureStorage already flushes prefs inline.
-    val quit: () -> Unit = {
+    val quit: () -> Unit = quit@{
+        if (SecureStorage.unlockState.value == UnlockState.NeedsPassphraseSetup) return@quit
         exitApplication()
         Thread {
             try { Thread.sleep(500) } catch (_: InterruptedException) {}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
@@ -30,6 +30,7 @@ import io.ktor.client.plugins.HttpTimeout
 import okio.Path.Companion.toOkioPath
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
+import org.nostr.nostrord.ui.PassphraseGate
 import org.nostr.nostrord.ui.window.DesktopWindowControls
 import org.nostr.nostrord.ui.window.LocalAwtWindow
 import org.nostr.nostrord.ui.window.LocalDesktopWindowControls
@@ -107,8 +108,25 @@ fun main(args: Array<String> = emptyArray()) {
         position = WindowPosition.Aligned(Alignment.Center)
     )
 
+    // Background threads (java-keyring's DBus connection, Ktor/Coil pools) keep the
+    // JVM alive after exitApplication(). A daemon "watchdog" gives clean shutdown a
+    // brief window, then halts — Runtime.halt skips shutdown hooks (which is what we
+    // want: java-keyring's DBus close hook deadlocks on shutdown). Safe here because
+    // every save*() in SecureStorage already flushes prefs inline.
+    val quit: () -> Unit = {
+        exitApplication()
+        Thread {
+            try { Thread.sleep(500) } catch (_: InterruptedException) {}
+            Runtime.getRuntime().halt(0)
+        }.apply {
+            isDaemon = true
+            name = "nostrord-exit-watchdog"
+            start()
+        }
+    }
+
     Window(
-        onCloseRequest = ::exitApplication,
+        onCloseRequest = quit,
         title = "Nostrord",
         icon = ImageIO.read(
             Thread.currentThread().contextClassLoader
@@ -120,7 +138,7 @@ fun main(args: Array<String> = emptyArray()) {
             if (event.type == KeyEventType.KeyDown) {
                 // Ctrl+Q (Windows/Linux) or Cmd+Q (macOS) - quit application
                 if (event.key == Key.Q && (event.isCtrlPressed || event.isMetaPressed)) {
-                    exitApplication()
+                    quit()
                     true
                 } else {
                     false
@@ -137,7 +155,7 @@ fun main(args: Array<String> = emptyArray()) {
                     windowState.placement = if (windowState.placement == WindowPlacement.Maximized)
                         WindowPlacement.Floating else WindowPlacement.Maximized
                 }
-                override fun close() { exitApplication() }
+                override fun close() { quit() }
                 override val isMaximized: Boolean
                     get() = windowState.placement == WindowPlacement.Maximized
             }
@@ -147,7 +165,9 @@ fun main(args: Array<String> = emptyArray()) {
             LocalDesktopWindowControls provides controls,
             LocalAwtWindow provides window
         ) {
-            App()
+            PassphraseGate {
+                App()
+            }
         }
     }
     }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/KeychainStore.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/KeychainStore.kt
@@ -1,0 +1,53 @@
+package org.nostr.nostrord.storage
+
+import com.github.javakeyring.BackendNotSupportedException
+import com.github.javakeyring.Keyring
+import com.github.javakeyring.PasswordAccessException
+import java.util.Base64
+
+internal object KeychainStore {
+    private const val SERVICE = "org.nostr.nostrord"
+    private const val ACCOUNT_MASTER_KEY = "master_encryption_key"
+
+    private val keyring: Keyring? by lazy {
+        try {
+            Keyring.create()
+        } catch (_: BackendNotSupportedException) {
+            null
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    fun isAvailable(): Boolean = keyring != null
+
+    fun getMasterKey(): ByteArray? {
+        val ring = keyring ?: return null
+        return try {
+            val b64 = ring.getPassword(SERVICE, ACCOUNT_MASTER_KEY) ?: return null
+            Base64.getDecoder().decode(b64)
+        } catch (_: PasswordAccessException) {
+            null
+        } catch (_: Throwable) {
+            null
+        }
+    }
+
+    fun setMasterKey(key: ByteArray): Boolean {
+        val ring = keyring ?: return false
+        return try {
+            ring.setPassword(SERVICE, ACCOUNT_MASTER_KEY, Base64.getEncoder().encodeToString(key))
+            true
+        } catch (_: Throwable) {
+            false
+        }
+    }
+
+    fun deleteMasterKey() {
+        val ring = keyring ?: return
+        try {
+            ring.deletePassword(SERVICE, ACCOUNT_MASTER_KEY)
+        } catch (_: Throwable) {
+        }
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.jvm.kt
@@ -1,0 +1,9 @@
+package org.nostr.nostrord.storage
+
+actual object PassphraseSettings {
+    actual val isApplicable: Boolean = true
+    actual fun usesKeychain(): Boolean = SecureStorage.usesKeychain()
+    actual fun usesPassphrase(): Boolean = SecureStorage.usesPassphrase()
+    actual fun changePassphrase(current: String, new: String): Boolean =
+        SecureStorage.changePassphrase(current, new)
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
@@ -22,6 +22,7 @@ sealed class UnlockState {
     object Unlocked : UnlockState()
     object NeedsPassphrase : UnlockState()
     object NeedsPassphraseSetup : UnlockState()
+    object NeedsLegacyMigration : UnlockState()
 }
 
 internal enum class KeySource { Keychain, Passphrase, Ephemeral }
@@ -92,15 +93,23 @@ actual object SecureStorage {
             }
         }
 
-        if (prefs.get(PASSPHRASE_VERIFIER_PREF, null) != null) {
-            _unlockState.value = UnlockState.NeedsPassphrase
-        } else {
-            // No keychain and no prior passphrase: run unlocked with an in-memory key.
-            // A sensitive save (nsec / bunker) will later transition to NeedsPassphraseSetup.
-            masterKey = SecretKeySpec(randomKeyBytes(), "AES")
-            keySource = KeySource.Ephemeral
-            _unlockState.value = UnlockState.Unlocked
-            migrateLegacyIfNeeded()
+        when {
+            prefs.get(PASSPHRASE_VERIFIER_PREF, null) != null -> {
+                _unlockState.value = UnlockState.NeedsPassphrase
+            }
+            legacyKey != null -> {
+                // Pre-existing v1 data on a machine without keychain: force a passphrase
+                // setup before any read or write. Migrating to an ephemeral key here would
+                // orphan the data on next launch.
+                _unlockState.value = UnlockState.NeedsLegacyMigration
+            }
+            else -> {
+                // Fresh install without keychain: run unlocked with an in-memory key.
+                // A sensitive save (nsec / bunker) will later transition to NeedsPassphraseSetup.
+                masterKey = SecretKeySpec(randomKeyBytes(), "AES")
+                keySource = KeySource.Ephemeral
+                _unlockState.value = UnlockState.Unlocked
+            }
         }
     }
 
@@ -124,16 +133,24 @@ actual object SecureStorage {
 
     fun setupPassphrase(passphrase: String): Boolean {
         if (passphrase.isEmpty()) return false
-        if (_unlockState.value !is UnlockState.NeedsPassphraseSetup) return false
-        val ephemeral = masterKey ?: return false
+        val state = _unlockState.value
+        if (state !is UnlockState.NeedsPassphraseSetup && state !is UnlockState.NeedsLegacyMigration) {
+            return false
+        }
         val salt = ByteArray(16).also { SecureRandom().nextBytes(it) }
         val newKey = deriveKeyFromPassphrase(passphrase, salt)
-        reencryptAllV2Blobs(ephemeral, newKey)
+
+        // Re-encrypt anything this session already wrote with the ephemeral key.
+        masterKey?.let { reencryptAllV2Blobs(it, newKey) }
+
+        masterKey = newKey
+        keySource = KeySource.Passphrase
+        // Convert any v1 blobs from a previous install to v2 with the new key.
+        migrateLegacyIfNeeded()
+
         prefs.put(PASSPHRASE_SALT_PREF, Base64.getEncoder().encodeToString(salt))
         prefs.put(PASSPHRASE_VERIFIER_PREF, encryptV2(PASSPHRASE_VERIFIER_PLAINTEXT, newKey))
         prefs.flush()
-        masterKey = newKey
-        keySource = KeySource.Passphrase
         _unlockState.value = UnlockState.Unlocked
         return true
     }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
@@ -1,20 +1,35 @@
 package org.nostr.nostrord.storage
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.security.SecureRandom
+import java.util.Base64
 import java.util.prefs.Preferences
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
-import java.security.SecureRandom
-import java.util.Base64
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.decodeFromString
-import kotlinx.serialization.json.Json
+
+sealed class UnlockState {
+    object Initializing : UnlockState()
+    object Unlocked : UnlockState()
+    object NeedsPassphrase : UnlockState()
+    object NeedsPassphraseSetup : UnlockState()
+}
+
+internal enum class KeySource { Keychain, Passphrase, Ephemeral }
 
 actual object SecureStorage {
     private val prefs = Preferences.userNodeForPackage(SecureStorage::class.java)
+
     private const val PRIVATE_KEY_PREF = "nostr_private_key"
-    private const val ENCRYPTION_KEY_PREF = "encryption_key"
     private const val JOINED_GROUPS_PREFIX = "joined_groups_"
     private const val CURRENT_RELAY_URL = "current_relay_url"
     private const val RELAY_LIST = "relay_list"
@@ -28,74 +43,286 @@ actual object SecureStorage {
     private const val RELAY_GROUPS_PREFIX = "relay_groups_"
     private const val JOINED_GROUP_META_PREFIX = "joined_group_meta_"
     private const val LIVE_CURSORS_PREFIX = "live_cursors_"
-    private const val RELAY_METADATA_KEY = "relay_metadata"
+
+    private const val LEGACY_ENCRYPTION_KEY_PREF = "encryption_key"
+    private const val PASSPHRASE_SALT_PREF = "passphrase_salt"
+    private const val PASSPHRASE_VERIFIER_PREF = "passphrase_verifier"
+
+    private const val V2_PREFIX = "v2:"
+    private const val GCM_IV_LEN = 12
+    private const val GCM_TAG_BITS = 128
+    private const val KEY_LEN_BITS = 256
+    private const val PBKDF2_ITERATIONS = 600_000
+    private const val PASSPHRASE_VERIFIER_PLAINTEXT = "nostrord-passphrase-ok"
+
+    private val _unlockState = MutableStateFlow<UnlockState>(UnlockState.Initializing)
+    val unlockState: StateFlow<UnlockState> = _unlockState.asStateFlow()
+
+    private var masterKey: SecretKey? = null
+    private var legacyKey: SecretKey? = null
+    private var keySource: KeySource = KeySource.Ephemeral
+
+    fun usesKeychain(): Boolean = keySource == KeySource.Keychain
+    fun usesPassphrase(): Boolean = keySource == KeySource.Passphrase
 
     init {
-        if (prefs.get(ENCRYPTION_KEY_PREF, null) == null) {
-            val key = generateEncryptionKey()
-            prefs.put(ENCRYPTION_KEY_PREF, Base64.getEncoder().encodeToString(key.encoded))
+        initialize()
+    }
+
+    private fun initialize() {
+        legacyKey = loadLegacyKey()
+
+        val existingKeychainKey = KeychainStore.getMasterKey()
+        if (existingKeychainKey != null) {
+            masterKey = SecretKeySpec(existingKeychainKey, "AES")
+            keySource = KeySource.Keychain
+            _unlockState.value = UnlockState.Unlocked
+            migrateLegacyIfNeeded()
+            return
+        }
+
+        if (KeychainStore.isAvailable()) {
+            val freshKey = randomKeyBytes()
+            if (KeychainStore.setMasterKey(freshKey)) {
+                masterKey = SecretKeySpec(freshKey, "AES")
+                keySource = KeySource.Keychain
+                _unlockState.value = UnlockState.Unlocked
+                migrateLegacyIfNeeded()
+                return
+            }
+        }
+
+        if (prefs.get(PASSPHRASE_VERIFIER_PREF, null) != null) {
+            _unlockState.value = UnlockState.NeedsPassphrase
+        } else {
+            // No keychain and no prior passphrase: run unlocked with an in-memory key.
+            // A sensitive save (nsec / bunker) will later transition to NeedsPassphraseSetup.
+            masterKey = SecretKeySpec(randomKeyBytes(), "AES")
+            keySource = KeySource.Ephemeral
+            _unlockState.value = UnlockState.Unlocked
+            migrateLegacyIfNeeded()
         }
     }
-    
-    private fun generateEncryptionKey(): SecretKey {
-        val keyGen = KeyGenerator.getInstance("AES")
-        keyGen.init(256, SecureRandom())
-        return keyGen.generateKey()
+
+    fun unlockWithPassphrase(passphrase: String): Boolean {
+        if (passphrase.isEmpty()) return false
+        val saltB64 = prefs.get(PASSPHRASE_SALT_PREF, null) ?: return false
+        val verifier = prefs.get(PASSPHRASE_VERIFIER_PREF, null) ?: return false
+        val key = deriveKeyFromPassphrase(passphrase, Base64.getDecoder().decode(saltB64))
+        val plain = try {
+            decryptV2(verifier, key)
+        } catch (_: Exception) {
+            return false
+        }
+        if (plain != PASSPHRASE_VERIFIER_PLAINTEXT) return false
+        masterKey = key
+        keySource = KeySource.Passphrase
+        _unlockState.value = UnlockState.Unlocked
+        migrateLegacyIfNeeded()
+        return true
     }
-    
-    private fun getEncryptionKey(): SecretKey {
-        val keyString = prefs.get(ENCRYPTION_KEY_PREF, null)
-            ?: throw IllegalStateException("Encryption key not found")
-        val keyBytes = Base64.getDecoder().decode(keyString)
-        return SecretKeySpec(keyBytes, "AES")
-    }
-    
-    private fun encrypt(data: String): String {
-        val cipher = Cipher.getInstance("AES")
-        cipher.init(Cipher.ENCRYPT_MODE, getEncryptionKey())
-        val encrypted = cipher.doFinal(data.toByteArray())
-        return Base64.getEncoder().encodeToString(encrypted)
-    }
-    
-    private fun decrypt(encryptedData: String): String {
-        val cipher = Cipher.getInstance("AES")
-        cipher.init(Cipher.DECRYPT_MODE, getEncryptionKey())
-        val decrypted = cipher.doFinal(Base64.getDecoder().decode(encryptedData))
-        return String(decrypted)
-    }
-    
-    actual fun savePrivateKey(privateKeyHex: String) {
-        val encrypted = encrypt(privateKeyHex)
-        prefs.put(PRIVATE_KEY_PREF, encrypted)
+
+    fun setupPassphrase(passphrase: String): Boolean {
+        if (passphrase.isEmpty()) return false
+        if (_unlockState.value !is UnlockState.NeedsPassphraseSetup) return false
+        val ephemeral = masterKey ?: return false
+        val salt = ByteArray(16).also { SecureRandom().nextBytes(it) }
+        val newKey = deriveKeyFromPassphrase(passphrase, salt)
+        reencryptAllV2Blobs(ephemeral, newKey)
+        prefs.put(PASSPHRASE_SALT_PREF, Base64.getEncoder().encodeToString(salt))
+        prefs.put(PASSPHRASE_VERIFIER_PREF, encryptV2(PASSPHRASE_VERIFIER_PLAINTEXT, newKey))
         prefs.flush()
+        masterKey = newKey
+        keySource = KeySource.Passphrase
+        _unlockState.value = UnlockState.Unlocked
+        return true
     }
-    
-    actual fun getPrivateKey(): String? {
-        val encrypted = prefs.get(PRIVATE_KEY_PREF, null) ?: return null
+
+    fun changePassphrase(current: String, new: String): Boolean {
+        if (new.isEmpty()) return false
+        if (keySource != KeySource.Passphrase) return false
+        val saltB64 = prefs.get(PASSPHRASE_SALT_PREF, null) ?: return false
+        val verifier = prefs.get(PASSPHRASE_VERIFIER_PREF, null) ?: return false
+        val currentKey = deriveKeyFromPassphrase(current, Base64.getDecoder().decode(saltB64))
+        val plain = try {
+            decryptV2(verifier, currentKey)
+        } catch (_: Exception) {
+            return false
+        }
+        if (plain != PASSPHRASE_VERIFIER_PLAINTEXT) return false
+        val oldKey = masterKey ?: return false
+        val newSalt = ByteArray(16).also { SecureRandom().nextBytes(it) }
+        val newKey = deriveKeyFromPassphrase(new, newSalt)
+        reencryptAllV2Blobs(oldKey, newKey)
+        prefs.put(PASSPHRASE_SALT_PREF, Base64.getEncoder().encodeToString(newSalt))
+        prefs.put(PASSPHRASE_VERIFIER_PREF, encryptV2(PASSPHRASE_VERIFIER_PLAINTEXT, newKey))
+        prefs.flush()
+        masterKey = newKey
+        return true
+    }
+
+    private fun reencryptAllV2Blobs(oldKey: SecretKey, newKey: SecretKey) {
+        val protectedKeys = setOf(
+            LEGACY_ENCRYPTION_KEY_PREF,
+            PASSPHRASE_SALT_PREF,
+            PASSPHRASE_VERIFIER_PREF,
+        )
+        val keys = try { prefs.keys().toList() } catch (_: Exception) { emptyList() }
+        keys.forEach { k ->
+            if (k in protectedKeys) return@forEach
+            val v = prefs.get(k, null) ?: return@forEach
+            if (!v.startsWith(V2_PREFIX)) return@forEach
+            val plain = try { decryptV2(v, oldKey) } catch (_: Exception) { return@forEach }
+            try { prefs.put(k, encryptV2(plain, newKey)) } catch (_: Exception) {}
+        }
+        try { prefs.flush() } catch (_: Exception) {}
+    }
+
+    private fun maybePromptPassphraseSetup() {
+        if (keySource == KeySource.Ephemeral && _unlockState.value == UnlockState.Unlocked) {
+            _unlockState.value = UnlockState.NeedsPassphraseSetup
+        }
+    }
+
+    private fun loadLegacyKey(): SecretKey? {
+        val s = prefs.get(LEGACY_ENCRYPTION_KEY_PREF, null) ?: return null
         return try {
-            decrypt(encrypted)
-        } catch (e: Exception) {
+            SecretKeySpec(Base64.getDecoder().decode(s), "AES")
+        } catch (_: Exception) {
             null
         }
     }
-    
+
+    private fun randomKeyBytes(): ByteArray {
+        val kg = KeyGenerator.getInstance("AES")
+        kg.init(KEY_LEN_BITS, SecureRandom())
+        return kg.generateKey().encoded
+    }
+
+    private fun deriveKeyFromPassphrase(passphrase: String, salt: ByteArray): SecretKey {
+        val spec = PBEKeySpec(passphrase.toCharArray(), salt, PBKDF2_ITERATIONS, KEY_LEN_BITS)
+        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        val keyBytes = factory.generateSecret(spec).encoded
+        return SecretKeySpec(keyBytes, "AES")
+    }
+
+    private fun encryptV2(plain: String, key: SecretKey): String {
+        val iv = ByteArray(GCM_IV_LEN).also { SecureRandom().nextBytes(it) }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        val ct = cipher.doFinal(plain.toByteArray(Charsets.UTF_8))
+        val out = ByteArray(iv.size + ct.size)
+        System.arraycopy(iv, 0, out, 0, iv.size)
+        System.arraycopy(ct, 0, out, iv.size, ct.size)
+        return V2_PREFIX + Base64.getEncoder().encodeToString(out)
+    }
+
+    private fun decryptV2(blob: String, key: SecretKey): String {
+        require(blob.startsWith(V2_PREFIX)) { "not a v2 blob" }
+        val raw = Base64.getDecoder().decode(blob.removePrefix(V2_PREFIX))
+        val iv = raw.copyOfRange(0, GCM_IV_LEN)
+        val ct = raw.copyOfRange(GCM_IV_LEN, raw.size)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        return String(cipher.doFinal(ct), Charsets.UTF_8)
+    }
+
+    private fun decryptLegacy(blob: String, key: SecretKey): String {
+        // "AES" alone resolves to AES/ECB/PKCS5Padding — kept only to read v1 blobs during migration.
+        val cipher = Cipher.getInstance("AES")
+        cipher.init(Cipher.DECRYPT_MODE, key)
+        return String(cipher.doFinal(Base64.getDecoder().decode(blob)), Charsets.UTF_8)
+    }
+
+    private fun encrypt(plain: String): String {
+        val k = masterKey ?: throw IllegalStateException("SecureStorage is locked")
+        return encryptV2(plain, k)
+    }
+
+    private fun decrypt(blob: String): String? {
+        return try {
+            if (blob.startsWith(V2_PREFIX)) {
+                val k = masterKey ?: return null
+                decryptV2(blob, k)
+            } else {
+                val k = legacyKey ?: return null
+                decryptLegacy(blob, k)
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun migrateLegacyIfNeeded() {
+        val legacy = legacyKey ?: return
+        val newKey = masterKey ?: return
+
+        val protectedKeys = setOf(
+            LEGACY_ENCRYPTION_KEY_PREF,
+            PASSPHRASE_SALT_PREF,
+            PASSPHRASE_VERIFIER_PREF,
+        )
+
+        val keys = try { prefs.keys().toList() } catch (_: Exception) { emptyList() }
+        var saveFailed = false
+        keys.forEach { k ->
+            if (k in protectedKeys) return@forEach
+            val v = prefs.get(k, null) ?: return@forEach
+            if (v.startsWith(V2_PREFIX)) return@forEach
+            val plain = try {
+                decryptLegacy(v, legacy)
+            } catch (_: Exception) {
+                return@forEach
+            }
+            try {
+                prefs.put(k, encryptV2(plain, newKey))
+            } catch (_: Exception) {
+                // Keep the legacy key so the next launch can retry — losing it now would orphan the v1 blob.
+                saveFailed = true
+            }
+        }
+        try {
+            prefs.flush()
+        } catch (_: Exception) {
+        }
+        if (!saveFailed) {
+            try {
+                prefs.remove(LEGACY_ENCRYPTION_KEY_PREF)
+                prefs.flush()
+            } catch (_: Exception) {
+            }
+            legacyKey = null
+        }
+    }
+
+    actual fun savePrivateKey(privateKeyHex: String) {
+        prefs.put(PRIVATE_KEY_PREF, encrypt(privateKeyHex))
+        prefs.flush()
+        maybePromptPassphraseSetup()
+    }
+
+    actual fun getPrivateKey(): String? {
+        val encrypted = prefs.get(PRIVATE_KEY_PREF, null) ?: return null
+        return decrypt(encrypted)
+    }
+
     actual fun hasPrivateKey(): Boolean {
         return prefs.get(PRIVATE_KEY_PREF, null) != null
     }
-    
+
     actual fun clearPrivateKey() {
         prefs.remove(PRIVATE_KEY_PREF)
         prefs.flush()
     }
-    
+
     actual fun saveCurrentRelayUrl(relayUrl: String) {
         saveString(CURRENT_RELAY_URL, relayUrl)
     }
-    
+
     actual fun getCurrentRelayUrl(): String? {
         return getString(CURRENT_RELAY_URL)
     }
-    
+
     actual fun clearCurrentRelayUrl() {
         remove(CURRENT_RELAY_URL)
     }
@@ -110,7 +337,6 @@ actual object SecureStorage {
     }
 
     actual fun saveJoinedGroupsForRelay(pubkey: String, relayUrl: String, groupIds: Set<String>) {
-        // Account-scoped key: prefix + pubkey hash + relay hash
         val key = JOINED_GROUPS_PREFIX + pubkey.hashCode() + "_" + relayUrl.hashCode()
         val json = Json.encodeToString(groupIds.toList())
         saveString(key, json)
@@ -143,67 +369,52 @@ actual object SecureStorage {
         } catch (e: Exception) {
         }
     }
-    
-    // NIP-46 Bunker URL support
+
     actual fun saveBunkerUrl(bunkerUrl: String) {
-        val encrypted = encrypt(bunkerUrl)
-        prefs.put(BUNKER_URL_PREF, encrypted)
+        prefs.put(BUNKER_URL_PREF, encrypt(bunkerUrl))
         prefs.flush()
+        maybePromptPassphraseSetup()
     }
-    
+
     actual fun getBunkerUrl(): String? {
         val encrypted = prefs.get(BUNKER_URL_PREF, null) ?: return null
-        return try {
-            decrypt(encrypted)
-        } catch (e: Exception) {
-            null
-        }
+        return decrypt(encrypted)
     }
-    
+
     actual fun hasBunkerUrl(): Boolean {
         return prefs.get(BUNKER_URL_PREF, null) != null
     }
-    
+
     actual fun clearBunkerUrl() {
         prefs.remove(BUNKER_URL_PREF)
         prefs.flush()
     }
-    
-    // NIP-46 Bunker User Pubkey support
+
     actual fun saveBunkerUserPubkey(pubkey: String) {
-        val encrypted = encrypt(pubkey)
-        prefs.put(BUNKER_USER_PUBKEY_PREF, encrypted)
+        prefs.put(BUNKER_USER_PUBKEY_PREF, encrypt(pubkey))
         prefs.flush()
+        maybePromptPassphraseSetup()
     }
-    
+
     actual fun getBunkerUserPubkey(): String? {
         val encrypted = prefs.get(BUNKER_USER_PUBKEY_PREF, null) ?: return null
-        return try {
-            decrypt(encrypted)
-        } catch (e: Exception) {
-            null
-        }
+        return decrypt(encrypted)
     }
-    
+
     actual fun clearBunkerUserPubkey() {
         prefs.remove(BUNKER_USER_PUBKEY_PREF)
         prefs.flush()
     }
-    
-    // NIP-46 Bunker Client Private Key (for session persistence)
+
     actual fun saveBunkerClientPrivateKey(privateKey: String) {
-        val encrypted = encrypt(privateKey)
-        prefs.put(BUNKER_CLIENT_PRIVATE_KEY_PREF, encrypted)
+        prefs.put(BUNKER_CLIENT_PRIVATE_KEY_PREF, encrypt(privateKey))
         prefs.flush()
+        maybePromptPassphraseSetup()
     }
 
     actual fun getBunkerClientPrivateKey(): String? {
         val encrypted = prefs.get(BUNKER_CLIENT_PRIVATE_KEY_PREF, null) ?: return null
-        return try {
-            decrypt(encrypted)
-        } catch (e: Exception) {
-            null
-        }
+        return decrypt(encrypted)
     }
 
     actual fun clearBunkerClientPrivateKey() {
@@ -211,7 +422,6 @@ actual object SecureStorage {
         prefs.flush()
     }
 
-    // NIP-07 Browser Extension (not used on JVM, but required by expect)
     actual fun saveNip07UserPubkey(pubkey: String) {}
     actual fun getNip07UserPubkey(): String? = null
     actual fun clearNip07UserPubkey() {}
@@ -219,9 +429,9 @@ actual object SecureStorage {
     actual fun clearAll() {
         prefs.clear()
         prefs.flush()
+        KeychainStore.deleteMasterKey()
     }
 
-    // Last read timestamp tracking
     actual fun saveLastReadTimestamp(pubkey: String, groupId: String, timestamp: Long) {
         val key = LAST_READ_PREFIX + pubkey.hashCode() + "_" + groupId.hashCode()
         prefs.putLong(key, timestamp)
@@ -254,35 +464,27 @@ actual object SecureStorage {
                 }
             }
         } catch (e: Exception) {
-            // Ignore errors
         }
         return result
     }
 
     private fun saveString(key: String, value: String) {
-        val encrypted = encrypt(value)
-        prefs.put(key, encrypted)
+        prefs.put(key, encrypt(value))
         prefs.flush()
     }
-    
+
     private fun getString(key: String): String? {
         val encrypted = prefs.get(key, null) ?: return null
-        return try {
-            decrypt(encrypted)
-        } catch (e: Exception) {
-            null
-        }
+        return decrypt(encrypted)
     }
-    
+
     private fun remove(key: String) {
         prefs.remove(key)
         prefs.flush()
     }
 
-    // Last viewed group persistence
     actual fun saveLastViewedGroup(pubkey: String, groupId: String, groupName: String?) {
         val key = LAST_VIEWED_GROUP_PREFIX + pubkey.hashCode()
-        // Store as "groupId|groupName" (groupName can be empty)
         val value = "$groupId|${groupName ?: ""}"
         saveString(key, value)
     }
@@ -302,7 +504,6 @@ actual object SecureStorage {
         remove(key)
     }
 
-    // Message persistence
     actual fun saveMessagesForGroup(pubkey: String, groupId: String, messagesJson: String) {
         val key = MESSAGES_PREFIX + pubkey.hashCode() + "_" + groupId.hashCode()
         saveString(key, messagesJson)
@@ -328,11 +529,9 @@ actual object SecureStorage {
             }
             prefs.flush()
         } catch (e: Exception) {
-            // Ignore errors
         }
     }
 
-    // Pending events persistence
     actual fun savePendingEvents(pubkey: String, eventsJson: String) {
         val key = PENDING_EVENTS_PREFIX + pubkey.hashCode()
         saveString(key, eventsJson)
@@ -348,7 +547,6 @@ actual object SecureStorage {
         remove(key)
     }
 
-    // Group metadata cache
     actual fun saveGroupsForRelay(relayUrl: String, groupsJson: String) {
         val key = RELAY_GROUPS_PREFIX + relayUrl.hashCode()
         saveString(key, groupsJson)
@@ -399,7 +597,6 @@ actual object SecureStorage {
         try {
             relayMetadataFile.writeText(json)
         } catch (_: Exception) {
-            // Non-critical
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/PassphraseGate.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/PassphraseGate.kt
@@ -1,0 +1,193 @@
+package org.nostr.nostrord.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.UnlockState
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordTypography
+
+@Composable
+fun PassphraseGate(content: @Composable () -> Unit) {
+    val state by SecureStorage.unlockState.collectAsState()
+    when (state) {
+        UnlockState.Initializing -> Box(Modifier.fillMaxSize().background(NostrordColors.Background))
+        UnlockState.NeedsPassphrase -> PassphrasePrompt(isNew = false)
+        UnlockState.Unlocked, UnlockState.NeedsPassphraseSetup -> {
+            Box(Modifier.fillMaxSize()) {
+                content()
+                if (state == UnlockState.NeedsPassphraseSetup) {
+                    PassphrasePrompt(isNew = true)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PassphrasePrompt(isNew: Boolean) {
+    var passphrase by remember { mutableStateOf("") }
+    var confirm by remember { mutableStateOf("") }
+    var visible by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    val canSubmit = if (isNew) {
+        passphrase.length >= 8 && passphrase == confirm
+    } else {
+        passphrase.isNotEmpty()
+    }
+
+    fun submit() {
+        if (!canSubmit) return
+        val ok = if (isNew) {
+            SecureStorage.setupPassphrase(passphrase)
+        } else {
+            SecureStorage.unlockWithPassphrase(passphrase)
+        }
+        if (!ok) {
+            error = if (isNew) "Could not set the passphrase." else "Incorrect passphrase."
+            passphrase = ""
+            confirm = ""
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(NostrordColors.Background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            modifier = Modifier
+                .widthIn(max = 440.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(NostrordColors.Surface)
+                .padding(32.dp),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = if (isNew) "Protect your saved credentials" else "Enter your passphrase",
+                style = NostrordTypography.ServerHeader,
+                color = NostrordColors.TextPrimary
+            )
+            Text(
+                text = if (isNew)
+                    "Your operating system keychain is not available. Set a passphrase to encrypt the credentials you just saved on this device. The passphrase cannot be recovered."
+                else
+                    "Your operating system keychain is not available. Enter the passphrase you set previously to unlock your stored data.",
+                style = NostrordTypography.MessageBody,
+                color = NostrordColors.TextSecondary
+            )
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = passphrase,
+                onValueChange = { passphrase = it; error = null },
+                label = { Text("Passphrase", color = NostrordColors.TextMuted) },
+                singleLine = true,
+                visualTransformation = if (visible) VisualTransformation.None else PasswordVisualTransformation(),
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = if (isNew) ImeAction.Next else ImeAction.Done
+                ),
+                keyboardActions = KeyboardActions(onDone = { submit() }),
+                trailingIcon = {
+                    IconButton(onClick = { visible = !visible }) {
+                        Icon(
+                            imageVector = if (visible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            contentDescription = if (visible) "Hide passphrase" else "Show passphrase",
+                            tint = NostrordColors.TextSecondary
+                        )
+                    }
+                },
+                colors = passphraseFieldColors(),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            if (isNew) {
+                OutlinedTextField(
+                    value = confirm,
+                    onValueChange = { confirm = it; error = null },
+                    label = { Text("Confirm passphrase", color = NostrordColors.TextMuted) },
+                    singleLine = true,
+                    visualTransformation = if (visible) VisualTransformation.None else PasswordVisualTransformation(),
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Done
+                    ),
+                    keyboardActions = KeyboardActions(onDone = { submit() }),
+                    colors = passphraseFieldColors(),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text(
+                    text = "At least 8 characters. Must match.",
+                    style = NostrordTypography.Caption,
+                    color = NostrordColors.TextSecondary
+                )
+            }
+
+            error?.let {
+                Text(
+                    text = it,
+                    style = NostrordTypography.MessageBody,
+                    color = NostrordColors.Error
+                )
+            }
+
+            Spacer(Modifier.height(4.dp))
+            AppButton(
+                text = if (isNew) "Set passphrase" else "Unlock",
+                onClick = ::submit,
+                enabled = canSubmit,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun passphraseFieldColors() = OutlinedTextFieldDefaults.colors(
+    focusedBorderColor = NostrordColors.Primary,
+    unfocusedBorderColor = NostrordColors.Divider,
+    focusedContainerColor = NostrordColors.InputBackground,
+    unfocusedContainerColor = NostrordColors.InputBackground,
+    cursorColor = NostrordColors.Primary,
+    focusedTextColor = Color.White,
+    unfocusedTextColor = Color.White
+)

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/PassphraseGate.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/PassphraseGate.kt
@@ -42,17 +42,20 @@ import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 
+private enum class PromptMode { Unlock, Setup, LegacyMigration }
+
 @Composable
 fun PassphraseGate(content: @Composable () -> Unit) {
     val state by SecureStorage.unlockState.collectAsState()
     when (state) {
         UnlockState.Initializing -> Box(Modifier.fillMaxSize().background(NostrordColors.Background))
-        UnlockState.NeedsPassphrase -> PassphrasePrompt(isNew = false)
+        UnlockState.NeedsPassphrase -> PassphrasePrompt(PromptMode.Unlock)
+        UnlockState.NeedsLegacyMigration -> PassphrasePrompt(PromptMode.LegacyMigration)
         UnlockState.Unlocked, UnlockState.NeedsPassphraseSetup -> {
             Box(Modifier.fillMaxSize()) {
                 content()
                 if (state == UnlockState.NeedsPassphraseSetup) {
-                    PassphrasePrompt(isNew = true)
+                    PassphrasePrompt(PromptMode.Setup)
                 }
             }
         }
@@ -60,12 +63,13 @@ fun PassphraseGate(content: @Composable () -> Unit) {
 }
 
 @Composable
-private fun PassphrasePrompt(isNew: Boolean) {
+private fun PassphrasePrompt(mode: PromptMode) {
     var passphrase by remember { mutableStateOf("") }
     var confirm by remember { mutableStateOf("") }
     var visible by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
 
+    val isNew = mode != PromptMode.Unlock
     val canSubmit = if (isNew) {
         passphrase.length >= 8 && passphrase == confirm
     } else {
@@ -102,15 +106,23 @@ private fun PassphrasePrompt(isNew: Boolean) {
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Text(
-                text = if (isNew) "Protect your saved credentials" else "Enter your passphrase",
+                text = when (mode) {
+                    PromptMode.Unlock -> "Enter your passphrase"
+                    PromptMode.Setup -> "Protect your saved credentials"
+                    PromptMode.LegacyMigration -> "Set a passphrase to keep your data"
+                },
                 style = NostrordTypography.ServerHeader,
                 color = NostrordColors.TextPrimary
             )
             Text(
-                text = if (isNew)
-                    "Your operating system keychain is not available. Set a passphrase to encrypt the credentials you just saved on this device. The passphrase cannot be recovered."
-                else
-                    "Your operating system keychain is not available. Enter the passphrase you set previously to unlock your stored data.",
+                text = when (mode) {
+                    PromptMode.Unlock ->
+                        "Your operating system keychain is not available. Enter the passphrase you set previously to unlock your stored data."
+                    PromptMode.Setup ->
+                        "Your operating system keychain is not available. Set a passphrase to encrypt the credentials you just saved on this device. The passphrase cannot be recovered."
+                    PromptMode.LegacyMigration ->
+                        "Your operating system keychain is not available and we found data from a previous version. Set a passphrase to migrate and protect it. The passphrase cannot be recovered."
+                },
                 style = NostrordTypography.MessageBody,
                 color = NostrordColors.TextSecondary
             )

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/storage/PassphraseSettings.wasmJs.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.storage
+
+actual object PassphraseSettings {
+    actual val isApplicable: Boolean = false
+    actual fun usesKeychain(): Boolean = false
+    actual fun usesPassphrase(): Boolean = false
+    actual fun changePassphrase(current: String, new: String): Boolean = false
+}


### PR DESCRIPTION
The JVM build was storing the AES encryption key in plaintext inside
`java.util.prefs.Preferences`, exposing all saved credentials (nsec, bunker
URL, bunker client key) to anyone with read access to the home directory.

## Changes

**Key-management tiers (`SecureStorage.jvm.kt`, `KeychainStore.kt`)**
1. OS keychain via `java-keyring` - master key lives only in the system keychain, never on disk.
2. Passphrase fallback - PBKDF2-HMAC-SHA256 (600k iterations) when keychain is unavailable.
3. Ephemeral in-memory key for fresh installs with no keychain; transitions to passphrase setup on first sensitive save.

**Encryption upgrade** - v1 (AES/ECB, no IV, no auth) -> v2 (AES/GCM, random IV, 128-bit tag). Migration runs automatically on first unlock; legacy blobs are re-encrypted and the old plaintext key pref is removed.

**Boot gate (`PassphraseGate.kt`)** - wraps `App()` and blocks the UI until `SecureStorage.unlockState` reaches `Unlocked`, showing the appropriate prompt (`NeedsPassphrase`, `NeedsPassphraseSetup`, or `NeedsLegacyMigration`).

**Settings** - change-passphrase option and key-source badge (keychain / passphrase / ephemeral).

**Shutdown watchdog (`main.kt`)** - `java-keyring`'s DBus close hook deadlocks on normal JVM shutdown; a daemon thread calls `Runtime.halt(0)` 500 ms after `exitApplication()`.

**Close guard** - closing the window or pressing Ctrl+Q while passphrase setup is pending is a no-op; the only exits are completing setup or logging out (which clears data and returns to an unlocked state).
