### PR TITLE
fix(video): Android fullscreen + cross-platform polish

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:name=".MainActivity"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|uiMode"
             android:windowSoftInputMode="adjustNothing">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -42,9 +42,6 @@ class MainActivity : ComponentActivity() {
                     Box(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
                         App()
                     }
-                    // Rendered outside the safe-area Box so the fullscreen overlay covers
-                    // status/navigation bars too. Lives outside App() so it survives any
-                    // unmount of the chat composable that triggered the fullscreen.
                     FullscreenVideoOverlay(fullscreenVideoController)
                 }
             }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -14,11 +14,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import org.nostr.nostrord.network.upload.ShareMediaQueue
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
+import org.nostr.nostrord.ui.components.media.FullscreenVideoController
+import org.nostr.nostrord.ui.components.media.FullscreenVideoOverlay
+import org.nostr.nostrord.ui.components.media.LocalFullscreenVideoController
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.utils.toRelayUrl
 
@@ -31,9 +36,16 @@ class MainActivity : ComponentActivity() {
         handleDeepLink(intent)
         handleShareIntent(intent)
         setContent {
-            Box(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
-                Box(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
-                    App()
+            val fullscreenVideoController = remember { FullscreenVideoController() }
+            CompositionLocalProvider(LocalFullscreenVideoController provides fullscreenVideoController) {
+                Box(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
+                    Box(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
+                        App()
+                    }
+                    // Rendered outside the safe-area Box so the fullscreen overlay covers
+                    // status/navigation bars too. Lives outside App() so it survives any
+                    // unmount of the chat composable that triggered the fullscreen.
+                    FullscreenVideoOverlay(fullscreenVideoController)
                 }
             }
         }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/NostrordApplication.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/NostrordApplication.kt
@@ -13,6 +13,7 @@ import okio.Path.Companion.toOkioPath
 import org.nostr.nostrord.network.managers.AndroidNetworkMonitorInit
 import org.nostr.nostrord.notifications.AndroidNotificationSoundInit
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.ui.components.media.VideoCache
 
 /**
  * Custom Application class that registers Coil's animated GIF decoders.
@@ -38,6 +39,7 @@ class NostrordApplication :
         SecureStorage.initialize(applicationContext)
         AndroidNetworkMonitorInit.initialize(applicationContext)
         AndroidNotificationSoundInit.initialize(applicationContext)
+        VideoCache.initialize(applicationContext)
     }
 
     override fun newImageLoader(context: PlatformContext): ImageLoader = ImageLoader

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
@@ -9,3 +9,4 @@ class AndroidPlatform : Platform {
 actual fun getPlatform(): Platform = AndroidPlatform()
 
 actual val isAndroid: Boolean = true
+actual val isHandheldPlatform: Boolean = true

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/CurrentPlayPositionCacher.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/CurrentPlayPositionCacher.kt
@@ -1,0 +1,48 @@
+package org.nostr.nostrord.ui.components.media
+
+import androidx.media3.common.Player
+import kotlin.math.abs
+
+/**
+ * URL is passed at construction (not derived from `onMediaItemTransition`) because we
+ * create one player per composable, so the URL is fixed for the listener's lifetime.
+ * Relying on the transition callback would lose the URL when notifications race with
+ * `release()`, leaving the dispose-time save with no key to persist under.
+ */
+class CurrentPlayPositionCacher(
+    private val player: Player,
+    private val url: String,
+) : Player.Listener {
+    override fun onIsPlayingChanged(isPlaying: Boolean) {
+        save()
+    }
+
+    override fun onPlaybackStateChanged(playbackState: Int) {
+        when (playbackState) {
+            Player.STATE_READY -> {
+                VideoViewedPositionCache.get(url)?.let { saved ->
+                    if (abs(player.currentPosition - saved) > VideoViewedPositionCache.RESUME_THRESHOLD_MS) {
+                        player.seekTo(saved)
+                    }
+                }
+            }
+            else -> save()
+        }
+    }
+
+    override fun onPositionDiscontinuity(
+        oldPosition: Player.PositionInfo,
+        newPosition: Player.PositionInfo,
+        reason: Int,
+    ) {
+        if (player.playbackState != Player.STATE_IDLE) {
+            VideoViewedPositionCache.put(url, newPosition.positionMs)
+        }
+    }
+
+    private fun save() {
+        if (abs(player.currentPosition) > 1) {
+            VideoViewedPositionCache.put(url, player.currentPosition)
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/FullscreenVideoController.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/FullscreenVideoController.kt
@@ -1,0 +1,157 @@
+package org.nostr.nostrord.ui.components.media
+
+import android.app.Activity
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.activity.compose.BackHandler
+import androidx.annotation.OptIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.ui.AspectRatioFrameLayout
+import androidx.media3.ui.PlayerView
+
+/**
+ * State carried into the fullscreen overlay. [startPositionMs] lets the overlay resume from
+ * wherever the inline player was, so toggling fullscreen feels seamless.
+ */
+data class FullscreenVideoRequest(
+    val url: String,
+    val startPositionMs: Long,
+)
+
+/**
+ * Hoists the fullscreen video state out of the chat composable tree. Without this, the
+ * fullscreen Dialog was a child of [PlatformVideoPlayer], so any recomposition that
+ * unmounted the inline player (scroll, navigation, layout breakpoint switch) destroyed
+ * the dialog too — fullscreen would snap shut mid-watch.
+ */
+class FullscreenVideoController {
+    var active: FullscreenVideoRequest? by mutableStateOf(null)
+        private set
+
+    private var onCloseListener: ((Long) -> Unit)? = null
+
+    fun open(
+        url: String,
+        startPositionMs: Long,
+        onClose: (Long) -> Unit,
+    ) {
+        active = FullscreenVideoRequest(url, startPositionMs)
+        onCloseListener = onClose
+    }
+
+    fun close(currentPositionMs: Long) {
+        val cb = onCloseListener
+        onCloseListener = null
+        active = null
+        cb?.invoke(currentPositionMs)
+    }
+}
+
+val LocalFullscreenVideoController = compositionLocalOf<FullscreenVideoController> {
+    error(
+        "FullscreenVideoController not provided. Wrap content with " +
+            "CompositionLocalProvider(LocalFullscreenVideoController provides controller).",
+    )
+}
+
+@Composable
+fun FullscreenVideoOverlay(controller: FullscreenVideoController) {
+    val request = controller.active ?: return
+    FullscreenVideoOverlayContent(
+        url = request.url,
+        startPositionMs = request.startPositionMs,
+        onClose = { positionMs -> controller.close(positionMs) },
+    )
+}
+
+@OptIn(UnstableApi::class)
+@Composable
+private fun FullscreenVideoOverlayContent(
+    url: String,
+    startPositionMs: Long,
+    onClose: (positionMs: Long) -> Unit,
+) {
+    val context = LocalContext.current
+    val activity = context as? Activity
+
+    val exoPlayer =
+        remember(url) {
+            ExoPlayer.Builder(context).build().apply {
+                setMediaItem(MediaItem.fromUri(url))
+                prepare()
+                seekTo(startPositionMs)
+                playWhenReady = true
+            }
+        }
+
+    DisposableEffect(url) {
+        onDispose { exoPlayer.release() }
+    }
+
+    // Hide system bars while fullscreen is active; restore on dismiss.
+    DisposableEffect(activity) {
+        val window = activity?.window
+        val insetsController =
+            window?.let { WindowCompat.getInsetsController(it, it.decorView) }
+        insetsController?.apply {
+            hide(WindowInsetsCompat.Type.systemBars())
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+        onDispose {
+            insetsController?.show(WindowInsetsCompat.Type.systemBars())
+        }
+    }
+
+    BackHandler { onClose(exoPlayer.currentPosition) }
+
+    Box(
+        modifier =
+        Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+    ) {
+        AndroidView(
+            factory = { ctx ->
+                PlayerView(ctx).apply {
+                    player = exoPlayer
+                    useController = true
+                    setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
+                    setBackgroundColor(android.graphics.Color.BLACK)
+                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                    layoutParams =
+                        FrameLayout.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                        )
+                    setShowPreviousButton(false)
+                    setShowNextButton(false)
+                    controllerShowTimeoutMs = 3000
+                    controllerHideOnTouch = true
+                    setFullscreenButtonState(true)
+                    setFullscreenButtonClickListener { _ -> onClose(exoPlayer.currentPosition) }
+                }
+            },
+            update = { it.player = exoPlayer },
+            modifier = Modifier.fillMaxSize(),
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/FullscreenVideoController.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/FullscreenVideoController.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/FullscreenVideoController.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/FullscreenVideoController.kt
@@ -10,10 +10,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -22,92 +21,65 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 
 /**
- * State carried into the fullscreen overlay. [startPositionMs] lets the overlay resume from
- * wherever the inline player was, so toggling fullscreen feels seamless.
- */
-data class FullscreenVideoRequest(
-    val url: String,
-    val startPositionMs: Long,
-)
-
-/**
  * Hoists the fullscreen video state out of the chat composable tree. Without this, the
  * fullscreen Dialog was a child of [PlatformVideoPlayer], so any recomposition that
  * unmounted the inline player (scroll, navigation, layout breakpoint switch) destroyed
  * the dialog too — fullscreen would snap shut mid-watch.
+ *
+ * Ownership model: inline borrows the player to the overlay. The inline composable
+ * normally owns release; while fullscreen is active, inline's onDispose defers release
+ * to the overlay, which calls [onCloseListener] on dismiss with whether inline is still
+ * around to take the player back.
  */
 class FullscreenVideoController {
-    var active: FullscreenVideoRequest? by mutableStateOf(null)
+    var active: ExoPlayer? by mutableStateOf(null)
         private set
 
-    private var onCloseListener: ((Long) -> Unit)? = null
+    private var onCloseListener: (() -> Unit)? = null
 
     fun open(
-        url: String,
-        startPositionMs: Long,
-        onClose: (Long) -> Unit,
+        player: ExoPlayer,
+        onClose: () -> Unit,
     ) {
-        active = FullscreenVideoRequest(url, startPositionMs)
+        active = player
         onCloseListener = onClose
     }
 
-    fun close(currentPositionMs: Long) {
+    fun close() {
         val cb = onCloseListener
         onCloseListener = null
         active = null
-        cb?.invoke(currentPositionMs)
+        cb?.invoke()
     }
 }
 
-val LocalFullscreenVideoController = compositionLocalOf<FullscreenVideoController> {
-    error(
-        "FullscreenVideoController not provided. Wrap content with " +
-            "CompositionLocalProvider(LocalFullscreenVideoController provides controller).",
-    )
-}
+/** Null when unprovided — callers fall back to no-op so @Preview and other entrypoints don't crash. */
+val LocalFullscreenVideoController = staticCompositionLocalOf<FullscreenVideoController?> { null }
 
 @Composable
 fun FullscreenVideoOverlay(controller: FullscreenVideoController) {
-    val request = controller.active ?: return
+    val player = controller.active ?: return
     FullscreenVideoOverlayContent(
-        url = request.url,
-        startPositionMs = request.startPositionMs,
-        onClose = { positionMs -> controller.close(positionMs) },
+        exoPlayer = player,
+        onClose = { controller.close() },
     )
 }
 
 @OptIn(UnstableApi::class)
 @Composable
 private fun FullscreenVideoOverlayContent(
-    url: String,
-    startPositionMs: Long,
-    onClose: (positionMs: Long) -> Unit,
+    exoPlayer: ExoPlayer,
+    onClose: () -> Unit,
 ) {
     val context = LocalContext.current
     val activity = context as? Activity
 
-    val exoPlayer =
-        remember(url) {
-            ExoPlayer.Builder(context).build().apply {
-                setMediaItem(MediaItem.fromUri(url))
-                prepare()
-                seekTo(startPositionMs)
-                playWhenReady = true
-            }
-        }
-
-    DisposableEffect(url) {
-        onDispose { exoPlayer.release() }
-    }
-
-    // Hide system bars while fullscreen is active; restore on dismiss.
     DisposableEffect(activity) {
         val window = activity?.window
         val insetsController =
@@ -121,7 +93,7 @@ private fun FullscreenVideoOverlayContent(
         }
     }
 
-    BackHandler { onClose(exoPlayer.currentPosition) }
+    BackHandler { onClose() }
 
     Box(
         modifier =
@@ -147,7 +119,7 @@ private fun FullscreenVideoOverlayContent(
                     controllerShowTimeoutMs = 3000
                     controllerHideOnTouch = true
                     setFullscreenButtonState(true)
-                    setFullscreenButtonClickListener { _ -> onClose(exoPlayer.currentPosition) }
+                    setFullscreenButtonClickListener { _ -> onClose() }
                 }
             },
             update = { it.player = exoPlayer },

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoCache.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoCache.kt
@@ -63,8 +63,7 @@ object VideoCache {
                 .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
     }
 
-    fun dataSourceFactory(): CacheDataSource.Factory =
-        factory ?: error("VideoCache not initialized — call VideoCache.initialize() in Application.onCreate")
+    fun dataSourceFactory(): CacheDataSource.Factory = factory ?: error("VideoCache not initialized — call VideoCache.initialize() in Application.onCreate")
 
     private fun calculateCacheSize(cacheDir: File): Long {
         val available = runCatching { StatFs(cacheDir.absolutePath).availableBytes }.getOrDefault(0L)

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoCache.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoCache.kt
@@ -1,0 +1,74 @@
+package org.nostr.nostrord.ui.components.media
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.StatFs
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import java.io.File
+
+/**
+ * Disk-backed video byte cache. ExoPlayer streams from disk after the first watch, so
+ * re-opening a video (re-mount, fullscreen toggle, app restart) is instant instead of
+ * re-buffering from the network. Idea borrowed from Amethyst's `VideoCache`.
+ *
+ * Sizing: targets 10% of currently-available disk, clamped to [MIN_BYTES, MAX_BYTES].
+ * LRU eviction is a good approximation of FIFO for Nostr feeds (rarely re-watch old).
+ *
+ * Must be initialized once from [org.nostr.nostrord.NostrordApplication.onCreate] before
+ * any video player is constructed.
+ */
+@SuppressLint("UnsafeOptInUsageError")
+object VideoCache {
+    private const val CACHE_DIR_NAME = "video_cache"
+    private const val CACHE_SIZE_PERCENT = 0.10
+    private const val MIN_BYTES = 256L * 1024 * 1024 // 256 MB
+    private const val MAX_BYTES = 1L * 1024 * 1024 * 1024 // 1 GB
+
+    private var simpleCache: SimpleCache? = null
+    private var databaseProvider: StandaloneDatabaseProvider? = null
+    private var factory: CacheDataSource.Factory? = null
+
+    /**
+     * Initialize the disk cache. [upstreamFactory] is the network source used when a byte
+     * range isn't cached yet — defaults to [DefaultHttpDataSource], but if/when the app
+     * gains a shared OkHttp client (for Tor, proxy, TLS pinning, etc.) wrap it with
+     * Media3's `OkHttpDataSource.Factory` and pass it here.
+     */
+    @Synchronized
+    fun initialize(
+        context: Context,
+        upstreamFactory: DataSource.Factory = DefaultHttpDataSource.Factory(),
+    ) {
+        if (simpleCache != null) return
+        val cacheDir = File(context.cacheDir, CACHE_DIR_NAME).apply { mkdirs() }
+        val provider = StandaloneDatabaseProvider(context)
+        val cache =
+            SimpleCache(
+                cacheDir,
+                LeastRecentlyUsedCacheEvictor(calculateCacheSize(cacheDir)),
+                provider,
+            )
+        databaseProvider = provider
+        simpleCache = cache
+        factory =
+            CacheDataSource
+                .Factory()
+                .setCache(cache)
+                .setUpstreamDataSourceFactory(upstreamFactory)
+                .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+    }
+
+    fun dataSourceFactory(): CacheDataSource.Factory =
+        factory ?: error("VideoCache not initialized — call VideoCache.initialize() in Application.onCreate")
+
+    private fun calculateCacheSize(cacheDir: File): Long {
+        val available = runCatching { StatFs(cacheDir.absolutePath).availableBytes }.getOrDefault(0L)
+        val target = (available * CACHE_SIZE_PERCENT).toLong()
+        return target.coerceIn(MIN_BYTES, MAX_BYTES)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.android.kt
@@ -124,13 +124,12 @@ actual fun PlatformVideoPlayer(
  * kick-in (~750ms). Pattern from Amethyst's `ExoPlayerBuilder.feedTunedLoadControl`.
  */
 @OptIn(UnstableApi::class)
-private fun feedTunedLoadControl(): DefaultLoadControl =
-    DefaultLoadControl
-        .Builder()
-        .setBufferDurationsMs(
-            10_000, // minBufferMs
-            15_000, // maxBufferMs
-            750, // bufferForPlaybackMs
-            2_000, // bufferForPlaybackAfterRebufferMs
-        ).setPrioritizeTimeOverSizeThresholds(true)
-        .build()
+private fun feedTunedLoadControl(): DefaultLoadControl = DefaultLoadControl
+    .Builder()
+    .setBufferDurationsMs(
+        10_000, // minBufferMs
+        15_000, // maxBufferMs
+        750, // bufferForPlaybackMs
+        2_000, // bufferForPlaybackAfterRebufferMs
+    ).setPrioritizeTimeOverSizeThresholds(true)
+    .build()

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.android.kt
@@ -1,19 +1,12 @@
 package org.nostr.nostrord.ui.components.media
 
-import android.app.Activity
-import android.content.pm.ActivityInfo
-import android.view.View
-import android.view.ViewGroup
-import android.widget.FrameLayout
 import androidx.annotation.OptIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,14 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
@@ -46,7 +33,7 @@ actual fun PlatformVideoPlayer(
     modifier: Modifier,
 ) {
     val context = LocalContext.current
-    var isFullscreen by remember { mutableStateOf(false) }
+    val fullscreenController = LocalFullscreenVideoController.current
 
     val exoPlayer =
         remember(url) {
@@ -57,14 +44,17 @@ actual fun PlatformVideoPlayer(
             }
         }
 
-    DisposableEffect(url) {
-        onDispose { exoPlayer.release() }
-    }
+    // The inline player can be unmounted while fullscreen is still active (chat scrolled
+    // away, navigated to another group). Use a guard so the fullscreen-close callback
+    // doesn't seek on a released player.
+    var inlineAlive by remember { mutableStateOf(true) }
 
-    val fullscreenClickListener =
-        PlayerView.FullscreenButtonClickListener { _ ->
-            isFullscreen = true
+    DisposableEffect(url) {
+        onDispose {
+            inlineAlive = false
+            exoPlayer.release()
         }
+    }
 
     AndroidView(
         factory = { ctx ->
@@ -82,17 +72,26 @@ actual fun PlatformVideoPlayer(
                 controllerShowTimeoutMs = 3000
                 controllerHideOnTouch = true
                 setFullscreenButtonState(false)
-                setFullscreenButtonClickListener(fullscreenClickListener)
+                setFullscreenButtonClickListener { _ ->
+                    val position = exoPlayer.currentPosition
+                    exoPlayer.pause()
+                    fullscreenController.open(
+                        url = url,
+                        startPositionMs = position,
+                        onClose = { newPosition ->
+                            if (inlineAlive) {
+                                try {
+                                    exoPlayer.seekTo(newPosition)
+                                } catch (_: Exception) {
+                                    // Released between the guard check and seekTo — ignore.
+                                }
+                            }
+                        },
+                    )
+                }
             }
         },
-        update = { playerView ->
-            playerView.player = exoPlayer
-            if (!isFullscreen) {
-                playerView.setFullscreenButtonClickListener(null)
-                playerView.setFullscreenButtonState(false)
-                playerView.setFullscreenButtonClickListener(fullscreenClickListener)
-            }
-        },
+        update = { it.player = exoPlayer },
         modifier =
         modifier
             .widthIn(max = 400.dp)
@@ -100,95 +99,4 @@ actual fun PlatformVideoPlayer(
             .clip(RoundedCornerShape(8.dp))
             .background(Color.Black),
     )
-
-    if (isFullscreen) {
-        FullscreenVideoDialog(
-            exoPlayer = exoPlayer,
-            onDismiss = { isFullscreen = false },
-        )
-    }
-}
-
-@OptIn(UnstableApi::class)
-@Composable
-private fun FullscreenVideoDialog(
-    exoPlayer: ExoPlayer,
-    onDismiss: () -> Unit,
-) {
-    val context = LocalContext.current
-    val activity = context as? Activity
-
-    DisposableEffect(Unit) {
-        val originalOrientation = activity?.requestedOrientation
-        activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
-
-        val window = activity?.window
-        val insetsController =
-            window?.let {
-                WindowCompat.getInsetsController(it, it.decorView)
-            }
-        insetsController?.apply {
-            hide(WindowInsetsCompat.Type.systemBars())
-            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        }
-
-        onDispose {
-            insetsController?.show(WindowInsetsCompat.Type.systemBars())
-            activity?.requestedOrientation =
-                originalOrientation ?: ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-        }
-    }
-
-    Dialog(
-        onDismissRequest = onDismiss,
-        properties =
-        DialogProperties(
-            usePlatformDefaultWidth = false,
-            dismissOnBackPress = true,
-            dismissOnClickOutside = false,
-            decorFitsSystemWindows = false,
-        ),
-    ) {
-        val dialogView = LocalView.current
-        SideEffect {
-            dialogView.systemUiVisibility = (
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                    or View.SYSTEM_UI_FLAG_FULLSCREEN
-                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                )
-        }
-
-        AndroidView(
-            factory = { ctx ->
-                PlayerView(ctx).apply {
-                    player = exoPlayer
-                    useController = true
-                    setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
-                    setBackgroundColor(android.graphics.Color.BLACK)
-                    resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
-                    layoutParams =
-                        FrameLayout.LayoutParams(
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                            ViewGroup.LayoutParams.MATCH_PARENT,
-                        )
-                    setShowPreviousButton(false)
-                    setShowNextButton(false)
-                    controllerShowTimeoutMs = 3000
-                    controllerHideOnTouch = true
-                    setFullscreenButtonState(true)
-                    setFullscreenButtonClickListener { _ -> onDismiss() }
-                }
-            },
-            update = { playerView ->
-                playerView.player = exoPlayer
-            },
-            modifier =
-            Modifier
-                .fillMaxSize()
-                .background(Color.Black),
-        )
-    }
 }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.android.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
 
@@ -37,24 +39,38 @@ actual fun PlatformVideoPlayer(
 
     val exoPlayer =
         remember(url) {
-            ExoPlayer.Builder(context).build().apply {
-                setMediaItem(MediaItem.fromUri(url))
-                prepare()
-                playWhenReady = false
-            }
+            ExoPlayer
+                .Builder(context)
+                .setMediaSourceFactory(DefaultMediaSourceFactory(VideoCache.dataSourceFactory()))
+                .setLoadControl(feedTunedLoadControl())
+                .build()
+                .apply {
+                    addListener(CurrentPlayPositionCacher(this, url))
+                    setMediaItem(MediaItem.fromUri(url))
+                    prepare()
+                    playWhenReady = false
+                }
         }
 
-    // The inline player can be unmounted while fullscreen is still active (chat scrolled
-    // away, navigated to another group). Use a guard so the fullscreen-close callback
-    // doesn't seek on a released player.
+    // Inline composable can be unmounted (scroll, navigation) while the overlay still
+    // borrows our player. When that happens we defer release to the overlay's onClose.
     var inlineAlive by remember { mutableStateOf(true) }
 
     DisposableEffect(url) {
         onDispose {
             inlineAlive = false
-            exoPlayer.release()
+            // Belt-and-suspenders: listener notifications during ExoPlayer.release() can
+            // be lost to dispatch races, so persist the final position synchronously.
+            if (exoPlayer.currentPosition > 1_000 && fullscreenController?.active != exoPlayer) {
+                VideoViewedPositionCache.put(url, exoPlayer.currentPosition)
+            }
+            if (fullscreenController?.active != exoPlayer) {
+                exoPlayer.release()
+            }
         }
     }
+
+    val isBorrowedByFullscreen = fullscreenController?.active == exoPlayer
 
     AndroidView(
         factory = { ctx ->
@@ -73,25 +89,26 @@ actual fun PlatformVideoPlayer(
                 controllerHideOnTouch = true
                 setFullscreenButtonState(false)
                 setFullscreenButtonClickListener { _ ->
-                    val position = exoPlayer.currentPosition
-                    exoPlayer.pause()
-                    fullscreenController.open(
-                        url = url,
-                        startPositionMs = position,
-                        onClose = { newPosition ->
-                            if (inlineAlive) {
-                                try {
-                                    exoPlayer.seekTo(newPosition)
-                                } catch (_: Exception) {
-                                    // Released between the guard check and seekTo — ignore.
+                    fullscreenController?.open(
+                        player = exoPlayer,
+                        onClose = {
+                            if (!inlineAlive) {
+                                if (exoPlayer.currentPosition > 1_000) {
+                                    VideoViewedPositionCache.put(url, exoPlayer.currentPosition)
                                 }
+                                exoPlayer.release()
                             }
                         },
                     )
                 }
             }
         },
-        update = { it.player = exoPlayer },
+        update = { playerView ->
+            // While fullscreen has the player, detach from the inline view so the same
+            // ExoPlayer instance is only attached to one PlayerView at a time. When the
+            // overlay closes, re-attach.
+            playerView.player = if (isBorrowedByFullscreen) null else exoPlayer
+        },
         modifier =
         modifier
             .widthIn(max = 400.dp)
@@ -100,3 +117,20 @@ actual fun PlatformVideoPlayer(
             .background(Color.Black),
     )
 }
+
+/**
+ * Default ExoPlayer buffers ~50s. With many videos visible in a chat, each one would
+ * compete for memory and chew ~30MB per HD player. Cap at ~15s with fast playback
+ * kick-in (~750ms). Pattern from Amethyst's `ExoPlayerBuilder.feedTunedLoadControl`.
+ */
+@OptIn(UnstableApi::class)
+private fun feedTunedLoadControl(): DefaultLoadControl =
+    DefaultLoadControl
+        .Builder()
+        .setBufferDurationsMs(
+            10_000, // minBufferMs
+            15_000, // maxBufferMs
+            750, // bufferForPlaybackMs
+            2_000, // bufferForPlaybackAfterRebufferMs
+        ).setPrioritizeTimeOverSizeThresholds(true)
+        .build()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -44,6 +44,7 @@ import org.nostr.nostrord.storage.saveLastGroupForRelay
 import org.nostr.nostrord.ui.Screen
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.components.layout.DesktopShell
+import org.nostr.nostrord.ui.components.layout.responsiveDimension
 import org.nostr.nostrord.ui.components.navigation.MinimalTitleBar
 import org.nostr.nostrord.ui.components.navigation.NavigationToolbar
 import org.nostr.nostrord.ui.components.navigation.ServerRail
@@ -663,7 +664,7 @@ private fun AuthenticatedApp(
 
     Box(modifier = Modifier.fillMaxSize()) {
         BoxWithConstraints(modifier = Modifier.fillMaxSize().then(keyEventModifier)) {
-            val isDesktop = maxWidth >= 912.dp
+            val isDesktop = responsiveDimension >= 912.dp
 
             val hasNoRelays = relayList.isEmpty() && !isDiscoveringRelays
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
@@ -7,3 +7,11 @@ interface Platform {
 expect fun getPlatform(): Platform
 
 expect val isAndroid: Boolean
+
+/**
+ * True on platforms where the window size IS the device size (phone, tablet). On these,
+ * responsive breakpoints should look at the smallest dimension so rotation doesn't trigger
+ * a layout class change. False on desktop / browser where the user resizes the window
+ * intentionally and width-based breakpoints match their intent.
+ */
+expect val isHandheldPlatform: Boolean

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/ResponsiveScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/ResponsiveScaffold.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.nostr.nostrord.isHandheldPlatform
 
 enum class ScreenSize {
     Compact, // Mobile: < 912dp
@@ -15,16 +16,18 @@ enum class ScreenSize {
 }
 
 /**
- * Use the smallest available dimension (analogous to Android's `sw600dp` resource qualifier)
- * to decide mobile-vs-desktop layouts. Width alone would mis-classify a phone in landscape
- * as desktop, because the phone is suddenly wider than 912dp but the user still wants a
- * mobile layout.
+ * On handheld platforms (Android, iOS) the window IS the device, so use the smallest
+ * dimension (sw600dp-style) — rotating shouldn't flip mobile↔desktop layout. On desktop
+ * platforms the user resizes the window deliberately, so width is the right signal.
  *
- * If the container has unbounded height (e.g. inside a vertical scroll), falls back to
- * maxWidth so we don't divide by infinity.
+ * If maxHeight is unbounded (e.g. inside a vertical scroll), fall back to maxWidth.
  */
 val BoxWithConstraintsScope.responsiveDimension: Dp
-    get() = if (maxHeight == Dp.Infinity) maxWidth else minOf(maxWidth, maxHeight)
+    get() = when {
+        maxHeight == Dp.Infinity -> maxWidth
+        isHandheldPlatform -> minOf(maxWidth, maxHeight)
+        else -> maxWidth
+    }
 
 @Composable
 fun ResponsiveScaffold(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/ResponsiveScaffold.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/layout/ResponsiveScaffold.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.ui.components.layout
 
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -13,6 +14,18 @@ enum class ScreenSize {
     Large, // Desktop: > 1200dp
 }
 
+/**
+ * Use the smallest available dimension (analogous to Android's `sw600dp` resource qualifier)
+ * to decide mobile-vs-desktop layouts. Width alone would mis-classify a phone in landscape
+ * as desktop, because the phone is suddenly wider than 912dp but the user still wants a
+ * mobile layout.
+ *
+ * If the container has unbounded height (e.g. inside a vertical scroll), falls back to
+ * maxWidth so we don't divide by infinity.
+ */
+val BoxWithConstraintsScope.responsiveDimension: Dp
+    get() = if (maxHeight == Dp.Infinity) maxWidth else minOf(maxWidth, maxHeight)
+
 @Composable
 fun ResponsiveScaffold(
     compactBreakpoint: Dp = 912.dp,
@@ -21,7 +34,7 @@ fun ResponsiveScaffold(
     desktop: @Composable () -> Unit,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-        if (maxWidth < compactBreakpoint) {
+        if (responsiveDimension < compactBreakpoint) {
             mobile()
         } else {
             desktop()
@@ -36,10 +49,11 @@ fun ResponsiveScaffold(
     content: @Composable (screenSize: ScreenSize, gridColumns: Int) -> Unit,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val dim = responsiveDimension
         val screenSize =
             when {
-                maxWidth < compactBreakpoint -> ScreenSize.Compact
-                maxWidth < mediumBreakpoint -> ScreenSize.Medium
+                dim < compactBreakpoint -> ScreenSize.Compact
+                dim < mediumBreakpoint -> ScreenSize.Medium
                 else -> ScreenSize.Large
             }
         val gridColumns =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/media/VideoViewedPositionCache.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/media/VideoViewedPositionCache.kt
@@ -1,0 +1,21 @@
+package org.nostr.nostrord.ui.components.media
+
+import org.nostr.nostrord.utils.LruCache
+
+/** Survives player release so resumes work across re-mount, on any platform with a real player. */
+object VideoViewedPositionCache {
+    /** Below this many ms, restoring the saved position is more friction than help. */
+    const val RESUME_THRESHOLD_MS = 5_000L
+
+    private val cache = LruCache<String, Long>(100)
+
+    fun put(
+        url: String,
+        positionMs: Long,
+    ) {
+        if (cache.get(url) == positionMs) return
+        cache.put(url, positionMs)
+    }
+
+    fun get(url: String): Long? = cache.get(url)
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/onboarding/OnboardingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/onboarding/OnboardingScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.sp
 import nostrord.composeapp.generated.resources.Res
 import nostrord.composeapp.generated.resources.nostrord_logo
 import org.jetbrains.compose.resources.painterResource
+import org.nostr.nostrord.ui.components.layout.responsiveDimension
 import org.nostr.nostrord.ui.theme.NostrordColors
 
 @Composable
@@ -43,7 +44,7 @@ fun OnboardingScreen(onAddRelay: () -> Unit, onAddRelayCustomUrl: () -> Unit = o
             modifier = Modifier.weight(1f).fillMaxWidth(),
             contentAlignment = Alignment.Center,
         ) {
-            val isCompact = maxWidth < 912.dp
+            val isCompact = responsiveDimension < 912.dp
 
             val logoSize: Dp = if (isCompact) 64.dp else 88.dp
             val logoRadius: Dp = if (isCompact) 16.dp else 20.dp

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -58,6 +58,7 @@ import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.cards.InfoCard
 import org.nostr.nostrord.ui.components.cards.KeyCard
 import org.nostr.nostrord.ui.components.cards.WarningCard
+import org.nostr.nostrord.ui.components.layout.responsiveDimension
 import org.nostr.nostrord.ui.components.navigation.NavigationToolbar
 import org.nostr.nostrord.ui.components.upload.UploadImageField
 import org.nostr.nostrord.ui.navigation.PlatformBackHandler
@@ -286,7 +287,7 @@ fun SettingsScreen(
                 }
             },
     ) {
-        if (!forceDesktop && maxWidth < 912.dp) {
+        if (!forceDesktop && responsiveDimension < 912.dp) {
             MobileSettings(
                 activeSection = activeSection,
                 showPanel = showMobilePanel,

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
@@ -9,3 +9,4 @@ class IOSPlatform : Platform {
 actual fun getPlatform(): Platform = IOSPlatform()
 
 actual val isAndroid: Boolean = false
+actual val isHandheldPlatform: Boolean = true

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
@@ -7,3 +7,4 @@ class JsPlatform : Platform {
 actual fun getPlatform(): Platform = JsPlatform()
 
 actual val isAndroid: Boolean = false
+actual val isHandheldPlatform: Boolean = false

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.js.kt
@@ -55,6 +55,7 @@ actual fun PlatformVideoPlayer(
                     style.setProperty("object-fit", "contain")
                     style.setProperty("background-color", "#000")
                     style.display = "block"
+                    attachPositionRestore()
                 }
             },
             modifier =

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
@@ -7,3 +7,4 @@ class JVMPlatform : Platform {
 actual fun getPlatform(): Platform = JVMPlatform()
 
 actual val isAndroid: Boolean = false
+actual val isHandheldPlatform: Boolean = false

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.jvm.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +51,8 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
@@ -84,6 +87,39 @@ actual fun PlatformVideoPlayer(
         playerState.openUri(url, InitialPlayerState.PAUSE)
     }
 
+    // `rememberVideoPlayerState()` doesn't pause on composition exit, so the player
+    // would keep streaming audio after the user navigates away. The dispose hook covers
+    // navigation; the layout-coordinates check below covers in-screen scroll where the
+    // composable is clipped to zero size but not unmounted (non-lazy parent containers).
+    DisposableEffect(playerState) {
+        onDispose { playerState.pause() }
+    }
+
+    LaunchedEffect(url, playerState.isPlaying) {
+        if (!playerState.isPlaying) return@LaunchedEffect
+        while (true) {
+            delay(1000)
+            VideoViewedPositionCache.put(url, (playerState.currentTime * 1000).toLong())
+        }
+    }
+
+    // The library exposes seek as a 0..SLIDER_MAX slider position, so we need duration
+    // in ms to compute the target slider value.
+    val durationMs = playerState.metadata.duration
+    var hasRestored by remember(url) { mutableStateOf(false) }
+    LaunchedEffect(url, durationMs) {
+        if (durationMs != null && durationMs > 0 && !hasRestored) {
+            val saved = VideoViewedPositionCache.get(url)
+            if (saved != null &&
+                saved > VideoViewedPositionCache.RESUME_THRESHOLD_MS &&
+                saved < durationMs - VideoViewedPositionCache.RESUME_THRESHOLD_MS
+            ) {
+                playerState.seekTo((saved.toFloat() / durationMs.toFloat()) * SLIDER_MAX)
+            }
+            hasRestored = true
+        }
+    }
+
     VideoPlayerBox(
         playerState = playerState,
         thumbnail = thumbnail,
@@ -95,7 +131,13 @@ actual fun PlatformVideoPlayer(
             playerState.play()
         },
         onFullscreenClick = { isFullscreen = true },
-        modifier = modifier.widthIn(max = 400.dp),
+        modifier = modifier
+            .widthIn(max = 400.dp)
+            .onGloballyPositioned { coords ->
+                if (coords.boundsInWindow().height == 0f && playerState.isPlaying) {
+                    playerState.pause()
+                }
+            },
     )
 
     if (isFullscreen) {

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
@@ -7,3 +7,4 @@ class WasmPlatform : Platform {
 actual fun getPlatform(): Platform = WasmPlatform()
 
 actual val isAndroid: Boolean = false
+actual val isHandheldPlatform: Boolean = false

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPlayerContent.wasmJs.kt
@@ -55,6 +55,7 @@ actual fun PlatformVideoPlayer(
                     style.setProperty("object-fit", "contain")
                     style.setProperty("background-color", "#000")
                     style.display = "block"
+                    attachPositionRestore()
                 }
             },
             modifier =

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPositionRestore.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPositionRestore.kt
@@ -1,7 +1,7 @@
 package org.nostr.nostrord.ui.components.media
 
-import kotlin.time.TimeSource
 import org.w3c.dom.HTMLVideoElement
+import kotlin.time.TimeSource
 
 private const val SAVE_THROTTLE_MS = 1_000L
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPositionRestore.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/ui/components/media/VideoPositionRestore.kt
@@ -1,0 +1,34 @@
+package org.nostr.nostrord.ui.components.media
+
+import kotlin.time.TimeSource
+import org.w3c.dom.HTMLVideoElement
+
+private const val SAVE_THROTTLE_MS = 1_000L
+
+/**
+ * Wires [VideoViewedPositionCache] save/restore to a `<video>` element via DOM events.
+ * Reading `src` from the element (rather than capturing a Kotlin url param) avoids the
+ * stale-position-saved-under-new-url race when the same element gets a new src.
+ */
+fun HTMLVideoElement.attachPositionRestore() {
+    var lastSave: TimeSource.Monotonic.ValueTimeMark? = null
+    addEventListener("loadedmetadata", {
+        val saved = VideoViewedPositionCache.get(src)
+        val durationMs = (duration * 1000).toLong()
+        if (saved != null &&
+            saved > VideoViewedPositionCache.RESUME_THRESHOLD_MS &&
+            durationMs > 0 &&
+            saved < durationMs - VideoViewedPositionCache.RESUME_THRESHOLD_MS
+        ) {
+            currentTime = saved / 1000.0
+        }
+    })
+    addEventListener("timeupdate", {
+        val now = TimeSource.Monotonic.markNow()
+        val last = lastSave
+        if (last == null || (now - last).inWholeMilliseconds >= SAVE_THROTTLE_MS) {
+            lastSave = now
+            VideoViewedPositionCache.put(src, (currentTime * 1000).toLong())
+        }
+    })
+}


### PR DESCRIPTION
Original report: tapping fullscreen on an Android video flipped the activity to
landscape and immediately snapped shut without ever showing fullscreen. Scope
grew to fix the responsive-breakpoint regression that change introduced and
to add disk caching + position resume across platforms.

| Concern | Fix |
|---|---|
| Phone in landscape rendered desktop layout | \`responsiveDimension\` (min(w,h)) gated on \`isHandheldPlatform\` so desktop windows keep width-based breakpoints |
| Fullscreen unmounted mid-watch when chat recomposed | Hoist overlay to \`MainActivity\` via \`LocalFullscreenVideoController\` |
| Fullscreen forced \`SENSOR_LANDSCAPE\` | Drop orientation forcing; user rotates freely |
| Fullscreen spawned a 2nd \`ExoPlayer\` and re-buffered | Borrow the inline player to the overlay; return on close |
| Re-opening a video re-downloaded from scratch | \`VideoCache\` SimpleCache (10% disk, 256MB-1GB), upstream factory parameterizable |
| Position lost when scrolled off / re-mounted | commonMain \`VideoViewedPositionCache\` + Player.Listener (Android), \`loadedmetadata\`/\`timeupdate\` (web), \`LaunchedEffect\` poll (JVM) |
| ~50s default buffer chewed memory per visible player | \`feedTunedLoadControl\` caps at 15s with 750ms playback kick-in |
| Desktop video kept playing after scroll-off | \`onGloballyPositioned\` pause when zero-size (non-lazy parent doesn't unmount) |

Patterns for the cross-platform cache and the Android disk cache borrow from
Amethyst's playback module, simplified for our non-pooled setup.