### PR TITLE
chore(hooks): add pre-commit hook to enforce spotless

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Nostr NIP-29 group messaging client. Kotlin Multiplatform targeting Android, JVM Desktop, JS, and WebAssembly.
 
+## First-time setup
+
+```bash
+./scripts/install-hooks.sh
+```
+
+Points `core.hooksPath` at the repo-tracked hooks (covers all worktrees of this clone). The `pre-commit` hook runs `spotlessApply` on staged Kotlin files and then `spotlessCheck` to guarantee CI won't fail on formatting.
+
 ## Build Commands
 
 ```bash

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Auto-format staged Kotlin files via spotless before the commit lands.
+# Skip when no Kotlin files are staged so trivial commits (docs, scripts)
+# don't pay the ~15s Gradle startup cost.
+
+set -e
+
+STAGED_KT=$(git diff --cached --name-only --diff-filter=ACMR | grep -E '\.kts?$' || true)
+if [ -z "$STAGED_KT" ]; then
+    exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+echo "pre-commit: running spotlessApply..."
+./gradlew --quiet spotlessApply
+
+# Re-stage anything spotless touched among the files we already had staged.
+# Files staged that no longer exist (renames, deletes) are silently skipped.
+while IFS= read -r file; do
+    [ -f "$file" ] && git add "$file"
+done <<< "$STAGED_KT"
+
+# spotlessApply can leave residual violations on the first pass (multi-line
+# wrapping rules sometimes need a second). Verify before letting the commit
+# through.
+echo "pre-commit: verifying with spotlessCheck..."
+./gradlew --quiet spotlessCheck

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Install repo-tracked git hooks for this clone by pointing core.hooksPath at
+# scripts/git-hooks. core.hooksPath is a repo-wide setting (lives in .git/config)
+# so this install covers all worktrees automatically — no need to re-run per
+# worktree.
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+HOOKS_DIR="scripts/git-hooks"
+if [ ! -d "$HOOKS_DIR" ]; then
+    echo "Error: $HOOKS_DIR not found. Run from a checkout of this repo." >&2
+    exit 1
+fi
+
+chmod +x "$HOOKS_DIR"/*
+
+git config core.hooksPath "$HOOKS_DIR"
+
+echo "Git hooks installed: core.hooksPath = $HOOKS_DIR"
+echo "Active hooks:"
+ls -1 "$HOOKS_DIR"


### PR DESCRIPTION
PR #64 needed a follow-up \`style: apply spotless\` commit because the
Claude Code \`Stop\` hook that runs \`spotlessApply\` fires after the
response ends — by then commits made earlier in the same response had
already captured unformatted code and CI's \`spotlessCheck\` rejected
the push.

Adds a real git \`pre-commit\` hook tracked at \`scripts/git-hooks/\`.
\`core.hooksPath\` is a repo-wide config (lives in \`.git/config\`), so
one install covers every worktree of a clone.

- \`scripts/install-hooks.sh\` — runs \`git config core.hooksPath\`,
  chmods the hooks.
- \`scripts/git-hooks/pre-commit\` — fast-exits when no \`.kt\`/\`.kts\`
  is staged; otherwise \`spotlessApply\` + restages modified files +
  \`spotlessCheck\` to verify.
- README note added under "First-time setup" in \`CLAUDE.md\`.