### PR TITLE
Auth + signer polish: faster QR, re-login fixes, per-account UX

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
@@ -10,3 +10,4 @@ actual fun getPlatform(): Platform = AndroidPlatform()
 
 actual val isAndroid: Boolean = true
 actual val isHandheldPlatform: Boolean = true
+actual val platformDisplayName: String = "Nostrord Android"

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -64,6 +64,67 @@ actual class Nip46Client actual constructor(
     }
 
     /**
+     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
+     * one relay's WebSocket is open and the durable response sub is sent.
+     * Remaining relays continue connecting in [clientScope] and are appended
+     * to [relayClients] as they become ready, so the listening sub spans all
+     * relays even when this function has already returned. Throws only if
+     * every relay fails — partial failure is acceptable.
+     */
+    private suspend fun connectRelaysFirstWins(relays: List<String>) {
+        if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
+        val firstReady = CompletableDeferred<Unit>()
+        val total = relays.size
+        val failures = java.util.concurrent.atomic.AtomicInteger(0)
+
+        for (relayUrl in relays) {
+            clientScope.launch {
+                try {
+                    val cleanUrl = relayUrl.trimEnd('/')
+                    val client = NostrGroupClient(cleanUrl)
+                    client.connect { msg -> handleMessage(msg, client) }
+                    client.waitForConnection()
+                    openResponseSubscription(client)
+                    synchronized(relayClients) { relayClients.add(client) }
+                    firstReady.complete(Unit)
+                } catch (_: Exception) {
+                    if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
+                        firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
+                    }
+                }
+            }
+        }
+
+        firstReady.await()
+    }
+
+    /**
+     * Fire `get_public_key` in the background and cache the in-flight
+     * [CompletableDeferred] under [pendingRequests]'s special slot. Subsequent
+     * calls to [getPublicKey] await this deferred instead of starting a fresh
+     * round trip. Safe to call multiple times — putIfAbsent ensures only the
+     * first call kicks off the RPC.
+     */
+    private fun prefetchUserPubkey() {
+        val deferred = CompletableDeferred<String>()
+        val existing = pendingRequests.putIfAbsent("_pending_user_pubkey", deferred)
+        if (existing != null) return
+        clientScope.launch {
+            // No extra timeout here: the signer-side delay is often a user-tap
+            // approval prompt that can legitimately take tens of seconds. The
+            // underlying sendRequest already caps at 120s, which is the right
+            // ceiling for an interactive flow — a 10s wall here would mistake
+            // a slow human for a failed signer and abort the entire login.
+            try {
+                val pk = sendRequest(generateRequestId(), "get_public_key", emptyList())
+                deferred.complete(pk)
+            } catch (e: Exception) {
+                deferred.completeExceptionally(e)
+            }
+        }
+    }
+
+    /**
      * Opens the durable NIP-46 response subscription on [client]. The filter
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
@@ -122,16 +183,15 @@ actual class Nip46Client actual constructor(
         nostrConnectSecret = secret ?: generateRequestId().take(16)
         this.relayUrls = relays.map { it.trimEnd('/') }
 
-        relayClients.addAll(connectRelaysParallel(relays))
-
-        if (relayClients.isEmpty()) {
-            throw Exception("Failed to connect to any relay")
-        }
-        // The durable response subscription opened in connectRelaysParallel
-        // already filters kind:24133 #p:clientPubkey, so it doubles as the
-        // nostrconnect listening sub — no extra REQ needed here.
-
+        // Install the listening deferred BEFORE launching connects so that
+        // handleMessage can complete it as soon as the first relay starts
+        // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
+
+        // Return as soon as one relay is listening. Remaining relays finish
+        // in background; the durable sub on each picks up late-arriving
+        // signer events thanks to the `since = now - 10s` filter.
+        connectRelaysFirstWins(relays)
     }
 
     actual suspend fun awaitIncomingConnection(): String {
@@ -177,9 +237,13 @@ actual class Nip46Client actual constructor(
     }
 
     actual suspend fun getPublicKey(): String {
+        // In the nostrconnect:// flow, handleMessage pre-fires get_public_key
+        // the moment the signer's connect event arrives, so this await almost
+        // always returns the cached result instead of paying another full
+        // signer round trip.
+        pendingRequests["_pending_user_pubkey"]?.let { return it.await() }
         val requestId = generateRequestId()
-        val response = sendRequest(requestId, "get_public_key", emptyList())
-        return response
+        return sendRequest(requestId, "get_public_key", emptyList())
     }
 
     actual suspend fun signEvent(eventJson: String): String {
@@ -348,6 +412,14 @@ actual class Nip46Client actual constructor(
                             }
                         }
 
+                        // Pipeline get_public_key: kick it off the instant the
+                        // signer connects so the caller's subsequent
+                        // getPublicKey() returns the cached result instead of
+                        // paying another full signer round trip. putIfAbsent
+                        // guards against duplicate fires when multiple relays
+                        // deliver the same connect event.
+                        prefetchUserPubkey()
+
                         val deferred = pendingRequests["_incoming_connect"]
                         deferred?.complete(eventPubkey)
                         return
@@ -361,6 +433,7 @@ actual class Nip46Client actual constructor(
                             result == nostrConnectSecret
                     if (isConnectResponse) {
                         remoteSignerPubkey = eventPubkey
+                        prefetchUserPubkey()
                         pendingRequests["_incoming_connect"]?.complete(eventPubkey)
                         return
                     }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.android.kt
@@ -7,3 +7,5 @@ actual fun browserGoBack() {}
 actual fun browserGoForward() {}
 
 actual fun platformAppOrigin(): String? = null
+
+actual fun clearBrowserUrlQuery() {}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -56,6 +56,7 @@ import org.nostr.nostrord.ui.navigation.NavigationHistory
 import org.nostr.nostrord.ui.navigation.PlatformBackHandler
 import org.nostr.nostrord.ui.navigation.browserGoBack
 import org.nostr.nostrord.ui.navigation.browserGoForward
+import org.nostr.nostrord.ui.navigation.clearBrowserUrlQuery
 import org.nostr.nostrord.ui.navigation.platformHasBrowserNavigation
 import org.nostr.nostrord.ui.screens.backup.BackupScreen
 import org.nostr.nostrord.ui.screens.group.GroupScreen
@@ -129,6 +130,13 @@ fun App() {
                 }
 
                 is AppStartState.Unauthenticated -> {
+                    // Drop any leftover ?relay=…&group=… query from the previous
+                    // session. BrowserNavigationHandler lives inside
+                    // AuthenticatedApp and is unmounted while logged out, so
+                    // without this the login screen would still show the
+                    // ex-account's deep link in the address bar. No-op on
+                    // native platforms.
+                    LaunchedEffect(Unit) { clearBrowserUrlQuery() }
                     // Not logged in - show login
                     if (hasWindowControls) {
                         Column(Modifier.fillMaxSize()) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
@@ -15,3 +15,11 @@ expect val isAndroid: Boolean
  * intentionally and width-based breakpoints match their intent.
  */
 expect val isHandheldPlatform: Boolean
+
+/**
+ * Human-readable build identifier shown to remote signers during the
+ * nostrconnect:// handshake. Persists in the signer's authorized-apps
+ * list, so a user with Nostrord on several devices can tell them apart
+ * (and revoke individually).
+ */
+expect val platformDisplayName: String

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -18,6 +18,7 @@ import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip07
 import org.nostr.nostrord.nostr.Nip46Client
+import org.nostr.nostrord.platformDisplayName
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.clearAllCredentialsForAccount
 import org.nostr.nostrord.storage.getBunkerClientPrivateKeyFor
@@ -212,7 +213,7 @@ class AuthManager(
         // Connect to relays and subscribe FIRST
         newNip46Client.startListeningForConnection(relays, null)
         // Only then generate the URI for QR display
-        val uri = newNip46Client.generateNostrConnectUri(relays)
+        val uri = newNip46Client.generateNostrConnectUri(relays, name = platformDisplayName)
         return uri to newNip46Client
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -498,13 +498,17 @@ class NostrRepository(
         return userPubkey
     }
 
-    override suspend fun loginSuspend(privKey: String, pubKey: String): Result<Unit> = try {
+    override suspend fun loginSuspend(privKey: String, pubKey: String, isNewIdentity: Boolean): Result<Unit> = try {
         val previousPubkey = sessionManager.getPublicKey()
-        if (connectionManager.currentRelayUrl.value.isBlank()) {
+        // A freshly generated identity has nothing on the network yet — no
+        // kind:10002, no kind:10009 — so don't bother flagging the relay
+        // discovery spinner. The user will land on OnboardingScreen and pick
+        // their first relay manually.
+        if (!isNewIdentity && connectionManager.currentRelayUrl.value.isBlank()) {
             _isDiscoveringRelays.value = true
         }
         sessionManager.loginWithPrivateKey(privKey, pubKey)
-        finishLoginInit(previousPubkey, pubKey)
+        finishLoginInit(previousPubkey, pubKey, isNewIdentity = isNewIdentity)
         Result.Success(Unit)
     } catch (e: Exception) {
         Result.Error(AppError.Unknown(e.message ?: "Login failed", e))
@@ -532,7 +536,11 @@ class NostrRepository(
      *   then re-hydrate joined-group state for [newPubkey] from storage and
      *   force a reconnect so pubkey-filtered REQs reissue.
      */
-    private suspend fun finishLoginInit(previousPubkey: String?, newPubkey: String) {
+    private suspend fun finishLoginInit(
+        previousPubkey: String?,
+        newPubkey: String,
+        isNewIdentity: Boolean = false,
+    ) {
         val isWarmSwap = previousPubkey != null && previousPubkey != newPubkey
         // Activate an AccountSession for the logged-in account so all signing
         // routes through the isolated NostrSigner and the session scope is
@@ -570,7 +578,12 @@ class NostrRepository(
             connectionManager.loadSavedRelay()
             unreadManager.initialize(newPubkey)
             notificationHistoryStore?.initialize(newPubkey)
-            initializeOutboxModel()
+            // Skip the outbox bootstrap for a freshly generated identity:
+            // nothing has been published yet, so kind:10002 / kind:10009 fetches
+            // would only delay landing the user on the onboarding screen.
+            // The bootstrap connections will form on demand once the user
+            // adds their first relay.
+            if (!isNewIdentity) initializeOutboxModel()
             sessionManager.setLoggedIn(true)
             scope.launch { connect() }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -544,6 +544,30 @@ class NostrRepository(
             sessionManager.setLoggedIn(true)
             reloadForActiveAccount()
         } else {
+            // Re-bind GroupManager to the new identity. logout() called
+            // groupManager.clear() which nulls currentPubkey, and the cold-start
+            // path otherwise only resets it as a side-effect of
+            // loadJoinedGroupsFromStorage — which is not invoked here because
+            // the boot flow (initialize) is the one that calls it on cold start,
+            // not a login that happens later in the process. Without this,
+            // flushBatchToState drops every incoming kind:9 because of its
+            // `currentPubkey == null` guard, leaving every group stuck on
+            // "No messages yet" until the user restarts the app.
+            groupManager.setCurrentPubkey(newPubkey)
+            // Repopulate _currentRelayUrl from the per-account persisted slot.
+            // logout() called connectionManager.clearCurrentRelay() which blanked
+            // the StateFlow, so without this `connect()` below would dispatch
+            // to connect("") and return immediately. Worse: when the kind:10009
+            // arrives over the outbox bootstrap, onRelaysRestored fires
+            // autoConnectFirstRelay(newRelays), whose `isBlank()` guard passes
+            // and which OVERWRITES the persisted slot with relays.first() —
+            // silently moving the user off the relay they were on (e.g. from
+            // groups.fiatjaf.com to whatever happens to be first in their
+            // kind:10009 r-tag list). The cold-boot path (initialize) and the
+            // warm-swap path (applyActiveAccountChange) both call loadSavedRelay
+            // for the same reason; the cold-start re-login path was the only
+            // one missing it.
+            connectionManager.loadSavedRelay()
             unreadManager.initialize(newPubkey)
             notificationHistoryStore?.initialize(newPubkey)
             initializeOutboxModel()
@@ -575,6 +599,26 @@ class NostrRepository(
             connectionManager.clearAll()
         } catch (_: Exception) {}
         connectedPoolRelays.clear()
+
+        // Reset session-scoped in-memory dedup/scoping caches. These are NOT
+        // persisted state — they only make sense within a single login
+        // session. Leaving them populated meant a logout→re-login on the same
+        // process kept stale entries that made resubscribeAfterAuth and the
+        // mux/message refresh paths skip work for the new session, leaving
+        // every group stuck on "No messages yet" until the user restarted.
+        lastRequestGroupsAt.clear()
+        lastGapDetectionAt.clear()
+        pendingFullFetchMutex.withLock { pendingFullFetchRequests.clear() }
+        _closedGroupSubscriptions.value = emptySet()
+        activeRelayUrl = null
+        // Per-relay AUTH-required / restricted markers from the previous
+        // session would otherwise short-circuit switchRelay on re-login (early
+        // return at the restriction check), so a relay that just had a
+        // transient AUTH timeout — common on bunker logins — would stay
+        // permanently "restricted" in the UI until process restart, even
+        // though the new session's signer can answer the challenge fine.
+        _restrictedRelays.value = emptyMap()
+
         sessionManager.logout()
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -97,6 +97,7 @@ interface NostrRepositoryApi {
     suspend fun loginSuspend(
         privKey: String,
         pubKey: String,
+        isNewIdentity: Boolean = false,
     ): Result<Unit>
 
     suspend fun loginWithNip07(pubkey: String): Result<Unit>

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3056,6 +3056,15 @@ class GroupManager(
         // the new account during the swap window.
         recentRequests.clear()
         _activeGroupId = null
+        // Reset every per-group loading controller. Without this, controllers
+        // left mid-load (InitialLoading / Paginating / HasMore) at logout
+        // refuse startInitialLoad() on re-login — it only accepts Idle/Error
+        // — so requestGroupMessages returns false silently and the chat
+        // stays on "No messages yet" until the process restarts. Affects
+        // bunker logins disproportionately because their AUTH path is slow
+        // enough to leave more groups mid-load when the logout cancellation
+        // fires.
+        loadingRegistry.clear()
         clearForRelaySwitch()
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
@@ -63,6 +63,13 @@ class SessionManager(
      * Logout
      */
     fun logout() {
+        // Clear AUTH dedup so a logout→re-login on the same process doesn't
+        // skip the first AUTH for a relay whose entry was left behind by a
+        // coroutine cancelled mid-flight (scope.cancelChildren in
+        // NostrRepository.logout). A stale entry would make handleAuthChallenge
+        // return false, suppressing the resubscribeAfterAuth that normally
+        // re-requests group messages.
+        authInProgress.clear()
         authManager.logout()
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.launch
 import org.nostr.nostrord.auth.Account
+import org.nostr.nostrord.auth.AuthMethod
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.nostr.Nip19
@@ -391,15 +392,23 @@ private fun AccountRow(
             }
         }
         Spacer(Modifier.width(12.dp))
-        Text(
-            displayName,
-            color = Color.White,
-            style = MaterialTheme.typography.bodyMedium,
-            fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
-        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                displayName,
+                color = Color.White,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                authMethodLabel(account.authMethod),
+                color = NostrordColors.TextMuted,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
         if (isActive) {
             Icon(
                 Icons.Default.Check,
@@ -488,4 +497,10 @@ private fun RemoveAccountDialog(
             }
         },
     )
+}
+
+private fun authMethodLabel(method: AuthMethod): String = when (method) {
+    AuthMethod.LOCAL -> "Private key"
+    AuthMethod.BUNKER -> "Bunker (NIP-46)"
+    AuthMethod.NIP07 -> "Browser extension (NIP-07)"
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
@@ -203,8 +203,15 @@ fun MeMenu(
                     ?: userMetadata[fb.pubkey]?.name?.takeIf { it.isNotBlank() }
                     ?: fb.label
             }
+        // Resolve the same way the avatar/list rows do: kind:0 displayName,
+        // then kind:0 name, falling back to the persisted "Account N" only when
+        // metadata is still unknown.
+        val targetLabel =
+            userMetadata[target.pubkey]?.displayName?.takeIf { it.isNotBlank() }
+                ?: userMetadata[target.pubkey]?.name?.takeIf { it.isNotBlank() }
+                ?: target.label
         RemoveAccountDialog(
-            account = target,
+            accountLabel = targetLabel,
             isActive = isActiveTarget,
             fallbackLabel = fallbackLabel,
             isBusy = isBusy,
@@ -435,7 +442,7 @@ private fun ActionRow(
 
 @Composable
 private fun RemoveAccountDialog(
-    account: Account,
+    accountLabel: String,
     isActive: Boolean,
     fallbackLabel: String?,
     isBusy: Boolean,
@@ -447,16 +454,16 @@ private fun RemoveAccountDialog(
     val body =
         when {
             isActive && fallbackLabel != null ->
-                "Credentials and local data for \"${account.label}\" will be erased on " +
+                "Credentials and local data for \"$accountLabel\" will be erased on " +
                     "this device. You'll switch to \"$fallbackLabel\"."
             isActive ->
-                "Credentials and local data for \"${account.label}\" will be erased on " +
+                "Credentials and local data for \"$accountLabel\" will be erased on " +
                     "this device. You'll need to sign in again to continue."
             else ->
-                "Credentials and local data for \"${account.label}\" will be erased on " +
+                "Credentials and local data for \"$accountLabel\" will be erased on " +
                     "this device."
         }
-    val title = if (isActive) "Sign out of \"${account.label}\"?" else "Remove account?"
+    val title = if (isActive) "Sign out of \"$accountLabel\"?" else "Remove account?"
     val confirmLabel = if (isActive) "Sign out" else "Remove"
     val busyLabel = if (isActive) "Signing out…" else "Removing…"
     AlertDialog(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.kt
@@ -24,3 +24,13 @@ expect fun browserGoForward()
  * On native platforms returns null (invite links are web-only).
  */
 expect fun platformAppOrigin(): String?
+
+/**
+ * Replace the browser URL with the bare pathname, dropping any `?relay=…&group=…`
+ * query. Called on logout so the login screen doesn't show a stale deep link
+ * from the previous session (BrowserNavigationHandler is unmounted while
+ * unauthenticated, so the URL would otherwise stay frozen).
+ *
+ * No-op on native platforms.
+ */
+expect fun clearBrowserUrlQuery()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
@@ -34,10 +34,11 @@ class LoginViewModel(
     fun loginWithPrivateKey(
         privKey: String,
         pubKey: String,
+        isNewIdentity: Boolean = false,
         onResult: (Result<Unit>) -> Unit,
     ) {
         viewModelScope.launch {
-            onResult(repo.loginSuspend(privKey, pubKey).toKotlinResult())
+            onResult(repo.loginSuspend(privKey, pubKey, isNewIdentity).toKotlinResult())
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/components/PrivateKeyLoginTab.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/components/PrivateKeyLoginTab.kt
@@ -200,7 +200,11 @@ fun PrivateKeyLoginTab(onLoginSuccess: () -> Unit) {
                 privateKey = newPrivateKey
                 showGeneratedKey = true
                 val keyPair = KeyPair.fromPrivateKeyHex(newPrivateKey)
-                vm.loginWithPrivateKey(newPrivateKey, keyPair.publicKeyHex) { result ->
+                vm.loginWithPrivateKey(
+                    newPrivateKey,
+                    keyPair.publicKeyHex,
+                    isNewIdentity = true,
+                ) { result ->
                     isLoading = false
                     if (result.isSuccess) {
                         onLoginSuccess()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -127,6 +127,7 @@ class FakeNostrRepository : NostrRepositoryApi {
     override suspend fun loginSuspend(
         privKey: String,
         pubKey: String,
+        isNewIdentity: Boolean,
     ): Result<Unit> {
         calls += "loginSuspend"
         return loginSuspendAction(privKey, pubKey)

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
@@ -10,3 +10,4 @@ actual fun getPlatform(): Platform = IOSPlatform()
 
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = true
+actual val platformDisplayName: String = "Nostrord iOS"

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.ios.kt
@@ -7,3 +7,5 @@ actual fun browserGoBack() {}
 actual fun browserGoForward() {}
 
 actual fun platformAppOrigin(): String? = null
+
+actual fun clearBrowserUrlQuery() {}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
@@ -8,3 +8,4 @@ actual fun getPlatform(): Platform = JsPlatform()
 
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = false
+actual val platformDisplayName: String = "Nostrord Web"

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -63,6 +63,67 @@ actual class Nip46Client actual constructor(
     }
 
     /**
+     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
+     * one relay's WebSocket is open and the durable response sub is sent.
+     * Remaining relays continue connecting in [clientScope] and are appended
+     * to [relayClients] as they become ready, so the listening sub spans all
+     * relays even when this function has already returned. Throws only if
+     * every relay fails. Single-threaded on JS — plain counter is fine.
+     */
+    private suspend fun connectRelaysFirstWins(relays: List<String>) {
+        if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
+        val firstReady = CompletableDeferred<Unit>()
+        val total = relays.size
+        var failures = 0
+
+        for (relayUrl in relays) {
+            clientScope.launch {
+                try {
+                    val cleanUrl = relayUrl.trimEnd('/')
+                    val client = NostrGroupClient(cleanUrl)
+                    client.connect { msg -> handleMessage(msg, client) }
+                    client.waitForConnection()
+                    openResponseSubscription(client)
+                    relayClients.add(client)
+                    firstReady.complete(Unit)
+                } catch (_: Exception) {
+                    failures++
+                    if (failures == total && !firstReady.isCompleted) {
+                        firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
+                    }
+                }
+            }
+        }
+
+        firstReady.await()
+    }
+
+    /**
+     * Fire `get_public_key` in the background and cache the in-flight
+     * [CompletableDeferred] under [pendingRequests]'s special slot. Subsequent
+     * calls to [getPublicKey] await this deferred instead of starting a fresh
+     * round trip. Safe to call multiple times.
+     */
+    private fun prefetchUserPubkey() {
+        if (pendingRequests.containsKey("_pending_user_pubkey")) return
+        val deferred = CompletableDeferred<String>()
+        pendingRequests["_pending_user_pubkey"] = deferred
+        clientScope.launch {
+            // No extra timeout here: the signer-side delay is often a user-tap
+            // approval prompt that can legitimately take tens of seconds. The
+            // underlying sendRequest already caps at 120s, which is the right
+            // ceiling for an interactive flow — a 10s wall here would mistake
+            // a slow human for a failed signer and abort the entire login.
+            try {
+                val pk = sendRequest(generateRequestId(), "get_public_key", emptyList())
+                deferred.complete(pk)
+            } catch (e: Exception) {
+                deferred.completeExceptionally(e)
+            }
+        }
+    }
+
+    /**
      * Opens the durable NIP-46 response subscription on [client]. The filter
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
@@ -121,16 +182,15 @@ actual class Nip46Client actual constructor(
         nostrConnectSecret = secret ?: generateRequestId().take(16)
         this.relayUrls = relays.map { it.trimEnd('/') }
 
-        relayClients.addAll(connectRelaysParallel(relays))
-
-        if (relayClients.isEmpty()) {
-            throw Exception("Failed to connect to any relay")
-        }
-        // The durable response subscription opened in connectRelaysParallel
-        // already filters kind:24133 #p:clientPubkey, so it doubles as the
-        // nostrconnect listening sub — no extra REQ needed here.
-
+        // Install the listening deferred BEFORE launching connects so that
+        // handleMessage can complete it as soon as the first relay starts
+        // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
+
+        // Return as soon as one relay is listening. Remaining relays finish
+        // in background; the durable sub on each picks up late-arriving
+        // signer events thanks to the `since = now - 10s` filter.
+        connectRelaysFirstWins(relays)
     }
 
     actual suspend fun awaitIncomingConnection(): String {
@@ -176,9 +236,13 @@ actual class Nip46Client actual constructor(
     }
 
     actual suspend fun getPublicKey(): String {
+        // In the nostrconnect:// flow, handleMessage pre-fires get_public_key
+        // the moment the signer's connect event arrives, so this await almost
+        // always returns the cached result instead of paying another full
+        // signer round trip.
+        pendingRequests["_pending_user_pubkey"]?.let { return it.await() }
         val requestId = generateRequestId()
-        val response = sendRequest(requestId, "get_public_key", emptyList())
-        return response
+        return sendRequest(requestId, "get_public_key", emptyList())
     }
 
     actual suspend fun signEvent(eventJson: String): String {
@@ -342,6 +406,11 @@ actual class Nip46Client actual constructor(
                             } catch (_: Exception) {
                             }
                         }
+                        // Pipeline get_public_key: kick it off the instant the
+                        // signer connects so the caller's subsequent
+                        // getPublicKey() returns the cached result instead of
+                        // paying another full signer round trip.
+                        prefetchUserPubkey()
                         pendingRequests["_incoming_connect"]?.complete(eventPubkey)
                         return
                     }
@@ -353,6 +422,7 @@ actual class Nip46Client actual constructor(
                             result == nostrConnectSecret
                     if (isConnectResponse) {
                         remoteSignerPubkey = eventPubkey
+                        prefetchUserPubkey()
                         pendingRequests["_incoming_connect"]?.complete(eventPubkey)
                         return
                     }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.js.kt
@@ -13,3 +13,7 @@ actual fun browserGoForward() {
 }
 
 actual fun platformAppOrigin(): String? = window.location.origin
+
+actual fun clearBrowserUrlQuery() {
+    window.history.replaceState(null, "", window.location.pathname)
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
@@ -8,3 +8,4 @@ actual fun getPlatform(): Platform = JVMPlatform()
 
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = false
+actual val platformDisplayName: String = "Nostrord Desktop"

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -64,6 +64,67 @@ actual class Nip46Client actual constructor(
     }
 
     /**
+     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
+     * one relay's WebSocket is open and the durable response sub is sent.
+     * Remaining relays continue connecting in [clientScope] and are appended
+     * to [relayClients] as they become ready, so the listening sub spans all
+     * relays even when this function has already returned. Throws only if
+     * every relay fails — partial failure is acceptable.
+     */
+    private suspend fun connectRelaysFirstWins(relays: List<String>) {
+        if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
+        val firstReady = CompletableDeferred<Unit>()
+        val total = relays.size
+        val failures = java.util.concurrent.atomic.AtomicInteger(0)
+
+        for (relayUrl in relays) {
+            clientScope.launch {
+                try {
+                    val cleanUrl = relayUrl.trimEnd('/')
+                    val client = NostrGroupClient(cleanUrl)
+                    client.connect { msg -> handleMessage(msg, client) }
+                    client.waitForConnection()
+                    openResponseSubscription(client)
+                    synchronized(relayClients) { relayClients.add(client) }
+                    firstReady.complete(Unit)
+                } catch (_: Exception) {
+                    if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
+                        firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
+                    }
+                }
+            }
+        }
+
+        firstReady.await()
+    }
+
+    /**
+     * Fire `get_public_key` in the background and cache the in-flight
+     * [CompletableDeferred] under [pendingRequests]'s special slot. Subsequent
+     * calls to [getPublicKey] await this deferred instead of starting a fresh
+     * round trip. Safe to call multiple times — putIfAbsent ensures only the
+     * first call kicks off the RPC.
+     */
+    private fun prefetchUserPubkey() {
+        val deferred = CompletableDeferred<String>()
+        val existing = pendingRequests.putIfAbsent("_pending_user_pubkey", deferred)
+        if (existing != null) return
+        clientScope.launch {
+            // No extra timeout here: the signer-side delay is often a user-tap
+            // approval prompt that can legitimately take tens of seconds. The
+            // underlying sendRequest already caps at 120s, which is the right
+            // ceiling for an interactive flow — a 10s wall here would mistake
+            // a slow human for a failed signer and abort the entire login.
+            try {
+                val pk = sendRequest(generateRequestId(), "get_public_key", emptyList())
+                deferred.complete(pk)
+            } catch (e: Exception) {
+                deferred.completeExceptionally(e)
+            }
+        }
+    }
+
+    /**
      * Opens the durable NIP-46 response subscription on [client]. The filter
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
@@ -132,16 +193,15 @@ actual class Nip46Client actual constructor(
         nostrConnectSecret = secret ?: generateRequestId().take(16)
         this.relayUrls = relays.map { it.trimEnd('/') }
 
-        relayClients.addAll(connectRelaysParallel(relays))
-
-        if (relayClients.isEmpty()) {
-            throw Exception("Failed to connect to any relay")
-        }
-        // The durable response subscription opened in connectRelaysParallel
-        // already filters kind:24133 #p:clientPubkey, so it doubles as the
-        // nostrconnect listening sub — no extra REQ needed here.
-
+        // Install the listening deferred BEFORE launching connects so that
+        // handleMessage can complete it as soon as the first relay starts
+        // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
+
+        // Return as soon as one relay is listening. Remaining relays finish
+        // in background; the durable sub on each picks up late-arriving
+        // signer events thanks to the `since = now - 10s` filter.
+        connectRelaysFirstWins(relays)
     }
 
     actual suspend fun awaitIncomingConnection(): String {
@@ -187,9 +247,13 @@ actual class Nip46Client actual constructor(
     }
 
     actual suspend fun getPublicKey(): String {
+        // In the nostrconnect:// flow, handleMessage pre-fires get_public_key
+        // the moment the signer's connect event arrives, so this await almost
+        // always returns the cached result instead of paying another full
+        // signer round trip.
+        pendingRequests["_pending_user_pubkey"]?.let { return it.await() }
         val requestId = generateRequestId()
-        val response = sendRequest(requestId, "get_public_key", emptyList())
-        return response
+        return sendRequest(requestId, "get_public_key", emptyList())
     }
 
     actual suspend fun signEvent(eventJson: String): String {
@@ -359,6 +423,14 @@ actual class Nip46Client actual constructor(
                             }
                         }
 
+                        // Pipeline get_public_key: kick it off the instant the
+                        // signer connects so the caller's subsequent
+                        // getPublicKey() returns the cached result instead of
+                        // paying another full signer round trip. putIfAbsent
+                        // guards against duplicate fires when multiple relays
+                        // deliver the same connect event.
+                        prefetchUserPubkey()
+
                         val deferred = pendingRequests["_incoming_connect"]
                         deferred?.complete(eventPubkey)
                         return
@@ -372,6 +444,7 @@ actual class Nip46Client actual constructor(
                             result == nostrConnectSecret
                     if (isConnectResponse) {
                         remoteSignerPubkey = eventPubkey
+                        prefetchUserPubkey()
                         pendingRequests["_incoming_connect"]?.complete(eventPubkey)
                         return
                     }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.jvm.kt
@@ -7,3 +7,5 @@ actual fun browserGoBack() {}
 actual fun browserGoForward() {}
 
 actual fun platformAppOrigin(): String? = null
+
+actual fun clearBrowserUrlQuery() {}

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
@@ -8,3 +8,4 @@ actual fun getPlatform(): Platform = WasmPlatform()
 
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = false
+actual val platformDisplayName: String = "Nostrord Web"

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
@@ -63,6 +63,67 @@ actual class Nip46Client actual constructor(
     }
 
     /**
+     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
+     * one relay's WebSocket is open and the durable response sub is sent.
+     * Remaining relays continue connecting in [clientScope] and are appended
+     * to [relayClients] as they become ready, so the listening sub spans all
+     * relays even when this function has already returned. Throws only if
+     * every relay fails. Single-threaded on WASM — plain counter is fine.
+     */
+    private suspend fun connectRelaysFirstWins(relays: List<String>) {
+        if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
+        val firstReady = CompletableDeferred<Unit>()
+        val total = relays.size
+        var failures = 0
+
+        for (relayUrl in relays) {
+            clientScope.launch {
+                try {
+                    val cleanUrl = relayUrl.trimEnd('/')
+                    val client = NostrGroupClient(cleanUrl)
+                    client.connect { msg -> handleMessage(msg, client) }
+                    client.waitForConnection()
+                    openResponseSubscription(client)
+                    relayClients.add(client)
+                    firstReady.complete(Unit)
+                } catch (_: Exception) {
+                    failures++
+                    if (failures == total && !firstReady.isCompleted) {
+                        firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
+                    }
+                }
+            }
+        }
+
+        firstReady.await()
+    }
+
+    /**
+     * Fire `get_public_key` in the background and cache the in-flight
+     * [CompletableDeferred] under [pendingRequests]'s special slot. Subsequent
+     * calls to [getPublicKey] await this deferred instead of starting a fresh
+     * round trip. Safe to call multiple times.
+     */
+    private fun prefetchUserPubkey() {
+        if (pendingRequests.containsKey("_pending_user_pubkey")) return
+        val deferred = CompletableDeferred<String>()
+        pendingRequests["_pending_user_pubkey"] = deferred
+        clientScope.launch {
+            // No extra timeout here: the signer-side delay is often a user-tap
+            // approval prompt that can legitimately take tens of seconds. The
+            // underlying sendRequest already caps at 120s, which is the right
+            // ceiling for an interactive flow — a 10s wall here would mistake
+            // a slow human for a failed signer and abort the entire login.
+            try {
+                val pk = sendRequest(generateRequestId(), "get_public_key", emptyList())
+                deferred.complete(pk)
+            } catch (e: Exception) {
+                deferred.completeExceptionally(e)
+            }
+        }
+    }
+
+    /**
      * Opens the durable NIP-46 response subscription on [client]. The filter
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
@@ -121,16 +182,15 @@ actual class Nip46Client actual constructor(
         nostrConnectSecret = secret ?: generateRequestId().take(16)
         this.relayUrls = relays.map { it.trimEnd('/') }
 
-        relayClients.addAll(connectRelaysParallel(relays))
-
-        if (relayClients.isEmpty()) {
-            throw Exception("Failed to connect to any relay")
-        }
-        // The durable response subscription opened in connectRelaysParallel
-        // already filters kind:24133 #p:clientPubkey, so it doubles as the
-        // nostrconnect listening sub — no extra REQ needed here.
-
+        // Install the listening deferred BEFORE launching connects so that
+        // handleMessage can complete it as soon as the first relay starts
+        // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
+
+        // Return as soon as one relay is listening. Remaining relays finish
+        // in background; the durable sub on each picks up late-arriving
+        // signer events thanks to the `since = now - 10s` filter.
+        connectRelaysFirstWins(relays)
     }
 
     actual suspend fun awaitIncomingConnection(): String {
@@ -176,9 +236,13 @@ actual class Nip46Client actual constructor(
     }
 
     actual suspend fun getPublicKey(): String {
+        // In the nostrconnect:// flow, handleMessage pre-fires get_public_key
+        // the moment the signer's connect event arrives, so this await almost
+        // always returns the cached result instead of paying another full
+        // signer round trip.
+        pendingRequests["_pending_user_pubkey"]?.let { return it.await() }
         val requestId = generateRequestId()
-        val response = sendRequest(requestId, "get_public_key", emptyList())
-        return response
+        return sendRequest(requestId, "get_public_key", emptyList())
     }
 
     actual suspend fun signEvent(eventJson: String): String {
@@ -341,6 +405,11 @@ actual class Nip46Client actual constructor(
                             } catch (_: Exception) {
                             }
                         }
+                        // Pipeline get_public_key: kick it off the instant the
+                        // signer connects so the caller's subsequent
+                        // getPublicKey() returns the cached result instead of
+                        // paying another full signer round trip.
+                        prefetchUserPubkey()
                         pendingRequests["_incoming_connect"]?.complete(eventPubkey)
                         return
                     }
@@ -352,6 +421,7 @@ actual class Nip46Client actual constructor(
                             result == nostrConnectSecret
                     if (isConnectResponse) {
                         remoteSignerPubkey = eventPubkey
+                        prefetchUserPubkey()
                         pendingRequests["_incoming_connect"]?.complete(eventPubkey)
                         return
                     }

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.wasmJs.kt
@@ -24,3 +24,10 @@ actual fun browserGoForward() {
 private external fun jsGetOrigin(): String
 
 actual fun platformAppOrigin(): String? = jsGetOrigin()
+
+@JsFun("() => window.history.replaceState(null, '', window.location.pathname)")
+private external fun jsClearQuery()
+
+actual fun clearBrowserUrlQuery() {
+    jsClearQuery()
+}


### PR DESCRIPTION
Seven small commits cleaning up the auth, NIP-46, and multi-account flows. The biggest one is the logout/re-login fix: chat history was silently dropped after a logout-then-sign-back-in cycle, and the saved relay could be permanently overwritten. The rest are UX polish (QR shows sooner, per-platform signer labels, accounts surface auth method and kind:0 names) and skipping a useless outbox round trip when generating a fresh identity.

| Commit | Area | What |
|---|---|---|
| 5acbfb5 | nip46 | Show QR after first signer relay connects; pre-fire `get_public_key` |
| 4e6ecec | accounts | Use kind:0 display name in sign-out / remove dialogs |
| d90f240 | auth | Fix four leaks that broke logout → re-login in the same process |
| 44011c8 | web | Clear URL query (`?relay=…&group=…`) on logout so the stale deep link doesn't survive into the next session |
| ec7fa5f | nip46 | Identify build by platform in `nostrconnect://` metadata so signers can revoke per-device |
| eacec12 | accounts | Caption under each account row showing auth method |
| d0782db | login | Skip outbox bootstrap when generating a fresh identity (it can only resolve to empty) |