### PR TITLE
fix(nostr): protocol audit cleanup

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.android.kt
@@ -37,6 +37,8 @@ actual fun createHttpClient(): HttpClient = HttpClient(OkHttp) {
     }
 }
 
+actual fun hasEngineWebSocketPing(): Boolean = true
+
 actual fun createNip11HttpClient(): HttpClient = HttpClient(OkHttp) {
     install(HttpTimeout) {
         connectTimeoutMillis = 10_000

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -48,7 +48,7 @@ actual class Nip46Client actual constructor(
                     try {
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg) }
+                        client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
                         client
                     } catch (e: Exception) {
@@ -286,14 +286,34 @@ actual class Nip46Client actual constructor(
         }
     }
 
-    private fun handleMessage(msg: String) {
+    private fun handleMessage(msg: String, source: NostrGroupClient) {
         try {
             val json = nip46Json
             val arr = json.parseToJsonElement(msg).jsonArray
             val msgType = arr.getOrNull(0)?.jsonPrimitive?.contentOrNull ?: return
 
-            if (msgType == "EOSE" || msgType == "OK" || msgType == "NOTICE") {
-                return
+            when (msgType) {
+                "OK" -> {
+                    // Route relay's publish ACK into the source client so that
+                    // sendAndAwaitOk completes with the actual relay verdict
+                    // instead of timing out. OK false → PublishResult.Rejected.
+                    val parsed = source.parseOkMessage(arr) ?: return
+                    val (eventId, success, message) = parsed
+                    clientScope.launch { source.handleOkResponse(eventId, success, message) }
+                    return
+                }
+                "NOTICE" -> {
+                    val notice = arr.getOrNull(1)?.jsonPrimitive?.contentOrNull
+                    if (!notice.isNullOrBlank()) {
+                        println("[Nip46Client] NOTICE from ${source.getRelayUrl()}: $notice")
+                    }
+                    return
+                }
+                "EOSE" -> {
+                    // Catch-up boundary for the listening sub. No state to
+                    // advance yet, but the frame is no longer silently dropped.
+                    return
+                }
             }
 
             if (msgType == "EVENT" && arr.size >= 3) {

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.nostr
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.PublishResult
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -20,7 +21,7 @@ actual class Nip46Client actual constructor(
     private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests: MutableMap<String, CompletableDeferred<String>> = java.util.concurrent.ConcurrentHashMap()
-    private var listenSubscriptionId: String? = null
+    private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
     private val clientScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -50,6 +51,7 @@ actual class Nip46Client actual constructor(
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
+                        openResponseSubscription(client)
                         client
                     } catch (e: Exception) {
                         null
@@ -57,6 +59,32 @@ actual class Nip46Client actual constructor(
                 }
             }.awaitAll()
             .filterNotNull()
+    }
+
+    /**
+     * Opens the durable NIP-46 response subscription on [client]. The filter
+     * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
+     * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
+     * one stable subscription replaces the previous per-request ephemeral REQs.
+     */
+    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+        val subId = responseSubscriptionId
+            ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
+        val since = (epochMillis() / 1000) - 10
+        val filter = buildJsonObject {
+            putJsonArray("kinds") { add(24133) }
+            putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
+            put("since", since)
+        }
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(filter)
+        }.toString()
+        try {
+            client.send(req)
+        } catch (_: Exception) {
+        }
     }
 
     private suspend fun ensureRelaysConnected() {
@@ -97,31 +125,10 @@ actual class Nip46Client actual constructor(
         if (relayClients.isEmpty()) {
             throw Exception("Failed to connect to any relay")
         }
+        // The durable response subscription opened in connectRelaysParallel
+        // already filters kind:24133 #p:clientPubkey, so it doubles as the
+        // nostrconnect listening sub — no extra REQ needed here.
 
-        val subscriptionId = "nip46-listen-${generateRequestId().take(8)}"
-        listenSubscriptionId = subscriptionId
-        val since = (epochMillis() / 1000) - 10
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        relayClients.forEach {
-            try {
-                it.send(subMessage)
-            } catch (e: Exception) {
-            }
-        }
-
-        // Set up the deferred for the incoming connect
         pendingRequests["_incoming_connect"] = CompletableDeferred()
     }
 
@@ -216,36 +223,10 @@ actual class Nip46Client actual constructor(
             )
 
         val signedEvent = event.sign(clientKeyPair)
+        val eventId = signedEvent.id
+            ?: throw Exception("Failed to sign NIP-46 request event")
         val responseDeferred = CompletableDeferred<String>()
         pendingRequests[requestId] = responseDeferred
-
-        val subscriptionId = "nip46-${requestId.take(8)}"
-        val since = (epochMillis() / 1000) - 120
-
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        var sentToAny = false
-        relayClients.forEach { client ->
-            try {
-                client.send(subMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-
-        delay(100)
 
         val eventMessage =
             buildJsonArray {
@@ -253,36 +234,34 @@ actual class Nip46Client actual constructor(
                 add(signedEvent.toJsonObject())
             }.toString()
 
-        relayClients.forEach { client ->
-            try {
-                client.send(eventMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-
-        if (!sentToAny) {
-            pendingRequests.remove(requestId)
-            throw Exception("Failed to send signing request to any relay")
-        }
-
         try {
+            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+            // surfaces immediately. The response sub opened on connect routes
+            // the signer's reply back into responseDeferred.
+            val publishResults = relayClients.map { client ->
+                async {
+                    try {
+                        client.sendAndAwaitOk(eventMessage, eventId)
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        PublishResult.Error(eventId, e)
+                    }
+                }
+            }.awaitAll()
+            if (publishResults.none { it is PublishResult.Success }) {
+                val reason = publishResults.firstNotNullOfOrNull { r ->
+                    when (r) {
+                        is PublishResult.Rejected -> r.reason
+                        is PublishResult.Error -> r.exception.message
+                        is PublishResult.Timeout -> "publish timeout"
+                        else -> null
+                    }
+                } ?: "no relay accepted request"
+                throw Exception("Failed to publish NIP-46 request: $reason")
+            }
             responseDeferred.await()
         } finally {
             pendingRequests.remove(requestId)
-            val closeMessage =
-                buildJsonArray {
-                    add("CLOSE")
-                    add(subscriptionId)
-                }.toString()
-            withContext(NonCancellable) {
-                relayClients.forEach {
-                    try {
-                        it.send(closeMessage)
-                    } catch (_: Exception) {
-                    }
-                }
-            }
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -130,29 +130,14 @@ actual class Nip46Client actual constructor(
             pendingRequests["_incoming_connect"]
                 ?: throw Exception("Not listening. Call startListeningForConnection first.")
 
-        try {
-            val result = withTimeout(120_000) { connectDeferred.await() }
-            return result
-        } catch (e: Exception) {
-            throw e
+        return try {
+            // No wall-clock timeout: the QR sheet lifecycle drives cancellation
+            // via the calling coroutine. The listen subscription stays open
+            // until disconnect(), so a late scanner still completes instead of
+            // being killed by a 120s deadline.
+            connectDeferred.await()
         } finally {
             pendingRequests.remove("_incoming_connect")
-            listenSubscriptionId?.let { subId ->
-                val closeMessage =
-                    buildJsonArray {
-                        add("CLOSE")
-                        add(subId)
-                    }.toString()
-                withContext(NonCancellable) {
-                    relayClients.forEach {
-                        try {
-                            it.send(closeMessage)
-                        } catch (_: Exception) {
-                        }
-                    }
-                }
-            }
-            listenSubscriptionId = null
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.sendAndAwaitOkOrError
+import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -239,25 +241,10 @@ actual class Nip46Client actual constructor(
             // surfaces immediately. The response sub opened on connect routes
             // the signer's reply back into responseDeferred.
             val publishResults = relayClients.map { client ->
-                async {
-                    try {
-                        client.sendAndAwaitOk(eventMessage, eventId)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        PublishResult.Error(eventId, e)
-                    }
-                }
+                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
             }.awaitAll()
             if (publishResults.none { it is PublishResult.Success }) {
-                val reason = publishResults.firstNotNullOfOrNull { r ->
-                    when (r) {
-                        is PublishResult.Rejected -> r.reason
-                        is PublishResult.Error -> r.exception.message
-                        is PublishResult.Timeout -> "publish timeout"
-                        else -> null
-                    }
-                } ?: "no relay accepted request"
-                throw Exception("Failed to publish NIP-46 request: $reason")
+                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -459,6 +459,9 @@ actual class Nip46Client actual constructor(
             }
         }
         relayClients.clear()
+        // Fail any in-flight RPCs so callers unblock immediately instead of
+        // waiting out their wrapping withTimeout.
+        pendingRequests.values.forEach { it.completeExceptionally(CancellationException("Nip46Client disconnected")) }
         pendingRequests.clear()
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.kt
@@ -6,3 +6,14 @@ expect fun createHttpClient(): HttpClient
 
 /** Minimal HTTP client for NIP-11 — no ContentNegotiation, no WebSockets. */
 expect fun createNip11HttpClient(): HttpClient
+
+/**
+ * Whether the platform's WebSocket engine performs ws-level ping/pong on its
+ * own. Returns `true` on JVM/Android (Ktor `pingInterval`) and `false` on
+ * browser targets where the WebSocket API hides ping frames from JS code.
+ *
+ * When `false`, [NostrGroupClient] sends a periodic best-effort REQ/CLOSE
+ * probe to keep relay-side and intermediary timers happy. The probe never
+ * decides liveness — that is delegated to the engine's frame loop.
+ */
+expect fun hasEngineWebSocketPing(): Boolean

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -144,6 +144,48 @@ sealed class PublishResult {
     data class Error(val eventId: String, val exception: Exception) : PublishResult()
 }
 
+/**
+ * Aggregate a batch of publish results into a single diagnostic string of the
+ * form `rejected=N timeout=N error=N first=<reason>`. Used by callers that
+ * fan out an event to multiple relays and need to surface why none accepted.
+ */
+fun List<PublishResult>.summarizeFailures(): String {
+    var rejected = 0
+    var timeout = 0
+    var errors = 0
+    var firstReason: String? = null
+    for (r in this) {
+        when (r) {
+            is PublishResult.Rejected -> {
+                rejected++
+                if (firstReason == null) firstReason = r.reason
+            }
+            is PublishResult.Timeout -> {
+                timeout++
+                if (firstReason == null) firstReason = "timeout"
+            }
+            is PublishResult.Error -> {
+                errors++
+                if (firstReason == null) firstReason = r.exception.message
+            }
+            is PublishResult.Success -> {}
+        }
+    }
+    return "rejected=$rejected timeout=$timeout error=$errors first=${firstReason ?: "unknown"}"
+}
+
+/**
+ * Publish [eventJson] and return the relay's verdict as a [PublishResult],
+ * converting non-cancellation exceptions to [PublishResult.Error] so callers
+ * can collect results from many relays in parallel via `awaitAll`.
+ */
+suspend fun NostrGroupClient.sendAndAwaitOkOrError(eventJson: String, eventId: String): PublishResult = try {
+    sendAndAwaitOk(eventJson, eventId)
+} catch (e: Exception) {
+    if (e is kotlinx.coroutines.CancellationException) throw e
+    PublishResult.Error(eventId, e)
+}
+
 class NostrGroupClient(
     private val relayUrl: String = "wss://groups.fiatjaf.com",
 ) {
@@ -1373,19 +1415,18 @@ class NostrGroupClient(
         "⚠️ Failed to parse: $message (${e.message})"
     }
 
-    suspend fun requestMetadata(pubkeys: List<String>, subId: String? = null) {
+    suspend fun requestMetadata(pubkeys: List<String>, subId: String) {
         if (pubkeys.isEmpty()) return
-        val effectiveSubId = subId ?: "metadata_${pubkeys.first().take(8)}"
-        // CLOSE any previous subscription for this pubkey before re-subscribing
+        // CLOSE any previous subscription with this id before re-subscribing
         sendJson(
             buildJsonArray {
                 add("CLOSE")
-                add(effectiveSubId)
+                add(subId)
             },
         )
         val req = buildJsonArray {
             add("REQ")
-            add(effectiveSubId)
+            add(subId)
             add(
                 buildJsonObject {
                     putJsonArray("kinds") { add(0) } // kind 0 = metadata

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -1387,19 +1387,19 @@ class NostrGroupClient(
         "⚠️ Failed to parse: $message (${e.message})"
     }
 
-    suspend fun requestMetadata(pubkeys: List<String>) {
+    suspend fun requestMetadata(pubkeys: List<String>, subId: String? = null) {
         if (pubkeys.isEmpty()) return
-        val subId = "metadata_${pubkeys.first().take(8)}"
+        val effectiveSubId = subId ?: "metadata_${pubkeys.first().take(8)}"
         // CLOSE any previous subscription for this pubkey before re-subscribing
         sendJson(
             buildJsonArray {
                 add("CLOSE")
-                add(subId)
+                add(effectiveSubId)
             },
         )
         val req = buildJsonArray {
             add("REQ")
-            add(subId)
+            add(effectiveSubId)
             add(
                 buildJsonObject {
                     putJsonArray("kinds") { add(0) } // kind 0 = metadata

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -180,19 +180,10 @@ class NostrGroupClient(
     // Track if this was a graceful disconnect
     private var isDisconnecting = false
 
-    // Timestamp of the last WebSocket frame received — used by the heartbeat to detect
-    // relays that stop sending events without closing the connection ("frozen" relays).
-    private var lastMessageReceivedAt = 0L
-
     // Open subscription IDs tracked for diagnostic logging.
     // Updated in send() on every REQ/CLOSE. Not synchronised — count may be off by ±1
     // under concurrent sends, which is acceptable for logging purposes.
     private val openSubscriptions = mutableSetOf<String>()
-
-    companion object {
-        private const val HEARTBEAT_CHECK_INTERVAL_MS = 20_000L
-        private const val HEARTBEAT_STALE_MS = 90_000L
-    }
 
     fun getRelayUrl(): String = relayUrl
 
@@ -221,7 +212,6 @@ class NostrGroupClient(
         isDisconnecting = false
         authCompleted = CompletableDeferred()
         connectionJob = clientScope.launch {
-            lastMessageReceivedAt = epochMillis()
             try {
                 client.webSocket(relayUrl) {
                     session = this
@@ -229,46 +219,20 @@ class NostrGroupClient(
                     // Signal that connection is ready
                     connectionResult.complete(true)
 
-                    // Heartbeat: detect relays that stop sending without closing the WebSocket.
-                    // Ktor handles WebSocket-level ping/pong, but some relays freeze at the
-                    // application layer — the socket stays open but events stop arriving.
-                    // If no frame arrives for HEARTBEAT_STALE_MS, close gracefully so that
-                    // onConnectionLost fires and the reconnect loop re-establishes the session.
-                    //
-                    // Application-level keepalive: browser WebSocket doesn't expose ping/pong,
-                    // so we send a cheap REQ+CLOSE probe every check interval when idle for
-                    // more than 60s. The EOSE/CLOSED response resets lastMessageReceivedAt,
-                    // preventing false-positive stale detection on quiet relays.
-                    val wsSession = this
-                    launch {
-                        while (isActive) {
-                            delay(HEARTBEAT_CHECK_INTERVAL_MS)
-                            val idleMs = epochMillis() - lastMessageReceivedAt
-                            if (idleMs > HEARTBEAT_STALE_MS) {
-                                wsSession.close(CloseReason(CloseReason.Codes.GOING_AWAY, "heartbeat-stale"))
-                                break
-                            }
-                            // Probe: if idle for >60s, send a minimal REQ+CLOSE to provoke
-                            // a relay response (EOSE or CLOSED) that resets the heartbeat.
-                            if (idleMs > 60_000L) {
-                                try {
-                                    val probeId = "_hb"
-                                    wsSession.send(Frame.Text("""["REQ","$probeId",{"kinds":[0],"limit":1}]"""))
-                                    wsSession.send(Frame.Text("""["CLOSE","$probeId"]"""))
-                                } catch (_: Exception) {
-                                    // Send failed — connection is dead, next tick will close it.
-                                }
-                            }
-                        }
-                    }
+                    // Liveness detection is delegated to the engine. JVM/Android
+                    // Ktor clients are configured with WebSocket pingInterval, so
+                    // a frozen relay drops out on ping/pong failure and surfaces
+                    // here as a closed incoming channel. Browsers handle their
+                    // own keepalive at the network layer. The previous synthetic
+                    // REQ+CLOSE probe was removed: it added relay load, could
+                    // false-positive on healthy-but-quiet relays, and conflated
+                    // "no EOSE" with "relay dead" — neither of which is a valid
+                    // protocol signal.
 
                     // Listen to incoming messages
                     for (frame in incoming) {
                         when (frame) {
-                            is Frame.Text -> {
-                                lastMessageReceivedAt = epochMillis()
-                                onMessage(frame.readText())
-                            }
+                            is Frame.Text -> onMessage(frame.readText())
                             is Frame.Close -> {} // CLOSED event below captures code + reason
                             else -> {} // ping/pong handled by Ktor
                         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -185,6 +185,11 @@ class NostrGroupClient(
     // under concurrent sends, which is acceptable for logging purposes.
     private val openSubscriptions = mutableSetOf<String>()
 
+    companion object {
+        /** Probe interval for browser targets without engine ws ping/pong. */
+        private const val BROWSER_PROBE_INTERVAL_MS = 30_000L
+    }
+
     fun getRelayUrl(): String = relayUrl
 
     /**
@@ -219,15 +224,32 @@ class NostrGroupClient(
                     // Signal that connection is ready
                     connectionResult.complete(true)
 
-                    // Liveness detection is delegated to the engine. JVM/Android
-                    // Ktor clients are configured with WebSocket pingInterval, so
-                    // a frozen relay drops out on ping/pong failure and surfaces
-                    // here as a closed incoming channel. Browsers handle their
-                    // own keepalive at the network layer. The previous synthetic
-                    // REQ+CLOSE probe was removed: it added relay load, could
-                    // false-positive on healthy-but-quiet relays, and conflated
-                    // "no EOSE" with "relay dead" — neither of which is a valid
-                    // protocol signal.
+                    // Liveness detection is delegated to the engine on platforms
+                    // that perform ws-level ping/pong (JVM/Android via Ktor,
+                    // iOS via NSURLSession). The frame loop exits naturally
+                    // when the engine closes a dead socket.
+                    //
+                    // Browser engines hide ping/pong frames from JS code, so on
+                    // those targets we send a periodic best-effort REQ+CLOSE
+                    // probe. The probe only feeds activity to the underlying
+                    // socket — it never decides liveness, so a quiet healthy
+                    // relay is not forcibly reconnected.
+                    val wsSession = this
+                    if (!hasEngineWebSocketPing()) {
+                        launch {
+                            while (isActive) {
+                                delay(BROWSER_PROBE_INTERVAL_MS)
+                                try {
+                                    wsSession.send(Frame.Text("""["REQ","_hb",{"kinds":[0],"limit":1}]"""))
+                                    wsSession.send(Frame.Text("""["CLOSE","_hb"]"""))
+                                } catch (_: Exception) {
+                                    // Send failed — socket is gone, frame loop
+                                    // below will exit and trigger reconnect.
+                                    break
+                                }
+                            }
+                        }
+                    }
 
                     // Listen to incoming messages
                     for (frame in incoming) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -894,9 +894,10 @@ class NostrRepository(
                 // Also request metadata for the active group if the user navigated
                 // directly via URL (e.g. invite link) and the group isn't known yet.
                 scope.launch {
-                    // Small delay to let the group-list EOSE populate the cache first,
-                    // so we only target genuinely missing (private) groups.
-                    delay(2_000)
+                    // Wait for the group-list EOSE so we only request kind:39000 for
+                    // groups genuinely missing from the public listing. Bounded fallback
+                    // keeps slow relays from blocking the targeted fetches indefinitely.
+                    groupManager.awaitGroupListEose(relayUrl)
                     groupManager.requestPrivateGroupData(relayUrl)
                     groupManager.requestActiveGroupMetadataIfMissing(relayUrl)
                 }
@@ -1015,7 +1016,9 @@ class NostrRepository(
             // but not returned by the general kind 39000 listing), and for the active
             // group if navigated via URL before the relay was connected.
             scope.launch {
-                delay(2_000)
+                // Wait for the group-list EOSE before requesting per-group metadata —
+                // see the equivalent block in connect() for rationale.
+                groupManager.awaitGroupListEose(newRelayUrl)
                 groupManager.requestPrivateGroupData(newRelayUrl)
                 groupManager.requestActiveGroupMetadataIfMissing(newRelayUrl)
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1675,17 +1675,10 @@ class NostrRepository(
                 return Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
             }
             val results = clients.map { client ->
-                scope.async {
-                    try {
-                        client.sendAndAwaitOk(message, eventId)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        PublishResult.Error(eventId, e)
-                    }
-                }
+                scope.async { client.sendAndAwaitOkOrError(message, eventId) }
             }.awaitAll()
             if (results.none { it is PublishResult.Success }) {
-                return Result.Error(AppError.Network.PublishRejected(summarizePublishFailures(results)))
+                return Result.Error(AppError.Network.PublishRejected(results.summarizeFailures()))
             }
 
             val updatedMetadata = UserMetadata(
@@ -1736,17 +1729,10 @@ class NostrRepository(
                 return Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
             }
             val results = clients.map { client ->
-                scope.async {
-                    try {
-                        client.sendAndAwaitOk(message, eventId)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        PublishResult.Error(eventId, e)
-                    }
-                }
+                scope.async { client.sendAndAwaitOkOrError(message, eventId) }
             }.awaitAll()
             if (results.none { it is PublishResult.Success }) {
-                return Result.Error(AppError.Network.PublishRejected(summarizePublishFailures(results)))
+                return Result.Error(AppError.Network.PublishRejected(results.summarizeFailures()))
             }
 
             outboxManager.updateMyRelayList(pubKey, relays)
@@ -2486,21 +2472,6 @@ class NostrRepository(
             groupManager.requestGroupMessages(groupId)
         }
     }
-}
-
-private fun summarizePublishFailures(results: List<PublishResult>): String {
-    val rejected = results.count { it is PublishResult.Rejected }
-    val timeout = results.count { it is PublishResult.Timeout }
-    val errors = results.count { it is PublishResult.Error }
-    val firstReason = results.firstNotNullOfOrNull { r ->
-        when (r) {
-            is PublishResult.Rejected -> r.reason
-            is PublishResult.Error -> r.exception.message
-            is PublishResult.Timeout -> "timeout"
-            else -> null
-        }
-    } ?: "unknown"
-    return "rejected=$rejected timeout=$timeout error=$errors first=$firstReason"
 }
 
 // Helper function for parsing bunker URLs

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1968,6 +1968,8 @@ class NostrRepository(
                 scope.launch {
                     yield()
                     groupManager.handleEoseSuspend(subId, sourceRelayUrl)
+                    // Wake any pending batchFetch waiting on EOSE for this metadata sub.
+                    metadataManager.notifyMetadataEose(subId, sourceRelayUrl)
                     // After the mux chat subscription delivers its backlog, detect any gaps
                     // (groups whose cursor expected events that never arrived from this relay).
                     if (subId.startsWith("mux_chat_")) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1,6 +1,8 @@
 package org.nostr.nostrord.network
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -1669,12 +1671,18 @@ class NostrRepository(
             if (clients.isEmpty()) {
                 return Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
             }
-            clients.forEach { client ->
-                scope.launch {
+            val results = clients.map { client ->
+                scope.async {
                     try {
                         client.sendAndAwaitOk(message, eventId)
-                    } catch (_: Exception) {}
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        PublishResult.Error(eventId, e)
+                    }
                 }
+            }.awaitAll()
+            if (results.none { it is PublishResult.Success }) {
+                return Result.Error(AppError.Network.PublishRejected(summarizePublishFailures(results)))
             }
 
             val updatedMetadata = UserMetadata(
@@ -1724,12 +1732,18 @@ class NostrRepository(
             if (clients.isEmpty()) {
                 return Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
             }
-            clients.forEach { client ->
-                scope.launch {
+            val results = clients.map { client ->
+                scope.async {
                     try {
                         client.sendAndAwaitOk(message, eventId)
-                    } catch (_: Exception) {}
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        PublishResult.Error(eventId, e)
+                    }
                 }
+            }.awaitAll()
+            if (results.none { it is PublishResult.Success }) {
+                return Result.Error(AppError.Network.PublishRejected(summarizePublishFailures(results)))
             }
 
             outboxManager.updateMyRelayList(pubKey, relays)
@@ -2467,6 +2481,21 @@ class NostrRepository(
             groupManager.requestGroupMessages(groupId)
         }
     }
+}
+
+private fun summarizePublishFailures(results: List<PublishResult>): String {
+    val rejected = results.count { it is PublishResult.Rejected }
+    val timeout = results.count { it is PublishResult.Timeout }
+    val errors = results.count { it is PublishResult.Error }
+    val firstReason = results.firstNotNullOfOrNull { r ->
+        when (r) {
+            is PublishResult.Rejected -> r.reason
+            is PublishResult.Error -> r.exception.message
+            is PublishResult.Timeout -> "timeout"
+            else -> null
+        }
+    } ?: "unknown"
+    return "rejected=$rejected timeout=$timeout error=$errors first=$firstReason"
 }
 
 // Helper function for parsing bunker URLs

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupLoadingController.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupLoadingController.kt
@@ -64,7 +64,11 @@ sealed class GroupLoadingState {
     ) : GroupLoadingState()
 
     enum class ErrorReason {
+        /** Relay never emitted EOSE and no messages arrived in the window. */
         TIMEOUT,
+
+        /** Relay sent some messages then went silent without EOSE — cursor preserved. */
+        PARTIAL_TIMEOUT,
         SEND_FAILED,
         DISCONNECTED,
         RELAY_ERROR,
@@ -405,14 +409,15 @@ class GroupLoadingController(
             val tracker = currentTracker ?: return@withLock
             if (tracker.subscriptionId != subscriptionId) return@withLock
 
-            // Timeout occurred - transition to error state
             val cursor = getCurrentCursor()
-
-            // Preserve retry count from current state
             val existingRetryCount = getRetryCount()
 
-            // If we received some messages, treat as partial success
-            if (tracker.messageCount > 0) {
+            // A timeout is always a degraded relay signal — never a substitute
+            // for EOSE. Even when messages did arrive, we surface this as an
+            // explicit PARTIAL_TIMEOUT error (carrying the advanced cursor) so
+            // the UI does not auto-paginate against a flaky relay assuming
+            // "more history exists". Caller can retry via [retry] to resume.
+            val (reason, advancedCursor) = if (tracker.messageCount > 0) {
                 val newCursor = if (tracker.oldestEventId != null) {
                     (cursor ?: PaginationCursor.initial()).advance(
                         oldestTimestamp = tracker.oldestTimestamp,
@@ -422,17 +427,16 @@ class GroupLoadingController(
                 } else {
                     cursor
                 }
-
-                // Got some messages, assume more might be available
-                _state.value = GroupLoadingState.HasMore(newCursor ?: PaginationCursor.initial())
+                GroupLoadingState.ErrorReason.PARTIAL_TIMEOUT to newCursor
             } else {
-                // No messages at all - error state with preserved retry count
-                _state.value = GroupLoadingState.Error(
-                    cursor = cursor,
-                    reason = GroupLoadingState.ErrorReason.TIMEOUT,
-                    retryCount = existingRetryCount,
-                )
+                GroupLoadingState.ErrorReason.TIMEOUT to cursor
             }
+
+            _state.value = GroupLoadingState.Error(
+                cursor = advancedCursor,
+                reason = reason,
+                retryCount = existingRetryCount,
+            )
 
             currentTracker = null
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.DeclaredChild
 import org.nostr.nostrord.network.GroupAdmins
@@ -233,6 +234,24 @@ class GroupManager(
 
     fun markRelayLoaded(relayUrl: String) {
         _loadingRelays.update { it - relayUrl.normalizeRelayUrl() }
+    }
+
+    /**
+     * Suspends until the relay's `group-list` EOSE has arrived (i.e. it appears
+     * in [_completeGroupLoadRelays]), or until [timeoutMs] elapses. Returns true
+     * if EOSE was observed, false if the relay timed out without emitting one.
+     *
+     * Used by callers that need to act on the populated group cache after
+     * `requestGroups()` — preferred over a fixed `delay(N)` so fast relays
+     * proceed immediately and slow relays still get bounded latency.
+     */
+    suspend fun awaitGroupListEose(relayUrl: String, timeoutMs: Long = 5_000): Boolean {
+        val normalized = relayUrl.normalizeRelayUrl()
+        if (normalized in _completeGroupLoadRelays.value) return true
+        return withTimeoutOrNull(timeoutMs) {
+            _completeGroupLoadRelays.first { normalized in it }
+            true
+        } ?: false
     }
 
     private val _messages = MutableStateFlow<Map<String, List<NostrGroupClient.NostrMessage>>>(emptyMap())

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -3,6 +3,9 @@ package org.nostr.nostrord.network.managers
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -138,19 +141,14 @@ class MetadataManager(
             if (missing.isEmpty()) return
 
             // Register the batch BEFORE sending any REQ so a fast relay's EOSE
-            // is not dropped between dispatch and registration. A relay is added
-            // to pendingRelays under the lock just before requestMetadata, and
-            // rolled back if the send fails; the deferred reflects that exact
-            // set when notifyMetadataEose drains it.
+            // is not dropped between dispatch and registration.
             val deferred = CompletableDeferred<Unit>()
-            val batch = metadataBatchesMutex.withLock {
+            val (subId, pendingRelays) = metadataBatchesMutex.withLock {
                 val id = "metadata_batch_${++metadataBatchCounter}_$attempt"
-                val b = MetadataBatch(mutableSetOf(), deferred)
-                metadataBatches[id] = b
-                id to b
+                val relays = mutableSetOf<String>()
+                metadataBatches[id] = MetadataBatch(relays, deferred)
+                id to relays
             }
-            val subId = batch.first
-            val pendingRelays = batch.second.pendingRelays
 
             suspend fun trySendOn(client: NostrGroupClient?, relayUrl: String): Boolean {
                 if (client == null || !client.isConnected()) return false
@@ -169,8 +167,12 @@ class MetadataManager(
                 }
             }
 
-            candidates.forEach { relayUrl ->
-                trySendOn(connectionManager.getClientForRelay(relayUrl), relayUrl)
+            // Dispatch in parallel so we don't pay per-relay round-trip latency
+            // serially — all REQs go in flight before we start waiting on EOSE.
+            coroutineScope {
+                candidates.map { relayUrl ->
+                    async { trySendOn(connectionManager.getClientForRelay(relayUrl), relayUrl) }
+                }.awaitAll()
             }
 
             // All bootstrap relays offline — try to reconnect one.
@@ -178,13 +180,10 @@ class MetadataManager(
             if (!anySent) {
                 val handler = messageHandler
                 if (handler != null) {
-                    for (relayUrl in candidates) {
-                        try {
-                            if (trySendOn(connectionManager.getOrConnectRelay(relayUrl, handler), relayUrl)) {
-                                break
-                            }
-                        } catch (_: Exception) {
-                        }
+                    candidates.firstOrNull { relayUrl ->
+                        runCatching {
+                            trySendOn(connectionManager.getOrConnectRelay(relayUrl, handler), relayUrl)
+                        }.getOrDefault(false)
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.network.managers
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -9,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.CachedEvent
 import org.nostr.nostrord.network.NostrGroupClient
@@ -41,6 +43,9 @@ class MetadataManager(
 
         /** Coalesce window for metadata StateFlow emissions (ms). */
         const val METADATA_FLUSH_DELAY_MS = 100L
+
+        /** Wall-clock fallback if a relay never emits EOSE for a metadata batch. */
+        const val EOSE_FALLBACK_MS = 5_000L
     }
 
     /**
@@ -61,6 +66,20 @@ class MetadataManager(
     private val inFlightMutex = Mutex()
     private val inFlightEvents = mutableSetOf<String>()
     private val inFlightEventsMutex = Mutex()
+
+    /**
+     * Per-batch state for EOSE-driven completion of [batchFetch]. Each batch
+     * waits on its [deferred] until every relay in [pendingRelays] has emitted
+     * EOSE for the batch subscription id, or the wall-clock fallback fires.
+     */
+    private data class MetadataBatch(
+        val pendingRelays: MutableSet<String>,
+        val deferred: CompletableDeferred<Unit>,
+    )
+
+    private val metadataBatches = mutableMapOf<String, MetadataBatch>()
+    private val metadataBatchesMutex = Mutex()
+    private var metadataBatchCounter = 0L
 
     private val _userMetadata = MutableStateFlow<Map<String, UserMetadata>>(emptyMap())
     val userMetadata: StateFlow<Map<String, UserMetadata>> = _userMetadata.asStateFlow()
@@ -118,25 +137,26 @@ class MetadataManager(
                 }
             if (missing.isEmpty()) return
 
-            var sent =
-                candidates.count { relayUrl ->
-                    try {
-                        val client = connectionManager.getClientForRelay(relayUrl)
-                        if (client != null && client.isConnected()) {
-                            missing.chunked(BATCH_SIZE).forEach { chunk ->
-                                client.requestMetadata(chunk)
-                            }
-                            true
-                        } else {
-                            false
+            val subId = metadataBatchesMutex.withLock {
+                "metadata_batch_${++metadataBatchCounter}_$attempt"
+            }
+            val sentRelays = mutableSetOf<String>()
+
+            candidates.forEach { relayUrl ->
+                try {
+                    val client = connectionManager.getClientForRelay(relayUrl)
+                    if (client != null && client.isConnected()) {
+                        missing.chunked(BATCH_SIZE).forEach { chunk ->
+                            client.requestMetadata(chunk, subId)
                         }
-                    } catch (_: Exception) {
-                        false
+                        sentRelays.add(relayUrl)
                     }
+                } catch (_: Exception) {
                 }
+            }
 
             // All bootstrap relays offline — try to reconnect one.
-            if (sent == 0) {
+            if (sentRelays.isEmpty()) {
                 val handler = messageHandler
                 if (handler != null) {
                     for (relayUrl in candidates) {
@@ -144,9 +164,9 @@ class MetadataManager(
                             val client = connectionManager.getOrConnectRelay(relayUrl, handler)
                             if (client != null && client.isConnected()) {
                                 missing.chunked(BATCH_SIZE).forEach { chunk ->
-                                    client.requestMetadata(chunk)
+                                    client.requestMetadata(chunk, subId)
                                 }
-                                sent = 1
+                                sentRelays.add(relayUrl)
                                 break
                             }
                         } catch (_: Exception) {
@@ -155,8 +175,16 @@ class MetadataManager(
                 }
             }
 
-            if (sent > 0) {
-                delay(if (attempt == 0) 2_000L else 3_500L)
+            if (sentRelays.isNotEmpty()) {
+                val deferred = CompletableDeferred<Unit>()
+                metadataBatchesMutex.withLock {
+                    metadataBatches[subId] = MetadataBatch(sentRelays.toMutableSet(), deferred)
+                }
+                // Wait for EOSE from every relay we sent to; bounded fallback in
+                // case a relay never EOSEs so we don't hang the next attempt.
+                withTimeoutOrNull(EOSE_FALLBACK_MS) { deferred.await() }
+                metadataBatchesMutex.withLock { metadataBatches.remove(subId) }
+
                 val allFresh =
                     pubkeys.all { pk ->
                         val at = metadataCache.get(pk)?.fetchedAt
@@ -164,9 +192,25 @@ class MetadataManager(
                     }
                 if (allFresh) return
             } else if (attempt < MAX_FETCH_ATTEMPTS - 1) {
-                delay(if (attempt == 0) 2_000L else 4_000L)
+                // No bootstrap relay was reachable — back off briefly before retry.
+                delay(2_000L)
             }
         }
+    }
+
+    /**
+     * Marks [sourceRelayUrl] as done for the given batch [subId]. When every
+     * relay we dispatched the batch to has EOSEd, the batch's deferred
+     * completes and [batchFetch] proceeds to the next attempt (or returns).
+     */
+    suspend fun notifyMetadataEose(subId: String, sourceRelayUrl: String) {
+        if (!subId.startsWith("metadata_batch_")) return
+        val toComplete = metadataBatchesMutex.withLock {
+            val batch = metadataBatches[subId] ?: return@withLock null
+            batch.pendingRelays.remove(sourceRelayUrl)
+            if (batch.pendingRelays.isEmpty()) batch.deferred else null
+        }
+        toComplete?.complete(Unit)
     }
 
     suspend fun requestEventById(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -137,36 +137,50 @@ class MetadataManager(
                 }
             if (missing.isEmpty()) return
 
-            val subId = metadataBatchesMutex.withLock {
-                "metadata_batch_${++metadataBatchCounter}_$attempt"
+            // Register the batch BEFORE sending any REQ so a fast relay's EOSE
+            // is not dropped between dispatch and registration. A relay is added
+            // to pendingRelays under the lock just before requestMetadata, and
+            // rolled back if the send fails; the deferred reflects that exact
+            // set when notifyMetadataEose drains it.
+            val deferred = CompletableDeferred<Unit>()
+            val batch = metadataBatchesMutex.withLock {
+                val id = "metadata_batch_${++metadataBatchCounter}_$attempt"
+                val b = MetadataBatch(mutableSetOf(), deferred)
+                metadataBatches[id] = b
+                id to b
             }
-            val sentRelays = mutableSetOf<String>()
+            val subId = batch.first
+            val pendingRelays = batch.second.pendingRelays
 
-            candidates.forEach { relayUrl ->
-                try {
-                    val client = connectionManager.getClientForRelay(relayUrl)
-                    if (client != null && client.isConnected()) {
-                        missing.chunked(BATCH_SIZE).forEach { chunk ->
-                            client.requestMetadata(chunk, subId)
-                        }
-                        sentRelays.add(relayUrl)
+            suspend fun trySendOn(client: NostrGroupClient?, relayUrl: String): Boolean {
+                if (client == null || !client.isConnected()) return false
+                metadataBatchesMutex.withLock { pendingRelays.add(relayUrl) }
+                return try {
+                    missing.chunked(BATCH_SIZE).forEach { chunk ->
+                        client.requestMetadata(chunk, subId)
                     }
+                    true
                 } catch (_: Exception) {
+                    val complete = metadataBatchesMutex.withLock {
+                        pendingRelays.remove(relayUrl) && pendingRelays.isEmpty()
+                    }
+                    if (complete) deferred.complete(Unit)
+                    false
                 }
             }
 
+            candidates.forEach { relayUrl ->
+                trySendOn(connectionManager.getClientForRelay(relayUrl), relayUrl)
+            }
+
             // All bootstrap relays offline — try to reconnect one.
-            if (sentRelays.isEmpty()) {
+            val anySent = metadataBatchesMutex.withLock { pendingRelays.isNotEmpty() }
+            if (!anySent) {
                 val handler = messageHandler
                 if (handler != null) {
                     for (relayUrl in candidates) {
                         try {
-                            val client = connectionManager.getOrConnectRelay(relayUrl, handler)
-                            if (client != null && client.isConnected()) {
-                                missing.chunked(BATCH_SIZE).forEach { chunk ->
-                                    client.requestMetadata(chunk, subId)
-                                }
-                                sentRelays.add(relayUrl)
+                            if (trySendOn(connectionManager.getOrConnectRelay(relayUrl, handler), relayUrl)) {
                                 break
                             }
                         } catch (_: Exception) {
@@ -175,11 +189,8 @@ class MetadataManager(
                 }
             }
 
-            if (sentRelays.isNotEmpty()) {
-                val deferred = CompletableDeferred<Unit>()
-                metadataBatchesMutex.withLock {
-                    metadataBatches[subId] = MetadataBatch(sentRelays.toMutableSet(), deferred)
-                }
+            val finalSent = metadataBatchesMutex.withLock { pendingRelays.isNotEmpty() }
+            if (finalSent) {
                 // Wait for EOSE from every relay we sent to; bounded fallback in
                 // case a relay never EOSEs so we don't hang the next attempt.
                 withTimeoutOrNull(EOSE_FALLBACK_MS) { deferred.await() }
@@ -191,9 +202,12 @@ class MetadataManager(
                         at != null && at >= fetchStartedAt
                     }
                 if (allFresh) return
-            } else if (attempt < MAX_FETCH_ATTEMPTS - 1) {
-                // No bootstrap relay was reachable — back off briefly before retry.
-                delay(2_000L)
+            } else {
+                metadataBatchesMutex.withLock { metadataBatches.remove(subId) }
+                if (attempt < MAX_FETCH_ATTEMPTS - 1) {
+                    // No bootstrap relay was reachable — back off briefly before retry.
+                    delay(2_000L)
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.nostr.Nip07
+import org.nostr.nostrord.nostr.Nip46Client
 import org.nostr.nostrord.utils.toKotlinResult
 
 class LoginViewModel(
@@ -20,6 +21,13 @@ class LoginViewModel(
     val qrUri: StateFlow<String?> = _qrUri.asStateFlow()
 
     private var qrJob: Job? = null
+
+    /**
+     * The active QR-flow Nip46Client. Tracked here so [cancelQrSession] can
+     * tear its WebSocket connections down — the durable response subscription
+     * stays open until disconnect, so simply cancelling [qrJob] is not enough.
+     */
+    private var qrClient: Nip46Client? = null
 
     fun clearAuthUrl() = repo.clearAuthUrl()
 
@@ -67,19 +75,23 @@ class LoginViewModel(
         onError: (String?) -> Unit,
     ) {
         qrJob?.cancel()
+        qrClient?.disconnect()
+        qrClient = null
         _qrUri.value = null
         qrJob =
             viewModelScope.launch {
                 try {
                     val (uri, client) = repo.createNostrConnectSession()
+                    qrClient = client
                     _qrUri.value = uri
                     repo.completeNostrConnectLogin(client)
+                    qrClient = null
                     onConnected()
                 } catch (e: Exception) {
+                    qrClient?.disconnect()
+                    qrClient = null
                     val message =
                         when {
-                            e.message?.contains("timed out", ignoreCase = true) == true ->
-                                "Connection timed out. Make sure your signer scanned the QR code."
                             e.message?.contains("cancelled", ignoreCase = true) == true -> null
                             else -> "Connection failed: ${e.message}"
                         }
@@ -90,11 +102,15 @@ class LoginViewModel(
 
     fun cancelQrSession() {
         qrJob?.cancel()
+        qrClient?.disconnect()
+        qrClient = null
         _qrUri.value = null
     }
 
     override fun onCleared() {
         super.onCleared()
         qrJob?.cancel()
+        qrClient?.disconnect()
+        qrClient = null
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/Result.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/Result.kt
@@ -68,6 +68,10 @@ sealed class AppError(
         data class Disconnected(
             val relayUrl: String,
         ) : Network("Disconnected from relay: $relayUrl")
+
+        data class PublishRejected(
+            val reason: String,
+        ) : Network("Publish rejected by all relays: $reason")
     }
 
     /** Authentication errors */

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/PublishResultExtensionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/PublishResultExtensionsTest.kt
@@ -1,5 +1,9 @@
 package org.nostr.nostrord.network
 
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.utils.AppError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -75,8 +79,60 @@ class PublishResultExtensionsTest {
     @Test
     fun `publish rejected error type carries the summary in its message`() {
         val results = listOf(PublishResult.Rejected(eventId, "no-write-access"))
-        val error = org.nostr.nostrord.utils.AppError.Network.PublishRejected(results.summarizeFailures())
+        val error = AppError.Network.PublishRejected(results.summarizeFailures())
         assertTrue(error.message.contains("no-write-access"))
         assertTrue(error.message.startsWith("Publish rejected by all relays"))
+    }
+
+    /**
+     * NOSTR-004 end-to-end: drives the same recipe NostrRepository.updateProfileMetadata
+     * and publishRelayList use — parallel `sendAndAwaitOkOrError` across multiple
+     * clients, `none { Success }` check, AppError.Network.PublishRejected construction.
+     *
+     * Disconnected NostrGroupClient instances short-circuit sendAndAwaitOk to
+     * PublishResult.Error("Not connected"), so this exercises the all-fail branch
+     * without needing a fake relay.
+     */
+    @Test
+    fun `publish recipe surfaces PublishRejected when no relay accepts`() = runTest {
+        val clients = listOf(
+            NostrGroupClient("wss://disconnected-1.example"),
+            NostrGroupClient("wss://disconnected-2.example"),
+            NostrGroupClient("wss://disconnected-3.example"),
+        )
+        val message = """["EVENT",{"id":"$eventId","kind":0,"content":"{}"}]"""
+
+        val results = clients.map { client ->
+            async { client.sendAndAwaitOkOrError(message, eventId) }
+        }.awaitAll()
+
+        assertEquals(3, results.size)
+        assertTrue(
+            results.all { it is PublishResult.Error },
+            "disconnected clients must short-circuit to Error, got $results",
+        )
+        assertTrue(results.none { it is PublishResult.Success })
+
+        val error = AppError.Network.PublishRejected(results.summarizeFailures())
+        assertTrue(error.message.contains("error=3"), "expected 3 errors, got: ${error.message}")
+        assertTrue(error.message.contains("Not connected"), "expected first reason captured, got: ${error.message}")
+    }
+
+    @Test
+    fun `publish recipe returns Success-bearing results when any client succeeds`() {
+        // Mixed list — the production code's `none { Success }` check is the gate
+        // we want to verify; build the list directly since synthesising a Success
+        // from a real disconnected client is not possible.
+        val results = listOf<PublishResult>(
+            PublishResult.Error(eventId, Exception("Not connected")),
+            PublishResult.Success(eventId, "accepted"),
+            PublishResult.Rejected(eventId, "auth-required"),
+        )
+        assertEquals(false, results.none { it is PublishResult.Success })
+        // summarizeFailures should still report the failures for diagnostic logging,
+        // but the gate stops the caller from building a PublishRejected error.
+        val summary = results.summarizeFailures()
+        assertTrue(summary.contains("rejected=1"))
+        assertTrue(summary.contains("error=1"))
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/PublishResultExtensionsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/PublishResultExtensionsTest.kt
@@ -1,0 +1,82 @@
+package org.nostr.nostrord.network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class PublishResultExtensionsTest {
+    private val eventId = "a".repeat(64)
+
+    @Test
+    fun `empty list summarises as all-zero with unknown reason`() {
+        val summary = emptyList<PublishResult>().summarizeFailures()
+        assertEquals("rejected=0 timeout=0 error=0 first=unknown", summary)
+    }
+
+    @Test
+    fun `successes alone summarise as all-zero with unknown reason`() {
+        val results = listOf(
+            PublishResult.Success(eventId, "ok"),
+            PublishResult.Success(eventId, null),
+        )
+        assertEquals("rejected=0 timeout=0 error=0 first=unknown", results.summarizeFailures())
+    }
+
+    @Test
+    fun `rejected captures first reason and counts`() {
+        val results = listOf(
+            PublishResult.Success(eventId, null),
+            PublishResult.Rejected(eventId, "auth-required"),
+            PublishResult.Rejected(eventId, "blocked"),
+        )
+        val summary = results.summarizeFailures()
+        assertEquals("rejected=2 timeout=0 error=0 first=auth-required", summary)
+    }
+
+    @Test
+    fun `mixed failure types are counted independently`() {
+        val results = listOf(
+            PublishResult.Timeout(eventId),
+            PublishResult.Rejected(eventId, "denied"),
+            PublishResult.Error(eventId, Exception("boom")),
+            PublishResult.Timeout(eventId),
+        )
+        val summary = results.summarizeFailures()
+        // first non-null reason is the timeout literal "timeout"
+        assertEquals("rejected=1 timeout=2 error=1 first=timeout", summary)
+    }
+
+    @Test
+    fun `error exception message is preferred over later reasons`() {
+        val results = listOf(
+            PublishResult.Error(eventId, Exception("network down")),
+            PublishResult.Rejected(eventId, "blocked"),
+        )
+        val summary = results.summarizeFailures()
+        assertEquals("rejected=1 timeout=0 error=1 first=network down", summary)
+    }
+
+    @Test
+    fun `error with null exception message falls through to next reason`() {
+        val results = listOf(
+            PublishResult.Error(eventId, Exception()),
+            PublishResult.Rejected(eventId, "blocked"),
+        )
+        // Exception with no message — firstReason should still take it (null) and
+        // assign on the first non-Success entry, then NOT overwrite on the next.
+        // Implementation assigns firstReason once; null assignment is the "no message"
+        // case so we expect "unknown" fallback only when nothing else fills it.
+        val summary = results.summarizeFailures()
+        // The exception path sets firstReason to null (no message), which leaves it
+        // unset; the next iteration (Rejected) then fills it with "blocked".
+        assertEquals("rejected=1 timeout=0 error=1 first=blocked", summary)
+    }
+
+    @Test
+    fun `publish rejected error type carries the summary in its message`() {
+        val results = listOf(PublishResult.Rejected(eventId, "no-write-access"))
+        val error = org.nostr.nostrord.utils.AppError.Network.PublishRejected(results.summarizeFailures())
+        assertTrue(error.message.contains("no-write-access"))
+        assertTrue(error.message.startsWith("Publish rejected by all relays"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/AwaitGroupListEoseTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/AwaitGroupListEoseTest.kt
@@ -1,0 +1,94 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Tests for NOSTR-006: GroupManager.awaitGroupListEose suspends until the
+ * relay's group-list EOSE arrives, with a wall-clock fallback for degraded
+ * relays. The previous implementation used a fixed delay(2_000) in
+ * NostrRepository — these tests pin the new EOSE-driven behaviour.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class AwaitGroupListEoseTest {
+    private val relayUrl = "wss://example.com"
+
+    private fun makeManager(scope: TestScope): GroupManager {
+        val connManager = ConnectionManager(scope)
+        return GroupManager(connectionManager = connManager, scope = scope)
+    }
+
+    @Test
+    fun `returns true immediately when relay already EOSEd`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+        // Populate the complete-load set by feeding a legacy "group-list" EOSE.
+        manager.handleEoseSuspend("group-list", relayUrl)
+
+        var result: Boolean? = null
+        scope.launch { result = manager.awaitGroupListEose(relayUrl, timeoutMs = 100) }
+        runCurrent()
+
+        assertTrue(result == true, "should return true synchronously when relay is already EOSEd")
+        scope.cancel()
+    }
+
+    @Test
+    fun `suspends until EOSE arrives then returns true`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+
+        val deferred = scope.async { manager.awaitGroupListEose(relayUrl, timeoutMs = 10_000) }
+        runCurrent()
+        assertFalse(deferred.isCompleted, "should still be suspended before EOSE")
+
+        // Fire the EOSE.
+        manager.handleEoseSuspend("group-list", relayUrl)
+        runCurrent()
+
+        assertTrue(deferred.isCompleted)
+        assertTrue(deferred.await(), "should return true after EOSE")
+        scope.cancel()
+    }
+
+    @Test
+    fun `returns false on wall-clock fallback when relay never EOSEs`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+
+        val deferred = scope.async { manager.awaitGroupListEose(relayUrl, timeoutMs = 500) }
+        runCurrent()
+        assertFalse(deferred.isCompleted)
+
+        advanceTimeBy(600)
+        runCurrent()
+
+        assertTrue(deferred.isCompleted)
+        assertFalse(deferred.await(), "fallback timeout returns false for degraded relays")
+        scope.cancel()
+    }
+
+    @Test
+    fun `EOSE for unrelated relay does not wake the await`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = makeManager(scope)
+
+        val deferred = scope.async { manager.awaitGroupListEose(relayUrl, timeoutMs = 10_000) }
+        runCurrent()
+
+        manager.handleEoseSuspend("group-list", "wss://other.relay")
+        runCurrent()
+
+        assertFalse(deferred.isCompleted, "EOSE for a different relay must not complete the await")
+        scope.cancel()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupLoadingControllerTimeoutTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupLoadingControllerTimeoutTest.kt
@@ -1,0 +1,97 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Tests for NOSTR-008: timeout never produces HasMore.
+ *
+ * Pre-change behavior: handleTimeout transitioned to HasMore when at least one
+ * message had arrived, which made the UI auto-paginate against a flaky relay.
+ * Post-change: timeout always yields Error(TIMEOUT) or Error(PARTIAL_TIMEOUT)
+ * with the cursor preserved when messages were received.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class GroupLoadingControllerTimeoutTest {
+    @Test
+    fun `timeout with no messages yields Error TIMEOUT and null cursor`() = runTest {
+        val scope = TestScope(testScheduler)
+        val c = GroupLoadingController(groupId = "g".repeat(64), scope = scope, timeoutMs = 50L)
+        val subId = c.startInitialLoad()
+        assertNotNull(subId)
+        advanceTimeBy(200)
+        runCurrent()
+
+        val state = c.state.value
+        assertTrue(state is GroupLoadingState.Error, "expected Error, got $state")
+        assertEquals(GroupLoadingState.ErrorReason.TIMEOUT, state.reason)
+        assertNull(state.cursor, "no messages means no cursor to preserve")
+        scope.cancel()
+    }
+
+    @Test
+    fun `timeout after partial delivery yields PARTIAL_TIMEOUT with advanced cursor`() = runTest {
+        val scope = TestScope(testScheduler)
+        val c = GroupLoadingController(groupId = "g".repeat(64), scope = scope, timeoutMs = 50L)
+        val subId = c.startInitialLoad()
+        assertNotNull(subId)
+
+        c.trackMessage(subId, timestamp = 1_700_000_000L, eventId = "e".repeat(64))
+
+        advanceTimeBy(200)
+        runCurrent()
+
+        val state = c.state.value
+        assertTrue(state is GroupLoadingState.Error, "expected Error, got $state")
+        assertEquals(
+            GroupLoadingState.ErrorReason.PARTIAL_TIMEOUT,
+            state.reason,
+            "partial delivery must surface as PARTIAL_TIMEOUT, not HasMore",
+        )
+        assertNotNull(state.cursor, "cursor must be preserved so retry can resume")
+        assertEquals(1, state.cursor!!.totalReceived)
+        scope.cancel()
+    }
+
+    @Test
+    fun `timeout never produces HasMore even with many messages`() = runTest {
+        val scope = TestScope(testScheduler)
+        val c = GroupLoadingController(groupId = "g".repeat(64), scope = scope, timeoutMs = 50L)
+        val subId = c.startInitialLoad()!!
+        repeat(10) { i ->
+            c.trackMessage(subId, timestamp = 1_700_000_000L - i, eventId = i.toString().padStart(64, '0'))
+        }
+        advanceTimeBy(200)
+        runCurrent()
+
+        val state = c.state.value
+        assertTrue(state is GroupLoadingState.Error, "timeout must never become HasMore (NOSTR-008)")
+        scope.cancel()
+    }
+
+    @Test
+    fun `EOSE before timeout transitions to HasMore`() = runTest {
+        val scope = TestScope(testScheduler)
+        val c = GroupLoadingController(groupId = "g".repeat(64), scope = scope, timeoutMs = 10_000L)
+        val subId = c.startInitialLoad()!!
+        c.trackMessage(subId, timestamp = 1_700_000_000L, eventId = "f".repeat(64))
+
+        val handled = c.handleEose(subId, relayUrl = "wss://relay.example.com")
+        assertTrue(handled)
+
+        val state = c.state.value
+        // After EOSE with at least one message on the initial load, the state
+        // goes to HasMore (initial load never marks Exhausted directly).
+        assertTrue(state is GroupLoadingState.HasMore, "EOSE-driven path still produces HasMore")
+        scope.cancel()
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.ios.kt
@@ -25,6 +25,10 @@ actual fun createHttpClient(): HttpClient = HttpClient(Darwin) {
     }
 }
 
+// Darwin engine relies on NSURLSession's network-layer keepalive plus the
+// system's transport-level checks, so application-level probes are unneeded.
+actual fun hasEngineWebSocketPing(): Boolean = true
+
 actual fun createNip11HttpClient(): HttpClient = HttpClient(Darwin) {
     install(HttpTimeout) {
         connectTimeoutMillis = 5_000

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.js.kt
@@ -25,6 +25,11 @@ actual fun createHttpClient(): HttpClient = HttpClient(Js) {
     }
 }
 
+// Browser WebSocket API does not expose ping/pong frames, so the engine
+// cannot send keepalive on its own — NostrGroupClient runs a best-effort
+// REQ/CLOSE probe for browser targets.
+actual fun hasEngineWebSocketPing(): Boolean = false
+
 actual fun createNip11HttpClient(): HttpClient = HttpClient(Js) {
     install(HttpTimeout) {
         requestTimeoutMillis = 8_000

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.sendAndAwaitOkOrError
+import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -237,25 +239,10 @@ actual class Nip46Client actual constructor(
             // surfaces immediately. The response sub opened on connect routes
             // the signer's reply back into responseDeferred.
             val publishResults = relayClients.map { client ->
-                async {
-                    try {
-                        client.sendAndAwaitOk(eventMessage, eventId)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        PublishResult.Error(eventId, e)
-                    }
-                }
+                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
             }.awaitAll()
             if (publishResults.none { it is PublishResult.Success }) {
-                val reason = publishResults.firstNotNullOfOrNull { r ->
-                    when (r) {
-                        is PublishResult.Rejected -> r.reason
-                        is PublishResult.Error -> r.exception.message
-                        is PublishResult.Timeout -> "publish timeout"
-                        else -> null
-                    }
-                } ?: "no relay accepted request"
-                throw Exception("Failed to publish NIP-46 request: $reason")
+                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -429,6 +429,9 @@ actual class Nip46Client actual constructor(
             }
         }
         relayClients.clear()
+        // Fail any in-flight RPCs so callers unblock immediately instead of
+        // waiting out their wrapping withTimeout.
+        pendingRequests.values.forEach { it.completeExceptionally(CancellationException("Nip46Client disconnected")) }
         pendingRequests.clear()
     }
 }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -47,7 +47,7 @@ actual class Nip46Client actual constructor(
                     try {
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg) }
+                        client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
                         client
                     } catch (_: Exception) {
@@ -282,11 +282,35 @@ actual class Nip46Client actual constructor(
         }
     }
 
-    private fun handleMessage(msg: String) {
+    private fun handleMessage(msg: String, source: NostrGroupClient) {
         try {
             val json = nip46Json
             val arr = json.parseToJsonElement(msg).jsonArray
             val msgType = arr.getOrNull(0)?.jsonPrimitive?.contentOrNull ?: return
+
+            when (msgType) {
+                "OK" -> {
+                    // Route relay's publish ACK into the source client so that
+                    // sendAndAwaitOk completes with the actual relay verdict
+                    // instead of timing out. OK false → PublishResult.Rejected.
+                    val parsed = source.parseOkMessage(arr) ?: return
+                    val (eventId, success, message) = parsed
+                    clientScope.launch { source.handleOkResponse(eventId, success, message) }
+                    return
+                }
+                "NOTICE" -> {
+                    val notice = arr.getOrNull(1)?.jsonPrimitive?.contentOrNull
+                    if (!notice.isNullOrBlank()) {
+                        println("[Nip46Client] NOTICE from ${source.getRelayUrl()}: $notice")
+                    }
+                    return
+                }
+                "EOSE" -> {
+                    // Catch-up boundary for the listening sub. No state to
+                    // advance yet, but the frame is no longer silently dropped.
+                    return
+                }
+            }
 
             if (msgType == "EVENT" && arr.size >= 3) {
                 val eventObj = arr[2].jsonObject

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -128,26 +128,14 @@ actual class Nip46Client actual constructor(
             pendingRequests["_incoming_connect"]
                 ?: throw Exception("Not listening. Call startListeningForConnection first.")
 
-        try {
-            return withTimeout(120_000) { connectDeferred.await() }
+        return try {
+            // No wall-clock timeout: the QR sheet lifecycle drives cancellation
+            // via the calling coroutine. The listen subscription stays open
+            // until disconnect(), so a late scanner still completes instead of
+            // being killed by a 120s deadline.
+            connectDeferred.await()
         } finally {
             pendingRequests.remove("_incoming_connect")
-            listenSubscriptionId?.let { subId ->
-                val closeMessage =
-                    buildJsonArray {
-                        add("CLOSE")
-                        add(subId)
-                    }.toString()
-                withContext(NonCancellable) {
-                    relayClients.forEach {
-                        try {
-                            it.send(closeMessage)
-                        } catch (_: Exception) {
-                        }
-                    }
-                }
-            }
-            listenSubscriptionId = null
         }
     }
 

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.nostr
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.PublishResult
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -20,7 +21,7 @@ actual class Nip46Client actual constructor(
     private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests: MutableMap<String, CompletableDeferred<String>> = mutableMapOf()
-    private var listenSubscriptionId: String? = null
+    private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
     private val clientScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -49,6 +50,7 @@ actual class Nip46Client actual constructor(
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
+                        openResponseSubscription(client)
                         client
                     } catch (_: Exception) {
                         null
@@ -56,6 +58,32 @@ actual class Nip46Client actual constructor(
                 }
             }.awaitAll()
             .filterNotNull()
+    }
+
+    /**
+     * Opens the durable NIP-46 response subscription on [client]. The filter
+     * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
+     * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
+     * one stable subscription replaces the previous per-request ephemeral REQs.
+     */
+    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+        val subId = responseSubscriptionId
+            ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
+        val since = (epochMillis() / 1000) - 10
+        val filter = buildJsonObject {
+            putJsonArray("kinds") { add(24133) }
+            putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
+            put("since", since)
+        }
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(filter)
+        }.toString()
+        try {
+            client.send(req)
+        } catch (_: Exception) {
+        }
     }
 
     private suspend fun ensureRelaysConnected() {
@@ -96,29 +124,9 @@ actual class Nip46Client actual constructor(
         if (relayClients.isEmpty()) {
             throw Exception("Failed to connect to any relay")
         }
-
-        val subscriptionId = "nip46-listen-${generateRequestId().take(8)}"
-        listenSubscriptionId = subscriptionId
-        val since = (epochMillis() / 1000) - 10
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        relayClients.forEach {
-            try {
-                it.send(subMessage)
-            } catch (_: Exception) {
-            }
-        }
+        // The durable response subscription opened in connectRelaysParallel
+        // already filters kind:24133 #p:clientPubkey, so it doubles as the
+        // nostrconnect listening sub — no extra REQ needed here.
 
         pendingRequests["_incoming_connect"] = CompletableDeferred()
     }
@@ -213,35 +221,10 @@ actual class Nip46Client actual constructor(
             )
 
         val signedEvent = event.sign(clientKeyPair)
+        val eventId = signedEvent.id
+            ?: throw Exception("Failed to sign NIP-46 request event")
         val responseDeferred = CompletableDeferred<String>()
         pendingRequests[requestId] = responseDeferred
-
-        val subscriptionId = "nip46-${requestId.take(8)}"
-        val since = (epochMillis() / 1000) - 120
-
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        var sentToAny = false
-        relayClients.forEach {
-            try {
-                it.send(subMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-        delay(100)
 
         val eventMessage =
             buildJsonArray {
@@ -249,36 +232,34 @@ actual class Nip46Client actual constructor(
                 add(signedEvent.toJsonObject())
             }.toString()
 
-        relayClients.forEach {
-            try {
-                it.send(eventMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-
-        if (!sentToAny) {
-            pendingRequests.remove(requestId)
-            throw Exception("Failed to send signing request to any relay")
-        }
-
         try {
+            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+            // surfaces immediately. The response sub opened on connect routes
+            // the signer's reply back into responseDeferred.
+            val publishResults = relayClients.map { client ->
+                async {
+                    try {
+                        client.sendAndAwaitOk(eventMessage, eventId)
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        PublishResult.Error(eventId, e)
+                    }
+                }
+            }.awaitAll()
+            if (publishResults.none { it is PublishResult.Success }) {
+                val reason = publishResults.firstNotNullOfOrNull { r ->
+                    when (r) {
+                        is PublishResult.Rejected -> r.reason
+                        is PublishResult.Error -> r.exception.message
+                        is PublishResult.Timeout -> "publish timeout"
+                        else -> null
+                    }
+                } ?: "no relay accepted request"
+                throw Exception("Failed to publish NIP-46 request: $reason")
+            }
             responseDeferred.await()
         } finally {
             pendingRequests.remove(requestId)
-            val closeMessage =
-                buildJsonArray {
-                    add("CLOSE")
-                    add(subscriptionId)
-                }.toString()
-            withContext(NonCancellable) {
-                relayClients.forEach {
-                    try {
-                        it.send(closeMessage)
-                    } catch (_: Exception) {
-                    }
-                }
-            }
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.jvm.kt
@@ -31,6 +31,8 @@ actual fun createHttpClient(): HttpClient = HttpClient(CIO) {
     }
 }
 
+actual fun hasEngineWebSocketPing(): Boolean = true
+
 actual fun createNip11HttpClient(): HttpClient = HttpClient(CIO) {
     // Each NIP-11 client instance is used for exactly one request and then closed, so we
     // don't need persistent connection pools — just honest timeouts. Relays on Caddy/HTTP-2

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.sendAndAwaitOkOrError
+import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -250,25 +252,10 @@ actual class Nip46Client actual constructor(
             // surfaces immediately. The response sub opened on connect routes
             // the signer's reply back into responseDeferred.
             val publishResults = relayClients.map { client ->
-                async {
-                    try {
-                        client.sendAndAwaitOk(eventMessage, eventId)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        PublishResult.Error(eventId, e)
-                    }
-                }
+                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
             }.awaitAll()
             if (publishResults.none { it is PublishResult.Success }) {
-                val reason = publishResults.firstNotNullOfOrNull { r ->
-                    when (r) {
-                        is PublishResult.Rejected -> r.reason
-                        is PublishResult.Error -> r.exception.message
-                        is PublishResult.Timeout -> "publish timeout"
-                        else -> null
-                    }
-                } ?: "no relay accepted request"
-                throw Exception("Failed to publish NIP-46 request: $reason")
+                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -48,7 +48,7 @@ actual class Nip46Client actual constructor(
                     try {
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg) }
+                        client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
                         client
                     } catch (e: Exception) {
@@ -296,14 +296,34 @@ actual class Nip46Client actual constructor(
         }
     }
 
-    private fun handleMessage(msg: String) {
+    private fun handleMessage(msg: String, source: NostrGroupClient) {
         try {
             val json = nip46Json
             val arr = json.parseToJsonElement(msg).jsonArray
             val msgType = arr.getOrNull(0)?.jsonPrimitive?.contentOrNull ?: return
 
-            if (msgType == "EOSE" || msgType == "OK" || msgType == "NOTICE") {
-                return
+            when (msgType) {
+                "OK" -> {
+                    // Route relay's publish ACK into the source client so that
+                    // sendAndAwaitOk completes with the actual relay verdict
+                    // instead of timing out. OK false → PublishResult.Rejected.
+                    val parsed = source.parseOkMessage(arr) ?: return
+                    val (eventId, success, message) = parsed
+                    clientScope.launch { source.handleOkResponse(eventId, success, message) }
+                    return
+                }
+                "NOTICE" -> {
+                    val notice = arr.getOrNull(1)?.jsonPrimitive?.contentOrNull
+                    if (!notice.isNullOrBlank()) {
+                        println("[Nip46Client] NOTICE from ${source.getRelayUrl()}: $notice")
+                    }
+                    return
+                }
+                "EOSE" -> {
+                    // Catch-up boundary for the listening sub. No state to
+                    // advance yet, but the frame is no longer silently dropped.
+                    return
+                }
             }
 
             if (msgType == "EVENT" && arr.size >= 3) {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -139,29 +139,14 @@ actual class Nip46Client actual constructor(
             pendingRequests["_incoming_connect"]
                 ?: throw Exception("Not listening. Call startListeningForConnection first.")
 
-        try {
-            val result = withTimeout(120_000) { connectDeferred.await() }
-            return result
-        } catch (e: Exception) {
-            throw e
+        return try {
+            // No wall-clock timeout: the QR sheet lifecycle drives cancellation
+            // via the calling coroutine. The listen subscription stays open
+            // until disconnect(), so a late scanner still completes instead of
+            // being killed by a 120s deadline.
+            connectDeferred.await()
         } finally {
             pendingRequests.remove("_incoming_connect")
-            listenSubscriptionId?.let { subId ->
-                val closeMessage =
-                    buildJsonArray {
-                        add("CLOSE")
-                        add(subId)
-                    }.toString()
-                withContext(NonCancellable) {
-                    relayClients.forEach {
-                        try {
-                            it.send(closeMessage)
-                        } catch (_: Exception) {
-                        }
-                    }
-                }
-            }
-            listenSubscriptionId = null
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -470,6 +470,9 @@ actual class Nip46Client actual constructor(
             }
         }
         relayClients.clear()
+        // Fail any in-flight RPCs so callers unblock immediately instead of
+        // waiting out their wrapping withTimeout.
+        pendingRequests.values.forEach { it.completeExceptionally(CancellationException("Nip46Client disconnected")) }
         pendingRequests.clear()
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.nostr
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.PublishResult
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -20,7 +21,7 @@ actual class Nip46Client actual constructor(
     private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests: MutableMap<String, CompletableDeferred<String>> = java.util.concurrent.ConcurrentHashMap()
-    private var listenSubscriptionId: String? = null
+    private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
     private val clientScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -50,6 +51,7 @@ actual class Nip46Client actual constructor(
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
+                        openResponseSubscription(client)
                         client
                     } catch (e: Exception) {
                         null
@@ -57,6 +59,32 @@ actual class Nip46Client actual constructor(
                 }
             }.awaitAll()
             .filterNotNull()
+    }
+
+    /**
+     * Opens the durable NIP-46 response subscription on [client]. The filter
+     * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
+     * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
+     * one stable subscription replaces the previous per-request ephemeral REQs.
+     */
+    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+        val subId = responseSubscriptionId
+            ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
+        val since = (epochMillis() / 1000) - 10
+        val filter = buildJsonObject {
+            putJsonArray("kinds") { add(24133) }
+            putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
+            put("since", since)
+        }
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(filter)
+        }.toString()
+        try {
+            client.send(req)
+        } catch (_: Exception) {
+        }
     }
 
     /**
@@ -107,29 +135,9 @@ actual class Nip46Client actual constructor(
         if (relayClients.isEmpty()) {
             throw Exception("Failed to connect to any relay")
         }
-
-        val subscriptionId = "nip46-listen-${generateRequestId().take(8)}"
-        listenSubscriptionId = subscriptionId
-        val since = (epochMillis() / 1000) - 10
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        relayClients.forEach {
-            try {
-                it.send(subMessage)
-            } catch (e: Exception) {
-            }
-        }
+        // The durable response subscription opened in connectRelaysParallel
+        // already filters kind:24133 #p:clientPubkey, so it doubles as the
+        // nostrconnect listening sub — no extra REQ needed here.
 
         pendingRequests["_incoming_connect"] = CompletableDeferred()
     }
@@ -226,36 +234,10 @@ actual class Nip46Client actual constructor(
             )
 
         val signedEvent = event.sign(clientKeyPair)
+        val eventId = signedEvent.id
+            ?: throw Exception("Failed to sign NIP-46 request event")
         val responseDeferred = CompletableDeferred<String>()
         pendingRequests[requestId] = responseDeferred
-
-        val subscriptionId = "nip46-${requestId.take(8)}"
-        val since = (epochMillis() / 1000) - 120
-
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        var sentToAny = false
-        relayClients.forEach { client ->
-            try {
-                client.send(subMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-
-        delay(100)
 
         val eventMessage =
             buildJsonArray {
@@ -263,36 +245,34 @@ actual class Nip46Client actual constructor(
                 add(signedEvent.toJsonObject())
             }.toString()
 
-        relayClients.forEach { client ->
-            try {
-                client.send(eventMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-
-        if (!sentToAny) {
-            pendingRequests.remove(requestId)
-            throw Exception("Failed to send signing request to any relay")
-        }
-
         try {
+            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+            // surfaces immediately. The response sub opened on connect routes
+            // the signer's reply back into responseDeferred.
+            val publishResults = relayClients.map { client ->
+                async {
+                    try {
+                        client.sendAndAwaitOk(eventMessage, eventId)
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        PublishResult.Error(eventId, e)
+                    }
+                }
+            }.awaitAll()
+            if (publishResults.none { it is PublishResult.Success }) {
+                val reason = publishResults.firstNotNullOfOrNull { r ->
+                    when (r) {
+                        is PublishResult.Rejected -> r.reason
+                        is PublishResult.Error -> r.exception.message
+                        is PublishResult.Timeout -> "publish timeout"
+                        else -> null
+                    }
+                } ?: "no relay accepted request"
+                throw Exception("Failed to publish NIP-46 request: $reason")
+            }
             responseDeferred.await()
         } finally {
             pendingRequests.remove(requestId)
-            val closeMessage =
-                buildJsonArray {
-                    add("CLOSE")
-                    add(subscriptionId)
-                }.toString()
-            withContext(NonCancellable) {
-                relayClients.forEach {
-                    try {
-                        it.send(closeMessage)
-                    } catch (_: Exception) {
-                    }
-                }
-            }
         }
     }
 

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/network/HttpClientFactory.wasmJs.kt
@@ -25,6 +25,11 @@ actual fun createHttpClient(): HttpClient = HttpClient(Js) {
     }
 }
 
+// Browser WebSocket API does not expose ping/pong frames, so the engine
+// cannot send keepalive on its own — NostrGroupClient runs a best-effort
+// REQ/CLOSE probe for browser targets.
+actual fun hasEngineWebSocketPing(): Boolean = false
+
 actual fun createNip11HttpClient(): HttpClient = HttpClient(Js) {
     install(HttpTimeout) {
         requestTimeoutMillis = 8_000

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
@@ -4,6 +4,8 @@ import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.sendAndAwaitOkOrError
+import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -236,25 +238,10 @@ actual class Nip46Client actual constructor(
             // surfaces immediately. The response sub opened on connect routes
             // the signer's reply back into responseDeferred.
             val publishResults = relayClients.map { client ->
-                async {
-                    try {
-                        client.sendAndAwaitOk(eventMessage, eventId)
-                    } catch (e: Exception) {
-                        if (e is kotlinx.coroutines.CancellationException) throw e
-                        PublishResult.Error(eventId, e)
-                    }
-                }
+                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
             }.awaitAll()
             if (publishResults.none { it is PublishResult.Success }) {
-                val reason = publishResults.firstNotNullOfOrNull { r ->
-                    when (r) {
-                        is PublishResult.Rejected -> r.reason
-                        is PublishResult.Error -> r.exception.message
-                        is PublishResult.Timeout -> "publish timeout"
-                        else -> null
-                    }
-                } ?: "no relay accepted request"
-                throw Exception("Failed to publish NIP-46 request: $reason")
+                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
@@ -47,7 +47,7 @@ actual class Nip46Client actual constructor(
                     try {
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg) }
+                        client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
                         client
                     } catch (_: Exception) {
@@ -281,11 +281,35 @@ actual class Nip46Client actual constructor(
         }
     }
 
-    private fun handleMessage(msg: String) {
+    private fun handleMessage(msg: String, source: NostrGroupClient) {
         try {
             val json = nip46Json
             val arr = json.parseToJsonElement(msg).jsonArray
             val msgType = arr.getOrNull(0)?.jsonPrimitive?.contentOrNull ?: return
+
+            when (msgType) {
+                "OK" -> {
+                    // Route relay's publish ACK into the source client so that
+                    // sendAndAwaitOk completes with the actual relay verdict
+                    // instead of timing out. OK false → PublishResult.Rejected.
+                    val parsed = source.parseOkMessage(arr) ?: return
+                    val (eventId, success, message) = parsed
+                    clientScope.launch { source.handleOkResponse(eventId, success, message) }
+                    return
+                }
+                "NOTICE" -> {
+                    val notice = arr.getOrNull(1)?.jsonPrimitive?.contentOrNull
+                    if (!notice.isNullOrBlank()) {
+                        println("[Nip46Client] NOTICE from ${source.getRelayUrl()}: $notice")
+                    }
+                    return
+                }
+                "EOSE" -> {
+                    // Catch-up boundary for the listening sub. No state to
+                    // advance yet, but the frame is no longer silently dropped.
+                    return
+                }
+            }
 
             if (msgType == "EVENT" && arr.size >= 3) {
                 val eventObj = arr[2].jsonObject

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
@@ -128,26 +128,14 @@ actual class Nip46Client actual constructor(
             pendingRequests["_incoming_connect"]
                 ?: throw Exception("Not listening. Call startListeningForConnection first.")
 
-        try {
-            return withTimeout(120_000) { connectDeferred.await() }
+        return try {
+            // No wall-clock timeout: the QR sheet lifecycle drives cancellation
+            // via the calling coroutine. The listen subscription stays open
+            // until disconnect(), so a late scanner still completes instead of
+            // being killed by a 120s deadline.
+            connectDeferred.await()
         } finally {
             pendingRequests.remove("_incoming_connect")
-            listenSubscriptionId?.let { subId ->
-                val closeMessage =
-                    buildJsonArray {
-                        add("CLOSE")
-                        add(subId)
-                    }.toString()
-                withContext(NonCancellable) {
-                    relayClients.forEach {
-                        try {
-                            it.send(closeMessage)
-                        } catch (_: Exception) {
-                        }
-                    }
-                }
-            }
-            listenSubscriptionId = null
         }
     }
 

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.nostr
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.PublishResult
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
@@ -20,7 +21,7 @@ actual class Nip46Client actual constructor(
     private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests: MutableMap<String, CompletableDeferred<String>> = mutableMapOf()
-    private var listenSubscriptionId: String? = null
+    private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
     private val clientScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -49,6 +50,7 @@ actual class Nip46Client actual constructor(
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
                         client.waitForConnection()
+                        openResponseSubscription(client)
                         client
                     } catch (_: Exception) {
                         null
@@ -56,6 +58,32 @@ actual class Nip46Client actual constructor(
                 }
             }.awaitAll()
             .filterNotNull()
+    }
+
+    /**
+     * Opens the durable NIP-46 response subscription on [client]. The filter
+     * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
+     * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
+     * one stable subscription replaces the previous per-request ephemeral REQs.
+     */
+    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+        val subId = responseSubscriptionId
+            ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
+        val since = (epochMillis() / 1000) - 10
+        val filter = buildJsonObject {
+            putJsonArray("kinds") { add(24133) }
+            putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
+            put("since", since)
+        }
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(filter)
+        }.toString()
+        try {
+            client.send(req)
+        } catch (_: Exception) {
+        }
     }
 
     private suspend fun ensureRelaysConnected() {
@@ -96,29 +124,9 @@ actual class Nip46Client actual constructor(
         if (relayClients.isEmpty()) {
             throw Exception("Failed to connect to any relay")
         }
-
-        val subscriptionId = "nip46-listen-${generateRequestId().take(8)}"
-        listenSubscriptionId = subscriptionId
-        val since = (epochMillis() / 1000) - 10
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        relayClients.forEach {
-            try {
-                it.send(subMessage)
-            } catch (_: Exception) {
-            }
-        }
+        // The durable response subscription opened in connectRelaysParallel
+        // already filters kind:24133 #p:clientPubkey, so it doubles as the
+        // nostrconnect listening sub — no extra REQ needed here.
 
         pendingRequests["_incoming_connect"] = CompletableDeferred()
     }
@@ -212,35 +220,10 @@ actual class Nip46Client actual constructor(
             )
 
         val signedEvent = event.sign(clientKeyPair)
+        val eventId = signedEvent.id
+            ?: throw Exception("Failed to sign NIP-46 request event")
         val responseDeferred = CompletableDeferred<String>()
         pendingRequests[requestId] = responseDeferred
-
-        val subscriptionId = "nip46-${requestId.take(8)}"
-        val since = (epochMillis() / 1000) - 120
-
-        val filter =
-            buildJsonObject {
-                putJsonArray("kinds") { add(24133) }
-                putJsonArray("#p") { add(clientKeyPair.publicKeyHex) }
-                put("since", since)
-            }
-
-        val subMessage =
-            buildJsonArray {
-                add("REQ")
-                add(subscriptionId)
-                add(filter)
-            }.toString()
-
-        var sentToAny = false
-        relayClients.forEach {
-            try {
-                it.send(subMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-        delay(100)
 
         val eventMessage =
             buildJsonArray {
@@ -248,36 +231,34 @@ actual class Nip46Client actual constructor(
                 add(signedEvent.toJsonObject())
             }.toString()
 
-        relayClients.forEach {
-            try {
-                it.send(eventMessage)
-                sentToAny = true
-            } catch (_: Exception) {
-            }
-        }
-
-        if (!sentToAny) {
-            pendingRequests.remove(requestId)
-            throw Exception("Failed to send signing request to any relay")
-        }
-
         try {
+            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+            // surfaces immediately. The response sub opened on connect routes
+            // the signer's reply back into responseDeferred.
+            val publishResults = relayClients.map { client ->
+                async {
+                    try {
+                        client.sendAndAwaitOk(eventMessage, eventId)
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                        PublishResult.Error(eventId, e)
+                    }
+                }
+            }.awaitAll()
+            if (publishResults.none { it is PublishResult.Success }) {
+                val reason = publishResults.firstNotNullOfOrNull { r ->
+                    when (r) {
+                        is PublishResult.Rejected -> r.reason
+                        is PublishResult.Error -> r.exception.message
+                        is PublishResult.Timeout -> "publish timeout"
+                        else -> null
+                    }
+                } ?: "no relay accepted request"
+                throw Exception("Failed to publish NIP-46 request: $reason")
+            }
             responseDeferred.await()
         } finally {
             pendingRequests.remove(requestId)
-            val closeMessage =
-                buildJsonArray {
-                    add("CLOSE")
-                    add(subscriptionId)
-                }.toString()
-            withContext(NonCancellable) {
-                relayClients.forEach {
-                    try {
-                        it.send(closeMessage)
-                    } catch (_: Exception) {
-                    }
-                }
-            }
         }
     }
 

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
@@ -445,6 +445,9 @@ actual class Nip46Client actual constructor(
             }
         }
         relayClients.clear()
+        // Fail any in-flight RPCs so callers unblock immediately instead of
+        // waiting out their wrapping withTimeout.
+        pendingRequests.values.forEach { it.completeExceptionally(CancellationException("Nip46Client disconnected")) }
         pendingRequests.clear()
     }
 }


### PR DESCRIPTION
Closes #59.

Addresses every finding from the protocol audit. Each commit is one finding;
splits between protocol-level smell fixes, follow-up bug fixes caught in
review, helper consolidation, and tests.

| Finding | Severity | Fix |
|---|---|---|
| NOSTR-001 | High | Durable `nip46-resp-<id>` subscription per signer session; `sendRequest` publishes the encrypted RPC via `sendAndAwaitOk`; drops the magic `delay(100)` and per-request REQ/CLOSE |
| NOSTR-002 | Med | `awaitIncomingConnection` no longer imposes a 120s wall-clock; QR sheet lifecycle drives cancellation |
| NOSTR-003 | High | `Nip46Client.handleMessage(msg, source)` forwards `OK` into `source.handleOkResponse`, logs `NOTICE`, passes through `EOSE` instead of silently discarding |
| NOSTR-004 | Med | `updateProfileMetadata` and `publishRelayList` await all relay OKs via `async`/`awaitAll`; return `AppError.Network.PublishRejected(...)` when no relay accepts; local cache only updates on at-least-one-success |
| NOSTR-005 | Med | `MetadataManager.batchFetch` uses a unique `metadata_batch_<n>_<attempt>` sub id per retry, registers a `CompletableDeferred` before dispatching, and completes it when every relay emits EOSE for that sub; 5s wall-clock fallback for degraded relays |
| NOSTR-006 | Med | New `GroupManager.awaitGroupListEose(relayUrl, timeoutMs = 5_000)` reuses the existing `_completeGroupLoadRelays` StateFlow; replaces both `delay(2_000)` blocks in `NostrRepository.connect`/`switchRelay` |
| NOSTR-007 | Low | Drops the synthetic REQ+CLOSE heartbeat probe on platforms whose engine performs ws-level ping/pong (JVM/Android via Ktor `pingInterval`, iOS via Darwin). Browser targets keep a best-effort probe via new `expect fun hasEngineWebSocketPing()` — it no longer closes the WebSocket on idle |
| NOSTR-008 | Low | `GroupLoadingController.handleTimeout` never produces `HasMore`. New `PARTIAL_TIMEOUT` error preserves the advanced cursor so retry can resume cleanly without auto-paginating against a flaky relay |

Three follow-up bug fixes were caught during review and committed separately:

| Issue | Fix |
|---|---|
| MetadataManager batch was registered AFTER dispatching REQs — a fast relay's EOSE could be dropped | Register the batch BEFORE any send; pending relay added under the mutex just before `requestMetadata` |
| `Nip46Client.disconnect()` cleared `pendingRequests` without completing the deferreds — callers hung until the outer 120s timeout | `completeExceptionally(CancellationException)` every pending deferred before clearing |
| `LoginViewModel.cancelQrSession` only cancelled the job, not the underlying `Nip46Client` — the durable response sub leaked WebSockets on every QR retry | Track `qrClient` in the VM and call `disconnect()` from `cancelQrSession`, the startQrSession catch block, and `onCleared` |

One consolidation commit lifts `summarizePublishFailures` + the per-relay
`try { sendAndAwaitOk } catch` adapter out of inline duplication (5 sites)
and into `List<PublishResult>.summarizeFailures()` + `NostrGroupClient.sendAndAwaitOkOrError()`
extensions. Same commit makes `MetadataManager.batchFetch` dispatch the
per-relay REQs in parallel via `coroutineScope`/`async`/`awaitAll` rather
than serially.

15 new tests in `commonTest`:
- `PublishResultExtensionsTest` — counts/first-reason for every PublishResult subtype, AppError format, end-to-end recipe against disconnected clients
- `GroupLoadingControllerTimeoutTest` — TIMEOUT vs PARTIAL_TIMEOUT vs EOSE-driven transitions
- `AwaitGroupListEoseTest` — immediate return, EOSE-driven completion, fallback timeout, cross-relay isolation

NIP-46 end-to-end and `MetadataManager.batchFetch` integration tests are
deferred to a follow-up that builds the relay-frame injection harness the
audit explicitly recommended.