### PR TITLE
feat(ci): add GitHub Actions workflow for compile, spotless, tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Spotless check
+        run: ./gradlew spotlessCheck
+
+      - name: Compile (JVM)
+        run: ./gradlew compileKotlinJvm
+
+      - name: JVM tests
+        run: ./gradlew :composeApp:jvmTest

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/AdaptiveConfigTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/AdaptiveConfigTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -109,6 +110,7 @@ class AdaptiveConfigTest {
         config.recordRelayLatency("wss://slow.relay", 500)
         config.recordRelayLatency("wss://fast.relay", 50)
         config.recordRelayLatency("wss://medium.relay", 200)
+        testScheduler.runCurrent()
 
         val fastest = config.fastestRelay(listOf("wss://slow.relay", "wss://fast.relay", "wss://medium.relay"))
         assertEquals("wss://fast.relay", fastest)
@@ -119,6 +121,7 @@ class AdaptiveConfigTest {
         config.recordRelayLatency("wss://relay.test", 100)
         config.recordRelayLatency("wss://relay.test", 200)
         config.recordRelayLatency("wss://relay.test", 300)
+        testScheduler.runCurrent()
 
         val avg = config.getRelayLatency("wss://relay.test")
         assertEquals(200, avg) // (100+200+300)/3 = 200

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/AppViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/AppViewModelTest.kt
@@ -25,6 +25,11 @@ class AppViewModelTest {
 
     @AfterTest
     fun tearDown() {
+        // Drain any coroutines launched on Dispatchers.Main (e.g. viewModelScope
+        // jobs from AppViewModel.init) before resetMain — otherwise an unrun
+        // task can race with the dispatcher swap and surface as
+        // UncaughtExceptionsBeforeTest in a later test.
+        testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
     }
 


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` running on push to `main` and on every PR:

1. `./gradlew spotlessCheck`
2. `./gradlew compileKotlinJvm`
3. `./gradlew :composeApp:jvmTest`

JDK 17 Temurin (aligned with the existing `deploy-pages.yml`). Concurrency group with `cancel-in-progress` so quick successive pushes don't pile up runners. `timeout-minutes: 20` on the job.

Fail-fast is automatic: steps run sequentially, so a `spotlessCheck` failure short-circuits the rest.

This PR validates itself: opening the PR triggers the workflow against this very branch. If the YAML is wrong, CI fails on its own commit and we catch it before merge.