### PR TITLE
feat(login): make bunker QR code tappable to open signer app on Android

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
@@ -7,3 +7,5 @@ class AndroidPlatform : Platform {
 }
 
 actual fun getPlatform(): Platform = AndroidPlatform()
+
+actual val isAndroid: Boolean = true

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
@@ -5,3 +5,5 @@ interface Platform {
 }
 
 expect fun getPlatform(): Platform
+
+expect val isAndroid: Boolean

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/components/BunkerLoginTab.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/components/BunkerLoginTab.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.isAndroid
 import org.nostr.nostrord.ui.components.QrCode
 import org.nostr.nostrord.ui.screens.login.LoginViewModel
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -186,6 +187,7 @@ private fun QrCodeLoginContent(vm: LoginViewModel, onLoginSuccess: () -> Unit) {
     }
 
     val clipboardManager = LocalClipboardManager.current
+    val uriHandler = LocalUriHandler.current
 
     Column(
         horizontalAlignment = Alignment.CenterHorizontally
@@ -212,7 +214,18 @@ private fun QrCodeLoginContent(vm: LoginViewModel, onLoginSuccess: () -> Unit) {
                 QrCode(
                     data = uri,
                     size = 220.dp,
-                    quietZone = 12.dp
+                    quietZone = 12.dp,
+                    modifier = Modifier.clickable {
+                        try { uriHandler.openUri(uri) } catch (_: Exception) {}
+                    }
+                )
+            }
+            if (isAndroid) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    "Tap to open in signer app",
+                    color = NostrordColors.TextMuted,
+                    style = MaterialTheme.typography.labelSmall
                 )
             }
         } ?: run {

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
@@ -7,3 +7,5 @@ class IOSPlatform: Platform {
 }
 
 actual fun getPlatform(): Platform = IOSPlatform()
+
+actual val isAndroid: Boolean = false

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
@@ -5,3 +5,5 @@ class JsPlatform: Platform {
 }
 
 actual fun getPlatform(): Platform = JsPlatform()
+
+actual val isAndroid: Boolean = false

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
@@ -5,3 +5,5 @@ class JVMPlatform: Platform {
 }
 
 actual fun getPlatform(): Platform = JVMPlatform()
+
+actual val isAndroid: Boolean = false

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
@@ -5,3 +5,5 @@ class WasmPlatform: Platform {
 }
 
 actual fun getPlatform(): Platform = WasmPlatform()
+
+actual val isAndroid: Boolean = false


### PR DESCRIPTION
Tapping the nostrconnect:// QR code on Android now launches the Amber
signer directly (or shows a system chooser if multiple compatible apps
are installed), removing the need for an external QR scanner.

## Changes

**`BunkerLoginTab.kt`** - QrCode composable receives a `.clickable`
modifier that calls `LocalUriHandler.openUri(uri)` with a silent catch.
A "Tap to open in signer app" hint appears below the QR, gated on
`isAndroid` so desktop and web builds are unaffected.

**`Platform.kt` + actuals** - added `expect val isAndroid: Boolean`
with `true` on androidMain and `false` on jvmMain, jsMain, wasmJsMain,
and iosMain.

Closes #51