### PR TITLE
feat(notifications): notification center with cross-relay event tracking

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.android.kt
@@ -7,7 +7,7 @@ import org.nostr.nostrord.ui.Screen
 actual fun BrowserNavigationHandler(
     currentScreen: Screen,
     selectedRelayUrl: String,
-    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?) -> Unit
+    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?, viewNotifications: Boolean) -> Unit
 ) {
     // No browser history on Android
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -440,10 +440,19 @@ private fun AuthenticatedApp(
     // latest lambda — selectedRelayUrl is re-keyed whenever currentRelayUrl changes,
     // so the backing MutableState instance can change between recompositions.
     val latestNavigateToGroupWithRelay by rememberUpdatedState(onNavigateToGroupWithRelay)
+    val latestOpenGroupAtRelay by rememberUpdatedState(onOpenGroupAtRelay)
     LaunchedEffect(Unit) {
         AppModule.notificationService.notificationClicks.collect { click ->
-            val name = AppModule.nostrRepository.groups.value.firstOrNull { it.id == click.groupId }?.name
-            latestNavigateToGroupWithRelay(click.groupId, name, click.relayUrl.takeIf { it.isNotBlank() })
+            // Resolve group name cross-relay so notifications targeting groups on
+            // background relays still get a friendly title in the URL/history entry.
+            val name = AppModule.nostrRepository.groupsByRelay.value.values
+                .firstNotNullOfOrNull { list -> list.firstOrNull { it.id == click.groupId } }
+                ?.name
+            if (click.messageId != null) {
+                latestOpenGroupAtRelay(click.groupId, name, click.relayUrl, click.messageId)
+            } else {
+                latestNavigateToGroupWithRelay(click.groupId, name, click.relayUrl.takeIf { it.isNotBlank() })
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -235,10 +235,24 @@ private fun AuthenticatedApp(
     // [previousRelayUrl] must be captured before [selectedRelayUrl] is mutated by
     // the caller — reading it inside this fn would always see the new value and
     // break the same-relay toggle.
-    fun resolveScreenForRelay(clickedUrl: String, previousRelayUrl: String): Screen {
-        if (clickedUrl.isBlank() || clickedUrl == previousRelayUrl) return Screen.Home
+    //
+    // Notifications is a cross-relay screen with no per-relay context: clicking a
+    // relay icon from there restores that relay's last group (or Home) instead of
+    // applying the same-relay toggle, which would surprise the user by sending
+    // them away from the group they were just in.
+    fun resolveScreenForRelay(
+        clickedUrl: String,
+        previousRelayUrl: String,
+        currentScreen: Screen,
+    ): Screen {
+        if (clickedUrl.isBlank()) return Screen.Home
         val pk = pubKey ?: return Screen.Home
-        val (groupId, groupName) = SecureStorage.getLastGroupForRelay(pk, clickedUrl) ?: return Screen.Home
+        val lastGroup = SecureStorage.getLastGroupForRelay(pk, clickedUrl)
+        if (currentScreen is Screen.Notifications) {
+            return lastGroup?.let { (id, name) -> Screen.Group(id, name) } ?: Screen.Home
+        }
+        if (clickedUrl == previousRelayUrl) return Screen.Home
+        val (groupId, groupName) = lastGroup ?: return Screen.Home
         return Screen.Group(groupId, groupName)
     }
 
@@ -474,13 +488,15 @@ private fun AuthenticatedApp(
     BrowserNavigationHandler(
         currentScreen = currentScreen,
         selectedRelayUrl = selectedRelayUrl,
-        onUrlNavigation = { relayUrl, groupId, inviteCode ->
+        onUrlNavigation = { relayUrl, groupId, inviteCode, viewNotifications ->
             if (showSettings) {
                 // Browser back pressed while settings overlay is open — close it instead of navigating
                 showSettings = false
             } else {
-                // Switch relay if different
-                if (relayUrl != selectedRelayUrl) {
+                // Switch relay only when a relay is explicitly in the URL.
+                // `?view=notifications` has no relay (cross-relay screen) —
+                // keep whichever relay was already selected in the sidebar.
+                if (relayUrl.isNotBlank() && relayUrl != selectedRelayUrl) {
                     selectedRelayUrl = relayUrl
                     scope.launch { AppModule.nostrRepository.switchRelay(relayUrl) }
                 }
@@ -488,14 +504,15 @@ private fun AuthenticatedApp(
                 if (inviteCode != null) {
                     pendingInviteCode = inviteCode
                 }
-                // Navigate to the correct screen
-                val targetScreen = if (groupId != null) {
-                    Screen.Group(groupId, null)
-                } else {
-                    Screen.Home
+                // Navigate to the correct screen. `group` and `view=notifications`
+                // are mutually exclusive in the URL; group wins if both appear.
+                val targetScreen = when {
+                    groupId != null -> Screen.Group(groupId, null)
+                    viewNotifications -> Screen.Notifications
+                    else -> Screen.Home
                 }
                 if (targetScreen != currentScreen) {
-                    navHistory.navigate(targetScreen, relayUrl)
+                    navHistory.navigate(targetScreen, selectedRelayUrl)
                     AppModule.nostrRepository.setActiveGroup(
                         if (targetScreen is Screen.Group) targetScreen.groupId else null
                     )
@@ -608,9 +625,10 @@ private fun AuthenticatedApp(
                     isGroupsLoading = isGroupsLoading,
                     onRelayClick = { url ->
                         val previousRelayUrl = selectedRelayUrl
+                        val previousScreen = currentScreen
                         selectedRelayUrl = url
                         scope.launch { AppModule.nostrRepository.switchRelay(url) }
-                        onNavigate(resolveScreenForRelay(url, previousRelayUrl))
+                        onNavigate(resolveScreenForRelay(url, previousRelayUrl, previousScreen))
                     },
                     onRelayTitleClick = { onNavigate(Screen.Home) },
                     onAddRelayClick = { onNavigate(Screen.RelaySettings) },
@@ -665,12 +683,13 @@ private fun AuthenticatedApp(
                             isProfileActive = showSettings,
                             onRelayClick = { url ->
                                 val previousRelayUrl = selectedRelayUrl
+                                val previousScreen = currentScreen
                                 selectedRelayUrl = url
                                 scope.launch {
                                     drawerState.close()
                                     AppModule.nostrRepository.switchRelay(url)
                                 }
-                                onNavigate(resolveScreenForRelay(url, previousRelayUrl))
+                                onNavigate(resolveScreenForRelay(url, previousRelayUrl, previousScreen))
                             },
                             onRelayTitleClick = {
                                 scope.launch { drawerState.close() }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -64,6 +64,7 @@ import org.nostr.nostrord.ui.screens.login.NostrLoginScreen
 import org.nostr.nostrord.ui.screens.backup.BackupScreen
 import org.nostr.nostrord.ui.screens.onboarding.OnboardingScreen
 import org.nostr.nostrord.ui.screens.profile.EditProfileScreen
+import org.nostr.nostrord.ui.screens.notifications.NotificationsScreen
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.ui.theme.NostrordColors
 
@@ -375,6 +376,18 @@ private fun AuthenticatedApp(
             onNavigate(Screen.Group(groupId, groupName))
         }
 
+    // Notification-driven navigation. Same relay-switch logic as the regular
+    // cross-relay nav, but preserves [targetMessageId] so MessagesList can scroll
+    // to the exact event the user tapped on.
+    val onOpenGroupAtRelay: (String, String?, String, String?) -> Unit =
+        { groupId, groupName, relayUrl, targetMessageId ->
+            if (relayUrl.isNotBlank() && relayUrl != selectedRelayUrl) {
+                selectedRelayUrl = relayUrl
+                scope.launch { AppModule.nostrRepository.switchRelay(relayUrl) }
+            }
+            onNavigate(Screen.Group(groupId, groupName, targetMessageId))
+        }
+
     // Direct history navigation — called by native platforms and by BrowserNavigationHandler.
     // Restores the relay that was active when the entry was pushed.
     val onDirectHistoryBack: () -> Unit = {
@@ -600,6 +613,9 @@ private fun AuthenticatedApp(
                     onAddRelayFromSidebar = if (hasNoRelays) {{ addRelayInitialTab = 0; showAddRelayModal = true }} else null,
                     onUserClick = { showSettings = true },
                     isProfileActive = showSettings,
+                    onNotificationsClick = { onNavigate(Screen.Notifications) },
+                    isNotificationsActive = currentScreen is Screen.Notifications,
+                    hideGroupsSidebar = currentScreen is Screen.Notifications,
                     modifier = Modifier.weight(1f)
                 ) {
                     val hideAnimatedImages = showSettings || showCreateGroupModal || showAddRelayModal
@@ -610,6 +626,7 @@ private fun AuthenticatedApp(
                             homeGridState = homeGridState,
                             onNavigate = onNavigate,
                             onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
+                            onOpenGroupAtRelay = onOpenGroupAtRelay,
                             hasNoRelays = hasNoRelays,
                             onAddRelay = { addRelayInitialTab = 0; showAddRelayModal = true },
                             onAddRelayCustomUrl = { addRelayInitialTab = 1; showAddRelayModal = true },
@@ -673,6 +690,11 @@ private fun AuthenticatedApp(
                             onUserClick = {
                                 scope.launch { drawerState.close() }
                                 showSettings = true
+                            },
+                            isNotificationsActive = currentScreen is Screen.Notifications,
+                            onNotificationsClick = {
+                                scope.launch { drawerState.close() }
+                                onNavigate(Screen.Notifications)
                             }
                         )
                     }
@@ -686,6 +708,7 @@ private fun AuthenticatedApp(
                         homeGridState = homeGridState,
                         onNavigate = onNavigate,
                         onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
+                        onOpenGroupAtRelay = onOpenGroupAtRelay,
                         onCreateGroupClick = { showCreateGroupModal = true },
                         hasNoRelays = hasNoRelays,
                         onAddRelay = { addRelayInitialTab = 0; showAddRelayModal = true },
@@ -735,6 +758,7 @@ private fun DesktopContent(
     homeGridState: androidx.compose.foundation.lazy.grid.LazyGridState,
     onNavigate: (Screen) -> Unit,
     onNavigateToGroupWithRelay: (String, String?, String?) -> Unit = { _, _, _ -> },
+    onOpenGroupAtRelay: (String, String?, String, String?) -> Unit = { _, _, _, _ -> },
     hasNoRelays: Boolean = false,
     onAddRelay: () -> Unit = {},
     onAddRelayCustomUrl: () -> Unit = {},
@@ -770,7 +794,7 @@ private fun DesktopContent(
                 forceDesktop = true,
                 pendingInviteCode = pendingInviteCode,
                 onInviteCodeConsumed = onInviteCodeConsumed,
-                targetMessageId = pendingMessageId,
+                targetMessageId = screen.targetMessageId ?: pendingMessageId,
                 onTargetMessageConsumed = onMessageIdConsumed
             )
         }
@@ -794,6 +818,10 @@ private fun DesktopContent(
                 onNavigate(Screen.Home)
             }
         }
+        is Screen.Notifications -> NotificationsScreen(
+            onNavigate = onNavigate,
+            onOpenGroupAtRelay = onOpenGroupAtRelay,
+        )
         is Screen.BackupPrivateKey -> BackupScreen(forceDesktop = true)
         else -> HomeScreen(relayUrl = selectedRelayUrl, gridState = homeGridState, onNavigate = onNavigate, forceDesktop = true)
     }
@@ -809,6 +837,7 @@ private fun MobileContent(
     homeGridState: androidx.compose.foundation.lazy.grid.LazyGridState,
     onNavigate: (Screen) -> Unit,
     onNavigateToGroupWithRelay: (String, String?, String?) -> Unit = { _, _, _ -> },
+    onOpenGroupAtRelay: (String, String?, String, String?) -> Unit = { _, _, _, _ -> },
     onCreateGroupClick: () -> Unit = {},
     onOpenDrawer: () -> Unit = {},
     hasNoRelays: Boolean = false,
@@ -846,7 +875,7 @@ private fun MobileContent(
                 onOpenDrawer = onOpenDrawer,
                 pendingInviteCode = pendingInviteCode,
                 onInviteCodeConsumed = onInviteCodeConsumed,
-                targetMessageId = pendingMessageId,
+                targetMessageId = screen.targetMessageId ?: pendingMessageId,
                 onTargetMessageConsumed = onMessageIdConsumed
             )
         }
@@ -870,6 +899,11 @@ private fun MobileContent(
                 onNavigate(Screen.Home)
             }
         }
+        is Screen.Notifications -> NotificationsScreen(
+            onNavigate = onNavigate,
+            onOpenGroupAtRelay = onOpenGroupAtRelay,
+            onOpenDrawer = onOpenDrawer,
+        )
         is Screen.BackupPrivateKey -> BackupScreen()
         else -> HomeScreen(
             relayUrl = selectedRelayUrl,
@@ -893,6 +927,7 @@ private fun MobileDrawerContent(
     isGroupsLoading: Boolean,
     hasNoRelays: Boolean,
     isProfileActive: Boolean,
+    isNotificationsActive: Boolean,
     onRelayClick: (String) -> Unit,
     onRelayTitleClick: () -> Unit,
     onAddRelayClick: () -> Unit,
@@ -900,7 +935,8 @@ private fun MobileDrawerContent(
     onCreateGroupClick: () -> Unit,
     onJoinGroupClick: () -> Unit = {},
     onAddRelayFromSidebar: (() -> Unit)? = null,
-    onUserClick: () -> Unit = {}
+    onUserClick: () -> Unit = {},
+    onNotificationsClick: () -> Unit = {}
 ) {
     val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
     val joinedGroupsByRelay by AppModule.nostrRepository.joinedGroupsByRelay.collectAsState()
@@ -938,10 +974,15 @@ private fun MobileDrawerContent(
         pubKey?.let { userMetadata[it] }
     }
 
+    val notificationEntries by AppModule.notificationHistoryStore.entries.collectAsState()
+    val notificationCount = remember(notificationEntries) { notificationEntries.count { !it.read } }
+
     Row(Modifier.fillMaxSize()) {
         ServerRail(
             relays = relays,
-            activeRelayUrl = activeRelayUrl,
+            // Same suppression as DesktopShell — when notifications/profile is the
+            // active screen, no relay should claim the active indicator.
+            activeRelayUrl = if (isNotificationsActive || isProfileActive) "" else activeRelayUrl,
             onRelayClick = onRelayClick,
             onAddRelayClick = onAddRelayClick,
             relayMetadata = relayMetadata,
@@ -951,6 +992,9 @@ private fun MobileDrawerContent(
             userPubkey = pubKey,
             onUserClick = onUserClick,
             isProfileActive = isProfileActive,
+            notificationCount = notificationCount,
+            onNotificationsClick = onNotificationsClick,
+            isNotificationsActive = isNotificationsActive,
             showTooltips = false
         )
         GroupsNavSidebar(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -185,6 +185,7 @@ object AppModule {
                                 groupId = groupId,
                                 title = groupName,
                                 body = "$authorName: $preview",
+                                messageId = message.id,
                             )
                         )
                     }
@@ -224,6 +225,7 @@ object AppModule {
                             groupId = groupId,
                             title = groupName,
                             body = "$authorName replied to your message: $preview",
+                            messageId = message.id,
                         )
                     )
                 }
@@ -262,6 +264,7 @@ object AppModule {
                             groupId = groupId,
                             title = groupName,
                             body = "$authorName mentioned you: $preview",
+                            messageId = message.id,
                         )
                     )
                 }
@@ -303,6 +306,7 @@ object AppModule {
                                 groupId = groupId,
                                 title = groupName,
                                 body = "$authorName reacted $emoji to your message",
+                                messageId = reaction.targetEventId,
                             )
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -24,9 +24,12 @@ import org.nostr.nostrord.network.outbox.RelayListManager
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.notifications.FocusTracker
+import org.nostr.nostrord.notifications.NotificationEntry
+import org.nostr.nostrord.notifications.NotificationHistoryStore
 import org.nostr.nostrord.notifications.NotificationPermission
 import org.nostr.nostrord.notifications.NotificationRequest
 import org.nostr.nostrord.notifications.NotificationService
+import org.nostr.nostrord.notifications.NotificationType
 import org.nostr.nostrord.notifications.playNotificationSound
 import org.nostr.nostrord.settings.FeatureFlags
 import org.nostr.nostrord.settings.NotificationSettings
@@ -126,6 +129,8 @@ object AppModule {
 
     val notificationService: NotificationService by lazy { NotificationService() }
 
+    val notificationHistoryStore: NotificationHistoryStore by lazy { NotificationHistoryStore() }
+
     val unreadManager: UnreadManager by lazy {
         UnreadManager(
             // groupManager.isGroupJoined() is scoped to the active primary relay —
@@ -136,36 +141,171 @@ object AppModule {
             },
             isRestricted = { groupId -> groupManager.restrictedGroups.value.containsKey(groupId) },
             isAppFocused = { focusTracker.isAppFocused.value },
+            findMessageAuthor = { messageId ->
+                groupManager.findMessageByIdAcrossGroups(messageId)?.second?.pubkey
+            },
             onUnreadIncrement = { groupId, message, _ ->
-                // Sound — gated by the user-facing toggle in Settings → Notifications.
-                // Platform actuals no-op on unsupported targets (iOS for now).
+                val selfPubkey = sessionManager.getPublicKey()
+                if (selfPubkey == null || message.pubkey != selfPubkey) {
+                    val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
+                        ?: groupManager.getRelayForGroup(groupId) ?: ""
+                    val preview = resolveMentionsForNotification(message.content).take(120)
+                    val groupName = groupDisplayName(groupId)
+                    val relayName = relayDisplayName(relayUrl)
+                    notificationHistoryStore.add(
+                        NotificationEntry(
+                            id = message.id,
+                            type = NotificationType.MESSAGE,
+                            groupId = groupId,
+                            relayUrl = relayUrl,
+                            actorPubkey = message.pubkey,
+                            createdAt = message.createdAt,
+                            preview = preview,
+                            messageId = message.id,
+                            groupName = groupName,
+                            relayName = relayName,
+                        )
+                    )
+                    // Sound — gated by the user-facing toggle in Settings → Notifications.
+                    // Platform actuals no-op on unsupported targets (iOS for now).
+                    if (notificationSettings.soundEnabled.value) {
+                        playNotificationSound()
+                    }
+                    // Desktop popup — web-only; gated on platform support, granted permission,
+                    // and the user's toggle. The browser itself decides whether to surface
+                    // the popup based on tab focus.
+                    if (notificationSettings.systemNotificationsEnabled.value &&
+                        notificationService.isSupported() &&
+                        notificationService.permission.value == NotificationPermission.Granted) {
+                        val authorName = displayLabelFor(message.pubkey, prefixAt = false)
+                            ?: (message.pubkey.take(8) + "…")
+                        notificationService.notify(
+                            NotificationRequest(
+                                relayUrl = relayUrl,
+                                groupId = groupId,
+                                title = groupName,
+                                body = "$authorName: $preview",
+                            )
+                        )
+                    }
+                }
+            },
+            onReplyNotify = { groupId, message ->
+                val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
+                    ?: groupManager.getRelayForGroup(groupId) ?: ""
+                val preview = resolveMentionsForNotification(message.content).take(120)
+                val groupName = groupDisplayName(groupId)
+                val relayName = relayDisplayName(relayUrl)
+                notificationHistoryStore.add(
+                    NotificationEntry(
+                        id = message.id,
+                        type = NotificationType.REPLY,
+                        groupId = groupId,
+                        relayUrl = relayUrl,
+                        actorPubkey = message.pubkey,
+                        createdAt = message.createdAt,
+                        preview = preview,
+                        messageId = message.id,
+                        groupName = groupName,
+                        relayName = relayName,
+                    )
+                )
                 if (notificationSettings.soundEnabled.value) {
                     playNotificationSound()
                 }
-
-                // Desktop popup — web-only; gated on platform support, granted permission,
-                // and the user's toggle. The browser itself decides whether to surface
-                // the popup based on tab focus.
                 if (notificationSettings.systemNotificationsEnabled.value &&
                     notificationService.isSupported() &&
                     notificationService.permission.value == NotificationPermission.Granted) {
-                    val groupName = groupManager.groups.value.firstOrNull { it.id == groupId }?.name
-                        ?: groupId.take(8)
                     val authorName = displayLabelFor(message.pubkey, prefixAt = false)
                         ?: (message.pubkey.take(8) + "…")
-                    val preview = resolveMentionsForNotification(message.content).take(120)
-
-                    val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
-                        ?: groupManager.getRelayForGroup(groupId)
-                        ?: ""
                     notificationService.notify(
                         NotificationRequest(
                             relayUrl = relayUrl,
                             groupId = groupId,
                             title = groupName,
-                            body = "$authorName: $preview",
+                            body = "$authorName replied to your message: $preview",
                         )
                     )
+                }
+            },
+            onMentionNotify = { groupId, message ->
+                val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
+                    ?: groupManager.getRelayForGroup(groupId) ?: ""
+                val preview = resolveMentionsForNotification(message.content).take(120)
+                val groupName = groupDisplayName(groupId)
+                val relayName = relayDisplayName(relayUrl)
+                notificationHistoryStore.add(
+                    NotificationEntry(
+                        id = message.id,
+                        type = NotificationType.MENTION,
+                        groupId = groupId,
+                        relayUrl = relayUrl,
+                        actorPubkey = message.pubkey,
+                        createdAt = message.createdAt,
+                        preview = preview,
+                        messageId = message.id,
+                        groupName = groupName,
+                        relayName = relayName,
+                    )
+                )
+                if (notificationSettings.soundEnabled.value) {
+                    playNotificationSound()
+                }
+                if (notificationSettings.systemNotificationsEnabled.value &&
+                    notificationService.isSupported() &&
+                    notificationService.permission.value == NotificationPermission.Granted) {
+                    val authorName = displayLabelFor(message.pubkey, prefixAt = false)
+                        ?: (message.pubkey.take(8) + "…")
+                    notificationService.notify(
+                        NotificationRequest(
+                            relayUrl = relayUrl,
+                            groupId = groupId,
+                            title = groupName,
+                            body = "$authorName mentioned you: $preview",
+                        )
+                    )
+                }
+            },
+            onReactionNotify = { groupId, reaction ->
+                val selfPubkey = sessionManager.getPublicKey()
+                if (selfPubkey == null || reaction.pubkey != selfPubkey) {
+                    val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
+                        ?: groupManager.getRelayForGroup(groupId) ?: ""
+                    val emoji = reaction.emoji.ifBlank { "+" }
+                    val groupName = groupDisplayName(groupId)
+                    val relayName = relayDisplayName(relayUrl)
+                    notificationHistoryStore.add(
+                        NotificationEntry(
+                            id = reaction.id,
+                            type = NotificationType.REACTION,
+                            groupId = groupId,
+                            relayUrl = relayUrl,
+                            actorPubkey = reaction.pubkey,
+                            createdAt = reaction.createdAt,
+                            preview = emoji,
+                            messageId = reaction.targetEventId,
+                            emoji = emoji,
+                            groupName = groupName,
+                            relayName = relayName,
+                        )
+                    )
+                    if (notificationSettings.soundEnabled.value) {
+                        playNotificationSound()
+                    }
+                    if (notificationSettings.systemNotificationsEnabled.value &&
+                        notificationService.isSupported() &&
+                        notificationService.permission.value == NotificationPermission.Granted) {
+                        val authorName = displayLabelFor(reaction.pubkey, prefixAt = false)
+                            ?: (reaction.pubkey.take(8) + "…")
+                        notificationService.notify(
+                            NotificationRequest(
+                                relayUrl = relayUrl,
+                                groupId = groupId,
+                                title = groupName,
+                                body = "$authorName reacted $emoji to your message",
+                            )
+                        )
+                    }
                 }
             },
         )
@@ -191,6 +331,7 @@ object AppModule {
             relayMetadataManager = relayMetadataManager,
             liveCursorStore = liveCursorStore,
             connStats = connStats,
+            notificationHistoryStore = notificationHistoryStore,
             scope = appScope
         )
     }
@@ -207,6 +348,31 @@ object AppModule {
      * Returns null if no metadata is cached, so callers can decide a fallback
      * (e.g. truncated pubkey) and trigger an async fetch.
      */
+    /**
+     * Resolves a group's display name across every relay's cache. The
+     * notification callbacks fire for groups on background relays too, so
+     * `groupManager.groups` (active relay only) misses them and falls back to
+     * the truncated id. Joined-group metadata is also restored from
+     * [SecureStorage] at startup, so cached entries survive cold launches.
+     */
+    private fun groupDisplayName(groupId: String): String {
+        val name = groupManager.groupsByRelay.value.values
+            .firstNotNullOfOrNull { list ->
+                list.firstOrNull { it.id == groupId }?.name?.takeIf { it.isNotBlank() }
+            }
+        return name ?: groupId.take(8)
+    }
+
+    /**
+     * NIP-11 display name for [relayUrl] from the metadata cache. Returns null
+     * when no entry exists so callers can decide between snapshot omission and
+     * a URL-derived label.
+     */
+    private fun relayDisplayName(relayUrl: String): String? {
+        if (relayUrl.isBlank()) return null
+        return relayMetadataManager.relayMetadata.value[relayUrl]?.name?.takeIf { it.isNotBlank() }
+    }
+
     private fun displayLabelFor(pubkey: String, prefixAt: Boolean): String? {
         val meta = metadataManager.userMetadata.value[pubkey] ?: return null
         val name = meta.name?.takeIf { it.isNotBlank() }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -413,7 +413,11 @@ object AppModule {
                 sb.append('@').append(label)
             } else {
                 toFetch += pubkey
-                sb.append('@').append(ref.bech32.take(12)).append('…')
+                // Hex fallback (matches Nip19.summary, SystemEventItem, and the
+                // author-name fallback in the notification callbacks). Mixing
+                // bech32 here was the only place in the app that showed npub
+                // for unknown pubkeys, breaking the visual convention.
+                sb.append('@').append(pubkey.take(8)).append('…')
             }
             cursor = range.last + 1
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -1112,7 +1112,13 @@ suspend fun sendLiveSubscription(groupId: String, sinceSeconds: Long? = null) {
         val emoji: String,
         val emojiUrl: String? = null, // URL for custom emoji (NIP-30)
         val targetEventId: String,
-        val createdAt: Long
+        val createdAt: Long,
+        // NIP-25 `p` tag: pubkey of the author of the event being reacted to.
+        // Used to surface "someone reacted to your message" notifications without
+        // needing the target message to already be in the in-memory cache.
+        val targetAuthorPubkey: String? = null,
+        // NIP-29 `h` tag: group id the reaction was published to.
+        val groupId: String? = null,
     )
 
     fun parseMessage(message: String): NostrMessage? {
@@ -1176,13 +1182,18 @@ suspend fun sendLiveSubscription(groupId: String, sinceSeconds: Long? = null) {
                 tag.size >= 3 && tag[0] == "emoji" && tag[1] == shortcode
             }?.getOrNull(2)
 
+            val targetAuthorPubkey = tags.firstOrNull { it.size >= 2 && it[0] == "p" }?.get(1)
+            val groupId = tags.firstOrNull { it.size >= 2 && it[0] == "h" }?.get(1)
+
             NostrReaction(
                 id = event["id"]?.jsonPrimitive?.content ?: return null,
                 pubkey = event["pubkey"]?.jsonPrimitive?.content ?: return null,
                 emoji = emoji,
                 emojiUrl = emojiUrl,
                 targetEventId = targetEventId,
-                createdAt = event["created_at"]?.jsonPrimitive?.long ?: (epochMillis() / 1000)
+                createdAt = event["created_at"]?.jsonPrimitive?.long ?: (epochMillis() / 1000),
+                targetAuthorPubkey = targetAuthorPubkey,
+                groupId = groupId,
             )
         } catch (e: Exception) {
             null

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1975,9 +1975,21 @@ class NostrRepository(
                         }
                         val currentPubkey = sessionManager.getPublicKey()
                         if (currentPubkey != null && reaction.pubkey != currentPubkey) {
-                            val found = groupManager.findMessageByIdAcrossGroups(reaction.targetEventId)
-                            if (found != null && found.second.pubkey == currentPubkey) {
-                                unreadManager.onReactionReceived(found.first, reaction)
+                            // Prefer the NIP-25 `p` tag — it tells us the target author
+                            // directly, so we don't have to wait for the target message
+                            // to clear the EventOrderingBuffer. Fall back to the cross-
+                            // group cache lookup when the reactor omitted the `p` tag.
+                            val groupId = reaction.groupId
+                                ?: groupManager.findMessageByIdAcrossGroups(reaction.targetEventId)?.first
+                            val isForSelf = when {
+                                reaction.targetAuthorPubkey != null ->
+                                    reaction.targetAuthorPubkey == currentPubkey
+                                else -> groupManager
+                                    .findMessageByIdAcrossGroups(reaction.targetEventId)
+                                    ?.second?.pubkey == currentPubkey
+                            }
+                            if (isForSelf && groupId != null) {
+                                unreadManager.onReactionReceived(groupId, reaction)
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -56,6 +56,7 @@ class NostrRepository(
     private val relayMetadataManager: RelayMetadataManager? = null,
     private val liveCursorStore: LiveCursorStore? = null,
     private val connStats: ConnectionStats = ConnectionStats(),
+    private val notificationHistoryStore: org.nostr.nostrord.notifications.NotificationHistoryStore? = null,
     private val scope: CoroutineScope
 ) : NostrRepositoryApi {
     private val json = Json { ignoreUnknownKeys = true }
@@ -283,6 +284,7 @@ class NostrRepository(
             if (activeRelay.isBlank() && savedRelays.isEmpty() && deepLinkRelay == null) {
                 if (pubkey != null) {
                     unreadManager.initialize(pubkey)
+                    notificationHistoryStore?.initialize(pubkey)
                     initializeOutboxModel()
                     scope.launch {
                         outboxManager.loadJoinedGroupsFromNostr(pubkey) { msg, c ->
@@ -336,6 +338,7 @@ class NostrRepository(
                 groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
                 groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
                 unreadManager.initialize(pubkey)
+                notificationHistoryStore?.initialize(pubkey)
             }
             initializeOutboxModel()
 
@@ -435,6 +438,7 @@ class NostrRepository(
             }
             val userPubkey = sessionManager.loginWithBunker(bunkerUrl)
             unreadManager.initialize(userPubkey)
+            notificationHistoryStore?.initialize(userPubkey)
             initializeOutboxModel()
             connect()
             sessionManager.setLoggedIn(true)
@@ -458,6 +462,7 @@ class NostrRepository(
         }
         val userPubkey = sessionManager.completeNostrConnectLogin(client, relays)
         unreadManager.initialize(userPubkey)
+        notificationHistoryStore?.initialize(userPubkey)
         initializeOutboxModel()
         connect()
         sessionManager.setLoggedIn(true)
@@ -472,6 +477,7 @@ class NostrRepository(
             }
             sessionManager.loginWithPrivateKey(privKey, pubKey)
             unreadManager.initialize(pubKey)
+            notificationHistoryStore?.initialize(pubKey)
             initializeOutboxModel()
             sessionManager.setLoggedIn(true)
             scope.launch { connect() }
@@ -489,6 +495,7 @@ class NostrRepository(
             }
             sessionManager.loginWithNip07(pubkey)
             unreadManager.initialize(pubkey)
+            notificationHistoryStore?.initialize(pubkey)
             initializeOutboxModel()
             sessionManager.setLoggedIn(true)
             scope.launch { connect() }
@@ -513,6 +520,7 @@ class NostrRepository(
         outboxManager.clear()
         groupManager.clear()
         unreadManager.clear()
+        notificationHistoryStore?.clear()
         liveCursorStore?.clear()
         relayPipelines.values.forEach { (_, pipeline) -> pipeline.close() }
         relayPipelines.clear()
@@ -1963,6 +1971,13 @@ class NostrRepository(
                         if (reactorPubkey != null && !metadataManager.hasMetadata(reactorPubkey)) {
                             scope.launch {
                                 requestUserMetadata(setOf(reactorPubkey))
+                            }
+                        }
+                        val currentPubkey = sessionManager.getPublicKey()
+                        if (currentPubkey != null && reaction.pubkey != currentPubkey) {
+                            val found = groupManager.findMessageByIdAcrossGroups(reaction.targetEventId)
+                            if (found != null && found.second.pubkey == currentPubkey) {
+                                unreadManager.onReactionReceived(found.first, reaction)
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -2677,6 +2677,14 @@ class GroupManager(
         return _messages.value[groupId] ?: emptyList()
     }
 
+    fun findMessageByIdAcrossGroups(messageId: String): Pair<String, NostrGroupClient.NostrMessage>? {
+        for ((groupId, msgs) in _messages.value) {
+            val msg = msgs.firstOrNull { it.id == messageId } ?: continue
+            return groupId to msg
+        }
+        return null
+    }
+
     /**
      * Returns the [NostrGroupClient.NostrMessage.createdAt] of the newest message in the
      * in-memory list for [groupId], or null if the group has no messages loaded yet.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -77,12 +77,10 @@ class OutboxManager(
         if (saved.isNotEmpty()) {
             _kind10009Relays.value = saved
         }
-        // Restore the timestamp so handleKind10009Event rejects stale network events
-        // that would resurrect relays/groups the user removed in a previous session.
-        val persisted = SecureStorage.loadKind10009Timestamp()
-        if (persisted > latestKind10009CreatedAt) {
-            latestKind10009CreatedAt = persisted
-        }
+        // Timestamp is now pubkey-scoped (see initialize()). seedFromCache runs
+        // before login so we don't know the pubkey yet — just start at 0 and
+        // let initialize() rehydrate the right scope when login completes.
+        latestKind10009CreatedAt = 0
     }
 
     fun initialize(
@@ -90,6 +88,11 @@ class OutboxManager(
         messageHandler: (String, NostrGroupClient) -> Unit,
         onDiscoveryComplete: (() -> Unit)? = null
     ) {
+        // Rehydrate the freshness floor for THIS account. Without pubkey scoping,
+        // a previous account's high timestamp would bleed in and reject the new
+        // account's (legitimately older) kind:10009 as "stale", leaving the
+        // sidebar empty until restart.
+        latestKind10009CreatedAt = SecureStorage.loadKind10009Timestamp(pubKey)
         scope.launch {
             coroutineScope {
                 bootstrapRelays.forEach { url ->
@@ -229,7 +232,7 @@ class OutboxManager(
             groupsMutex.withLock {
                 latestKind10009CreatedAt = event.createdAt
             }
-            SecureStorage.saveKind10009Timestamp(event.createdAt)
+            SecureStorage.saveKind10009Timestamp(pubKey, event.createdAt)
 
             _kind10009Relays.value = nip29Relays.map { it.normalizeRelayUrl() }.filter { it.isNotBlank() }.toSet()
             refreshGroupTagRelays()
@@ -301,16 +304,26 @@ class OutboxManager(
             allRelayGroups = immutableRelayGroups
         }
 
-        val explicitSet = explicitNip29Relays.distinct().toSet()
-        _kind10009Relays.value = explicitSet
+        // Persisted relay list must include EVERY relay the kind:10009 event
+        // references — both explicit "r" tags AND relays implied by "group" tags
+        // (where the user has joined groups). Saving only "r" tags clobbers
+        // group-bearing relays from persistence; on next launch the rail loses
+        // them until kind:10009 is refetched.
+        val groupBearingRelays = newRelayGroups.keys.toList()
+        val rOnlyRelays = explicitNip29Relays.distinct().filter { it !in groupBearingRelays }
+        // Group-bearing relays go first so autoConnectFirstRelay picks something
+        // useful — a "r"-only relay that's offline shouldn't strand the user
+        // when another relay has their actual groups.
+        val allNip29Relays = (groupBearingRelays + rOnlyRelays).distinct()
+        val allNip29RelaysSet = allNip29Relays.toSet()
+        _kind10009Relays.value = allNip29RelaysSet
         refreshGroupTagRelays()
 
         val previouslySaved = SecureStorage.loadRelayList().map { it.normalizeRelayUrl() }.toSet()
-        if (explicitSet != previouslySaved) {
-            SecureStorage.saveRelayList(explicitSet.toList())
+        if (allNip29RelaysSet != previouslySaved) {
+            SecureStorage.saveRelayList(allNip29Relays)
         }
 
-        val allNip29Relays = (explicitNip29Relays + newRelayGroups.keys).distinct()
         val newlyRestoredRelays = allNip29Relays.filter { it !in previouslySaved }
 
         immutableRelayGroups.forEach { (relayUrl, groups) ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -136,12 +136,29 @@ class UnreadManager(
         if (reaction.pubkey == pubkey) return
         if (!isJoined(groupId) || isRestricted(groupId)) return
         val lastRead = SecureStorage.getLastReadTimestamp(pubkey, groupId)
-        val highWater = _latestMessageTimestamps.value[groupId] ?: 0L
+        val previousHighWater = _latestMessageTimestamps.value[groupId] ?: 0L
         val anchor = maxOf(
             lastRead ?: firstSeenAtByGroup.getOrPut(groupId) { epochSeconds() },
-            highWater
+            previousHighWater
         )
         if (reaction.createdAt <= anchor) return
+
+        // Reactions on the user's own message are direct interactions worth
+        // surfacing on the group/relay badges, not just the notification feed.
+        // Caller already verified the target message author == self.
+        val highWaterAdvanced = reaction.createdAt > previousHighWater
+        if (highWaterAdvanced) {
+            _latestMessageTimestamps.update { it + (groupId to reaction.createdAt) }
+        }
+
+        val isActive = groupId == activeGroupId
+        if (!(isActive && isAppFocused())) {
+            _unreadCounts.update { current ->
+                current + (groupId to ((current[groupId] ?: 0) + 1))
+            }
+        }
+        persistEntries()
+
         onReactionNotify?.invoke(groupId, reaction)
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -15,7 +15,11 @@ class UnreadManager(
     private val isJoined: (String) -> Boolean = { true },
     private val isRestricted: (String) -> Boolean = { false },
     private val isAppFocused: () -> Boolean = { true },
+    private val findMessageAuthor: (messageId: String) -> String? = { null },
     private val onUnreadIncrement: ((groupId: String, latestMessage: NostrGroupClient.NostrMessage, delta: Int) -> Unit)? = null,
+    private val onReplyNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
+    private val onMentionNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
+    private val onReactionNotify: ((groupId: String, reaction: NostrGroupClient.NostrReaction) -> Unit)? = null,
 ) {
 
     private val _unreadCounts = MutableStateFlow<Map<String, Int>>(emptyMap())
@@ -111,7 +115,34 @@ class UnreadManager(
             }
         }
         persistEntries()
-        onUnreadIncrement?.invoke(groupId, qualifying.maxBy { it.createdAt }, qualifying.size)
+
+        val latestReply = qualifying.filter { msg ->
+            msg.tags.any { tag -> tag.size >= 2 && tag[0] == "e" && findMessageAuthor(tag[1]) == pubkey }
+        }.maxByOrNull { it.createdAt }
+
+        val latestMention = qualifying.filter { msg ->
+            msg.tags.any { tag -> tag.size >= 2 && tag[0] == "p" && tag[1] == pubkey }
+        }.maxByOrNull { it.createdAt }
+
+        when {
+            latestReply != null -> onReplyNotify?.invoke(groupId, latestReply)
+            latestMention != null -> onMentionNotify?.invoke(groupId, latestMention)
+            else -> onUnreadIncrement?.invoke(groupId, qualifying.maxBy { it.createdAt }, qualifying.size)
+        }
+    }
+
+    fun onReactionReceived(groupId: String, reaction: NostrGroupClient.NostrReaction) {
+        val pubkey = currentPubkey ?: return
+        if (reaction.pubkey == pubkey) return
+        if (!isJoined(groupId) || isRestricted(groupId)) return
+        val lastRead = SecureStorage.getLastReadTimestamp(pubkey, groupId)
+        val highWater = _latestMessageTimestamps.value[groupId] ?: 0L
+        val anchor = maxOf(
+            lastRead ?: firstSeenAtByGroup.getOrPut(groupId) { epochSeconds() },
+            highWater
+        )
+        if (reaction.createdAt <= anchor) return
+        onReactionNotify?.invoke(groupId, reaction)
     }
 
     fun clear() {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -116,8 +116,15 @@ class UnreadManager(
         }
         persistEntries()
 
+        // NIP-29 marks replies with a "q" (quote) tag; NIP-10 chats use "e".
+        // Accept both so replies are classified correctly regardless of which
+        // client posted them.
         val latestReply = qualifying.filter { msg ->
-            msg.tags.any { tag -> tag.size >= 2 && tag[0] == "e" && findMessageAuthor(tag[1]) == pubkey }
+            msg.tags.any { tag ->
+                tag.size >= 2 &&
+                (tag[0] == "q" || tag[0] == "e") &&
+                findMessageAuthor(tag[1]) == pubkey
+            }
         }.maxByOrNull { it.createdAt }
 
         val latestMention = qualifying.filter { msg ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
@@ -1,0 +1,92 @@
+package org.nostr.nostrord.notifications
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.serialization.Serializable
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.getPersistedNotifications
+import org.nostr.nostrord.storage.savePersistedNotifications
+
+@Serializable
+enum class NotificationType { REPLY, MENTION, REACTION, MESSAGE }
+
+@Serializable
+data class NotificationEntry(
+    val id: String,
+    val type: NotificationType,
+    val groupId: String,
+    val relayUrl: String,
+    val actorPubkey: String,
+    val createdAt: Long,
+    val preview: String,
+    val messageId: String? = null,
+    val emoji: String? = null,
+    val read: Boolean = false,
+    // Snapshot of the group/relay display names at the moment the notification
+    // was generated. Stored so the feed remains readable even when the group is
+    // later forgotten or the relay's metadata cache misses on cold startup.
+    // Pictures/icons are intentionally NOT snapshotted — those should refresh.
+    val groupName: String? = null,
+    val relayName: String? = null,
+)
+
+class NotificationHistoryStore {
+    private val _entries = MutableStateFlow<List<NotificationEntry>>(emptyList())
+    val entries: StateFlow<List<NotificationEntry>> = _entries.asStateFlow()
+
+    private var currentPubkey: String? = null
+
+    fun initialize(pubkey: String?) {
+        currentPubkey = pubkey
+        _entries.value = if (pubkey == null) emptyList()
+        else SecureStorage.getPersistedNotifications(pubkey)
+    }
+
+    fun add(entry: NotificationEntry) {
+        _entries.update { current ->
+            if (current.any { it.id == entry.id }) current
+            else (listOf(entry) + current).take(MAX_ENTRIES)
+        }
+        persist()
+    }
+
+    fun markRead(id: String) {
+        var changed = false
+        _entries.update { current ->
+            current.map {
+                if (it.id == id && !it.read) {
+                    changed = true
+                    it.copy(read = true)
+                } else it
+            }
+        }
+        if (changed) persist()
+    }
+
+    fun markAllRead() {
+        _entries.update { current -> current.map { it.copy(read = true) } }
+        persist()
+    }
+
+    /** Drop every entry from the in-memory feed and erase the persisted blob. */
+    fun clearHistory() {
+        _entries.value = emptyList()
+        persist()
+    }
+
+    fun clear() {
+        currentPubkey = null
+        _entries.value = emptyList()
+    }
+
+    private fun persist() {
+        val pubkey = currentPubkey ?: return
+        SecureStorage.savePersistedNotifications(pubkey, _entries.value)
+    }
+
+    companion object {
+        private const val MAX_ENTRIES = 50
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationService.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationService.kt
@@ -20,11 +20,14 @@ data class NotificationRequest(
     /** Tag used by the browser to coalesce notifications from the same conversation. */
     val tag: String = groupId,
     val iconUrl: String? = null,
+    /** Event id the user should land on when the notification is clicked. */
+    val messageId: String? = null,
 )
 
 data class NotificationClick(
     val relayUrl: String,
     val groupId: String,
+    val messageId: String? = null,
 )
 
 /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/StartupResolver.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/StartupResolver.kt
@@ -47,6 +47,7 @@ object StartupResolver {
         get() = when (val ctx = externalLaunchContext) {
             is ExternalLaunchContext.OpenGroup -> ctx.relayUrl
             is ExternalLaunchContext.OpenRelay -> ctx.relayUrl
+            is ExternalLaunchContext.OpenNotifications -> ctx.relayUrl
             else -> null
         }
 
@@ -74,6 +75,10 @@ object StartupResolver {
                 )
                 is ExternalLaunchContext.OpenRelay -> ResolvedScreen(
                     screen = Screen.Home,
+                    relayUrl = external.relayUrl
+                )
+                is ExternalLaunchContext.OpenNotifications -> ResolvedScreen(
+                    screen = Screen.Notifications,
                     relayUrl = external.relayUrl
                 )
                 is ExternalLaunchContext.OpenHome -> ResolvedScreen(screen = Screen.Home)
@@ -162,5 +167,6 @@ sealed class ExternalLaunchContext {
         val messageId: String? = null
     ) : ExternalLaunchContext()
     data class OpenRelay(val relayUrl: String) : ExternalLaunchContext()
+    data class OpenNotifications(val relayUrl: String? = null) : ExternalLaunchContext()
     data object OpenHome : ExternalLaunchContext()
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -180,11 +180,22 @@ fun SecureStorage.isFullGroupListCacheFresh(relayUrl: String, nowSeconds: Long):
 // Persisted timestamp of the most recently published (or locally applied) kind:10009 event.
 // Survives app restarts so that handleKind10009Event can reject stale network events that
 // would otherwise restore relays/groups the user explicitly removed while offline.
-fun SecureStorage.saveKind10009Timestamp(timestamp: Long) {
-    saveStringPref("kind10009_latest_ts", timestamp.toString())
+//
+// Pubkey-scoped: a timestamp from account A must NOT bleed into account B's freshness
+// check after a logout+login, otherwise B's kind:10009 (with an older createdAt) gets
+// rejected as "stale" even though it's fresh for B. Without this, B sees no relays
+// because `_kind10009Relays` never populates.
+fun SecureStorage.saveKind10009Timestamp(pubkey: String, timestamp: Long) {
+    saveStringPref("kind10009_latest_ts_${pubkey.hashCode()}", timestamp.toString())
 }
 
-fun SecureStorage.loadKind10009Timestamp(): Long {
+fun SecureStorage.loadKind10009Timestamp(pubkey: String): Long {
+    return getStringPref("kind10009_latest_ts_${pubkey.hashCode()}", "0").toLongOrNull() ?: 0L
+}
+
+// Legacy global key — kept for one-shot migration on first run after the upgrade.
+// Removed once a fresh kind:10009 arrives for any user.
+internal fun SecureStorage.loadLegacyKind10009Timestamp(): Long {
     return getStringPref("kind10009_latest_ts", "0").toLongOrNull() ?: 0L
 }
 
@@ -298,6 +309,35 @@ internal fun SecureStorage.getUnreadEntries(pubkey: String): Map<String, UnreadE
 internal fun SecureStorage.saveUnreadEntries(pubkey: String, entries: Map<String, UnreadEntry>) {
     try {
         saveStringPref(unreadEntriesKey(pubkey), Json.encodeToString<Map<String, UnreadEntry>>(entries))
+    } catch (_: Exception) {}
+}
+
+// Notification history — persisted feed of cross-relay notifications shown in
+// the notification center. Scoped by pubkey so multi-account devices stay isolated.
+private fun notificationHistoryKey(pubkey: String): String =
+    "notification_history_${pubkey.hashCode()}"
+
+fun SecureStorage.getPersistedNotifications(
+    pubkey: String
+): List<org.nostr.nostrord.notifications.NotificationEntry> {
+    val raw = getStringPref(notificationHistoryKey(pubkey), "")
+    if (raw.isBlank()) return emptyList()
+    return try {
+        Json.decodeFromString(raw)
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
+fun SecureStorage.savePersistedNotifications(
+    pubkey: String,
+    entries: List<org.nostr.nostrord.notifications.NotificationEntry>
+) {
+    try {
+        saveStringPref(
+            notificationHistoryKey(pubkey),
+            Json.encodeToString<List<org.nostr.nostrord.notifications.NotificationEntry>>(entries)
+        )
     } catch (_: Exception) {}
 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/Screen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/Screen.kt
@@ -6,7 +6,8 @@ sealed class Screen {
     data object RelaySettings : Screen()
     data object Profile : Screen()
     data object EditProfile : Screen()
-    data class Group(val groupId: String, val groupName: String?) : Screen()
+    data class Group(val groupId: String, val groupName: String?, val targetMessageId: String? = null) : Screen()
+    data object Notifications : Screen()
     object NostrLogin : Screen()
     object BackupPrivateKey : Screen()
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/DesktopShell.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/DesktopShell.kt
@@ -52,6 +52,9 @@ fun DesktopShell(
     modifier: Modifier = Modifier,
     onUserClick: () -> Unit = {},
     isProfileActive: Boolean = false,
+    onNotificationsClick: () -> Unit = {},
+    isNotificationsActive: Boolean = false,
+    hideGroupsSidebar: Boolean = false,
     content: @Composable () -> Unit
 ) {
     // Sidebar-scoped state — changes here only recompose the sidebar columns,
@@ -94,6 +97,9 @@ fun DesktopShell(
         pubKey?.let { userMetadata[it] }
     }
 
+    val notificationEntries by AppModule.notificationHistoryStore.entries.collectAsState()
+    val notificationCount = remember(notificationEntries) { notificationEntries.count { !it.read } }
+
     BoxWithConstraints(
         modifier = modifier
             .fillMaxSize()
@@ -105,7 +111,10 @@ fun DesktopShell(
             // Column 1: Relay Rail (72dp)
             ServerRail(
                 relays = relays,
-                activeRelayUrl = activeRelayUrl,
+                // Suppress relay active indicator when a global screen (notifications,
+                // profile) owns the rail's active state — otherwise both indicators
+                // would show simultaneously.
+                activeRelayUrl = if (isNotificationsActive || isProfileActive) "" else activeRelayUrl,
                 onRelayClick = onRelayClick,
                 onAddRelayClick = onAddRelayClick,
                 relayMetadata = relayMetadata,
@@ -114,11 +123,16 @@ fun DesktopShell(
                 userDisplayName = currentUserMetadata?.displayName ?: currentUserMetadata?.name,
                 userPubkey = pubKey,
                 onUserClick = onUserClick,
-                isProfileActive = isProfileActive
+                isProfileActive = isProfileActive,
+                notificationCount = notificationCount,
+                onNotificationsClick = onNotificationsClick,
+                isNotificationsActive = isNotificationsActive,
             )
 
-            // Column 2: Groups Nav Sidebar (200dp on tablet, 240dp on desktop)
-            Box(modifier = Modifier.width(sidebarWidth)) {
+            // Column 2: Groups Nav Sidebar (200dp on tablet, 240dp on desktop).
+            // Hidden when the active screen is global (e.g. Notifications) so the
+            // content area can span the full remaining width.
+            if (!hideGroupsSidebar) Box(modifier = Modifier.width(sidebarWidth)) {
                 GroupsNavSidebar(
                     relayUrl = activeRelayUrl,
                     groups = groupsForRelay,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/navigation/ServerRail.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/navigation/ServerRail.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.PlainTooltip
@@ -78,6 +79,9 @@ fun ServerRail(
     userPubkey: String? = null,
     onUserClick: () -> Unit = {},
     isProfileActive: Boolean = false,
+    notificationCount: Int = 0,
+    onNotificationsClick: () -> Unit = {},
+    isNotificationsActive: Boolean = false,
     showTooltips: Boolean = true
 ) {
     val listState = rememberLazyListState()
@@ -140,6 +144,15 @@ fun ServerRail(
                 }
             }
         }
+
+        // Notification bell — global, cross-relay. Sits above the avatar so the
+        // badge surfaces unread totals regardless of which screen is active.
+        NotificationBell(
+            count = notificationCount,
+            isActive = isNotificationsActive,
+            onClick = onNotificationsClick,
+            tooltip = if (showTooltips) "Notifications" else null,
+        )
 
         // User avatar at bottom
         Spacer(modifier = Modifier.height(Spacing.sm))
@@ -476,6 +489,123 @@ private fun UserAvatar(
         }
     } else {
         avatarContent()
+    }
+}
+
+/**
+ * Notification bell in the server rail. Mirrors UserAvatar's layout (left pill
+ * indicator + centered icon) so it visually rhymes with the other "pinned"
+ * rail items. The badge reuses UnreadBadge to match per-relay styling.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun NotificationBell(
+    count: Int,
+    isActive: Boolean,
+    onClick: () -> Unit,
+    tooltip: String? = "Notifications",
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    val indicatorHeight by animateDpAsState(
+        targetValue = when {
+            isActive -> Spacing.activeIndicatorHeight
+            isHovered -> Spacing.hoverIndicatorHeight
+            else -> 0.dp
+        },
+        animationSpec = NostrordAnimation.indicatorSpec()
+    )
+
+    val cornerRadius by animateDpAsState(
+        targetValue = when {
+            isActive || isHovered -> NostrordShapes.serverIconActive
+            else -> NostrordShapes.serverIconDefault
+        },
+        animationSpec = NostrordAnimation.standardSpec()
+    )
+
+    val bellContent: @Composable () -> Unit = {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(Spacing.serverIconSize + Spacing.sm),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .width(Spacing.activeIndicatorWidth)
+                    .height(indicatorHeight)
+                    .background(
+                        if (indicatorHeight > 0.dp) Color.White else Color.Transparent,
+                        RoundedCornerShape(
+                            topEnd = Spacing.activeIndicatorWidth,
+                            bottomEnd = Spacing.activeIndicatorWidth
+                        )
+                    )
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Box(
+                modifier = Modifier
+                    .size(Spacing.serverIconSize)
+                    .hoverable(interactionSource)
+                    .clickable(onClick = onClick)
+                    .pointerHoverIcon(PointerIcon.Hand),
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(Spacing.serverIconSize)
+                        .clip(RoundedCornerShape(cornerRadius))
+                        .background(
+                            color = when {
+                                isActive -> NostrordColors.Primary
+                                isHovered -> NostrordColors.Primary.copy(alpha = 0.7f)
+                                else -> NostrordColors.SurfaceVariant
+                            }
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Notifications,
+                        contentDescription = "Notifications",
+                        tint = Color.White,
+                        modifier = Modifier.size(22.dp)
+                    )
+                }
+                if (count > 0) {
+                    UnreadBadge(
+                        count = count,
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .offset(x = 4.dp, y = (-4).dp)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+        }
+    }
+
+    if (tooltip != null) {
+        TooltipBox(
+            positionProvider = RightSideTooltipPositionProvider(),
+            tooltip = {
+                PlainTooltip(
+                    containerColor = NostrordColors.Surface,
+                    contentColor = NostrordColors.TextPrimary
+                ) {
+                    Text(tooltip)
+                }
+            },
+            state = rememberTooltipState()
+        ) {
+            bellContent()
+        }
+    } else {
+        bellContent()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.kt
@@ -14,11 +14,12 @@ import org.nostr.nostrord.ui.Screen
  * On all other platforms: no-op.
  *
  * @param onUrlNavigation Called on popstate with the relay URL, optional group ID,
- *   and optional invite code parsed from the browser URL.
+ *   optional invite code, and a flag indicating that the URL pointed at the
+ *   Notifications screen (`?view=notifications`).
  */
 @Composable
 expect fun BrowserNavigationHandler(
     currentScreen: Screen,
     selectedRelayUrl: String,
-    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?) -> Unit
+    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?, viewNotifications: Boolean) -> Unit
 )

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -81,7 +81,15 @@ fun GroupScreen(
     val reactionError by vm.reactionError.collectAsState()
     val moderationError by vm.moderationError.collectAsState()
     val connectionState by vm.connectionState.collectAsState()
-    val joinedGroups by vm.joinedGroups.collectAsState()
+    // Cross-relay membership view. `vm.joinedGroups` is filtered by
+    // _currentRelayUrl, which is null/stale during fresh-login bootstrap (kind:10009
+    // arrives before the primary relay is set, especially in NIP-46 flows where
+    // the remote signer dance delays everything). Flattening joinedGroupsByRelay
+    // gives a stable "any relay has me as a member" view that doesn't race.
+    val joinedGroupsByRelay by vm.joinedGroupsByRelay.collectAsState()
+    val joinedGroups = remember(joinedGroupsByRelay) {
+        joinedGroupsByRelay.values.flatten().toSet()
+    }
     val groups by vm.groups.collectAsState()
     val groupsByRelay by vm.groupsByRelay.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -16,6 +16,7 @@ class GroupViewModel(
     val messages = repo.messages
     val connectionState = repo.connectionState
     val joinedGroups = repo.joinedGroups
+    val joinedGroupsByRelay = repo.joinedGroupsByRelay
     val groups = repo.groups
     val groupsByRelay = repo.groupsByRelay
     val userMetadata = repo.userMetadata

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.managers.ConnectionManager
+import androidx.compose.runtime.collectAsState
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.ui.Screen
 import org.nostr.nostrord.utils.normalizeRelayUrl

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenDesktop.kt
@@ -169,7 +169,9 @@ fun HomeScreenDesktop(
 
             }
 
-            // Relay options menu — position:absolute; top:8px; right:8px
+            // Relay options — position:absolute; top:8px; right:8px.
+            // Notifications live in the server rail (always visible on desktop),
+            // so we don't duplicate the bell here.
             RelayOptionsMenu(
                 relayUrl = currentRelayUrl,
                 isRelaySaved = isRelaySaved,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsScreen.kt
@@ -38,6 +38,7 @@ import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.navigation.relayShortLabel
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
+import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.ui.util.generateColorFromString
 import org.nostr.nostrord.ui.util.relayFallbackPainter
 import org.nostr.nostrord.utils.formatTimestamp
@@ -199,6 +200,10 @@ private fun NotificationItem(
     relayIconUrl: String?,
     onClick: () -> Unit,
 ) {
+    // NotoColorEmoji loaded from app resources. Skia (desktop/web) has no
+    // system color-emoji font, so without this the badge glyph and reaction
+    // preview fall back to monochrome tofu.
+    val emojiFontFamily = rememberEmojiFontFamily()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -246,7 +251,8 @@ private fun NotificationItem(
                     Text(
                         text = notificationTypeEmoji(entry),
                         fontSize = 8.sp,
-                        lineHeight = 8.sp
+                        lineHeight = 8.sp,
+                        fontFamily = emojiFontFamily,
                     )
                 }
             }
@@ -273,13 +279,16 @@ private fun NotificationItem(
 
             Spacer(Modifier.height(2.dp))
 
+            val isReaction = entry.type == NotificationType.REACTION
             Text(
-                text = if (entry.type == NotificationType.REACTION) entry.emoji ?: entry.preview
-                       else entry.preview,
+                text = if (isReaction) entry.emoji ?: entry.preview else entry.preview,
                 color = NostrordColors.TextSecondary,
                 fontSize = 13.sp,
                 maxLines = 2,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
+                // Only swap the family when the body IS the emoji; for regular
+                // message previews we keep system text rendering.
+                fontFamily = if (isReaction) emojiFontFamily else null,
             )
 
             Spacer(Modifier.height(4.dp))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsScreen.kt
@@ -1,0 +1,429 @@
+package org.nostr.nostrord.ui.screens.notifications
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.notifications.NotificationEntry
+import org.nostr.nostrord.notifications.NotificationType
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
+import coil3.compose.LocalPlatformContext
+import coil3.request.CachePolicy
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import org.nostr.nostrord.ui.Screen
+import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
+import org.nostr.nostrord.ui.components.navigation.relayShortLabel
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordTypography
+import org.nostr.nostrord.ui.util.generateColorFromString
+import org.nostr.nostrord.ui.util.relayFallbackPainter
+import org.nostr.nostrord.utils.formatTimestamp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NotificationsScreen(
+    onNavigate: (Screen) -> Unit,
+    onOpenGroupAtRelay: (groupId: String, groupName: String?, relayUrl: String, targetMessageId: String?) -> Unit,
+    onOpenDrawer: (() -> Unit)? = null,
+) {
+    val entries by AppModule.notificationHistoryStore.entries.collectAsState()
+    val userMetadata by AppModule.nostrRepository.userMetadata.collectAsState()
+    // Cross-relay group lookup. The `groups` flow is scoped to the active relay,
+    // so notifications from background relays would fall back to a truncated id.
+    val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
+    val relayMetadata by AppModule.nostrRepository.relayMetadata.collectAsState()
+
+    val hasUnread = remember(entries) { entries.any { !it.read } }
+    var overflowOpen by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Notifications", style = NostrordTypography.ServerHeader, color = Color.White) },
+                navigationIcon = {
+                    // Mobile-only hamburger to reopen the drawer. On desktop the
+                    // bell lives in the server rail, so no navigation icon here —
+                    // users dismiss the screen by clicking elsewhere in the rail.
+                    if (onOpenDrawer != null) {
+                        IconButton(onClick = onOpenDrawer) {
+                            Icon(
+                                Icons.Default.Menu,
+                                contentDescription = "Open sidebar",
+                                tint = NostrordColors.TextSecondary
+                            )
+                        }
+                    }
+                },
+                actions = {
+                    IconButton(
+                        onClick = { AppModule.notificationHistoryStore.markAllRead() },
+                        enabled = hasUnread,
+                    ) {
+                        Icon(
+                            Icons.Default.DoneAll,
+                            contentDescription = "Mark all as read",
+                            tint = if (hasUnread) NostrordColors.TextSecondary
+                                   else NostrordColors.TextMuted.copy(alpha = 0.4f),
+                        )
+                    }
+                    Box {
+                        IconButton(onClick = { overflowOpen = true }) {
+                            Icon(
+                                Icons.Default.MoreVert,
+                                contentDescription = "More options",
+                                tint = NostrordColors.TextSecondary,
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = overflowOpen,
+                            onDismissRequest = { overflowOpen = false },
+                            containerColor = NostrordColors.Surface,
+                        ) {
+                            DropdownMenuItem(
+                                text = { Text("Clear all", color = NostrordColors.TextPrimary) },
+                                enabled = entries.isNotEmpty(),
+                                onClick = {
+                                    overflowOpen = false
+                                    AppModule.notificationHistoryStore.clearHistory()
+                                },
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = NostrordColors.BackgroundDark)
+            )
+        },
+        containerColor = NostrordColors.Background
+    ) { padding ->
+        if (entries.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Icon(
+                        Icons.Default.Notifications,
+                        contentDescription = null,
+                        tint = NostrordColors.TextMuted,
+                        modifier = Modifier.size(48.dp)
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    Text("No notifications yet", color = NostrordColors.TextMuted, fontSize = 15.sp)
+                }
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(padding),
+                contentPadding = PaddingValues(vertical = 8.dp)
+            ) {
+                items(entries, key = { it.id }) { entry ->
+                    val meta = userMetadata[entry.actorPubkey]
+                    val authorName = meta?.displayName?.takeIf { it.isNotBlank() }
+                        ?: meta?.name?.takeIf { it.isNotBlank() }
+                        ?: (entry.actorPubkey.take(8) + "…")
+                    // Prefer the entry's own relay bucket; fall back to any relay
+                    // that knows the group (joined groups can appear on multiple
+                    // mirrored relays). Last resort is the truncated id.
+                    val groupMeta = groupsByRelay[entry.relayUrl]?.firstOrNull { it.id == entry.groupId }
+                        ?: groupsByRelay.values.firstNotNullOfOrNull { list ->
+                            list.firstOrNull { it.id == entry.groupId }
+                        }
+                    // Prefer the snapshot captured at notification time. Live cache
+                    // lookup is the secondary path for legacy entries that predate
+                    // snapshotting. Truncated id is the last resort.
+                    val groupName = entry.groupName?.takeIf { it.isNotBlank() }
+                        ?: groupMeta?.name?.takeIf { it.isNotBlank() }
+                        ?: entry.groupId.take(8)
+                    val relayInfo = relayMetadata[entry.relayUrl]
+                    val relayName = entry.relayName?.takeIf { it.isNotBlank() }
+                        ?: relayInfo?.name?.takeIf { it.isNotBlank() }
+                        ?: entry.relayUrl.takeIf { it.isNotBlank() }?.let { relayShortLabel(it) }
+                        ?: ""
+
+                    NotificationItem(
+                        entry = entry,
+                        authorName = authorName,
+                        avatarUrl = meta?.picture,
+                        groupName = groupName,
+                        groupPicture = groupMeta?.picture,
+                        relayName = relayName,
+                        relayIconUrl = relayInfo?.icon,
+                        onClick = {
+                            AppModule.notificationHistoryStore.markRead(entry.id)
+                            onOpenGroupAtRelay(
+                                entry.groupId,
+                                groupName,
+                                entry.relayUrl,
+                                entry.messageId,
+                            )
+                        }
+                    )
+                    HorizontalDivider(color = NostrordColors.BackgroundDark, thickness = 1.dp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotificationItem(
+    entry: NotificationEntry,
+    authorName: String,
+    avatarUrl: String?,
+    groupName: String,
+    groupPicture: String?,
+    relayName: String,
+    relayIconUrl: String?,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .background(
+                if (!entry.read) MaterialTheme.colorScheme.primary.copy(alpha = 0.08f)
+                else Color.Transparent
+            )
+            .height(IntrinsicSize.Min),
+        verticalAlignment = Alignment.Top
+    ) {
+        // Left accent bar — primary-color stripe on unread, transparent spacer
+        // on read entries so content alignment stays stable across states.
+        Box(
+            modifier = Modifier
+                .width(3.dp)
+                .fillMaxHeight()
+                .background(
+                    if (!entry.read) MaterialTheme.colorScheme.primary else Color.Transparent
+                )
+        )
+
+        Row(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 13.dp, end = 16.dp, top = 12.dp, bottom = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Box {
+                OptimizedSmallAvatar(
+                    imageUrl = avatarUrl,
+                    identifier = entry.actorPubkey,
+                    displayName = authorName,
+                    size = 40.dp
+                )
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .align(Alignment.BottomEnd)
+                        .clip(CircleShape)
+                        .background(notificationTypeColor(entry.type)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = notificationTypeEmoji(entry),
+                        fontSize = 8.sp,
+                        lineHeight = 8.sp
+                    )
+                }
+            }
+
+        Column(modifier = Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = authorName,
+                    fontWeight = FontWeight.SemiBold,
+                    color = NostrordColors.TextPrimary,
+                    fontSize = 14.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                Spacer(Modifier.width(6.dp))
+                Text(
+                    text = notificationTypeLabel(entry.type),
+                    color = NostrordColors.TextMuted,
+                    fontSize = 13.sp,
+                    maxLines = 1
+                )
+            }
+
+            Spacer(Modifier.height(2.dp))
+
+            Text(
+                text = if (entry.type == NotificationType.REACTION) entry.emoji ?: entry.preview
+                       else entry.preview,
+                color = NostrordColors.TextSecondary,
+                fontSize = 13.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+
+            Spacer(Modifier.height(4.dp))
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                ContextIcon(
+                    imageUrl = groupPicture,
+                    identifier = entry.groupId,
+                    label = groupName,
+                    size = 16.dp,
+                )
+                Text(
+                    text = groupName,
+                    color = NostrordColors.TextMuted,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false)
+                )
+                if (relayName.isNotBlank()) {
+                    Text("·", color = NostrordColors.TextMuted, fontSize = 12.sp)
+                    ContextIcon(
+                        imageUrl = relayIconUrl,
+                        identifier = entry.relayUrl,
+                        label = relayName,
+                        size = 16.dp,
+                        bundledFallback = relayFallbackPainter(entry.relayUrl),
+                    )
+                    Text(
+                        text = relayName,
+                        color = NostrordColors.TextMuted,
+                        fontSize = 12.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false)
+                    )
+                }
+                Text("·", color = NostrordColors.TextMuted, fontSize = 12.sp)
+                Text(
+                    text = formatTimestamp(entry.createdAt),
+                    color = NostrordColors.TextMuted,
+                    fontSize = 12.sp,
+                    maxLines = 1
+                )
+            }
+        }
+        }
+    }
+}
+
+private fun notificationTypeLabel(type: NotificationType): String = when (type) {
+    NotificationType.REPLY -> "replied to your message"
+    NotificationType.MENTION -> "mentioned you"
+    NotificationType.REACTION -> "reacted to your message"
+    NotificationType.MESSAGE -> "sent a message"
+}
+
+private fun notificationTypeEmoji(entry: NotificationEntry): String = when (entry.type) {
+    NotificationType.REPLY -> "↩"
+    NotificationType.MENTION -> "@"
+    NotificationType.REACTION -> entry.emoji?.take(2) ?: "+"
+    NotificationType.MESSAGE -> "💬"
+}
+
+private fun notificationTypeColor(type: NotificationType): Color = when (type) {
+    NotificationType.REPLY -> Color(0xFF5B8AF5)
+    NotificationType.MENTION -> Color(0xFFE67E22)
+    NotificationType.REACTION -> Color(0xFFE74C3C)
+    NotificationType.MESSAGE -> Color(0xFF27AE60)
+}
+
+/**
+ * Small rounded square icon for groups and relays in the notification feed.
+ * Loads the image whenever a URL is provided; falls back to a colored square with
+ * the first letter of the label. Doesn't use [OptimizedSmallAvatar] because at
+ * sizes below 24dp that helper skips image loading and renders a user-style
+ * Jdenticon — wrong fallback for groups/relays, and hides real pictures.
+ */
+@Composable
+private fun ContextIcon(
+    imageUrl: String?,
+    identifier: String,
+    label: String,
+    size: Dp,
+    bundledFallback: androidx.compose.ui.graphics.painter.Painter? = null,
+) {
+    val context = LocalPlatformContext.current
+    val shape = RoundedCornerShape(4.dp)
+    var imageState by remember(imageUrl) {
+        mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty)
+    }
+    val remoteOk = !imageUrl.isNullOrBlank() && imageState !is AsyncImagePainter.State.Error
+    // Mirrors ServerRail: bundled painter only kicks in when the relay has no
+    // NIP-11 icon at all. A remote URL that fails still falls through to the
+    // letter glyph so the issue stays visible rather than masked by an asset.
+    val showBundled = imageUrl.isNullOrBlank() && bundledFallback != null
+    val showLetter = !remoteOk && !showBundled
+
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(shape)
+            .background(if (showLetter) generateColorFromString(identifier) else NostrordColors.BackgroundDark),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (showLetter) {
+            val glyphSp = (size.value * 0.55f).sp
+            Text(
+                text = label.take(1).uppercase(),
+                color = Color.White,
+                fontSize = glyphSp,
+                lineHeight = glyphSp,
+                fontWeight = FontWeight.Bold,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            )
+        }
+        if (showBundled && bundledFallback != null) {
+            androidx.compose.foundation.Image(
+                painter = bundledFallback,
+                contentDescription = label,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(shape),
+            )
+        }
+        if (!imageUrl.isNullOrBlank()) {
+            AsyncImage(
+                model = ImageRequest.Builder(context)
+                    .data(imageUrl)
+                    .crossfade(true)
+                    .memoryCachePolicy(CachePolicy.ENABLED)
+                    .diskCachePolicy(CachePolicy.ENABLED)
+                    .build(),
+                contentDescription = label,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(shape),
+                contentScale = ContentScale.Crop,
+                onState = { imageState = it },
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsScreen.kt
@@ -18,8 +18,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.nostr.nostrord.di.AppModule
@@ -258,24 +261,29 @@ private fun NotificationItem(
             }
 
         Column(modifier = Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Text(
-                    text = authorName,
-                    fontWeight = FontWeight.SemiBold,
-                    color = NostrordColors.TextPrimary,
-                    fontSize = 14.sp,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.weight(1f, fill = false)
-                )
-                Spacer(Modifier.width(6.dp))
-                Text(
-                    text = notificationTypeLabel(entry.type),
-                    color = NostrordColors.TextMuted,
-                    fontSize = 13.sp,
-                    maxLines = 1
-                )
+            // Author + action in a single AnnotatedString so the action label
+            // wraps to a second line instead of clipping off-screen on narrow
+            // viewports (e.g. Android compact). The previous two-Text Row had
+            // the label without weight or ellipsis, and "reacted to your
+            // message" went out of bounds before users could see it.
+            val header = buildAnnotatedString {
+                withStyle(
+                    SpanStyle(
+                        fontWeight = FontWeight.SemiBold,
+                        color = NostrordColors.TextPrimary,
+                    )
+                ) { append(authorName) }
+                append(' ')
+                withStyle(SpanStyle(color = NostrordColors.TextMuted)) {
+                    append(notificationTypeLabel(entry.type))
+                }
             }
+            Text(
+                text = header,
+                fontSize = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
 
             Spacer(Modifier.height(2.dp))
 

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.ios.kt
@@ -7,7 +7,7 @@ import org.nostr.nostrord.ui.Screen
 actual fun BrowserNavigationHandler(
     currentScreen: Screen,
     selectedRelayUrl: String,
-    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?) -> Unit
+    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?, viewNotifications: Boolean) -> Unit
 ) {
     // No browser history on iOS
 }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.js.kt
@@ -88,7 +88,7 @@ actual class NotificationService actual constructor() {
             request.body,
             request.tag,
             request.iconUrl ?: "",
-        ) { _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId)) }
+        ) { _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId, request.messageId)) }
     }
 
     private fun readPermission(): NotificationPermission {

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.js.kt
@@ -13,6 +13,9 @@ import org.nostr.nostrord.utils.toRelayUrl
 import org.w3c.dom.PopStateEvent
 
 private fun buildUrlQuery(relayUrl: String, screen: Screen): String {
+    // Notifications is cross-relay — keep it out of the relay namespace so the
+    // URL stays meaningful (and refresh-stable) even with no relay context.
+    if (screen is Screen.Notifications) return "?view=notifications"
     if (relayUrl.isBlank()) return window.location.pathname
     val relay = relayUrl
         .removePrefix("wss://")
@@ -26,7 +29,12 @@ private fun buildUrlQuery(relayUrl: String, screen: Screen): String {
 /**
  * Parse relay and group from a URL search string like "?relay=host&group=id".
  */
-private data class UrlParams(val relayUrl: String, val groupId: String?, val inviteCode: String?)
+private data class UrlParams(
+    val relayUrl: String,
+    val groupId: String?,
+    val inviteCode: String?,
+    val viewNotifications: Boolean,
+)
 
 private fun parseUrlQuery(search: String): UrlParams {
     val params = search.removePrefix("?").split("&").associate { param ->
@@ -38,14 +46,15 @@ private fun parseUrlQuery(search: String): UrlParams {
     val relayUrl = relay.toRelayUrl()
     val groupId = params["group"]?.takeIf { it.isNotBlank() }
     val inviteCode = params["code"]?.takeIf { it.isNotBlank() }
-    return UrlParams(relayUrl, groupId, inviteCode)
+    val viewNotifications = params["view"] == "notifications"
+    return UrlParams(relayUrl, groupId, inviteCode, viewNotifications)
 }
 
 @Composable
 actual fun BrowserNavigationHandler(
     currentScreen: Screen,
     selectedRelayUrl: String,
-    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?) -> Unit
+    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?, viewNotifications: Boolean) -> Unit
 ) {
     val currentOnUrlNavigation by rememberUpdatedState(onUrlNavigation)
 
@@ -72,8 +81,11 @@ actual fun BrowserNavigationHandler(
             val parsed = parseUrlQuery(window.location.search)
             skipNextPush.value = true
             lastPushedUrl.value = window.location.search.ifBlank { window.location.pathname }
-            if (parsed.relayUrl.isNotBlank()) {
-                currentOnUrlNavigation(parsed.relayUrl, parsed.groupId, parsed.inviteCode)
+            // `view=notifications` is allowed to fire without a relay — the
+            // Notifications screen is cross-relay and the app keeps its
+            // previously selected relay in the sidebar.
+            if (parsed.relayUrl.isNotBlank() || parsed.viewNotifications) {
+                currentOnUrlNavigation(parsed.relayUrl, parsed.groupId, parsed.inviteCode, parsed.viewNotifications)
             }
         }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.jvm.kt
@@ -7,7 +7,7 @@ import org.nostr.nostrord.ui.Screen
 actual fun BrowserNavigationHandler(
     currentScreen: Screen,
     selectedRelayUrl: String,
-    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?) -> Unit
+    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?, viewNotifications: Boolean) -> Unit
 ) {
     // No browser history on desktop JVM
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.wasmJs.kt
@@ -89,7 +89,7 @@ actual class NotificationService actual constructor() {
             request.body,
             request.tag,
             request.iconUrl ?: "",
-        ) { _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId)) }
+        ) { _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId, request.messageId)) }
     }
 
     private fun readPermission(): NotificationPermission {

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/navigation/BrowserNavigationHandler.wasmJs.kt
@@ -38,6 +38,9 @@ private external fun jsGetPathname(): String
 private external fun jsAddPopStateListener(callback: (String) -> Unit): () -> Unit
 
 private fun buildUrlQuery(relayUrl: String, screen: Screen): String {
+    // Notifications is cross-relay — keep it out of the relay namespace so the
+    // URL stays meaningful (and refresh-stable) even with no relay context.
+    if (screen is Screen.Notifications) return "?view=notifications"
     if (relayUrl.isBlank()) return jsGetPathname()
     val relay = relayUrl
         .removePrefix("wss://")
@@ -51,7 +54,12 @@ private fun buildUrlQuery(relayUrl: String, screen: Screen): String {
 /**
  * Parse relay and group from a URL search string like "?relay=host&group=id".
  */
-private data class UrlParams(val relayUrl: String, val groupId: String?, val inviteCode: String?)
+private data class UrlParams(
+    val relayUrl: String,
+    val groupId: String?,
+    val inviteCode: String?,
+    val viewNotifications: Boolean,
+)
 
 private fun parseUrlQuery(search: String): UrlParams {
     val params = search.removePrefix("?").split("&").associate { param ->
@@ -63,14 +71,15 @@ private fun parseUrlQuery(search: String): UrlParams {
     val relayUrl = relay.toRelayUrl()
     val groupId = params["group"]?.takeIf { it.isNotBlank() }
     val inviteCode = params["code"]?.takeIf { it.isNotBlank() }
-    return UrlParams(relayUrl, groupId, inviteCode)
+    val viewNotifications = params["view"] == "notifications"
+    return UrlParams(relayUrl, groupId, inviteCode, viewNotifications)
 }
 
 @Composable
 actual fun BrowserNavigationHandler(
     currentScreen: Screen,
     selectedRelayUrl: String,
-    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?) -> Unit
+    onUrlNavigation: (relayUrl: String, groupId: String?, inviteCode: String?, viewNotifications: Boolean) -> Unit
 ) {
     val currentOnUrlNavigation by rememberUpdatedState(onUrlNavigation)
 
@@ -96,8 +105,11 @@ actual fun BrowserNavigationHandler(
             val parsed = parseUrlQuery(search)
             skipNextPush.value = true
             lastPushedUrl.value = search.ifBlank { jsGetPathname() }
-            if (parsed.relayUrl.isNotBlank()) {
-                currentOnUrlNavigation(parsed.relayUrl, parsed.groupId, parsed.inviteCode)
+            // `view=notifications` is allowed to fire without a relay — the
+            // Notifications screen is cross-relay and the app keeps its
+            // previously selected relay in the sidebar.
+            if (parsed.relayUrl.isNotBlank() || parsed.viewNotifications) {
+                currentOnUrlNavigation(parsed.relayUrl, parsed.groupId, parsed.inviteCode, parsed.viewNotifications)
             }
         }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
@@ -43,16 +43,27 @@ private fun parseDeepLinkFromUrl() {
         else param to ""
     }
 
-    val relay = params["relay"]?.takeIf { it.isNotBlank() } ?: return
-    val relayUrl = relay.toRelayUrl().takeIf { it.isNotBlank() } ?: return
+    val viewNotifications = params["view"] == "notifications"
+    val relay = params["relay"]?.takeIf { it.isNotBlank() }
+    val relayUrl = relay?.toRelayUrl()?.takeIf { it.isNotBlank() }
+
+    // `?view=notifications` is cross-relay; the screen can boot without any
+    // relay query param and the app falls back to persisted state.
+    if (relayUrl == null) {
+        if (viewNotifications) {
+            StartupResolver.setExternalLaunchContext(ExternalLaunchContext.OpenNotifications())
+        }
+        return
+    }
+
     val groupId = params["group"]?.takeIf { it.isNotBlank() }
     val inviteCode = params["code"]?.takeIf { it.isNotBlank() }
     val messageId = params["e"]?.takeIf { it.isNotBlank() }
 
-    val context = if (groupId != null) {
-        ExternalLaunchContext.OpenGroup(groupId = groupId, groupName = null, relayUrl = relayUrl, inviteCode = inviteCode, messageId = messageId)
-    } else {
-        ExternalLaunchContext.OpenRelay(relayUrl)
+    val context = when {
+        groupId != null -> ExternalLaunchContext.OpenGroup(groupId = groupId, groupName = null, relayUrl = relayUrl, inviteCode = inviteCode, messageId = messageId)
+        viewNotifications -> ExternalLaunchContext.OpenNotifications(relayUrl)
+        else -> ExternalLaunchContext.OpenRelay(relayUrl)
     }
     StartupResolver.setExternalLaunchContext(context)
 }


### PR DESCRIPTION
Persisted feed of reactions, replies, mentions, and messages across every joined relay. Bell sits in the server rail with an unread badge; the Notifications screen lists entries with per-item read state, mark-all-read, and clear-all. Group/relay names are snapshotted at write time so entries stay readable when the live metadata cache misses.

UnreadManager now classifies inbound events into reply (e-tag to a message authored by self), mention (p-tag = self), reaction (kind:7 on a message authored by self), or generic message, routing each to a dedicated callback.

Fixes:
- kind:10009 freshness timestamp is pubkey-scoped. The previous global key let account A's higher createdAt reject account B's legitimately older event after logout+login, leaving B with an empty relay list and the onboarding screen instead of their groups.
- kind:10009 handler persists the union of "r"-tagged and group-bearing relays. Saving only "r" tags clobbered relays where the user had joined groups, dropping them from the rail until the next refetch.
- autoConnectFirstRelay prefers relays with joined groups over "r"-only entries, so an offline standalone "r" relay no longer strands the user.
- GroupScreen membership check reads joinedGroupsByRelay as a cross-relay union instead of the active-relay-scoped joinedGroups. The active-relay view raced with kind:10009 arrival on fresh login (especially NIP-46 where the signer dance widens the window).