### PR TITLE
Distinguish grouped messages and stop hover row growth

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -1,11 +1,8 @@
 package org.nostr.nostrord.ui.components.chat
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
@@ -60,8 +57,8 @@ import org.nostr.nostrord.utils.formatTime
  *
  * Spacing:
  * - 72dp total left column (16dp padding + 40dp avatar + 16dp gap)
- * - 16dp first message top padding (start of cluster)
- * - 2dp grouped message gap
+ * - 6dp uniform top/bottom padding on every row (no asymmetric first/last bumps)
+ * - Hairline divider above each grouped message to mark the boundary
  */
 @Composable
 fun MessageItem(
@@ -204,175 +201,185 @@ fun MessageItem(
         animationSpec = if (highlightActive) snap() else tween(durationMillis = 1200),
     )
 
-    Box(
-        modifier =
-        Modifier
-            .fillMaxWidth()
-            .hoverable(interactionSource)
-            // Right-click opens context menu directly (bypasses hover actions)
-            .then(
-                rightClickContextMenuModifier {
-                    showActions = false // Hide hover actions immediately
-                    showContextMenu = true
-                },
-            ).background(
-                when {
-                    showContextMenu -> NostrordColors.SurfaceVariant
-                    isHovered || isPressed -> NostrordColors.MessageHover
-                    else -> highlightColor
-                },
-            ),
-    ) {
-        // Main message content - this defines the Box size
-        Row(
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // Hairline sits outside the hover Box so the hover/highlight background
+        // doesn't extend across the boundary between two grouped messages.
+        // Aligned with the content column (starts after the avatar gutter).
+        if (!isFirstInGroup) {
+            androidx.compose.material3.HorizontalDivider(
+                thickness = Spacing.dividerThickness,
+                color = Color.White.copy(alpha = 0.05f),
+                modifier =
+                Modifier.padding(
+                    start = Spacing.avatarColumnWidth,
+                    end = Spacing.messagePaddingHorizontal,
+                ),
+            )
+        }
+        Box(
             modifier =
             Modifier
                 .fillMaxWidth()
-                .padding(
-                    start = Spacing.messagePaddingHorizontal,
-                    end = Spacing.messagePaddingHorizontal,
-                    top = if (isFirstInGroup) Spacing.messageGroupStart else Spacing.messageGroupGap,
-                    bottom = if (isLastInGroup) Spacing.sm else Spacing.messageGroupGap,
+                .hoverable(interactionSource)
+                // Right-click opens context menu directly (bypasses hover actions)
+                .then(
+                    rightClickContextMenuModifier {
+                        showActions = false // Hide hover actions immediately
+                        showContextMenu = true
+                    },
+                ).background(
+                    when {
+                        showContextMenu -> NostrordColors.SurfaceVariant
+                        isHovered || isPressed -> NostrordColors.MessageHover
+                        else -> highlightColor
+                    },
                 ),
         ) {
-            // Avatar column - 72dp total width
-            Box(
-                modifier = Modifier.width(Spacing.avatarColumnWidth - Spacing.messagePaddingHorizontal),
-                contentAlignment = Alignment.TopStart,
+            // Main message content - this defines the Box size
+            Row(
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = Spacing.messagePaddingHorizontal,
+                        end = Spacing.messagePaddingHorizontal,
+                        top = Spacing.messageGroupGap,
+                        bottom = Spacing.messageGroupGap,
+                    ),
             ) {
-                if (isFirstInGroup) {
-                    Box(
-                        modifier =
-                        Modifier
-                            .size(Spacing.avatarSize)
-                            .clip(CircleShape)
-                            .clickable { currentOnUsernameClick(message.pubkey) }
-                            .pointerHoverIcon(PointerIcon.Hand),
-                    ) {
-                        ProfileAvatar(
-                            imageUrl = metadata?.picture,
-                            displayName = displayName,
-                            pubkey = message.pubkey,
-                            size = Spacing.avatarSize,
-                        )
-                    }
-                } else if (isHovered) {
-                    // Show time on hover for grouped messages
-                    Text(
-                        text = formatTime(message.createdAt),
-                        color = NostrordColors.TextMuted,
-                        style = NostrordTypography.Timestamp,
-                        modifier = Modifier.padding(top = Spacing.xs),
-                    )
-                }
-            }
-
-            Column(modifier = Modifier.weight(1f)) {
-                // Header with name and time - only for first in group
-                if (isFirstInGroup) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = displayName,
-                            color = Color.White,
-                            style = NostrordTypography.Username,
+                // Avatar column - 72dp total width
+                Box(
+                    modifier = Modifier.width(Spacing.avatarColumnWidth - Spacing.messagePaddingHorizontal),
+                    contentAlignment = Alignment.TopStart,
+                ) {
+                    if (isFirstInGroup) {
+                        Box(
                             modifier =
                             Modifier
+                                .size(Spacing.avatarSize)
+                                .clip(CircleShape)
                                 .clickable { currentOnUsernameClick(message.pubkey) }
                                 .pointerHoverIcon(PointerIcon.Hand),
-                        )
-                        Spacer(modifier = Modifier.width(Spacing.sm))
+                        ) {
+                            ProfileAvatar(
+                                imageUrl = metadata?.picture,
+                                displayName = displayName,
+                                pubkey = message.pubkey,
+                                size = Spacing.avatarSize,
+                            )
+                        }
+                    } else if (isHovered) {
+                        // No padding/fixed height: this lives in the main Row, so any
+                        // extra vertical footprint here would grow the row on hover.
                         Text(
                             text = formatTime(message.createdAt),
                             color = NostrordColors.TextMuted,
                             style = NostrordTypography.Timestamp,
                         )
                     }
-                    Spacer(modifier = Modifier.height(Spacing.xs))
                 }
 
-                // Reply preview — shown whenever this message is a reply,
-                // even if the parent hasn't loaded yet (ReplyPreview handles null with a placeholder)
-                if (replyParentId != null) {
-                    ReplyPreview(
-                        parentMessage = resolvedParentMessage,
-                        parentMetadata = parentMetadata,
-                        resolveMetadata = resolveMetadata,
-                        onReplyClick = { onScrollToMessage(replyParentId) },
-                    )
-                    Spacer(modifier = Modifier.height(Spacing.xs))
-                }
+                Column(modifier = Modifier.weight(1f)) {
+                    // Header with name and time - only for first in group
+                    if (isFirstInGroup) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text(
+                                text = displayName,
+                                color = Color.White,
+                                style = NostrordTypography.Username,
+                                modifier =
+                                Modifier
+                                    .clickable { currentOnUsernameClick(message.pubkey) }
+                                    .pointerHoverIcon(PointerIcon.Hand),
+                            )
+                            Spacer(modifier = Modifier.width(Spacing.sm))
+                            Text(
+                                text = formatTime(message.createdAt),
+                                color = NostrordColors.TextMuted,
+                                style = NostrordTypography.Timestamp,
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(Spacing.xs))
+                    }
 
-                // Message content with NIP-30 custom emoji support
-                MessageContent(
-                    content = message.content,
-                    tags = message.tags,
-                    onMentionClick = currentOnUsernameClick,
-                    onHashtagClick = { hashtag ->
-                        // TODO: Implement hashtag click handler (e.g., search for hashtag)
-                    },
-                    currentGroupId = currentGroupId,
-                    currentRelayUrl = currentRelayUrl,
-                    onNavigateToGroup = onNavigateToGroup,
-                )
+                    // Reply preview — shown whenever this message is a reply,
+                    // even if the parent hasn't loaded yet (ReplyPreview handles null with a placeholder)
+                    if (replyParentId != null) {
+                        ReplyPreview(
+                            parentMessage = resolvedParentMessage,
+                            parentMetadata = parentMetadata,
+                            resolveMetadata = resolveMetadata,
+                            onReplyClick = { onScrollToMessage(replyParentId) },
+                        )
+                        Spacer(modifier = Modifier.height(Spacing.xs))
+                    }
 
-                // Reaction badges
-                if (reactions.isNotEmpty()) {
-                    ReactionBadges(
-                        reactions = reactions,
-                        currentUserPubkey = currentUserPubkey,
-                        resolveMetadata = resolveMetadata,
-                        onReactionClick = onReactionBadgeClick,
+                    // Message content with NIP-30 custom emoji support
+                    MessageContent(
+                        content = message.content,
+                        tags = message.tags,
+                        onMentionClick = currentOnUsernameClick,
+                        onHashtagClick = { hashtag ->
+                            // TODO: Implement hashtag click handler (e.g., search for hashtag)
+                        },
+                        currentGroupId = currentGroupId,
+                        currentRelayUrl = currentRelayUrl,
+                        onNavigateToGroup = onNavigateToGroup,
                     )
+
+                    // Reaction badges
+                    if (reactions.isNotEmpty()) {
+                        ReactionBadges(
+                            reactions = reactions,
+                            currentUserPubkey = currentUserPubkey,
+                            resolveMetadata = resolveMetadata,
+                            onReactionClick = onReactionBadgeClick,
+                        )
+                    }
                 }
             }
-        }
 
-        // Overlay layer for hover actions - uses matchParentSize to not affect layout
-        // This Box matches parent size exactly, then positions content inside
-        Box(
-            modifier =
-            Modifier
-                .matchParentSize() // Critical: doesn't affect parent measurement
-                .padding(end = Spacing.sm),
-            contentAlignment = Alignment.TopEnd,
-        ) {
-            // Hover actions - fade in/out without affecting layout
-            androidx.compose.animation.AnimatedVisibility(
-                visible = showActions && !showContextMenu,
-                enter = fadeIn(animationSpec = tween(NostrordAnimation.actionsAppear)),
-                exit = fadeOut(animationSpec = tween(NostrordAnimation.actionsDisappear)),
-            ) {
-                // DisableSelection prevents toolbar from being part of text selection
-                DisableSelection {
-                    MessageActions(
-                        onReplyClick = currentOnReplyClick,
-                        onReactionClick = currentOnReactionClick,
-                        onMoreClick = { showContextMenu = true },
-                    )
+            // matchParentSize keeps this overlay out of parent measurement, so the
+            // row height is identical whether or not the toolbar is showing.
+            if (showActions && !showContextMenu) {
+                Box(
+                    modifier =
+                    Modifier
+                        .matchParentSize()
+                        .padding(end = Spacing.sm),
+                    contentAlignment = Alignment.TopEnd,
+                ) {
+                    DisableSelection {
+                        MessageActions(
+                            onReplyClick = currentOnReplyClick,
+                            onReactionClick = currentOnReactionClick,
+                            onMoreClick = { showContextMenu = true },
+                        )
+                    }
                 }
             }
-        }
 
-        // Context menu - appears on right-click or "More" click
-        // This is a Popup so it floats outside the layout tree
-        MessageContextMenu(
-            visible = showContextMenu,
-            onDismiss = { showContextMenu = false },
-            onAction = { action ->
-                when (action) {
-                    MessageContextAction.AddReaction -> currentOnReactionClick()
-                    MessageContextAction.Reply -> currentOnReplyClick()
-                    MessageContextAction.CopyText -> currentOnCopyText()
-                    MessageContextAction.CopyMessageLink -> currentOnCopyLink()
-                    MessageContextAction.ShareMessageLink -> currentOnShareLink()
-                    MessageContextAction.CopyEventJson -> currentOnCopyJson()
-                    MessageContextAction.PinMessage -> currentOnPinMessage()
-                    MessageContextAction.DeleteMessage -> currentOnDeleteMessage()
-                }
-            },
-            isAuthor = isAuthor,
-            isAdmin = isAdmin,
-        )
+            // Context menu - appears on right-click or "More" click
+            // This is a Popup so it floats outside the layout tree
+            MessageContextMenu(
+                visible = showContextMenu,
+                onDismiss = { showContextMenu = false },
+                onAction = { action ->
+                    when (action) {
+                        MessageContextAction.AddReaction -> currentOnReactionClick()
+                        MessageContextAction.Reply -> currentOnReplyClick()
+                        MessageContextAction.CopyText -> currentOnCopyText()
+                        MessageContextAction.CopyMessageLink -> currentOnCopyLink()
+                        MessageContextAction.ShareMessageLink -> currentOnShareLink()
+                        MessageContextAction.CopyEventJson -> currentOnCopyJson()
+                        MessageContextAction.PinMessage -> currentOnPinMessage()
+                        MessageContextAction.DeleteMessage -> currentOnDeleteMessage()
+                    }
+                },
+                isAuthor = isAuthor,
+                isAdmin = isAdmin,
+            )
+        }
     }
 }
 
@@ -451,7 +458,7 @@ private fun ActionButton(
     Box(
         modifier =
         Modifier
-            .size(28.dp) // Fixed size for touch target
+            .size(Spacing.messageActionButtonSize)
             .clip(NostrordShapes.channelItemShape)
             .background(if (isHovered) NostrordColors.HoverBackground else Color.Transparent)
             .hoverable(interactionSource)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/theme/Spacing.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/theme/Spacing.kt
@@ -65,15 +65,22 @@ object Spacing {
     val avatarColumnWidth: Dp = 72.dp
 
     /**
-     * Space between grouped messages (same author).
-     * Very tight spacing for grouped messages.
+     * Vertical padding applied uniformly to the top and bottom of every message row.
+     * Combined with the hairline divider above grouped messages, this gives a
+     * consistent rhythm regardless of whether the message starts a new cluster.
      */
-    val messageGroupGap: Dp = 2.dp
+    val messageGroupGap: Dp = 6.dp
 
     /**
      * Space above first message in a new group.
      */
     val messageGroupStart: Dp = 16.dp
+
+    /**
+     * Hover toolbar action button size. Kept at one text line's height so the
+     * toolbar never looks larger than the message line it overlays.
+     */
+    val messageActionButtonSize: Dp = 22.dp
 
     /**
      * Channel list item horizontal padding.


### PR DESCRIPTION
Consecutive messages from the same author were impossible to tell apart without hovering — a blank line and a wrapped continuation looked identical. This adds a hairline divider above each grouped (non-first) message and switches to uniform 6dp top/bottom padding on every row, so each message reads as a distinct line regardless of grouping. Closes #57.

While testing this, hovering a short message visibly stretched its row. The cause was the hover-only timestamp rendered in the avatar column: it carried a top padding that pushed its vertical footprint past the content text's line height, and since the avatar column is part of the main row (not the floating action overlay), that extra height grew the row. The timestamp now renders as plain text that stays within the line, and the hover toolbar buttons are sized to a single line-height so the overlay never appears taller than the message it sits on.

Not addressed here: every `MessageItem` in the list subscribes to the shared `cachedEvents` flow even when the message isn't a reply, so a cache write re-derives parent lookups list-wide. Pre-existing, left for a follow-up.