### PR TITLE
fix(offline-relay): surface offline relay UX with manage/remove flow

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -764,6 +764,7 @@ private fun DesktopContent(
                 groupId = screen.groupId,
                 groupName = screen.groupName,
                 onNavigateHome = { onNavigate(Screen.Home) },
+                onNavigateHomeManageRelay = { onNavigate(Screen.HomeManageRelay) },
                 onNavigateToGroup = onNavigateToGroupWithRelay,
                 showServerRail = false,
                 forceDesktop = true,
@@ -771,6 +772,15 @@ private fun DesktopContent(
                 onInviteCodeConsumed = onInviteCodeConsumed,
                 targetMessageId = pendingMessageId,
                 onTargetMessageConsumed = onMessageIdConsumed
+            )
+        }
+        is Screen.HomeManageRelay -> {
+            HomeScreen(
+                relayUrl = selectedRelayUrl,
+                gridState = homeGridState,
+                onNavigate = onNavigate,
+                forceDesktop = true,
+                initiallyManaging = true
             )
         }
         is Screen.EditProfile -> {
@@ -831,12 +841,23 @@ private fun MobileContent(
                 groupId = screen.groupId,
                 groupName = screen.groupName,
                 onNavigateHome = { onNavigate(Screen.Home) },
+                onNavigateHomeManageRelay = { onNavigate(Screen.HomeManageRelay) },
                 onNavigateToGroup = onNavigateToGroupWithRelay,
                 onOpenDrawer = onOpenDrawer,
                 pendingInviteCode = pendingInviteCode,
                 onInviteCodeConsumed = onInviteCodeConsumed,
                 targetMessageId = pendingMessageId,
                 onTargetMessageConsumed = onMessageIdConsumed
+            )
+        }
+        is Screen.HomeManageRelay -> {
+            HomeScreen(
+                relayUrl = selectedRelayUrl,
+                gridState = homeGridState,
+                onNavigate = onNavigate,
+                onCreateGroupClick = onCreateGroupClick,
+                onOpenDrawer = onOpenDrawer,
+                initiallyManaging = true
             )
         }
         is Screen.EditProfile -> {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -152,7 +152,7 @@ class NostrGroupClient(
     private var session: DefaultClientWebSocketSession? = null
     private val json = Json { ignoreUnknownKeys = true }
     private var connectionJob: Job? = null
-    private val connectionReady = Channel<Unit>(Channel.CONFLATED)
+    private val connectionResult = CompletableDeferred<Boolean>()
 
     // Signalled after the relay's NIP-42 AUTH challenge has been answered.
     // connect()/switchRelay() await this so REQs are not sent before auth.
@@ -229,7 +229,7 @@ class NostrGroupClient(
                     session = this
 
                     // Signal that connection is ready
-                    connectionReady.trySend(Unit)
+                    connectionResult.complete(true)
 
                     // Heartbeat: detect relays that stop sending without closing the WebSocket.
                     // Ktor handles WebSocket-level ping/pong, but some relays freeze at the
@@ -279,9 +279,13 @@ class NostrGroupClient(
                 }
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
+                // Signal failure immediately so waitForConnection() returns without
+                // burning the full 7-second timeout on unreachable relays.
+                connectionResult.complete(false)
             } finally {
                 val wasConnected = session != null
                 session = null
+                connectionResult.complete(false) // no-op if already completed
                 if (wasConnected && !isDisconnecting) {
                     onConnectionLost?.invoke()
                 }
@@ -291,11 +295,8 @@ class NostrGroupClient(
 
     suspend fun waitForConnection(timeoutMs: Long = 7_000): Boolean {
         return withTimeoutOrNull(timeoutMs) {
-            connectionReady.receive()
-            true
-        } ?: run {
-            false
-        }
+            connectionResult.await()
+        } ?: false
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -234,6 +234,21 @@ class NostrRepository(
             scope.launch { refreshVisibleUserMetadata() }
         }
 
+        // Clear the sidebar skeleton for a relay that becomes unreachable. EOSE never
+        // arrives for a failed connection, so without this the loading flag would
+        // pulse indefinitely while the offline management screen is already showing.
+        scope.launch {
+            connectionManager.connectionState.collect { state ->
+                if (state is ConnectionManager.ConnectionState.Error ||
+                    state is ConnectionManager.ConnectionState.Reconnecting) {
+                    val relay = connectionManager.currentRelayUrl.value
+                    if (relay.isNotBlank()) {
+                        groupManager.markRelayLoaded(relay)
+                    }
+                }
+            }
+        }
+
         metadataManager.messageHandler = { msg, client -> enqueueToRelayPipeline(msg, client) }
 
         connectionManager.startNetworkMonitor()
@@ -701,6 +716,11 @@ class NostrRepository(
         if (relayUrl.isBlank()) return
         _relayMetadataManager.fetch(relayUrl)
 
+        // Mark loading before the connection attempt so the skeleton shows during
+        // the initial Connecting state on cold start. The state-flow observer in
+        // initialize() clears this if the connection fails (Error/Reconnecting).
+        groupManager.markRelayLoading(relayUrl)
+
         val connected = connectionManager.connectPrimary(relayUrl) { msg, client ->
             enqueueToRelayPipeline(msg, client)
         }
@@ -731,6 +751,9 @@ class NostrRepository(
                     groupManager.markPendingFullFetch(relayUrl)
                     groupManager.markRelayLoading(relayUrl)
                     client.requestGroups()
+                } else {
+                    // Cache hit — no EOSE will arrive, so clear the early loading mark.
+                    groupManager.markRelayLoaded(relayUrl)
                 }
                 // After AUTH (or if no AUTH needed), request metadata for private
                 // groups that are in the joined list (kind 10009) but not in the
@@ -875,25 +898,16 @@ class NostrRepository(
         val remaining = existing.filter { it != normalized }
         val pubKey = sessionManager.getPublicKey()
 
-        // Publish kind:10009 first — only persist removal on success
-        if (pubKey != null) {
-            val result = publishJoinedGroupsListWith(pubKey, nip29Relays = remaining)
-            if (result !is Result.Success) {
-                return // signer denied or publish failed — don't remove
-            }
-        }
-
+        // Apply removal locally first so the relay vanishes even when the relay is offline.
+        // The kind:10009 publish is attempted afterwards; failure is non-fatal — the local
+        // removal and the persisted timestamp guard in OutboxManager prevent resurrection.
         SecureStorage.saveRelayList(remaining)
-
-        // Clean up persisted joined groups for this relay
         if (pubKey != null) {
             SecureStorage.clearJoinedGroupsForRelay(pubKey, normalized)
         }
-
-        // Remove from in-memory maps so the rail and kind:10009 cache update immediately
         groupManager.removeRelayEntry(normalized)
         outboxManager.removeRelayFromCache(normalized)
-        // Switch to first remaining relay, or clear persisted relay if none left
+
         val fallback = remaining.firstOrNull()
         if (fallback != null && fallback != connectionManager.currentRelayUrl.value.normalizeRelayUrl()) {
             switchRelay(fallback)
@@ -901,9 +915,15 @@ class NostrRepository(
             SecureStorage.clearCurrentRelayUrl()
             connectionManager.clearCurrentRelay()
         }
-        // Disconnect the removed relay (pool or primary)
         connectionManager.disconnectRelay(normalized)
         connectedPoolRelays.remove(normalized)
+
+        // Publish updated kind:10009 to remaining relays. Signer denial is the only error
+        // that would matter here (user explicitly cancelled), but at this point the relay is
+        // already gone locally, so we just fire-and-forget.
+        if (pubKey != null) {
+            publishJoinedGroupsListWith(pubKey, nip29Relays = remaining)
+        }
     }
 
     override suspend fun disconnect() {
@@ -2114,22 +2134,14 @@ class NostrRepository(
      */
     private suspend fun resubscribeAllGroups(client: NostrGroupClient) {
         val relayUrl = connectionManager.currentRelayUrl.value
+        // Restore cache so the UI shows groups immediately while the re-fetch is in flight.
         groupManager.restoreGroupsForRelay(relayUrl)
-        if (!groupManager.hasCachedGroupsForRelay(relayUrl)) {
-            lastRequestGroupsAt[relayUrl] = epochSeconds()
-            groupManager.markRelayLoading(relayUrl)
-            requestGroupsForRelay(client, relayUrl)
-        } else if (
-            SecureStorage.isGroupFetchLazy(relayUrl) &&
-            !groupManager.hasFullGroupListBeenFetched(relayUrl) &&
-            SecureStorage.getBooleanPref("sidebar_other_expanded_$relayUrl", default = true)
-        ) {
-            // Cache is fresh (partial, joined-only) but OTHER GROUPS is open and the full
-            // list was never fetched. Re-fetch on reconnect so OTHER GROUPS stays populated.
-            groupManager.markPendingFullFetch(relayUrl)
-            groupManager.markRelayLoading(relayUrl)
-            client.requestGroups()
-        }
+        // Always re-fetch on reconnect. restoreGroupsForRelay already populated the UI;
+        // the fresh EOSE will prune any stale groups the relay no longer serves
+        // (e.g. an ephemeral relay that was restarted and lost its group list).
+        lastRequestGroupsAt[relayUrl] = epochSeconds()
+        groupManager.markRelayLoading(relayUrl)
+        requestGroupsForRelay(client, relayUrl)
 
         // Reset loading states for opened groups so pagination works if user scrolls up.
         val openedGroupIds = groupManager.getOpenedGroupIds()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -188,9 +188,13 @@ class GroupManager(
     // EOSE hasn't arrived yet. Lets handleEoseSuspend() distinguish a full fetch from a
     // lazy (joined-only) fetch when the same sub ID is reused.
     private val pendingFullFetchRelays = mutableSetOf<String>()
+    // Group IDs seen during an in-flight full fetch; cleared on EOSE to prune stale groups.
+    private val pendingFetchSeenGroups = mutableMapOf<String, MutableSet<String>>()
 
     fun markPendingFullFetch(relayUrl: String) {
-        pendingFullFetchRelays.add(relayUrl.normalizeRelayUrl())
+        val normalized = relayUrl.normalizeRelayUrl()
+        pendingFullFetchRelays.add(normalized)
+        pendingFetchSeenGroups[normalized] = mutableSetOf()
     }
 
     /**
@@ -1790,6 +1794,15 @@ class GroupManager(
                     // hasFullGroupListBeenFetched() returns true after an app restart.
                     _fullGroupListFetchedRelays.update { it + normalizedRelay }
                     try { SecureStorage.saveFullGroupListEoseTimestamp(normalizedRelay, now) } catch (_: Exception) {}
+                    // Prune stale groups: keep only those seen in this fetch, plus joined
+                    // groups (which become orphans the user can manually forget).
+                    val seenIds = pendingFetchSeenGroups.remove(normalizedRelay) ?: emptySet()
+                    val joinedIds = _joinedGroupsByRelay.value[normalizedRelay] ?: emptySet()
+                    _groupsByRelay.update { current ->
+                        val pruned = (current[normalizedRelay] ?: emptyList())
+                            .filter { it.id in seenIds || it.id in joinedIds }
+                        current + (normalizedRelay to pruned)
+                    }
                 }
                 // Always update the general cache timestamp (used by hasCachedGroupsForRelay).
                 try { SecureStorage.saveGroupListEoseTimestamp(normalizedRelay, now) } catch (_: Exception) {}
@@ -2171,6 +2184,7 @@ class GroupManager(
     fun handleGroupMetadata(metadata: GroupMetadata, relayUrl: String) {
         if (metadata.id in deletedGroupIds) return
         val normalized = relayUrl.normalizeRelayUrl()
+        pendingFetchSeenGroups[normalized]?.add(metadata.id)
         // ALL relays contribute to the unified group list regardless of which relay
         // is currently active. _groupsByRelay handles per-relay filtering for the UI.
         val wasNew = _groups.value.none { it.id == metadata.id }
@@ -2850,6 +2864,7 @@ class GroupManager(
         _completeGroupLoadRelays.update { it - normalized }
         _fullGroupListFetchedRelays.update { it - normalized }
         _groupsByRelay.update { current -> current - normalized }
+        _joinedGroupsByRelay.update { current -> current - normalized }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -16,6 +16,8 @@ import org.nostr.nostrord.network.outbox.RelayListManager
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.loadKind10009Timestamp
+import org.nostr.nostrord.storage.saveKind10009Timestamp
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochMillis
@@ -74,6 +76,12 @@ class OutboxManager(
             .toSet()
         if (saved.isNotEmpty()) {
             _kind10009Relays.value = saved
+        }
+        // Restore the timestamp so handleKind10009Event rejects stale network events
+        // that would resurrect relays/groups the user removed in a previous session.
+        val persisted = SecureStorage.loadKind10009Timestamp()
+        if (persisted > latestKind10009CreatedAt) {
+            latestKind10009CreatedAt = persisted
         }
     }
 
@@ -221,6 +229,7 @@ class OutboxManager(
             groupsMutex.withLock {
                 latestKind10009CreatedAt = event.createdAt
             }
+            SecureStorage.saveKind10009Timestamp(event.createdAt)
 
             _kind10009Relays.value = nip29Relays.map { it.normalizeRelayUrl() }.filter { it.isNotBlank() }.toSet()
             refreshGroupTagRelays()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -177,6 +177,17 @@ fun SecureStorage.isFullGroupListCacheFresh(relayUrl: String, nowSeconds: Long):
     return ts > 0L && (nowSeconds - ts) < GROUP_CACHE_TTL_S
 }
 
+// Persisted timestamp of the most recently published (or locally applied) kind:10009 event.
+// Survives app restarts so that handleKind10009Event can reject stale network events that
+// would otherwise restore relays/groups the user explicitly removed while offline.
+fun SecureStorage.saveKind10009Timestamp(timestamp: Long) {
+    saveStringPref("kind10009_latest_ts", timestamp.toString())
+}
+
+fun SecureStorage.loadKind10009Timestamp(): Long {
+    return getStringPref("kind10009_latest_ts", "0").toLongOrNull() ?: 0L
+}
+
 // Per-relay lazy fetch mode — when true (the default), only joined-group metadata is fetched on
 // connect; the full group list is deferred until the user expands "OTHER GROUPS".
 // Set to false on relays where you always want the full list loaded at startup (EAGER mode).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/Screen.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui
 
 sealed class Screen {
     data object Home : Screen()
+    data object HomeManageRelay : Screen()
     data object RelaySettings : Screen()
     data object Profile : Screen()
     data object EditProfile : Screen()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/ConnectionStatusBanner.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/ConnectionStatusBanner.kt
@@ -4,106 +4,139 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.WifiOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 
-/**
- * Banner displayed when connection to relay is lost or reconnecting.
- * Shows status and provides a manual retry button.
- */
 @Composable
 fun ConnectionStatusBanner(
     connectionState: ConnectionManager.ConnectionState,
     onRetry: () -> Unit,
+    onManageRelay: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val showBanner = connectionState is ConnectionManager.ConnectionState.Error ||
-            connectionState is ConnectionManager.ConnectionState.Reconnecting ||
-            connectionState is ConnectionManager.ConnectionState.Disconnected
+    val visible = connectionState is ConnectionManager.ConnectionState.Error ||
+            connectionState is ConnectionManager.ConnectionState.Reconnecting
 
     AnimatedVisibility(
-        visible = showBanner,
+        visible = visible,
         enter = expandVertically(),
         exit = shrinkVertically(),
         modifier = modifier
     ) {
-        val (message, showRetryButton, isReconnecting) = when (connectionState) {
-            is ConnectionManager.ConnectionState.Reconnecting -> Triple(
-                "Reconnecting (${connectionState.attempt}/${connectionState.maxAttempts})...",
-                false,
-                true
-            )
-            is ConnectionManager.ConnectionState.Error -> Triple(
-                connectionState.message,
-                true,
-                false
-            )
-            is ConnectionManager.ConnectionState.Disconnected -> Triple(
-                "Disconnected from relay",
-                true,
-                false
-            )
-            else -> Triple("", false, false)
-        }
-
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(NostrordColors.Warning.copy(alpha = 0.15f))
-                .clickable(enabled = showRetryButton) { onRetry() }
+                .padding(bottom = Spacing.sm)
+                .clip(RoundedCornerShape(8.dp))
+                .background(NostrordColors.Warning.copy(alpha = 0.12f))
                 .padding(horizontal = Spacing.md, vertical = Spacing.sm),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            if (isReconnecting) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(16.dp),
-                    color = NostrordColors.Warning,
-                    strokeWidth = 2.dp
-                )
-            } else {
-                Icon(
-                    Icons.Default.WifiOff,
-                    contentDescription = null,
-                    tint = NostrordColors.Warning,
-                    modifier = Modifier.size(16.dp)
-                )
-            }
-
-            Spacer(modifier = Modifier.width(Spacing.sm))
-
-            Text(
-                text = message,
-                style = NostrordTypography.Caption,
-                color = NostrordColors.Warning
-            )
-
-            if (showRetryButton) {
-                Spacer(modifier = Modifier.width(Spacing.sm))
-                Icon(
-                    Icons.Default.Refresh,
-                    contentDescription = "Retry",
-                    tint = NostrordColors.Warning,
-                    modifier = Modifier.size(16.dp)
-                )
-                Spacer(modifier = Modifier.width(Spacing.xs))
-                Text(
-                    text = "Tap to retry",
-                    style = NostrordTypography.Caption,
-                    color = NostrordColors.Warning
-                )
+            when (connectionState) {
+                is ConnectionManager.ConnectionState.Reconnecting -> {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        color = NostrordColors.Warning,
+                        strokeWidth = 2.dp
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "Reconnecting (${connectionState.attempt}/${connectionState.maxAttempts})...",
+                        style = NostrordTypography.Caption,
+                        color = NostrordColors.Warning,
+                        modifier = Modifier.weight(1f)
+                    )
+                    TextButton(
+                        onClick = onRetry,
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = null,
+                            tint = NostrordColors.Warning,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            "Retry now",
+                            style = NostrordTypography.Caption,
+                            color = NostrordColors.Warning,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+                is ConnectionManager.ConnectionState.Error -> {
+                    Icon(
+                        Icons.Default.WifiOff,
+                        contentDescription = null,
+                        tint = NostrordColors.Warning,
+                        modifier = Modifier.size(14.dp)
+                    )
+                    Spacer(Modifier.width(8.dp))
+                    Text(
+                        text = "Unable to connect",
+                        style = NostrordTypography.Caption,
+                        color = NostrordColors.Warning,
+                        modifier = Modifier.weight(1f)
+                    )
+                    TextButton(
+                        onClick = onRetry,
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Refresh,
+                            contentDescription = null,
+                            tint = NostrordColors.Warning,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            "Retry",
+                            style = NostrordTypography.Caption,
+                            color = NostrordColors.Warning,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                    Spacer(Modifier.width(4.dp))
+                    Button(
+                        onClick = onManageRelay,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = NostrordColors.Warning.copy(alpha = 0.2f),
+                            contentColor = NostrordColors.Warning
+                        ),
+                        shape = RoundedCornerShape(6.dp),
+                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 4.dp),
+                        elevation = ButtonDefaults.buttonElevation(0.dp)
+                    ) {
+                        Icon(
+                            Icons.Default.Settings,
+                            contentDescription = null,
+                            modifier = Modifier.size(13.dp)
+                        )
+                        Spacer(Modifier.width(4.dp))
+                        Text(
+                            "Manage relay",
+                            style = NostrordTypography.Caption,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                }
+                else -> {}
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -42,6 +42,7 @@ fun GroupScreen(
     groupId: String,
     groupName: String?,
     onNavigateHome: () -> Unit = {},
+    onNavigateHomeManageRelay: () -> Unit = onNavigateHome,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     showServerRail: Boolean = true, // When false, server rail is handled by parent shell
     onOpenDrawer: () -> Unit = {},
@@ -739,6 +740,7 @@ fun GroupScreen(
                 onNavigateToGroup = onNavigateToGroup,
                 onUserClick = { pubkey -> selectedUserPubkey = pubkey },
                 onReconnect = { vm.reconnect() },
+                onManageRelay = onNavigateHomeManageRelay,
                 isSending = isSending,
                 onMediaUploaded = { upload ->
                         if (pendingUploads.none { it.url == upload.url }) {
@@ -842,6 +844,7 @@ fun GroupScreen(
                 onNavigateToGroup = onNavigateToGroup,
                 onUserClick = { pubkey -> selectedUserPubkey = pubkey },
                 onReconnect = { vm.reconnect() },
+                onManageRelay = onNavigateHomeManageRelay,
                 isSending = isSending,
                 onMediaUploaded = { upload ->
                         if (pendingUploads.none { it.url == upload.url }) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -98,6 +98,7 @@ fun GroupScreenDesktop(
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     onUserClick: (String) -> Unit = {},
     onReconnect: () -> Unit = {},
+    onManageRelay: () -> Unit = {},
     isSending: Boolean = false,
     onMediaUploaded: (org.nostr.nostrord.network.upload.UploadResult) -> Unit = {},
     showMemberSidebar: Boolean = true,
@@ -170,7 +171,8 @@ fun GroupScreenDesktop(
 
             ConnectionStatusBanner(
                 connectionState = connectionState,
-                onRetry = onReconnect
+                onRetry = onReconnect,
+                onManageRelay = onManageRelay
             )
 
             Box(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -130,6 +130,7 @@ fun GroupScreenMobile(
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     onUserClick: (String) -> Unit = {},
     onReconnect: () -> Unit = {},
+    onManageRelay: () -> Unit = {},
     isSending: Boolean = false,
     onMediaUploaded: (org.nostr.nostrord.network.upload.UploadResult) -> Unit = {},
     isCurrentUserAdmin: Boolean = false,
@@ -220,7 +221,8 @@ fun GroupScreenMobile(
             Column(modifier = Modifier.fillMaxSize()) {
                 ConnectionStatusBanner(
                     connectionState = connectionState,
-                    onRetry = onReconnect
+                    onRetry = onReconnect,
+                    onManageRelay = onManageRelay
                 )
 
                 Box(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
@@ -1,8 +1,6 @@
 package org.nostr.nostrord.ui.screens.home
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -14,6 +12,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.ui.Screen
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
 @Composable
 fun HomeScreen(
@@ -22,7 +21,8 @@ fun HomeScreen(
     onNavigate: (Screen) -> Unit,
     onCreateGroupClick: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
-    forceDesktop: Boolean = false
+    forceDesktop: Boolean = false,
+    initiallyManaging: Boolean = false
 ) {
     val vm = viewModel { HomeViewModel(AppModule.nostrRepository) }
 
@@ -42,13 +42,25 @@ fun HomeScreen(
         groupsByRelay[displayRelayUrl] ?: emptyList()
     }
 
-    // Use relay-specific joined groups so the filter matches the sidebar for the same relay
+    // Use relay-specific joined groups so the filter matches the sidebar for the same relay.
+    // Normalize the lookup key — joinedGroupsByRelay keys are always normalized but
+    // displayRelayUrl may arrive un-normalized from a deep link or navigation argument.
     val joinedGroupIds = remember(displayRelayUrl, joinedGroupsByRelay) {
-        joinedGroupsByRelay[displayRelayUrl] ?: emptySet()
+        val key = displayRelayUrl.normalizeRelayUrl()
+        joinedGroupsByRelay[key] ?: emptySet()
+    }
+
+    val offlineGroups = remember(joinedGroupIds, groups) {
+        joinedGroupIds.map { id ->
+            groups.find { it.id == id } ?: org.nostr.nostrord.network.GroupMetadata(
+                id = id, name = null, about = null, picture = null, isPublic = false, isOpen = false
+            )
+        }
     }
 
     var searchQuery by remember(displayRelayUrl) { mutableStateOf("") }
     var activeFilter by remember(displayRelayUrl) { mutableStateOf(GroupFilter.All) }
+    var isManagingRelay by remember(displayRelayUrl) { mutableStateOf(false) }
 
     val orphanedIds = remember(displayRelayUrl, orphanedJoinedByRelay) {
         orphanedJoinedByRelay[displayRelayUrl] ?: emptySet()
@@ -91,24 +103,28 @@ fun HomeScreen(
 
     LaunchedEffect(Unit) {
         vm.connect()
+        if (initiallyManaging) isManagingRelay = true
     }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
         val isCompact = !forceDesktop
-        val gridColumns = when {
-            maxWidth < 840.dp -> 2
-            else -> 3
-        }
 
-        val isLoading = displayRelayUrl in loadingRelays || displayRelayUrl.isBlank()
         val connectionState by vm.connectionState.collectAsState()
         val restrictionMessage = restrictedRelays[displayRelayUrl]
-        val hasError = restrictionMessage != null || connectionState is ConnectionManager.ConnectionState.Error
-        val errorMessage = restrictionMessage ?: (connectionState as? ConnectionManager.ConnectionState.Error)?.message
-
-        // Check if current relay is in the user's kind:10009 event.
+        // hasError covers relay-level restrictions only; generic failures show via ConnectionStatusBanner
+        val hasError = restrictionMessage != null
+        val isLoading = displayRelayUrl in loadingRelays ||
+                displayRelayUrl.isBlank() ||
+                connectionState !is ConnectionManager.ConnectionState.Connected
         val isRelaySaved = remember(displayRelayUrl, kind10009Relays) {
             displayRelayUrl.isNotBlank() && displayRelayUrl in kind10009Relays
+        }
+        val isReachabilityError = connectionState is ConnectionManager.ConnectionState.Error ||
+                connectionState is ConnectionManager.ConnectionState.Reconnecting
+
+        val onRemoveRelayConfirmed: () -> Unit = {
+            vm.removeRelay(displayRelayUrl)
+            onNavigate(Screen.Home)
         }
 
         if (isCompact) {
@@ -125,17 +141,22 @@ fun HomeScreen(
                 currentRelayUrl = displayRelayUrl,
                 relayMeta = relayMeta,
                 isLoading = isLoading,
+                isReachabilityError = isReachabilityError,
+                connectionState = connectionState,
                 hasError = hasError,
-                errorMessage = errorMessage,
+                errorMessage = restrictionMessage,
                 onRetry = { vm.connect() },
                 onCreateGroupClick = onCreateGroupClick,
                 onOpenDrawer = onOpenDrawer,
-                onRemoveRelay = {
-                    vm.removeRelay(displayRelayUrl)
-                    onNavigate(Screen.Home)
-                },
+                onRemoveRelay = { isManagingRelay = true },
+                onRemoveRelayConfirmed = onRemoveRelayConfirmed,
+                onDismissManagement = { isManagingRelay = false },
                 onAddRelay = { vm.addRelay(displayRelayUrl) },
-                isRelaySaved = isRelaySaved
+                isRelaySaved = isRelaySaved,
+                isOffline = isManagingRelay,
+                isActuallyOffline = isReachabilityError,
+                offlineGroups = offlineGroups,
+                onForgetGroup = { vm.forgetGroup(it, displayRelayUrl) }
             )
         } else {
             HomeScreenDesktop(
@@ -152,15 +173,20 @@ fun HomeScreen(
                 currentRelayUrl = displayRelayUrl,
                 relayMeta = relayMeta,
                 isLoading = isLoading,
+                isReachabilityError = isReachabilityError,
+                connectionState = connectionState,
                 hasError = hasError,
-                errorMessage = errorMessage,
+                errorMessage = restrictionMessage,
                 onRetry = { vm.connect() },
-                onRemoveRelay = {
-                    vm.removeRelay(displayRelayUrl)
-                    onNavigate(Screen.Home)
-                },
+                onRemoveRelay = { isManagingRelay = true },
+                onRemoveRelayConfirmed = onRemoveRelayConfirmed,
+                onDismissManagement = { isManagingRelay = false },
                 onAddRelay = { vm.addRelay(displayRelayUrl) },
-                isRelaySaved = isRelaySaved
+                isRelaySaved = isRelaySaved,
+                isOffline = isManagingRelay,
+                isActuallyOffline = isReachabilityError,
+                offlineGroups = offlineGroups,
+                onForgetGroup = { vm.forgetGroup(it, displayRelayUrl) }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenDesktop.kt
@@ -27,8 +27,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.MoreVert
-import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -65,7 +65,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.ui.Screen
-import org.nostr.nostrord.ui.components.loading.ConnectionErrorState
 import org.nostr.nostrord.ui.components.loading.RestrictedRelayState
 import org.nostr.nostrord.ui.components.loading.GroupCardSkeleton
 import org.nostr.nostrord.ui.components.navigation.relayShortLabel
@@ -96,9 +95,34 @@ fun HomeScreenDesktop(
     errorMessage: String? = null,
     onRetry: () -> Unit = {},
     onRemoveRelay: () -> Unit = {},
+    onRemoveRelayConfirmed: () -> Unit = {},
+    onDismissManagement: () -> Unit = {},
     onAddRelay: () -> Unit = {},
-    isRelaySaved: Boolean = true
+    isRelaySaved: Boolean = true,
+    isOffline: Boolean = false,
+    isActuallyOffline: Boolean = false,
+    offlineGroups: List<org.nostr.nostrord.network.GroupMetadata> = emptyList(),
+    onForgetGroup: (String) -> Unit = {},
+    isReachabilityError: Boolean = false,
+    connectionState: org.nostr.nostrord.network.managers.ConnectionManager.ConnectionState =
+        org.nostr.nostrord.network.managers.ConnectionManager.ConnectionState.Disconnected
 ) {
+    if (isOffline) {
+        ManageRelayContent(
+            relayUrl = currentRelayUrl,
+            groups = offlineGroups,
+            isCompact = false,
+            onForgetGroup = onForgetGroup,
+            onRemoveRelay = onRemoveRelayConfirmed,
+            relayMeta = relayMeta,
+            isOffline = isActuallyOffline,
+            isRelaySaved = isRelaySaved,
+            onDismiss = onDismissManagement,
+            dismissAtBottom = true
+        )
+        return
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -155,19 +179,22 @@ fun HomeScreenDesktop(
             )
         }
 
+        org.nostr.nostrord.ui.components.ConnectionStatusBanner(
+            connectionState = connectionState,
+            onRetry = onRetry,
+            onManageRelay = onRemoveRelay,
+            modifier = Modifier.padding(horizontal = 24.dp)
+        )
+
         // Scrollable content area
         Box(modifier = Modifier.weight(1f)) {
             when {
                 hasError -> {
                     Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        if (errorMessage != null && errorMessage.contains("restricted")) {
-                            RestrictedRelayState(message = errorMessage)
-                        } else {
-                            ConnectionErrorState(onRetry = onRetry)
-                        }
+                        RestrictedRelayState(message = errorMessage ?: "Access restricted")
                     }
                 }
-                isLoading && groups.isEmpty() -> {
+                isLoading && groups.isEmpty() && !isReachabilityError -> {
                     LazyVerticalGrid(
                         columns = GridCells.Adaptive(minSize = 280.dp),
                         modifier = Modifier.fillMaxSize(),
@@ -391,27 +418,31 @@ internal fun RelayOptionsMenu(
 ) {
     val copyToClipboard = rememberClipboardWriter()
     var expanded by remember { mutableStateOf(false) }
-    var showConfirm by remember { mutableStateOf(false) }
+    var confirmAdd by remember { mutableStateOf(false) }
 
-    if (showConfirm) {
+    if (confirmAdd) {
         androidx.compose.material3.AlertDialog(
-            onDismissRequest = { showConfirm = false },
+            onDismissRequest = { confirmAdd = false },
             containerColor = NostrordColors.Surface,
             titleContentColor = NostrordColors.TextPrimary,
             textContentColor = NostrordColors.TextSecondary,
-            title = { Text("Remove relay?") },
-            text = { Text("This will disconnect and remove ${relayUrl.removePrefix("wss://")} from your relay list.") },
+            title = { androidx.compose.material3.Text("Add relay?") },
+            text = { androidx.compose.material3.Text("$relayUrl will be added to your relay list.") },
             confirmButton = {
                 androidx.compose.material3.TextButton(onClick = {
-                    showConfirm = false
-                    onRemoveRelay()
+                    confirmAdd = false
+                    onAddRelay()
                 }) {
-                    Text("Remove", color = NostrordColors.Error)
+                    androidx.compose.material3.Text(
+                        "Add",
+                        color = NostrordColors.Primary,
+                        fontWeight = FontWeight.SemiBold
+                    )
                 }
             },
             dismissButton = {
-                androidx.compose.material3.TextButton(onClick = { showConfirm = false }) {
-                    Text("Cancel", color = NostrordColors.TextSecondary)
+                androidx.compose.material3.TextButton(onClick = { confirmAdd = false }) {
+                    androidx.compose.material3.Text("Cancel", color = NostrordColors.TextSecondary)
                 }
             }
         )
@@ -419,15 +450,15 @@ internal fun RelayOptionsMenu(
 
     Row(modifier = modifier.wrapContentSize(Alignment.TopEnd)) {
         if (isRelaySaved) {
-            IconButton(onClick = { showConfirm = true }) {
+            IconButton(onClick = onRemoveRelay) {
                 Icon(
-                    Icons.Default.Remove,
+                    Icons.Default.Settings,
                     contentDescription = "Remove relay from your list",
-                    tint = NostrordColors.Error
+                    tint = NostrordColors.TextMuted
                 )
             }
         } else {
-            IconButton(onClick = onAddRelay) {
+            IconButton(onClick = { confirmAdd = true }) {
                 Icon(
                     Icons.Default.Add,
                     contentDescription = "Add relay to your list",
@@ -481,7 +512,7 @@ internal fun RelayOptionsMenu(
 }
 
 @Composable
-private fun RelayHeaderIcon(
+internal fun RelayHeaderIcon(
     relayUrl: String,
     iconUrl: String?,
     label: String,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenMobile.kt
@@ -33,8 +33,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -46,7 +44,6 @@ import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.isValidIconUrl
 import org.nostr.nostrord.ui.Screen
-import org.nostr.nostrord.ui.components.loading.ConnectionErrorState
 import org.nostr.nostrord.ui.components.loading.GroupCardSkeleton
 import org.nostr.nostrord.ui.components.loading.RestrictedRelayState
 import org.nostr.nostrord.ui.components.navigation.relayShortLabel
@@ -72,14 +69,23 @@ fun HomeScreenMobile(
     currentRelayUrl: String,
     relayMeta: Nip11RelayInfo? = null,
     isLoading: Boolean = false,
+    isReachabilityError: Boolean = false,
+    connectionState: org.nostr.nostrord.network.managers.ConnectionManager.ConnectionState =
+        org.nostr.nostrord.network.managers.ConnectionManager.ConnectionState.Disconnected,
     hasError: Boolean = false,
     errorMessage: String? = null,
     onRetry: () -> Unit = {},
     onCreateGroupClick: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
     onRemoveRelay: () -> Unit = {},
+    onRemoveRelayConfirmed: () -> Unit = {},
+    onDismissManagement: () -> Unit = {},
     onAddRelay: () -> Unit = {},
-    isRelaySaved: Boolean = true
+    isRelaySaved: Boolean = true,
+    isOffline: Boolean = false,
+    isActuallyOffline: Boolean = false,
+    offlineGroups: List<org.nostr.nostrord.network.GroupMetadata> = emptyList(),
+    onForgetGroup: (String) -> Unit = {}
 ) {
     Scaffold(
         topBar = {
@@ -176,19 +182,30 @@ fun HomeScreenMobile(
         containerColor = NostrordColors.Background
     ) { paddingValues ->
         when {
+            isOffline -> {
+                ManageRelayContent(
+                    relayUrl = currentRelayUrl,
+                    groups = offlineGroups,
+                    isCompact = true,
+                    onForgetGroup = onForgetGroup,
+                    onRemoveRelay = onRemoveRelayConfirmed,
+                    relayMeta = relayMeta,
+                    isOffline = isActuallyOffline,
+                    isRelaySaved = isRelaySaved,
+                    onDismiss = onDismissManagement,
+                    dismissAtBottom = true,
+                    modifier = Modifier.padding(paddingValues)
+                )
+            }
             hasError -> {
                 Box(
                     modifier = Modifier.fillMaxSize().padding(paddingValues),
                     contentAlignment = Alignment.Center
                 ) {
-                    if (errorMessage != null && errorMessage.contains("restricted")) {
-                        RestrictedRelayState(message = errorMessage)
-                    } else {
-                        ConnectionErrorState(onRetry = onRetry)
-                    }
+                    RestrictedRelayState(message = errorMessage ?: "Access restricted")
                 }
             }
-            isLoading && filteredGroups.isEmpty() -> {
+            isLoading && filteredGroups.isEmpty() && !isReachabilityError -> {
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(1),
                     modifier = Modifier.fillMaxSize().padding(paddingValues),
@@ -199,12 +216,23 @@ fun HomeScreenMobile(
                 }
             }
             else -> {
-                LazyVerticalGrid(
-                    state = gridState,
-                    columns = GridCells.Fixed(1),
+                Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues)
+                        .background(NostrordColors.Background)
+                ) {
+                    org.nostr.nostrord.ui.components.ConnectionStatusBanner(
+                        connectionState = connectionState,
+                        onRetry = onRetry,
+                        onManageRelay = onRemoveRelay,
+                        modifier = Modifier.padding(top = Spacing.lg, start = Spacing.lg, end = Spacing.lg)
+                    )
+                    LazyVerticalGrid(
+                    state = gridState,
+                    columns = GridCells.Fixed(1),
+                    modifier = Modifier
+                        .weight(1f)
                         .background(NostrordColors.Background),
                     contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 16.dp),
                     verticalArrangement = Arrangement.spacedBy(10.dp)
@@ -247,7 +275,8 @@ fun HomeScreenMobile(
                             )
                         }
                     }
-                }
+                } // LazyVerticalGrid
+                } // Column
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeViewModel.kt
@@ -32,6 +32,15 @@ class HomeViewModel(private val repo: NostrRepositoryApi) : ViewModel() {
     }
 
     fun addRelay(url: String) {
-        viewModelScope.launch { repo.addRelay(url) }
+        viewModelScope.launch {
+            repo.addRelay(url)
+            // Connect to the relay immediately — addRelay only saves the list;
+            // autoConnectFirstRelay is skipped when any primary client already exists.
+            repo.switchRelay(url)
+        }
+    }
+
+    fun forgetGroup(groupId: String, relayUrl: String) {
+        viewModelScope.launch { repo.forgetGroup(groupId, relayUrl) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/ManageRelayContent.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/ManageRelayContent.kt
@@ -1,0 +1,395 @@
+package org.nostr.nostrord.ui.screens.home
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import org.nostr.nostrord.network.GroupMetadata
+import org.nostr.nostrord.nostr.Nip11RelayInfo
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.util.generateColorFromString
+
+@Composable
+fun ManageRelayContent(
+    relayUrl: String,
+    groups: List<GroupMetadata>,
+    isCompact: Boolean,
+    onForgetGroup: (groupId: String) -> Unit,
+    onRemoveRelay: () -> Unit,
+    relayMeta: Nip11RelayInfo? = null,
+    isOffline: Boolean = false,
+    isRelaySaved: Boolean = true,
+    onDismiss: (() -> Unit)? = null,
+    dismissAtBottom: Boolean = false,
+    modifier: Modifier = Modifier
+) {
+    val domain = relayUrl.removePrefix("wss://").removePrefix("ws://").trimEnd('/')
+    val relayName = relayMeta?.name?.takeIf { it.isNotBlank() } ?: domain
+
+    var confirmRemoveRelay by remember { mutableStateOf(false) }
+
+    if (confirmRemoveRelay) {
+        AlertDialog(
+            onDismissRequest = { confirmRemoveRelay = false },
+            containerColor = NostrordColors.Surface,
+            titleContentColor = NostrordColors.TextPrimary,
+            textContentColor = NostrordColors.TextSecondary,
+            title = { Text("Remove relay?") },
+            text = {
+                Text(
+                    if (isRelaySaved) {
+                        if (groups.isEmpty()) "$relayName will be removed from your relay list."
+                        else "$relayName and all its groups will be removed from your list."
+                    } else {
+                        "Your groups on $relayName will be removed from your list."
+                    }
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    confirmRemoveRelay = false
+                    onRemoveRelay()
+                }) {
+                    Text("Remove", color = NostrordColors.Error, fontWeight = FontWeight.SemiBold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { confirmRemoveRelay = false }) {
+                    Text("Cancel", color = NostrordColors.TextSecondary)
+                }
+            }
+        )
+    }
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .background(NostrordColors.BackgroundDark),
+        contentPadding = PaddingValues(
+            horizontal = if (isCompact) 16.dp else 24.dp,
+            vertical = if (isCompact) 16.dp else 24.dp
+        ),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item {
+            RelayManagementHeader(
+                relayUrl = relayUrl,
+                relayName = relayName,
+                relayMeta = relayMeta,
+                isCompact = isCompact,
+                isOffline = isOffline,
+                onDismiss = if (dismissAtBottom) null else onDismiss
+            )
+        }
+
+        if (groups.isEmpty()) {
+            item {
+                Text(
+                    text = "No groups joined on this relay.",
+                    color = NostrordColors.TextMuted,
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(vertical = 8.dp)
+                )
+            }
+        } else {
+            item {
+                Text(
+                    text = "My groups",
+                    color = NostrordColors.TextSecondary,
+                    style = MaterialTheme.typography.labelMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier.padding(bottom = 4.dp)
+                )
+            }
+            items(groups, key = { it.id }) { group ->
+                OfflineGroupRow(
+                    group = group,
+                    isCompact = isCompact,
+                    onForget = { onForgetGroup(group.id) }
+                )
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+            if (dismissAtBottom && onDismiss != null) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        shape = RoundedCornerShape(8.dp),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Back", color = NostrordColors.TextSecondary, fontWeight = FontWeight.SemiBold)
+                    }
+                    Button(
+                        onClick = { confirmRemoveRelay = true },
+                        colors = ButtonDefaults.buttonColors(containerColor = NostrordColors.Error),
+                        shape = RoundedCornerShape(8.dp),
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text("Remove relay", color = Color.White, fontWeight = FontWeight.SemiBold)
+                    }
+                }
+            } else {
+                Button(
+                    onClick = { confirmRemoveRelay = true },
+                    colors = ButtonDefaults.buttonColors(containerColor = NostrordColors.Error),
+                    shape = RoundedCornerShape(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "Remove relay",
+                        color = Color.White,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RelayManagementHeader(
+    relayUrl: String,
+    relayName: String,
+    relayMeta: Nip11RelayInfo?,
+    isCompact: Boolean,
+    isOffline: Boolean,
+    onDismiss: (() -> Unit)?
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        if (isCompact) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                if (onDismiss != null) {
+                    IconButton(onClick = onDismiss, modifier = Modifier.size(36.dp)) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = "Back",
+                            tint = NostrordColors.TextSecondary
+                        )
+                    }
+                }
+                Text(
+                    text = "Manage relay",
+                    color = NostrordColors.TextPrimary,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        } else {
+            if (onDismiss != null) {
+                IconButton(onClick = onDismiss, modifier = Modifier.size(36.dp)) {
+                    Icon(
+                        imageVector = Icons.Default.ArrowBack,
+                        contentDescription = "Back",
+                        tint = NostrordColors.TextSecondary
+                    )
+                }
+            }
+            Text(
+                text = "Manage relay",
+                color = NostrordColors.TextPrimary,
+                style = MaterialTheme.typography.titleLarge,
+                fontWeight = FontWeight.Bold
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                RelayHeaderIcon(
+                    relayUrl = relayUrl,
+                    iconUrl = relayMeta?.icon,
+                    label = relayName,
+                    size = 56.dp
+                )
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = relayName,
+                        color = NostrordColors.TextPrimary,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                    if (isOffline) {
+                        Spacer(modifier = Modifier.height(2.dp))
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.WifiOff,
+                                contentDescription = null,
+                                tint = NostrordColors.StatusOffline,
+                                modifier = Modifier.size(14.dp)
+                            )
+                            Text(
+                                text = "Offline",
+                                color = NostrordColors.StatusOffline,
+                                style = MaterialTheme.typography.bodySmall,
+                                fontWeight = FontWeight.Medium
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun OfflineGroupRow(
+    group: GroupMetadata,
+    isCompact: Boolean,
+    onForget: () -> Unit
+) {
+    var showConfirm by remember { mutableStateOf(false) }
+
+    if (showConfirm) {
+        val groupLabel = group.name ?: group.id
+        AlertDialog(
+            onDismissRequest = { showConfirm = false },
+            containerColor = NostrordColors.Surface,
+            titleContentColor = NostrordColors.TextPrimary,
+            textContentColor = NostrordColors.TextSecondary,
+            title = { Text("Leave group?") },
+            text = { Text("You will be removed from \"$groupLabel\".") },
+            confirmButton = {
+                TextButton(onClick = {
+                    showConfirm = false
+                    onForget()
+                }) {
+                    Text("Leave", color = NostrordColors.Error, fontWeight = FontWeight.SemiBold)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showConfirm = false }) {
+                    Text("Cancel", color = NostrordColors.TextSecondary)
+                }
+            }
+        )
+    }
+
+    Surface(
+        color = NostrordColors.Surface,
+        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            GroupIcon(
+                group = group,
+                size = if (isCompact) 36.dp else 40.dp
+            )
+            Spacer(modifier = Modifier.width(10.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                if (group.name != null) {
+                    Text(
+                        text = group.name,
+                        color = NostrordColors.TextPrimary,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.Medium,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+                Text(
+                    text = group.id,
+                    color = if (group.name != null) NostrordColors.TextMuted else NostrordColors.TextSecondary,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = androidx.compose.ui.text.font.FontFamily.Monospace,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+            IconButton(
+                onClick = { showConfirm = true },
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Leave group",
+                    tint = NostrordColors.TextMuted,
+                    modifier = Modifier.size(16.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun GroupIcon(group: GroupMetadata, size: Dp) {
+    val context = LocalPlatformContext.current
+    val pictureUrl = group.picture
+    var imageState by remember(pictureUrl) {
+        mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty)
+    }
+    val showImage = !pictureUrl.isNullOrBlank() && imageState !is AsyncImagePainter.State.Error
+    val displayName = group.name ?: group.id
+    val shape = RoundedCornerShape(8.dp)
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(shape)
+            .background(if (!showImage) generateColorFromString(group.id) else NostrordColors.BackgroundDark),
+        contentAlignment = Alignment.Center
+    ) {
+        if (!showImage) {
+            Text(
+                text = displayName.take(1).uppercase(),
+                color = Color.White,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+        if (!pictureUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(pictureUrl)
+                    .crossfade(true)
+                    .memoryCachePolicy(CachePolicy.ENABLED)
+                    .diskCachePolicy(CachePolicy.ENABLED)
+                    .build(),
+                contentDescription = displayName,
+                modifier = Modifier.fillMaxSize().clip(shape),
+                contentScale = ContentScale.Crop,
+                onState = { imageState = it }
+            )
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.network
 
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
 import org.nostr.nostrord.network.RoleDefinition
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupManager
@@ -74,8 +75,10 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val groups: StateFlow<List<GroupMetadata>> = _groups
     override val groupsByRelay: StateFlow<Map<String, List<GroupMetadata>>> = MutableStateFlow(emptyMap())
     override val messages: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> = _messages
+    val _joinedGroupsByRelay = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+
     override val joinedGroups: StateFlow<Set<String>> = _joinedGroups
-    override val joinedGroupsByRelay: StateFlow<Map<String, Set<String>>> = MutableStateFlow(emptyMap())
+    override val joinedGroupsByRelay: StateFlow<Map<String, Set<String>>> = _joinedGroupsByRelay
     override val isLoadingMore: StateFlow<Map<String, Boolean>> = _isLoadingMore
     override val hasMoreMessages: StateFlow<Map<String, Boolean>> = _hasMoreMessages
     override val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = _reactions
@@ -125,11 +128,15 @@ class FakeNostrRepository : NostrRepositoryApi {
 
     override suspend fun logout() { calls += "logout"; _isLoggedIn.value = false }
 
+    var removeRelayAction: suspend (String) -> Unit = { url ->
+        _joinedGroupsByRelay.update { it - url }
+    }
+
     override suspend fun connect() {}
     override suspend fun reconnect(): Boolean = true
     override fun triggerReconnect() {}
     override suspend fun switchRelay(newRelayUrl: String) { _currentRelayUrl.value = newRelayUrl }
-    override suspend fun removeRelay(url: String) {}
+    override suspend fun removeRelay(url: String) { calls += "removeRelay:$url"; removeRelayAction(url) }
     override suspend fun disconnect() {}
 
     override suspend fun createGroup(name: String, about: String?, relayUrl: String, isPrivate: Boolean, isClosed: Boolean, picture: String?, customGroupId: String?): Result<String> =
@@ -140,7 +147,12 @@ class FakeNostrRepository : NostrRepositoryApi {
     override suspend fun joinGroup(groupId: String, inviteCode: String?): Result<Unit> = Result.Success(Unit)
     override suspend fun leaveGroup(groupId: String, reason: String?): Result<Unit> = leaveGroupAction(groupId, reason)
     override suspend fun forgetGroup(groupId: String, relayUrl: String): Result<Unit> {
+        calls += "forgetGroup:$groupId:$relayUrl"
         _joinedGroups.value = _joinedGroups.value - groupId
+        _joinedGroupsByRelay.update { current ->
+            val updated: Set<String> = (current[relayUrl] ?: emptySet()) - groupId
+            current + (relayUrl to updated)
+        }
         return Result.Success(Unit)
     }
     override val orphanedJoinedByRelay: StateFlow<Map<String, Set<String>>> =
@@ -213,4 +225,5 @@ class FakeNostrRepository : NostrRepositoryApi {
     override fun setGroupFetchLazy(relayUrl: String, lazy: Boolean) {}
     override fun isGroupFetchLazy(relayUrl: String): Boolean = false
     override suspend fun requestFullGroupListForRelay(relayUrl: String) {}
+    override suspend fun fetchGroupMessageById(groupId: String, messageId: String) {}
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupManagerRemoveRelayTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupManagerRemoveRelayTest.kt
@@ -1,0 +1,111 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+// normalizeRelayUrl trims trailing slashes and lowercases the host, so
+// "wss://example.com/" → "wss://example.com". Tests must use the same canonical form
+// that the production code will store and look up.
+private const val RELAY_A = "wss://example.com"
+private const val RELAY_B = "wss://other.relay"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GroupManagerRemoveRelayTest {
+
+    private fun makeManager(scope: TestScope): GroupManager {
+        val connManager = ConnectionManager(scope)
+        return GroupManager(connectionManager = connManager, scope = scope)
+    }
+
+    @Test
+    fun `removeRelayEntry removes relay from groupsByRelay`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+
+        manager.prePopulateRelayList(listOf(RELAY_A))
+        assertTrue(
+            manager.groupsByRelay.value.containsKey(RELAY_A),
+            "groupsByRelay should contain the relay after pre-population; keys=${manager.groupsByRelay.value.keys}"
+        )
+
+        manager.removeRelayEntry(RELAY_A)
+        assertFalse(
+            manager.groupsByRelay.value.containsKey(RELAY_A),
+            "groupsByRelay should not contain the relay after removal"
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `removeRelayEntry removes relay from joinedGroupsByRelay`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+
+        manager.updateAllRelayJoinedGroups(
+            mapOf(
+                RELAY_A to setOf("group-1", "group-2"),
+                RELAY_B to setOf("group-3")
+            )
+        )
+
+        assertTrue(
+            manager.joinedGroupsByRelay.value.containsKey(RELAY_A),
+            "Relay should be present before removal; keys=${manager.joinedGroupsByRelay.value.keys}"
+        )
+
+        manager.removeRelayEntry(RELAY_A)
+
+        assertFalse(
+            manager.joinedGroupsByRelay.value.containsKey(RELAY_A),
+            "joinedGroupsByRelay should not contain the removed relay"
+        )
+        assertTrue(
+            manager.joinedGroupsByRelay.value.containsKey(RELAY_B),
+            "Other relay should remain untouched"
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `removeRelayEntry with trailing slash normalizes correctly`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+
+        manager.updateAllRelayJoinedGroups(mapOf(RELAY_A to setOf("group-1")))
+
+        // Pass URL with trailing slash — normalizeRelayUrl() strips it, so lookup must still work
+        manager.removeRelayEntry("$RELAY_A/")
+
+        assertNull(
+            manager.joinedGroupsByRelay.value[RELAY_A],
+            "Relay entry should be gone regardless of trailing slash"
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `removeRelayEntry on unknown relay is a no-op`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+
+        manager.updateAllRelayJoinedGroups(mapOf(RELAY_B to setOf("group-1")))
+
+        manager.removeRelayEntry("wss://unknown.relay")
+
+        assertTrue(
+            manager.joinedGroupsByRelay.value.containsKey(RELAY_B),
+            "Other relays should not be affected by removal of an unknown relay"
+        )
+
+        scope.cancel()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomeViewModelOfflineRelayTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomeViewModelOfflineRelayTest.kt
@@ -1,0 +1,214 @@
+package org.nostr.nostrord.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.network.managers.ConnectionManager
+import org.nostr.nostrord.ui.screens.home.HomeViewModel
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for the offline-relay removal flow introduced in issue #32.
+ *
+ * Verifies:
+ * - forgetGroup delegates to repo and updates joinedGroupsByRelay
+ * - removeRelay delegates to repo and clears the relay from joinedGroupsByRelay
+ * - joinedGroupsByRelay reflects repo state so HomeScreen can compute isOffline correctly
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class HomeViewModelOfflineRelayTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // -------------------------------------------------------------------------
+    // forgetGroup
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `forgetGroup calls repo forgetGroup with correct args`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._currentRelayUrl.value = "wss://offline.relay/"
+        fake._joinedGroupsByRelay.value = mapOf(
+            "wss://offline.relay/" to setOf("group-1", "group-2")
+        )
+        val vm = HomeViewModel(fake)
+
+        vm.forgetGroup("group-1", "wss://offline.relay/")
+        advanceUntilIdle()
+
+        assertTrue(
+            fake.calls.contains("forgetGroup:group-1:wss://offline.relay/"),
+            "Expected forgetGroup call in call log, got: ${fake.calls}"
+        )
+    }
+
+    @Test
+    fun `forgetGroup removes group from joinedGroupsByRelay`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._currentRelayUrl.value = "wss://offline.relay/"
+        fake._joinedGroupsByRelay.value = mapOf(
+            "wss://offline.relay/" to setOf("group-1", "group-2")
+        )
+        val vm = HomeViewModel(fake)
+
+        vm.forgetGroup("group-1", "wss://offline.relay/")
+        advanceUntilIdle()
+
+        val remaining = vm.joinedGroupsByRelay.value["wss://offline.relay/"] ?: emptySet()
+        assertFalse(remaining.contains("group-1"), "group-1 should be removed")
+        assertTrue(remaining.contains("group-2"), "group-2 should remain")
+    }
+
+    @Test
+    fun `forgetGroup on last group leaves relay with empty set`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._currentRelayUrl.value = "wss://offline.relay/"
+        fake._joinedGroupsByRelay.value = mapOf(
+            "wss://offline.relay/" to setOf("only-group")
+        )
+        val vm = HomeViewModel(fake)
+
+        vm.forgetGroup("only-group", "wss://offline.relay/")
+        advanceUntilIdle()
+
+        val remaining = vm.joinedGroupsByRelay.value["wss://offline.relay/"] ?: emptySet()
+        assertTrue(remaining.isEmpty(), "Relay entry should be empty after removing last group")
+    }
+
+    // -------------------------------------------------------------------------
+    // removeRelay
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `removeRelay calls repo removeRelay`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._currentRelayUrl.value = "wss://offline.relay/"
+        fake._joinedGroupsByRelay.value = mapOf(
+            "wss://offline.relay/" to setOf("group-1")
+        )
+        val vm = HomeViewModel(fake)
+
+        vm.removeRelay("wss://offline.relay/")
+        advanceUntilIdle()
+
+        assertTrue(
+            fake.calls.any { it.startsWith("removeRelay:") },
+            "Expected removeRelay call in call log, got: ${fake.calls}"
+        )
+    }
+
+    @Test
+    fun `removeRelay clears relay from joinedGroupsByRelay`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._currentRelayUrl.value = "wss://offline.relay/"
+        fake._joinedGroupsByRelay.value = mapOf(
+            "wss://offline.relay/" to setOf("group-1", "group-2"),
+            "wss://other.relay/" to setOf("group-3")
+        )
+        val vm = HomeViewModel(fake)
+
+        vm.removeRelay("wss://offline.relay/")
+        advanceUntilIdle()
+
+        assertFalse(
+            vm.joinedGroupsByRelay.value.containsKey("wss://offline.relay/"),
+            "Removed relay should not appear in joinedGroupsByRelay"
+        )
+        // Other relay untouched
+        assertTrue(vm.joinedGroupsByRelay.value.containsKey("wss://other.relay/"))
+    }
+
+    // -------------------------------------------------------------------------
+    // isOffline flag (computed in HomeScreen — tested here via state preconditions)
+    // HomeScreen formula: isOffline = isReachabilityError && restrictionMessage == null
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `isOffline is true when relay errors with joined groups`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._connectionState.value = ConnectionManager.ConnectionState.Error("Connection refused")
+        fake._joinedGroupsByRelay.value = mapOf(
+            "wss://offline.relay/" to setOf("group-1")
+        )
+        val vm = HomeViewModel(fake)
+
+        val connectionState = vm.connectionState.value
+        val isReachabilityError = connectionState is ConnectionManager.ConnectionState.Error ||
+                connectionState is ConnectionManager.ConnectionState.Reconnecting
+        val isOffline = isReachabilityError  // no groups requirement
+
+        assertTrue(isReachabilityError, "Should detect error state")
+        assertTrue(isOffline, "isOffline should be true when relay is unreachable")
+    }
+
+    @Test
+    fun `isOffline is true when relay has no joined groups but is unreachable`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._connectionState.value = ConnectionManager.ConnectionState.Error("Connection refused")
+        fake._joinedGroupsByRelay.value = emptyMap()
+        val vm = HomeViewModel(fake)
+
+        val connectionState = vm.connectionState.value
+        val isReachabilityError = connectionState is ConnectionManager.ConnectionState.Error ||
+                connectionState is ConnectionManager.ConnectionState.Reconnecting
+        val isOffline = isReachabilityError
+
+        assertTrue(isReachabilityError)
+        assertTrue(isOffline, "isOffline should be true even with no groups — ManageRelayContent shows Remove relay")
+    }
+
+    @Test
+    fun `isOffline is false when relay is connected despite having groups`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._connectionState.value = ConnectionManager.ConnectionState.Connected
+        fake._joinedGroupsByRelay.value = mapOf(
+            "wss://relay.example.com/" to setOf("group-1")
+        )
+        val vm = HomeViewModel(fake)
+
+        val connectionState = vm.connectionState.value
+        val isReachabilityError = connectionState is ConnectionManager.ConnectionState.Error ||
+                connectionState is ConnectionManager.ConnectionState.Reconnecting
+        val isOffline = isReachabilityError
+
+        assertFalse(isReachabilityError)
+        assertFalse(isOffline, "Connected relay should not show offline screen")
+    }
+
+    @Test
+    fun `isOffline is true during Reconnecting state regardless of joined groups`() = runTest {
+        val fake = FakeNostrRepository()
+        // Reconnecting fires before Error — relay goes through up to 10 attempts before Error
+        fake._connectionState.value = ConnectionManager.ConnectionState.Reconnecting(attempt = 1, maxAttempts = 10)
+        fake._joinedGroupsByRelay.value = emptyMap()
+        val vm = HomeViewModel(fake)
+
+        val connectionState = vm.connectionState.value
+        val isReachabilityError = connectionState is ConnectionManager.ConnectionState.Error ||
+                connectionState is ConnectionManager.ConnectionState.Reconnecting
+        val isOffline = isReachabilityError
+
+        assertTrue(isReachabilityError, "Reconnecting should count as a reachability error")
+        assertTrue(isOffline, "isOffline should be true during Reconnecting even without joined groups")
+    }
+}


### PR DESCRIPTION
## Summary

- When a relay is unreachable the app now shows a `ConnectionStatusBanner` with **Retry** and **Manage relay** actions instead of spinning the skeleton indefinitely.
- **Manage relay** opens `ManageRelayContent`, a panel that lists joined groups on that relay and lets the user leave individual groups or remove the relay entirely, with confirmation dialogs whose text adapts to whether the relay was explicitly saved in kind:10009.
- Clicking **Manage relay** from inside a group navigates directly to HomeScreen with the panel already open (one-click flow via `Screen.HomeManageRelay`).
- The connection failure path is fixed: `NostrGroupClient` now uses `CompletableDeferred<Boolean>` to signal failure immediately, so the skeleton loop exits as soon as the relay is confirmed unreachable instead of waiting for the timeout.
- `removeRelay` and `forgetGroup` are wired through `GroupManager`, `HomeViewModel`, and `SecureStorage` and covered by unit tests.

Closes #32