### PR TITLE
Home: land on My Groups, rename tabs, lazy-load Other Groups

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
@@ -67,7 +67,14 @@ fun HomeScreen(
         }
 
     var searchQuery by remember(displayRelayUrl) { mutableStateOf("") }
-    var activeFilter by remember(displayRelayUrl) { mutableStateOf(GroupFilter.All) }
+    // Default to the Joined tab whenever this relay has joined groups: when opening
+    // a relay we already belong to, and the moment the user joins their first group
+    // (the empty -> non-empty flip re-runs this). Keyed on the boolean rather than the
+    // set itself so a deliberate switch to All isn't undone on every join/leave.
+    val hasJoinedGroups = joinedGroupIds.isNotEmpty()
+    var activeFilter by remember(displayRelayUrl, hasJoinedGroups) {
+        mutableStateOf(if (hasJoinedGroups) GroupFilter.Joined else GroupFilter.All)
+    }
     var isManagingRelay by remember(displayRelayUrl) { mutableStateOf(false) }
 
     val orphanedIds =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
@@ -35,6 +35,7 @@ fun HomeScreen(
     val pendingDeepLinkRelay by vm.pendingDeepLinkRelay.collectAsState()
     val kind10009Relays by vm.kind10009Relays.collectAsState()
     val restrictedRelays by vm.restrictedRelays.collectAsState()
+    val fullGroupListFetchedRelays by vm.fullGroupListFetchedRelays.collectAsState()
 
     val displayRelayUrl = relayUrl ?: currentRelayUrl
     val relayMeta: Nip11RelayInfo? = relayMetadata[displayRelayUrl]
@@ -76,6 +77,21 @@ fun HomeScreen(
         mutableStateOf(if (hasJoinedGroups) GroupFilter.Joined else GroupFilter.All)
     }
     var isManagingRelay by remember(displayRelayUrl) { mutableStateOf(false) }
+
+    // On a lazy relay only the joined groups are fetched up front; the full kind:39000
+    // list is loaded on demand. The sidebar triggers that fetch when OTHER GROUPS is
+    // expanded — mirror it here so switching to the All tab also pulls the full list.
+    val isGroupFetchLazy = remember(displayRelayUrl) { vm.isGroupFetchLazy(displayRelayUrl) }
+    val hasFullGroupList =
+        remember(displayRelayUrl, fullGroupListFetchedRelays) {
+            displayRelayUrl.normalizeRelayUrl() in fullGroupListFetchedRelays
+        }
+    // Need a fetch if it hasn't happened this session, or if the in-memory list still
+    // holds only joined groups (so the All tab would otherwise look identical to Joined).
+    val needsFullGroupFetch =
+        remember(hasFullGroupList, groups, joinedGroupIds) {
+            !hasFullGroupList || groups.none { it.id !in joinedGroupIds }
+        }
 
     val orphanedIds =
         remember(displayRelayUrl, orphanedJoinedByRelay) {
@@ -147,6 +163,16 @@ fun HomeScreen(
         val isReachabilityError =
             connectionState is ConnectionManager.ConnectionState.Error ||
                 connectionState is ConnectionManager.ConnectionState.Reconnecting
+
+        // Selecting the All tab on a lazy relay must trigger the full group list fetch,
+        // the same way expanding OTHER GROUPS in the sidebar does. isRelayConnected is a key
+        // so the fetch re-fires once the WebSocket handshake completes if the tab opened first.
+        val isRelayConnected = connectionState is ConnectionManager.ConnectionState.Connected
+        LaunchedEffect(activeFilter, isGroupFetchLazy, needsFullGroupFetch, isRelayConnected) {
+            if (activeFilter == GroupFilter.All && isGroupFetchLazy && needsFullGroupFetch && isRelayConnected) {
+                vm.requestFullGroupList(displayRelayUrl)
+            }
+        }
 
         val onRemoveRelayConfirmed: () -> Unit = {
             vm.removeRelay(displayRelayUrl)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreen.kt
@@ -68,26 +68,26 @@ fun HomeScreen(
         }
 
     var searchQuery by remember(displayRelayUrl) { mutableStateOf("") }
-    // Default to the Joined tab whenever this relay has joined groups: when opening
+    // Default to the My Groups tab whenever this relay has joined groups: when opening
     // a relay we already belong to, and the moment the user joins their first group
     // (the empty -> non-empty flip re-runs this). Keyed on the boolean rather than the
-    // set itself so a deliberate switch to All isn't undone on every join/leave.
+    // set itself so a deliberate switch to Other Groups isn't undone on every join/leave.
     val hasJoinedGroups = joinedGroupIds.isNotEmpty()
     var activeFilter by remember(displayRelayUrl, hasJoinedGroups) {
-        mutableStateOf(if (hasJoinedGroups) GroupFilter.Joined else GroupFilter.All)
+        mutableStateOf(if (hasJoinedGroups) GroupFilter.Mine else GroupFilter.Other)
     }
     var isManagingRelay by remember(displayRelayUrl) { mutableStateOf(false) }
 
     // On a lazy relay only the joined groups are fetched up front; the full kind:39000
     // list is loaded on demand. The sidebar triggers that fetch when OTHER GROUPS is
-    // expanded — mirror it here so switching to the All tab also pulls the full list.
+    // expanded — mirror it here so switching to the Other Groups tab also pulls the full list.
     val isGroupFetchLazy = remember(displayRelayUrl) { vm.isGroupFetchLazy(displayRelayUrl) }
     val hasFullGroupList =
         remember(displayRelayUrl, fullGroupListFetchedRelays) {
             displayRelayUrl.normalizeRelayUrl() in fullGroupListFetchedRelays
         }
     // Need a fetch if it hasn't happened this session, or if the in-memory list still
-    // holds only joined groups (so the All tab would otherwise look identical to Joined).
+    // holds only joined groups (so the Other Groups tab would otherwise be empty).
     val needsFullGroupFetch =
         remember(hasFullGroupList, groups, joinedGroupIds) {
             !hasFullGroupList || groups.none { it.id !in joinedGroupIds }
@@ -104,8 +104,8 @@ fun HomeScreen(
                 groups
                     .filter { group ->
                         when (activeFilter) {
-                            GroupFilter.All -> true
-                            GroupFilter.Joined -> group.id in joinedGroupIds
+                            GroupFilter.Mine -> group.id in joinedGroupIds
+                            GroupFilter.Other -> group.id !in joinedGroupIds
                         }
                     }.filter { group ->
                         if (searchQuery.isBlank()) {
@@ -115,10 +115,10 @@ fun HomeScreen(
                                 group.id.contains(searchQuery, ignoreCase = true)
                         }
                     }
-            // In the Joined tab, surface orphan pins (kind:10009 ids without a
+            // In the My Groups tab, surface orphan pins (kind:10009 ids without a
             // kind:39000) as stub cards so the user can see the count matches
             // reality. Sidebar ghost rows let them forget.
-            if (activeFilter == GroupFilter.Joined && orphanedIds.isNotEmpty()) {
+            if (activeFilter == GroupFilter.Mine && orphanedIds.isNotEmpty()) {
                 val knownIds = base.map { it.id }.toSet()
                 val stubs =
                     orphanedIds
@@ -164,12 +164,12 @@ fun HomeScreen(
             connectionState is ConnectionManager.ConnectionState.Error ||
                 connectionState is ConnectionManager.ConnectionState.Reconnecting
 
-        // Selecting the All tab on a lazy relay must trigger the full group list fetch,
-        // the same way expanding OTHER GROUPS in the sidebar does. isRelayConnected is a key
-        // so the fetch re-fires once the WebSocket handshake completes if the tab opened first.
+        // Selecting the Other Groups tab on a lazy relay must trigger the full group list
+        // fetch, the same way expanding OTHER GROUPS in the sidebar does. isRelayConnected is a
+        // key so the fetch re-fires once the WebSocket handshake completes if the tab opened first.
         val isRelayConnected = connectionState is ConnectionManager.ConnectionState.Connected
         LaunchedEffect(activeFilter, isGroupFetchLazy, needsFullGroupFetch, isRelayConnected) {
-            if (activeFilter == GroupFilter.All && isGroupFetchLazy && needsFullGroupFetch && isRelayConnected) {
+            if (activeFilter == GroupFilter.Other && isGroupFetchLazy && needsFullGroupFetch && isRelayConnected) {
                 vm.requestFullGroupList(displayRelayUrl)
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenDesktop.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenDesktop.kt
@@ -74,7 +74,7 @@ import org.nostr.nostrord.ui.util.generateColorFromString
 import org.nostr.nostrord.ui.util.relayFallbackPainter
 import org.nostr.nostrord.utils.rememberClipboardWriter
 
-enum class GroupFilter { All, Joined }
+enum class GroupFilter { Mine, Other }
 
 @Composable
 fun HomeScreenDesktop(
@@ -283,10 +283,11 @@ private fun FilterBar(
     allCount: Int = 0,
     joinedCount: Int = 0,
 ) {
+    val otherCount = (allCount - joinedCount).coerceAtLeast(0)
     val filters =
         listOf(
-            GroupFilter.All to if (allCount > 0) "All ($allCount)" else "All",
-            GroupFilter.Joined to if (joinedCount > 0) "Joined ($joinedCount)" else "Joined",
+            GroupFilter.Mine to if (joinedCount > 0) "My Groups ($joinedCount)" else "My Groups",
+            GroupFilter.Other to if (otherCount > 0) "Other Groups ($otherCount)" else "Other Groups",
         )
 
     Row(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenMobile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeScreenMobile.kt
@@ -298,10 +298,11 @@ private fun MobileFilterBar(
     allCount: Int = 0,
     joinedCount: Int = 0,
 ) {
+    val otherCount = (allCount - joinedCount).coerceAtLeast(0)
     val filters =
         listOf(
-            GroupFilter.All to if (allCount > 0) "All ($allCount)" else "All",
-            GroupFilter.Joined to if (joinedCount > 0) "Joined ($joinedCount)" else "Joined",
+            GroupFilter.Mine to if (joinedCount > 0) "My Groups ($joinedCount)" else "My Groups",
+            GroupFilter.Other to if (otherCount > 0) "Other Groups ($otherCount)" else "Other Groups",
         )
 
     Row(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomeViewModel.kt
@@ -21,8 +21,16 @@ class HomeViewModel(
     val pendingDeepLinkRelay = repo.pendingDeepLinkRelay
     val kind10009Relays = repo.kind10009Relays
     val restrictedRelays = repo.restrictedRelays
+    val fullGroupListFetchedRelays = repo.fullGroupListFetchedRelays
 
     fun getPublicKey() = repo.getPublicKey()
+
+    fun isGroupFetchLazy(relayUrl: String) = repo.isGroupFetchLazy(relayUrl)
+
+    /** Lazily fetch the relay's full group list (kind:39000). No-op if already in flight. */
+    fun requestFullGroupList(relayUrl: String) {
+        viewModelScope.launch { repo.requestFullGroupListForRelay(relayUrl) }
+    }
 
     fun connect() {
         viewModelScope.launch { repo.connect() }


### PR DESCRIPTION
The home group list now opens on the user's own groups instead of the full relay listing. When you open a relay you already belong to — or the moment you join your first group — the list defaults to the joined-groups tab. The two tabs are also renamed and reworked into a non-overlapping split that matches the sidebar's MY GROUPS / OTHER GROUPS vocabulary, and the full relay listing is fetched on demand when you open the Other Groups tab (it was only ever fetched by expanding OTHER GROUPS in the sidebar, so the renamed tab would otherwise show nothing on a lazy relay).

| Tab | Before | After |
|---|---|---|
| `Joined` → `My Groups` | groups you joined | unchanged (just renamed) |
| `All` → `Other Groups` | every group, joined included | only groups you have **not** joined |
| Default tab | always `All` | `My Groups` when the relay has joined groups, else `Other Groups` |
| Other Groups load | filtered in-memory list only | triggers the on-demand kind:39000 fetch |

Other Groups count is total minus joined. The default is keyed on whether any joined group exists (not the set itself), so a deliberate switch to Other Groups isn't undone on every join/leave.

Commits:
- `385e928` default to the joined tab when the relay has joined groups
- `9156f9c` fetch the full group list when the all/other tab is selected
- `06f39bd` rename group tabs to My Groups / Other Groups