### PR TITLE
fix(web): hide HTML media overlays when emoji pickers open

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -157,6 +157,7 @@ fun GroupScreen(
     var showMemberManagementModal by remember { mutableStateOf(false) }
     var showInviteCodesModal by remember { mutableStateOf(false) }
     var showCreateSubgroupModal by remember { mutableStateOf(false) }
+    var inputOverlayOpen by remember { mutableStateOf(false) }
     var createdInviteCode by remember { mutableStateOf<String?>(null) }
     var resolvedRequestPubkeys by remember(groupId) { mutableStateOf(emptySet<String>()) }
     val isJoined =
@@ -702,7 +703,8 @@ fun GroupScreen(
             showMemberSheet ||
             memberToRemove != null ||
             showJoinRequestsModal ||
-            showInviteCodesModal
+            showInviteCodesModal ||
+            inputOverlayOpen
     CompositionLocalProvider(LocalAnimatedImageHidden provides anyDialogOpen) {
         BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
             val isCompact = !forceDesktop
@@ -811,6 +813,7 @@ fun GroupScreen(
                     targetMessageId = targetMessageId,
                     onTargetConsumed = onTargetMessageConsumed,
                     onFetchTargetById = { id -> vm.fetchMessageById(id) },
+                    onInputOverlayVisibilityChange = { inputOverlayOpen = it },
                 )
             } else {
                 GroupScreenDesktop(
@@ -918,6 +921,7 @@ fun GroupScreen(
                     targetMessageId = targetMessageId,
                     onTargetConsumed = onTargetMessageConsumed,
                     onFetchTargetById = { id -> vm.fetchMessageById(id) },
+                    onInputOverlayVisibilityChange = { inputOverlayOpen = it },
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -119,6 +119,7 @@ fun GroupScreenDesktop(
     targetMessageId: String? = null,
     onTargetConsumed: () -> Unit = {},
     onFetchTargetById: (String) -> Unit = {},
+    onInputOverlayVisibilityChange: (Boolean) -> Unit = {},
 ) {
     Row(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -233,6 +234,7 @@ fun GroupScreenDesktop(
                 onCancelReply = onCancelReply,
                 isSending = isSending,
                 onMediaUploaded = onMediaUploaded,
+                onOverlayVisibilityChange = onInputOverlayVisibilityChange,
             )
         }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -145,6 +145,7 @@ fun GroupScreenMobile(
     targetMessageId: String? = null,
     onTargetConsumed: () -> Unit = {},
     onFetchTargetById: (String) -> Unit = {},
+    onInputOverlayVisibilityChange: (Boolean) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
     var showMemberSheet by remember { mutableStateOf(false) }
@@ -279,6 +280,7 @@ fun GroupScreenMobile(
                         onCancelReply = onCancelReply,
                         isSending = isSending,
                         onMediaUploaded = onMediaUploaded,
+                        onOverlayVisibilityChange = onInputOverlayVisibilityChange,
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -90,6 +90,7 @@ fun MessageInput(
     onCancelReply: () -> Unit = {},
     isSending: Boolean = false,
     onMediaUploaded: (UploadResult) -> Unit = {},
+    onOverlayVisibilityChange: (Boolean) -> Unit = {},
 ) {
     val scope = rememberCoroutineScope()
     val clipboardReader = rememberClipboardImageReader()
@@ -105,6 +106,11 @@ fun MessageInput(
     var groupMentionQuery by remember { mutableStateOf("") }
     var groupMentionSelectedIndex by remember { mutableStateOf(0) }
     var showEmojiPicker by remember { mutableStateOf(false) }
+    val anyOverlayOpen = showMentionPopup || showGroupMentionPopup || showEmojiPicker
+    val currentOnOverlayVisibilityChange by rememberUpdatedState(onOverlayVisibilityChange)
+    LaunchedEffect(anyOverlayOpen) {
+        currentOnOverlayVisibilityChange(anyOverlayOpen)
+    }
     val focusRequester = remember { FocusRequester() }
     val showEmojiButton = remember {
         val platform = getPlatform().name

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -329,7 +329,7 @@ fun MessagesList(
     }
 
     CompositionLocalProvider(
-        LocalAnimatedImageHidden provides (parentHidden || imageViewerUrl.value != null),
+        LocalAnimatedImageHidden provides (parentHidden || imageViewerUrl.value != null || reactingToMessageId != null),
         LocalImageViewerUrl provides imageViewerUrl,
     ) {
         when {


### PR DESCRIPTION
On web, chat `<img>`/`<video>` are mounted as HTML elements above the Compose canvas (via `WebElementView`) and only disappear when `LocalAnimatedImageHidden` is set. The reaction picker and the input emoji/mention popups never toggled that signal, so HTML media in messages rendered on top of the picker overlay instead of behind it.

This wires both pickers into the existing hide signal: the reaction picker via `MessagesList`'s `LocalAnimatedImageHidden` provider, and the input popups via a new `onOverlayVisibilityChange` callback hoisted up to `GroupScreen`'s `anyDialogOpen`.

| Surface | Before | After |
|---|---|---|
| Reaction emoji picker | HTML media bleeds over picker | media hidden while picker open |
| Input emoji / mention popups | HTML media bleeds over popup | media hidden while popup open |

Commits:
- fix(web): hide HTML media overlays when emoji pickers open