### PR TITLE
Android polish: context menu, mention autocomplete, swipe gestures

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.android.kt
@@ -1,0 +1,3 @@
+package org.nostr.nostrord.ui.components.chat
+
+actual val messagesTextSelectionEnabled: Boolean = false

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.android.kt
@@ -5,5 +5,5 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 
 actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier = Modifier.pointerInput(onRightClick) {
-    detectTapGestures(onLongPress = { onRightClick() })
+    detectTapGestures(onTap = { onRightClick() })
 }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.android.kt
@@ -9,3 +9,6 @@ actual fun browserGoForward() {}
 actual fun platformAppOrigin(): String? = null
 
 actual fun clearBrowserUrlQuery() {}
+
+// Native uses the Compose ancestor gesture in App.kt; nothing to register here.
+actual fun registerLeftEdgeSwipeToOpen(onOpen: () -> Unit): () -> Unit = {}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -26,6 +27,9 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChangeIgnoreConsumed
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -58,6 +62,7 @@ import org.nostr.nostrord.ui.navigation.browserGoBack
 import org.nostr.nostrord.ui.navigation.browserGoForward
 import org.nostr.nostrord.ui.navigation.clearBrowserUrlQuery
 import org.nostr.nostrord.ui.navigation.platformHasBrowserNavigation
+import org.nostr.nostrord.ui.navigation.registerLeftEdgeSwipeToOpen
 import org.nostr.nostrord.ui.screens.backup.BackupScreen
 import org.nostr.nostrord.ui.screens.group.GroupScreen
 import org.nostr.nostrord.ui.screens.group.components.CreateGroupModal
@@ -71,6 +76,7 @@ import org.nostr.nostrord.ui.screens.relay.AddRelayModal
 import org.nostr.nostrord.ui.screens.settings.SettingsScreen
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.window.LocalDesktopWindowControls
+import kotlin.math.abs
 
 /**
  * Main application entry point.
@@ -749,6 +755,21 @@ private fun AuthenticatedApp(
                 }
             } else {
                 val onOpenDrawer: () -> Unit = { scope.launch { drawerState.open() } }
+                // Web-only raw-JS left-edge swipe to open the drawer (issue #77). The
+                // Compose ancestor gesture below loses the drag to the chat's scrollable
+                // on mobile browsers, so a window-level capture-phase touch listener wins
+                // the gesture before Compose. No-op on native (they keep the Compose
+                // gesture). Only fires when closed so it can't fight the drawer's own
+                // reverse-swipe-to-close.
+                DisposableEffect(Unit) {
+                    val dispose =
+                        registerLeftEdgeSwipeToOpen {
+                            if (drawerState.targetValue == DrawerValue.Closed) {
+                                scope.launch { drawerState.open() }
+                            }
+                        }
+                    onDispose { dispose() }
+                }
                 ModalNavigationDrawer(
                     drawerState = drawerState,
                     drawerContent = {
@@ -824,29 +845,94 @@ private fun AuthenticatedApp(
                             showMeMenu ||
                             showAddAccount
                     CompositionLocalProvider(LocalAnimatedImageHidden provides hideAnimatedImages) {
-                        MobileContent(
-                            currentScreen = currentScreen,
-                            selectedRelayUrl = selectedRelayUrl,
-                            homeGridState = homeGridState,
-                            onNavigate = onNavigate,
-                            onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
-                            onOpenGroupAtRelay = onOpenGroupAtRelay,
-                            onCreateGroupClick = { showCreateGroupModal = true },
-                            hasNoRelays = hasNoRelays,
-                            onAddRelay = {
-                                addRelayInitialTab = 0
-                                showAddRelayModal = true
-                            },
-                            onAddRelayCustomUrl = {
-                                addRelayInitialTab = 1
-                                showAddRelayModal = true
-                            },
-                            onOpenDrawer = onOpenDrawer,
-                            pendingInviteCode = pendingInviteCode,
-                            onInviteCodeConsumed = { pendingInviteCode = null },
-                            pendingMessageId = pendingMessageId,
-                            onMessageIdConsumed = { pendingMessageId = null },
-                        )
+                        // Left-edge swipe opens the drawer (issue #77). Detected on the Initial
+                        // pass from an ancestor of the screen content so it pre-empts inner
+                        // scrollables (e.g. the group chat list) that otherwise swallow the drag
+                        // on some mobile browsers. The top menu button still works; reverse-swipe
+                        // close stays with the drawer's built-in gesture.
+                        Box(
+                            modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .pointerInput(Unit) {
+                                    val edgeWidthPx = 24.dp.toPx()
+                                    // Claim threshold: well below the LazyColumn's touch slop
+                                    // (~18dp) so the ancestor wins the gesture before the chat
+                                    // scrollable can start dragging. Detection uses
+                                    // positionChangeIgnoreConsumed() so a child consuming the
+                                    // change on a prior Main pass can't zero out our delta.
+                                    val claimX = 10.dp.toPx()
+                                    val abortY = 14.dp.toPx()
+                                    awaitPointerEventScope {
+                                        while (true) {
+                                            val down =
+                                                awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
+                                            if (down.position.x > edgeWidthPx ||
+                                                drawerState.targetValue != DrawerValue.Closed
+                                            ) {
+                                                continue
+                                            }
+                                            var totalX = 0f
+                                            var totalY = 0f
+                                            var triggered = false
+                                            while (true) {
+                                                val event = awaitPointerEvent(PointerEventPass.Initial)
+                                                val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                                                if (triggered) {
+                                                    change.consume()
+                                                } else {
+                                                    // Ignore-consumed: detect raw movement even if the
+                                                    // chat scrollable already consumed this change on a
+                                                    // previous pass. We still decide consumption below.
+                                                    val delta = change.positionChangeIgnoreConsumed()
+                                                    totalX += delta.x
+                                                    totalY += delta.y
+                                                    // Clearly vertical first → release to the chat list so
+                                                    // a left-edge vertical scroll still works. Only abort
+                                                    // once Y movement is meaningful, so coarse coalesced
+                                                    // moves (Brave on Android) whose first sample carries a
+                                                    // little Y drift don't abort a real horizontal swipe.
+                                                    if (totalY < -abortY || (totalY > abortY && totalY > abs(totalX))) {
+                                                        break
+                                                    }
+                                                    // Clearly rightward → claim immediately, consuming on
+                                                    // the Initial pass so the inner scrollable never starts.
+                                                    if (totalX > claimX && totalX > abs(totalY)) {
+                                                        triggered = true
+                                                        change.consume()
+                                                        onOpenDrawer()
+                                                    }
+                                                }
+                                                if (!change.pressed) break
+                                            }
+                                        }
+                                    }
+                                },
+                        ) {
+                            MobileContent(
+                                currentScreen = currentScreen,
+                                selectedRelayUrl = selectedRelayUrl,
+                                homeGridState = homeGridState,
+                                onNavigate = onNavigate,
+                                onNavigateToGroupWithRelay = onNavigateToGroupWithRelay,
+                                onOpenGroupAtRelay = onOpenGroupAtRelay,
+                                onCreateGroupClick = { showCreateGroupModal = true },
+                                hasNoRelays = hasNoRelays,
+                                onAddRelay = {
+                                    addRelayInitialTab = 0
+                                    showAddRelayModal = true
+                                },
+                                onAddRelayCustomUrl = {
+                                    addRelayInitialTab = 1
+                                    showAddRelayModal = true
+                                },
+                                onOpenDrawer = onOpenDrawer,
+                                pendingInviteCode = pendingInviteCode,
+                                onInviteCodeConsumed = { pendingInviteCode = null },
+                                pendingMessageId = pendingMessageId,
+                                onMessageIdConsumed = { pendingMessageId = null },
+                            )
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -193,11 +193,14 @@ fun MessageItem(
     val isHovered by interactionSource.collectIsHoveredAsState()
     val isPressed by interactionSource.collectIsPressedAsState()
 
-    // Delayed hover state for actions toolbar (50ms delay)
-    // On mobile (touch), show actions immediately on press
+    // Delayed hover state for actions toolbar (50ms delay). This is a desktop-only
+    // pointer affordance: on touch/compact layouts (Android, iOS, narrow web) a tap
+    // would otherwise register as a press and trip it. Those layouts use tap (context
+    // menu) and swipe (reply) instead, so the toolbar is suppressed there — gated by
+    // swipeToReplyEnabled, the same compact-layout signal.
     var showActions by remember { mutableStateOf(false) }
-    LaunchedEffect(isHovered, isPressed) {
-        if (isHovered || isPressed) {
+    LaunchedEffect(isHovered, isPressed, swipeToReplyEnabled) {
+        if (!swipeToReplyEnabled && (isHovered || isPressed)) {
             delay(NostrordAnimation.hoverActionsDelay.toLong())
             showActions = true
         } else {
@@ -290,7 +293,9 @@ fun MessageItem(
             ).background(
                 when {
                     isContextMenuOpen -> NostrordColors.SurfaceVariant
-                    isHovered || isPressed -> NostrordColors.MessageHover
+                    // Hover tint is a desktop-only pointer affordance; a touch tap fires
+                    // isPressed too, so suppress it in compact/touch layouts.
+                    !swipeToReplyEnabled && (isHovered || isPressed) -> NostrordColors.MessageHover
                     else -> highlightColor
                 },
             ),

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -2,12 +2,15 @@ package org.nostr.nostrord.ui.components.chat
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -29,16 +32,25 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
@@ -50,6 +62,8 @@ import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.utils.formatTime
+import kotlin.math.abs
+import kotlin.math.roundToInt
 
 /**
  * Enhanced message item with grouping support and hover actions.
@@ -93,6 +107,7 @@ fun MessageItem(
     isHighlighted: Boolean = false,
     isContextMenuOpen: Boolean = false,
     onContextMenuOpenChange: (Boolean) -> Unit = {},
+    swipeToReplyEnabled: Boolean = false,
 ) {
     // Use rememberUpdatedState to avoid recomposition when callbacks change reference
     val currentOnUsernameClick by rememberUpdatedState(onUsernameClick)
@@ -203,6 +218,18 @@ fun MessageItem(
         animationSpec = if (highlightActive) snap() else tween(durationMillis = 1200),
     )
 
+    // Swipe-to-reply (touch layouts only): drag the message left to reveal a reply
+    // affordance; releasing past the threshold enters reply mode and focuses the input.
+    // Left direction is deliberate so it doesn't fight the left-edge swipe that opens
+    // the side menu (that gesture pulls content the other way).
+    val swipeScope = rememberCoroutineScope()
+    val haptics = LocalHapticFeedback.current
+    val density = LocalDensity.current
+    val swipeOffset = remember { Animatable(0f) }
+    val triggerPx = with(density) { 56.dp.toPx() }
+    val maxOffsetPx = with(density) { 80.dp.toPx() }
+    var swipeArmed by remember { mutableStateOf(false) }
+
     Box(
         modifier =
         Modifier
@@ -215,6 +242,51 @@ fun MessageItem(
                     showActions = false // Hide hover actions immediately
                     onContextMenuOpenChange(true)
                 },
+            ).then(
+                if (swipeToReplyEnabled) {
+                    Modifier.pointerInput(Unit) {
+                        val touchSlop = viewConfiguration.touchSlop
+                        awaitEachGesture {
+                            val down = awaitFirstDown(requireUnconsumed = false)
+                            var totalX = 0f
+                            var totalY = 0f
+                            var claimed = false
+                            var offset = 0f
+                            while (true) {
+                                val event = awaitPointerEvent()
+                                val change = event.changes.firstOrNull { it.id == down.id }
+                                if (change == null || !change.pressed) break
+                                val delta = change.positionChange()
+                                if (!claimed) {
+                                    totalX += delta.x
+                                    totalY += delta.y
+                                    // Vertical intent → let the list scroll; never consume.
+                                    if (abs(totalY) > touchSlop && abs(totalY) >= abs(totalX)) break
+                                    // Rightward intent → let the left-edge swipe open the side menu.
+                                    if (totalX >= touchSlop) break
+                                    // Leftward past slop → this is a reply swipe; claim it.
+                                    if (totalX <= -touchSlop) claimed = true
+                                }
+                                if (claimed) {
+                                    change.consume()
+                                    offset = (offset + delta.x).coerceIn(-maxOffsetPx, 0f)
+                                    swipeScope.launch { swipeOffset.snapTo(offset) }
+                                    if (!swipeArmed && offset <= -triggerPx) {
+                                        swipeArmed = true
+                                        haptics.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    } else if (swipeArmed && offset > -triggerPx) {
+                                        swipeArmed = false
+                                    }
+                                }
+                            }
+                            if (claimed && offset <= -triggerPx) currentOnReplyClick()
+                            swipeArmed = false
+                            swipeScope.launch { swipeOffset.animateTo(0f) }
+                        }
+                    }
+                } else {
+                    Modifier
+                },
             ).background(
                 when {
                     isContextMenuOpen -> NostrordColors.SurfaceVariant
@@ -223,11 +295,26 @@ fun MessageItem(
                 },
             ),
     ) {
+        // Reply affordance revealed underneath the message as it slides left.
+        if (swipeToReplyEnabled && swipeOffset.value < 0f) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.Reply,
+                contentDescription = null,
+                tint = if (swipeArmed) NostrordColors.Primary else NostrordColors.TextMuted,
+                modifier =
+                Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = Spacing.messagePaddingHorizontal)
+                    .size(24.dp)
+                    .alpha((-swipeOffset.value / triggerPx).coerceIn(0f, 1f)),
+            )
+        }
         // Main message content - this defines the Box size
         Row(
             modifier =
             Modifier
                 .fillMaxWidth()
+                .offset { IntOffset(swipeOffset.value.roundToInt(), 0) }
                 .padding(
                     start = Spacing.messagePaddingHorizontal,
                     end = Spacing.messagePaddingHorizontal,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -56,7 +56,7 @@ import org.nostr.nostrord.utils.formatTime
  *
  * Interaction behavior:
  * - Desktop: hover shows action toolbar; right-click opens context menu
- * - Android: long-press opens context menu directly
+ * - Mobile (Android / touch web): single tap opens the context menu directly
  *
  * Spacing:
  * - 72dp total left column (16dp padding + 40dp avatar + 16dp gap)
@@ -91,6 +91,8 @@ fun MessageItem(
     onScrollToMessage: (String) -> Unit = {},
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     isHighlighted: Boolean = false,
+    isContextMenuOpen: Boolean = false,
+    onContextMenuOpenChange: (Boolean) -> Unit = {},
 ) {
     // Use rememberUpdatedState to avoid recomposition when callbacks change reference
     val currentOnUsernameClick by rememberUpdatedState(onUsernameClick)
@@ -188,9 +190,6 @@ fun MessageItem(
         }
     }
 
-    // Context menu state
-    var showContextMenu by remember { mutableStateOf(false) }
-
     var highlightActive by remember(isHighlighted) { mutableStateOf(isHighlighted) }
     LaunchedEffect(isHighlighted) {
         if (isHighlighted) {
@@ -209,15 +208,16 @@ fun MessageItem(
         Modifier
             .fillMaxWidth()
             .hoverable(interactionSource)
-            // Right-click opens context menu directly (bypasses hover actions)
+            // Tap (mobile) / right-click (desktop) opens the context menu directly.
+            // Closing is handled by the menu's full-screen scrim (see MessageContextMenu).
             .then(
                 rightClickContextMenuModifier {
                     showActions = false // Hide hover actions immediately
-                    showContextMenu = true
+                    onContextMenuOpenChange(true)
                 },
             ).background(
                 when {
-                    showContextMenu -> NostrordColors.SurfaceVariant
+                    isContextMenuOpen -> NostrordColors.SurfaceVariant
                     isHovered || isPressed -> NostrordColors.MessageHover
                     else -> highlightColor
                 },
@@ -338,7 +338,7 @@ fun MessageItem(
         ) {
             // Hover actions - fade in/out without affecting layout
             androidx.compose.animation.AnimatedVisibility(
-                visible = showActions && !showContextMenu,
+                visible = showActions && !isContextMenuOpen,
                 enter = fadeIn(animationSpec = tween(NostrordAnimation.actionsAppear)),
                 exit = fadeOut(animationSpec = tween(NostrordAnimation.actionsDisappear)),
             ) {
@@ -347,7 +347,7 @@ fun MessageItem(
                     MessageActions(
                         onReplyClick = currentOnReplyClick,
                         onReactionClick = currentOnReactionClick,
-                        onMoreClick = { showContextMenu = true },
+                        onMoreClick = { onContextMenuOpenChange(true) },
                     )
                 }
             }
@@ -356,8 +356,8 @@ fun MessageItem(
         // Context menu - appears on right-click or "More" click
         // This is a Popup so it floats outside the layout tree
         MessageContextMenu(
-            visible = showContextMenu,
-            onDismiss = { showContextMenu = false },
+            visible = isContextMenuOpen,
+            onDismiss = { onContextMenuOpenChange(false) },
             onAction = { action ->
                 when (action) {
                     MessageContextAction.AddReaction -> currentOnReactionClick()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.kt
@@ -1,0 +1,26 @@
+package org.nostr.nostrord.ui.components.chat
+
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.runtime.Composable
+
+/**
+ * Whether messages should support native text selection.
+ *
+ * Enabled on desktop (mouse-driven) where drag-to-select is the norm. Disabled on
+ * mobile (Android, iOS, and coarse-pointer web) so a long-press shows only the app
+ * context menu instead of stacking the native "Copy / Select all" toolbar on top.
+ */
+expect val messagesTextSelectionEnabled: Boolean
+
+/**
+ * Wraps [content] in a [SelectionContainer] only when [messagesTextSelectionEnabled].
+ * On mobile it is a pass-through, which disables native text selection for messages.
+ */
+@Composable
+fun MessageSelectionContainer(content: @Composable () -> Unit) {
+    if (messagesTextSelectionEnabled) {
+        SelectionContainer { content() }
+    } else {
+        content()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
  *
  * Platform behavior:
  * - Desktop (JVM): right-click via PointerEvent secondary button
- * - Android: long-press via detectTapGestures
+ * - Android: single tap via detectTapGestures
  * - iOS: no-op (context menu accessed via "More" button)
  * - Web (JS/WasmJS): contextmenu event
  */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.kt
@@ -34,3 +34,23 @@ expect fun platformAppOrigin(): String?
  * No-op on native platforms.
  */
 expect fun clearBrowserUrlQuery()
+
+/**
+ * Register a web-only raw touch listener that opens the navigation drawer on a
+ * left-edge left-to-right swipe (issue #77).
+ *
+ * On JS/WasmJS this attaches `touchstart`/`touchmove`/`touchend` listeners on
+ * `window` in the CAPTURE phase with `{ passive: false }`, so the gesture is
+ * detected before it reaches the Compose canvas — the Compose pointer-pass
+ * approach loses this race over the scrolling chat list on mobile browsers.
+ * Only horizontal swipes that START within ~24px of the left edge act; vertical
+ * scrolls and non-edge touches are left untouched so chat scrolling, the
+ * scroll-to-bottom FAB, message taps, and the right-edge member-sheet swipe all
+ * keep working. When triggered it calls [onOpen] once and preventDefault's the
+ * gesture so Compose doesn't double-handle it.
+ *
+ * No-op on native platforms (they use the Compose ancestor gesture in App.kt).
+ *
+ * @return a dispose lambda that removes the listeners.
+ */
+expect fun registerLeftEdgeSwipeToOpen(onOpen: () -> Unit): () -> Unit

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -2,7 +2,7 @@ package org.nostr.nostrord.ui.screens.group
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -57,6 +58,7 @@ import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.utils.rememberClipboardWriter
+import kotlin.math.abs
 
 /**
  * Mobile group screen with gesture navigation.
@@ -150,9 +152,6 @@ fun GroupScreenMobile(
     var showMemberSheet by remember { mutableStateOf(false) }
     val memberSheetState = rememberModalBottomSheetState()
 
-    var dragStartX by remember { mutableStateOf(0f) }
-    var isDragging by remember { mutableStateOf(false) }
-
     val parentHidden = LocalAnimatedImageHidden.current
     CompositionLocalProvider(LocalAnimatedImageHidden provides (parentHidden || showMemberSheet)) {
         Scaffold(
@@ -190,30 +189,37 @@ fun GroupScreenMobile(
                     .fillMaxSize()
                     .padding(paddingValues)
                     .pointerInput(Unit) {
-                        detectHorizontalDragGestures(
-                            onDragStart = { offset ->
-                                dragStartX = offset.x
-                                isDragging = true
-                            },
-                            onDragEnd = {
-                                isDragging = false
-                            },
-                            onDragCancel = {
-                                isDragging = false
-                            },
-                            onHorizontalDrag = { change, dragAmount ->
-                                change.consume()
-                                val screenWidth = size.width.toFloat()
-                                val edgeThreshold = screenWidth * 0.15f // 15% of screen width
-                                val swipeThreshold = 100f // Minimum drag distance
-
-                                // Swipe left from right edge -> open member sheet
-                                if (dragStartX > screenWidth - edgeThreshold && dragAmount < -swipeThreshold) {
-                                    showMemberSheet = true
-                                    isDragging = false
+                        // Right-edge leftward swipe opens the member sheet. Custom gesture
+                        // (not detectHorizontalDragGestures) so it only claims/consumes drags
+                        // that start at the right edge — left-edge drags stay free for the
+                        // nav-drawer swipe handled in App.kt (issue #77). Kept as a Box modifier,
+                        // not an overlay, so it never blocks the scroll-to-bottom button.
+                        val rightZonePx = size.width * 0.15f
+                        awaitPointerEventScope {
+                            while (true) {
+                                val down = awaitFirstDown(requireUnconsumed = false)
+                                if (down.position.x < size.width - rightZonePx) continue
+                                var totalX = 0f
+                                var totalY = 0f
+                                var triggered = false
+                                while (true) {
+                                    val event = awaitPointerEvent()
+                                    val change = event.changes.firstOrNull { it.id == down.id } ?: break
+                                    if (triggered) {
+                                        change.consume()
+                                    } else {
+                                        totalX += change.positionChange().x
+                                        totalY += change.positionChange().y
+                                        if (totalX < -80f && -totalX > abs(totalY)) {
+                                            triggered = true
+                                            change.consume()
+                                            showMemberSheet = true
+                                        }
+                                    }
+                                    if (!change.pressed) break
                                 }
-                            },
-                        )
+                            }
+                        }
                     },
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -259,6 +259,7 @@ fun GroupScreenMobile(
                             targetMessageId = targetMessageId,
                             onTargetConsumed = onTargetConsumed,
                             onFetchTargetById = onFetchTargetById,
+                            swipeToReplyEnabled = true,
                         )
                     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
@@ -180,6 +181,18 @@ fun MessageInput(
         return Pair(triggerIndex, queryPart)
     }
 
+    // The Android IME can briefly report a stale/zeroed cursor while composing,
+    // which makes findMentionContext fail for one frame. As long as the trigger
+    // token still runs unbroken to the end of the text, treat the mention as
+    // active so the popup doesn't flicker closed mid-typing.
+    fun triggerStillActive(text: String, startIndex: Int, trigger: Char): Boolean {
+        if (startIndex < 0 || startIndex >= text.length || text[startIndex] != trigger) return false
+        val charBefore = text.getOrNull(startIndex - 1)
+        if (charBefore != null && !charBefore.isWhitespace()) return false
+        val token = text.substring(startIndex + 1)
+        return !token.contains(' ') && !token.contains('\n')
+    }
+
     fun updateMentionState(value: TextFieldValue) {
         val (index, query) = findMentionContext(value.text, value.selection.start, '@')
         if (index >= 0) {
@@ -188,6 +201,10 @@ fun MessageInput(
             showEmojiPicker = false
             mentionStartIndex = index
             mentionQuery = query
+        } else if (showMentionPopup && triggerStillActive(value.text, mentionStartIndex, '@')) {
+            val token = value.text.substring(mentionStartIndex + 1)
+            if (mentionQuery != token) mentionSelectedIndex = 0
+            mentionQuery = token
         } else {
             showMentionPopup = false
             mentionStartIndex = -1
@@ -203,6 +220,10 @@ fun MessageInput(
             showEmojiPicker = false
             groupMentionStartIndex = index
             groupMentionQuery = query
+        } else if (showGroupMentionPopup && triggerStillActive(value.text, groupMentionStartIndex, '%')) {
+            val token = value.text.substring(groupMentionStartIndex + 1)
+            if (groupMentionQuery != token) groupMentionSelectedIndex = 0
+            groupMentionQuery = token
         } else {
             showGroupMentionPopup = false
             groupMentionStartIndex = -1
@@ -339,6 +360,20 @@ fun MessageInput(
         }
     } else {
         val textFieldInteractionSource = remember { MutableInteractionSource() }
+        val isAndroid = remember { getPlatform().name.startsWith("Android") }
+
+        // Keep a stable VisualTransformation instance: rebuilding it on every
+        // recomposition restarts the Android IME input session, which drops the
+        // character being typed while the mention popup is open.
+        val emojiFontFamily = rememberEmojiFontFamily()
+        val mentionVisualTransformation = remember(mentions.keys, groupMentions.keys, emojiFontFamily) {
+            MentionVisualTransformation(
+                mentionedNames = mentions.keys,
+                mentionColor = NostrordColors.MentionText,
+                emojiFontFamily = emojiFontFamily,
+                groupMentionedNames = groupMentions.keys,
+            )
+        }
 
         Column(
             modifier = Modifier.fillMaxWidth(),
@@ -350,6 +385,59 @@ fun MessageInput(
                     userMetadata = userMetadata,
                     onCancelReply = onCancelReply,
                 )
+            }
+
+            // On Android the suggestion list is rendered INLINE (same window) rather
+            // than in a Popup. A Popup is a separate Android window: adding/removing it
+            // (or the soft keyboard gaining/losing focus to it) restarts the IME
+            // InputConnection on the focused TextField, which drops the composing
+            // character. Because the popup toggled on every keystroke, this produced
+            // the "every other character eaten + popup flicker" symptom. Rendering the
+            // list in the same window leaves the IME input connection untouched.
+            // canFocus = false keeps the list (whose items are clickable/focusable)
+            // from stealing focus away from the TextField while typing.
+            if (isAndroid &&
+                showMentionPopup &&
+                groupMembers.isNotEmpty() &&
+                getFilteredMembers(groupMembers, mentionQuery).isNotEmpty()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .focusProperties { canFocus = false }
+                        .fillMaxWidth()
+                        .heightIn(max = 240.dp)
+                        .padding(horizontal = Spacing.lg),
+                ) {
+                    MentionPopup(
+                        members = groupMembers,
+                        query = mentionQuery,
+                        selectedIndex = mentionSelectedIndex,
+                        onMemberSelect = { handleMemberSelect(it) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+
+            if (isAndroid &&
+                showGroupMentionPopup &&
+                availableGroups.isNotEmpty() &&
+                getFilteredGroups(availableGroups, groupMentionQuery).isNotEmpty()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .focusProperties { canFocus = false }
+                        .fillMaxWidth()
+                        .heightIn(max = 240.dp)
+                        .padding(horizontal = Spacing.lg),
+                ) {
+                    GroupMentionPopup(
+                        groups = availableGroups,
+                        query = groupMentionQuery,
+                        selectedIndex = groupMentionSelectedIndex,
+                        onGroupSelect = { handleGroupSelect(it) },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
 
             Box(
@@ -390,7 +478,11 @@ fun MessageInput(
                             .clip(NostrordShapes.inputShape)
                             .focusRequester(focusRequester)
                             .onFocusChanged { focusState ->
-                                if (!focusState.isFocused) {
+                                // On Android the focus transiently drops while the IME
+                                // composes; dismissing here would flicker the inline
+                                // suggestion list and break keyboard input. Let typing,
+                                // selection, or back-press close it instead.
+                                if (!isAndroid && !focusState.isFocused) {
                                     showMentionPopup = false
                                     showGroupMentionPopup = false
                                 }
@@ -551,12 +643,7 @@ fun MessageInput(
                         shape = NostrordShapes.inputShape,
                         singleLine = false,
                         maxLines = 4,
-                        visualTransformation = MentionVisualTransformation(
-                            mentionedNames = mentions.keys,
-                            mentionColor = NostrordColors.MentionText,
-                            emojiFontFamily = rememberEmojiFontFamily(),
-                            groupMentionedNames = groupMentions.keys,
-                        ),
+                        visualTransformation = mentionVisualTransformation,
                     )
 
                     if (showEmojiButton) {
@@ -611,14 +698,24 @@ fun MessageInput(
                     }
                 }
 
-                if (showMentionPopup && groupMembers.isNotEmpty()) {
+                // Desktop / web / iOS keep the floating Popup (with keyboard nav).
+                // Android renders the list inline above (see top of this Column) to
+                // avoid the IME-restart character drop caused by the Popup window.
+                if (!isAndroid && showMentionPopup && groupMembers.isNotEmpty()) {
                     val density = LocalDensity.current
                     val filteredCount = getFilteredMembers(groupMembers, mentionQuery).size
                     val popupHeightDp = 28 + 2 + (filteredCount.coerceAtMost(8) * 36)
                     val popupHeightPx = with(density) { popupHeightDp.dp.roundToPx() }
                     val offsetXPx = with(density) { Spacing.lg.roundToPx() }
 
-                    Popup(alignment = Alignment.Center, onDismissRequest = { showMentionPopup = false }) {
+                    // dismissOnClickOutside must stay false: on Android each soft-keyboard
+                    // key tap is delivered as an outside touch and would otherwise close the
+                    // popup on every character. Tap-to-dismiss is handled by the clickable Box.
+                    Popup(
+                        alignment = Alignment.Center,
+                        onDismissRequest = { showMentionPopup = false },
+                        properties = PopupProperties(focusable = false, dismissOnClickOutside = false),
+                    ) {
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()
@@ -646,14 +743,18 @@ fun MessageInput(
                     }
                 }
 
-                if (showGroupMentionPopup && availableGroups.isNotEmpty()) {
+                if (!isAndroid && showGroupMentionPopup && availableGroups.isNotEmpty()) {
                     val density = LocalDensity.current
                     val filteredCount = getFilteredGroups(availableGroups, groupMentionQuery).size
                     val popupHeightDp = 28 + 2 + (filteredCount.coerceAtMost(8) * 36)
                     val popupHeightPx = with(density) { popupHeightDp.dp.roundToPx() }
                     val offsetXPx = with(density) { Spacing.lg.roundToPx() }
 
-                    Popup(alignment = Alignment.Center, onDismissRequest = { showGroupMentionPopup = false }) {
+                    Popup(
+                        alignment = Alignment.Center,
+                        onDismissRequest = { showGroupMentionPopup = false },
+                        properties = PopupProperties(focusable = false, dismissOnClickOutside = false),
+                    ) {
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -119,9 +119,11 @@ fun MessageInput(
         }
     }
 
-    // Refocus input when reply is activated or after message send (input cleared)
+    // Refocus input when reply is activated. Unlike the screen-open auto-focus above,
+    // this fires only on an explicit reply action (tap or swipe), so opening the
+    // keyboard on Android here is desired — reply mode should land in the input.
     LaunchedEffect(replyingToMessage) {
-        if (replyingToMessage != null && !getPlatform().name.startsWith("Android")) {
+        if (replyingToMessage != null) {
             focusRequester.requestFocus()
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
@@ -12,7 +13,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -35,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -59,6 +60,7 @@ import org.nostr.nostrord.ui.components.chat.ImageViewerModal
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.components.chat.LocalImageViewerUrl
 import org.nostr.nostrord.ui.components.chat.MessageItem
+import org.nostr.nostrord.ui.components.chat.MessageSelectionContainer
 import org.nostr.nostrord.ui.components.chat.NewMessagesDivider
 import org.nostr.nostrord.ui.components.chat.SystemEventItem
 import org.nostr.nostrord.ui.components.chat.ZapEventItem
@@ -70,6 +72,9 @@ import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.util.buildShareMessageLink
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.utils.rememberTextSharer
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 /**
  * Messages list with infinite scroll pagination.
@@ -111,6 +116,18 @@ fun MessagesList(
 
     val coroutineScope = rememberCoroutineScope()
     var reactingToMessageId by remember { mutableStateOf<String?>(null) }
+    // Hoisted so only one message context menu can be open at a time
+    var openContextMenuId by remember { mutableStateOf<String?>(null) }
+    // Guard against the web-mobile "blink": a single tap on the source message can both
+    // dismiss the menu and re-fire the open gesture, reopening it. After a menu closes,
+    // briefly ignore an open request for that same message so it does not flash back open.
+    var lastClosedMenuId by remember { mutableStateOf<String?>(null) }
+    var lastClosedMark by remember { mutableStateOf<TimeMark?>(null) }
+    val closeContextMenu = {
+        lastClosedMenuId = openContextMenuId
+        lastClosedMark = TimeSource.Monotonic.markNow()
+        openContextMenuId = null
+    }
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
     val currentRelayUrl by AppModule.nostrRepository.currentRelayUrl.collectAsState()
     val copyToClipboard = rememberClipboardWriter()
@@ -413,7 +430,7 @@ fun MessagesList(
                 }
             }
             else -> {
-                SelectionContainer {
+                MessageSelectionContainer {
                     Box(modifier = Modifier.fillMaxSize()) {
                         LazyColumn(
                             state = listState,
@@ -469,6 +486,20 @@ fun MessagesList(
                                             onScrollToMessage = { id -> internalScrollTarget = id },
                                             onNavigateToGroup = onNavigateToGroup,
                                             isHighlighted = item.message.id == highlightedMessageId,
+                                            isContextMenuOpen = openContextMenuId == item.message.id,
+                                            onContextMenuOpenChange = { open ->
+                                                val id = item.message.id
+                                                if (open) {
+                                                    val mark = lastClosedMark
+                                                    val recentlyClosed =
+                                                        id == lastClosedMenuId &&
+                                                            mark != null &&
+                                                            mark.elapsedNow() < 350.milliseconds
+                                                    if (!recentlyClosed) openContextMenuId = id
+                                                } else if (openContextMenuId == id) {
+                                                    closeContextMenu()
+                                                }
+                                            },
                                             onCopyLink = {
                                                 val relay = currentRelayUrl ?: return@MessageItem
                                                 copyToClipboard(buildShareMessageLink(relay, groupId, item.message.id))
@@ -577,6 +608,20 @@ fun MessagesList(
                                     contentDescription = "Jump to latest message",
                                 )
                             }
+                        }
+
+                        // Dismiss the open message context menu when tapping anywhere
+                        // outside it. Popup.dismissOnClickOutside is unreliable for touch on
+                        // web; the menu Popup still renders above this overlay.
+                        if (openContextMenuId != null) {
+                            Box(
+                                modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .pointerInput(Unit) {
+                                        detectTapGestures { closeContextMenu() }
+                                    },
+                            )
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -502,6 +502,7 @@ fun MessagesList(
                                                     closeContextMenu()
                                                 }
                                             },
+                                            onCopyText = { copyToClipboard(item.message.content) },
                                             onCopyLink = {
                                                 val relay = currentRelayUrl ?: return@MessageItem
                                                 copyToClipboard(buildShareMessageLink(relay, groupId, item.message.id))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -106,6 +106,7 @@ fun MessagesList(
     targetMessageId: String? = null,
     onTargetConsumed: () -> Unit = {},
     onFetchTargetById: (String) -> Unit = {},
+    swipeToReplyEnabled: Boolean = false,
 ) {
     val currentOnUsernameClick by rememberUpdatedState(onUsernameClick)
     val currentOnReplyClick by rememberUpdatedState(onReplyClick)
@@ -476,6 +477,7 @@ fun MessagesList(
                                             currentUserPubkey = currentUserPubkey,
                                             currentGroupId = groupId,
                                             currentRelayUrl = currentRelayUrl,
+                                            swipeToReplyEnabled = swipeToReplyEnabled,
                                             onUsernameClick = currentOnUsernameClick,
                                             onReplyClick = { currentOnReplyClick(item.message) },
                                             onReactionClick = { reactingToMessageId = item.message.id },

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.ios.kt
@@ -1,0 +1,3 @@
+package org.nostr.nostrord.ui.components.chat
+
+actual val messagesTextSelectionEnabled: Boolean = false

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.ios.kt
@@ -9,3 +9,6 @@ actual fun browserGoForward() {}
 actual fun platformAppOrigin(): String? = null
 
 actual fun clearBrowserUrlQuery() {}
+
+// Native uses the Compose ancestor gesture in App.kt; nothing to register here.
+actual fun registerLeftEdgeSwipeToOpen(onOpen: () -> Unit): () -> Unit = {}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.js.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.ui.components.chat
+
+import kotlinx.browser.window
+
+/** True when the browser's primary pointer is coarse (touch), i.e. a mobile device. */
+internal fun isCoarsePointer(): Boolean = runCatching { window.matchMedia("(pointer: coarse)").matches }.getOrDefault(false)
+
+actual val messagesTextSelectionEnabled: Boolean = !isCoarsePointer()

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.js.kt
@@ -1,13 +1,30 @@
 package org.nostr.nostrord.ui.components.chat
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
 
 /**
- * JS implementation: No-op for now.
- * Could potentially hook into browser contextmenu event in the future.
+ * Web (JS) implementation:
+ * - Mobile (coarse pointer): single tap opens the context menu, matching Android.
+ * - Desktop (mouse): secondary (right) click opens the context menu, matching JVM.
  */
-actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier {
-    // No-op on JS - users access context menu via the "More" button
-    // Browser's native right-click menu will appear instead
-    return Modifier
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier = if (isCoarsePointer()) {
+    Modifier.pointerInput(onRightClick) {
+        detectTapGestures(onTap = { onRightClick() })
+    }
+} else {
+    Modifier.pointerInput(onRightClick) {
+        awaitEachGesture {
+            val event = awaitPointerEvent()
+            if (event.type == PointerEventType.Press && event.buttons.isSecondaryPressed) {
+                onRightClick()
+            }
+        }
+    }
 }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/navigation/LeftEdgeSwipe.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/ui/navigation/LeftEdgeSwipe.js.kt
@@ -1,0 +1,59 @@
+package org.nostr.nostrord.ui.navigation
+
+/**
+ * Raw-JS left-edge swipe detector (issue #77).
+ *
+ * The Compose pointer-pass approach loses the gesture to the chat's scrollable on
+ * mobile browsers, so we intercept it before Compose by listening on `window` in
+ * the CAPTURE phase with `{ passive: false }`. preventDefault keeps Compose from
+ * double-handling and stops the browser's own edge gestures.
+ */
+@Suppress("UnsafeCastFromDynamic")
+private fun jsRegisterLeftEdgeSwipe(onOpen: () -> Unit): () -> Unit = js(
+    """
+        (function() {
+            var EDGE_PX = 24;       // gesture must START this close to the left edge
+            var TRIGGER_PX = 36;    // ...and move right at least this far
+            var startX = 0, startY = 0;
+            var tracking = false, fired = false;
+            function onStart(e) {
+                if (!e.touches || e.touches.length !== 1) { tracking = false; return; }
+                var t = e.touches[0];
+                fired = false;
+                tracking = t.clientX <= EDGE_PX;
+                if (tracking) {
+                    startX = t.clientX;
+                    startY = t.clientY;
+                }
+            }
+            function onMove(e) {
+                if (!tracking || fired) return;
+                if (!e.touches || e.touches.length !== 1) return;
+                var t = e.touches[0];
+                var dx = t.clientX - startX;
+                var dy = t.clientY - startY;
+                if (dx >= TRIGGER_PX && dx > Math.abs(dy)) {
+                    fired = true;
+                    tracking = false;
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onOpen();
+                }
+            }
+            function onEnd() { tracking = false; fired = false; }
+            var opts = { capture: true, passive: false };
+            window.addEventListener('touchstart', onStart, opts);
+            window.addEventListener('touchmove', onMove, opts);
+            window.addEventListener('touchend', onEnd, opts);
+            window.addEventListener('touchcancel', onEnd, opts);
+            return function() {
+                window.removeEventListener('touchstart', onStart, opts);
+                window.removeEventListener('touchmove', onMove, opts);
+                window.removeEventListener('touchend', onEnd, opts);
+                window.removeEventListener('touchcancel', onEnd, opts);
+            };
+        })()
+        """,
+)
+
+actual fun registerLeftEdgeSwipeToOpen(onOpen: () -> Unit): () -> Unit = jsRegisterLeftEdgeSwipe(onOpen)

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.jvm.kt
@@ -1,0 +1,3 @@
+package org.nostr.nostrord.ui.components.chat
+
+actual val messagesTextSelectionEnabled: Boolean = true

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/navigation/PlatformNavigation.jvm.kt
@@ -9,3 +9,6 @@ actual fun browserGoForward() {}
 actual fun platformAppOrigin(): String? = null
 
 actual fun clearBrowserUrlQuery() {}
+
+// Native uses the Compose ancestor gesture in App.kt; nothing to register here.
+actual fun registerLeftEdgeSwipeToOpen(onOpen: () -> Unit): () -> Unit = {}

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.wasmJs.kt
@@ -1,0 +1,13 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package org.nostr.nostrord.ui.components.chat
+
+import kotlin.js.ExperimentalWasmJsInterop
+
+@JsFun("() => (typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(pointer: coarse)').matches) || false")
+private external fun jsIsCoarsePointer(): Boolean
+
+/** True when the browser's primary pointer is coarse (touch), i.e. a mobile device. */
+internal fun isCoarsePointer(): Boolean = jsIsCoarsePointer()
+
+actual val messagesTextSelectionEnabled: Boolean = !isCoarsePointer()

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.wasmJs.kt
@@ -1,13 +1,30 @@
 package org.nostr.nostrord.ui.components.chat
 
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
 
 /**
- * WasmJS implementation: No-op for now.
- * Could potentially hook into browser contextmenu event in the future.
+ * Web (WasmJS) implementation:
+ * - Mobile (coarse pointer): single tap opens the context menu, matching Android.
+ * - Desktop (mouse): secondary (right) click opens the context menu, matching JVM.
  */
-actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier {
-    // No-op on WasmJS - users access context menu via the "More" button
-    // Browser's native right-click menu will appear instead
-    return Modifier
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier = if (isCoarsePointer()) {
+    Modifier.pointerInput(onRightClick) {
+        detectTapGestures(onTap = { onRightClick() })
+    }
+} else {
+    Modifier.pointerInput(onRightClick) {
+        awaitEachGesture {
+            val event = awaitPointerEvent()
+            if (event.type == PointerEventType.Press && event.buttons.isSecondaryPressed) {
+                onRightClick()
+            }
+        }
+    }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/navigation/LeftEdgeSwipe.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/ui/navigation/LeftEdgeSwipe.wasmJs.kt
@@ -1,0 +1,62 @@
+@file:OptIn(ExperimentalWasmJsInterop::class)
+
+package org.nostr.nostrord.ui.navigation
+
+import kotlin.js.ExperimentalWasmJsInterop
+
+/**
+ * Raw-JS left-edge swipe detector (issue #77).
+ *
+ * The Compose pointer-pass approach loses the gesture to the chat's scrollable on
+ * mobile browsers, so we intercept it before Compose by listening on `window` in
+ * the CAPTURE phase with `{ passive: false }`. preventDefault keeps Compose from
+ * double-handling and stops the browser's own edge gestures. Returns a cleanup
+ * function that removes the listeners.
+ */
+@JsFun(
+    """(onOpen) => {
+    var EDGE_PX = 24;       // gesture must START this close to the left edge
+    var TRIGGER_PX = 36;    // ...and move right at least this far
+    var startX = 0, startY = 0;
+    var tracking = false, fired = false;
+    function onStart(e) {
+        if (!e.touches || e.touches.length !== 1) { tracking = false; return; }
+        var t = e.touches[0];
+        fired = false;
+        tracking = t.clientX <= EDGE_PX;
+        if (tracking) {
+            startX = t.clientX;
+            startY = t.clientY;
+        }
+    }
+    function onMove(e) {
+        if (!tracking || fired) return;
+        if (!e.touches || e.touches.length !== 1) return;
+        var t = e.touches[0];
+        var dx = t.clientX - startX;
+        var dy = t.clientY - startY;
+        if (dx >= TRIGGER_PX && dx > Math.abs(dy)) {
+            fired = true;
+            tracking = false;
+            e.preventDefault();
+            e.stopPropagation();
+            onOpen();
+        }
+    }
+    function onEnd() { tracking = false; fired = false; }
+    var opts = { capture: true, passive: false };
+    window.addEventListener('touchstart', onStart, opts);
+    window.addEventListener('touchmove', onMove, opts);
+    window.addEventListener('touchend', onEnd, opts);
+    window.addEventListener('touchcancel', onEnd, opts);
+    return () => {
+        window.removeEventListener('touchstart', onStart, opts);
+        window.removeEventListener('touchmove', onMove, opts);
+        window.removeEventListener('touchend', onEnd, opts);
+        window.removeEventListener('touchcancel', onEnd, opts);
+    };
+}""",
+)
+private external fun jsRegisterLeftEdgeSwipe(onOpen: () -> Unit): () -> Unit
+
+actual fun registerLeftEdgeSwipeToOpen(onOpen: () -> Unit): () -> Unit = jsRegisterLeftEdgeSwipe(onOpen)

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -7,6 +7,18 @@ html, body {
 }
 
 /*
+ * Compose does all of its own scrolling/gesture handling on the canvas, so the
+ * browser must not claim touch gestures itself (horizontal pan / edge back-swipe
+ * / pull-to-refresh). Without this the browser intercepts the left-edge
+ * left-to-right swipe over the scrolling chat list before it reaches the app
+ * (issue #77). touch-action:none is exactly what Compose wants here.
+ */
+#composeApplication, #composeApplication canvas {
+    touch-action: none;
+    overscroll-behavior: none;
+}
+
+/*
  * Compose WebElementView wraps each native HTML element in an absolutely-positioned
  * <div> appended to <body>. These wrappers sit above the Compose <canvas> and block
  * wheel/scroll events from reaching it. pointer-events:none lets events pass through


### PR DESCRIPTION
A batch of mobile/touch chat polish on the `android-polish` branch.

- **Message context menu (mobile):** tap to open/close, copy-text wired up, and desktop hover affordances suppressed on touch layouts.
- **Mention autocomplete:** stays open while typing on Android instead of closing on keyboard mode changes.
- **Swipe gestures:** left-edge swipe opens the side menu; swipe a message left to reply on mobile and touch web.

| | |
|---|---|
| Area | Chat + navigation (commonMain) |
| Platforms | Android / touch web focus, all targets compile |
| Verified | `compileKotlinJvm` clean |

Closes #75
Closes #77
Closes #76