### PR TITLE
fix(share): put relay pubkey in group naddr author

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
@@ -8,12 +8,15 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.util.buildGroupNaddr
 import org.nostr.nostrord.ui.util.buildShareGroupLink
@@ -27,8 +30,11 @@ fun ShareGroupModal(
     groupId: String,
     onDismiss: () -> Unit,
 ) {
+    val relayMetadata by AppModule.nostrRepository.relayMetadata.collectAsState()
+    val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
+
     val link = buildShareGroupLink(relayUrl, groupId)
-    val naddr = buildGroupNaddr(relayUrl, groupId)
+    val naddr = buildGroupNaddr(relayUrl, groupId, relayPubkey)
     val copyToClipboard = rememberClipboardWriter()
     val shareText = rememberTextSharer()
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/util/ShareLinks.kt
@@ -36,4 +36,5 @@ fun buildShareMessageLink(
 fun buildGroupNaddr(
     relayUrl: String,
     groupId: String,
-): String = "nostr:" + Nip19.encodeNaddr(identifier = groupId, relay = relayUrl, kind = 39000)
+    relayPubkey: String? = null,
+): String = "nostr:" + Nip19.encodeNaddr(identifier = groupId, relay = relayUrl, kind = 39000, pubkeyHex = relayPubkey)


### PR DESCRIPTION
The Share Group modal's `naddr` always carried an all-zeros author. `buildGroupNaddr` called `Nip19.encodeNaddr` without `pubkeyHex`, so the author TLV fell back to 32 zero bytes every time — even though `encodeNaddr` already accepted the relay's NIP-11 pubkey.

`ShareGroupModal` now reads the relay's pubkey from `relayMetadata` (NIP-11) and threads it through `buildGroupNaddr`. The author resolves to the real relay key when the relay advertises `pubkey` in its NIP-11 doc; it gracefully stays zero otherwise. Group resolution itself is unchanged (NIP-29 addresses by relay + `d` tag, not author).

| File | Change |
|---|---|
| `ui/util/ShareLinks.kt` | `buildGroupNaddr` takes `relayPubkey` and passes it as `pubkeyHex` |
| `ui/screens/group/components/ShareGroupModal.kt` | resolves `relayMetadata[relayUrl]?.pubkey` and passes it in |

- fix(share): put relay pubkey in group naddr author