### PR TITLE
fix(chat): keep messages visible when the keyboard opens

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -17,7 +17,7 @@
             android:launchMode="singleTask"
             android:name=".MainActivity"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|uiMode"
-            android:windowSoftInputMode="adjustNothing">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -34,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -296,6 +298,34 @@ fun MessagesList(
             .debounce(500)
             .filter { it }
             .collect { currentOnReachedBottom() }
+    }
+
+    // Compensate the LazyColumn's scroll as the IME animates so visible content rides
+    // with the input bar. The IME absorbs the navigation bar inset on Android, so the
+    // viewport actually shrinks by (ime - navBars), not by ime alone. Skip while any
+    // overlay is showing — opening an image viewer or modal closes the IME as a focus
+    // side-effect and we don't want the chat to scroll behind the overlay. Negative
+    // deltas are also skipped at the end of the list because LazyColumn auto-clamps.
+    val density = LocalDensity.current
+    val imeInsets = WindowInsets.ime
+    val navInsets = WindowInsets.navigationBars
+    val overlayObscured by rememberUpdatedState(parentHidden || imageViewerUrl.value != null)
+    LaunchedEffect(listState, density) {
+        var previous: Int? = null
+        snapshotFlow {
+            maxOf(0, imeInsets.getBottom(density) - navInsets.getBottom(density))
+        }
+            .distinctUntilChanged()
+            .collect { current ->
+                val prev = previous
+                previous = current
+                if (prev == null) return@collect
+                if (overlayObscured) return@collect
+                val delta = current - prev
+                if (delta > 0 || listState.canScrollForward) {
+                    listState.scrollBy(delta.toFloat())
+                }
+            }
     }
 
     CompositionLocalProvider(


### PR DESCRIPTION
Soft keyboard covered the chat input and latest message on Android. Switch the activity to `adjustResize` and pair it with a `LaunchedEffect` on `MessagesList` that compensates the LazyColumn scroll by the per-frame `(ime - navBars)` delta — the IME absorbs the navigation bar inset, so measuring `ime` alone overshoots. Skip while overlays (image viewer, modals) are showing, since opening one closes the IME as a focus side-effect.

| Where | What |
|---|---|
| `AndroidManifest.xml` | `adjustNothing` → `adjustResize` |
| `MessagesList.kt` | Per-frame scroll compensation gated by overlay state |
