### PR TITLE
fix(group): distinguish NIP-29 role changes from member adds

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -73,6 +73,11 @@ object AppModule {
     private val _systemMessages = kotlinx.coroutines.flow.MutableSharedFlow<String>(extraBufferCapacity = 4)
     val systemMessages: kotlinx.coroutines.flow.SharedFlow<String> = _systemMessages
 
+    /** Surface a one-shot transient confirmation/notice to the user (snackbar). */
+    fun postSystemMessage(message: String) {
+        _systemMessages.tryEmit(message)
+    }
+
     val authManager: AuthManager by lazy {
         AuthManager(accountStore).also { am ->
             am.onSessionInvalidated = { invalidatedPubkey ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/SystemEventItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/SystemEventItem.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Login
 import androidx.compose.material.icons.automirrored.filled.Logout
+import androidx.compose.material.icons.filled.PersonRemove
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -31,6 +33,7 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.ui.components.avatars.Jdenticon
+import org.nostr.nostrord.ui.screens.group.model.SystemEventType
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.utils.formatTimestamp
 
@@ -44,13 +47,26 @@ fun SystemEventItem(
     pubkey: String,
     action: String,
     createdAt: Long,
+    type: SystemEventType,
     metadata: UserMetadata? = null,
     additionalUsers: List<String> = emptyList(),
     allUserMetadata: Map<String, UserMetadata> = emptyMap(),
 ) {
-    val isJoinEvent = action.contains("joined", ignoreCase = true)
     val totalUsers = 1 + additionalUsers.size
-    val accentColor = if (isJoinEvent) NostrordColors.Success else NostrordColors.TextMuted
+    val accentColor =
+        when (type) {
+            SystemEventType.JOINED -> NostrordColors.Success
+            SystemEventType.ROLE_CHANGED -> NostrordColors.WarningOrange
+            SystemEventType.REMOVED -> NostrordColors.Error
+            SystemEventType.LEFT -> NostrordColors.TextMuted
+        }
+    val eventIcon =
+        when (type) {
+            SystemEventType.JOINED -> Icons.AutoMirrored.Filled.Login
+            SystemEventType.ROLE_CHANGED -> Icons.Filled.Shield
+            SystemEventType.REMOVED -> Icons.Filled.PersonRemove
+            SystemEventType.LEFT -> Icons.AutoMirrored.Filled.Logout
+        }
 
     Row(
         modifier =
@@ -70,7 +86,7 @@ fun SystemEventItem(
             contentAlignment = Alignment.Center,
         ) {
             Icon(
-                imageVector = if (isJoinEvent) Icons.AutoMirrored.Filled.Login else Icons.AutoMirrored.Filled.Logout,
+                imageVector = eventIcon,
                 contentDescription = null,
                 modifier = Modifier.size(14.dp),
                 tint = accentColor,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.utils.Result
 
@@ -155,6 +156,7 @@ class GroupViewModel(
     fun addUser(
         targetPubkey: String,
         roles: List<String> = emptyList(),
+        successMessage: String = "User added to the group",
     ) {
         viewModelScope.launch {
             when (val result = repo.addUser(groupId, targetPubkey, roles)) {
@@ -166,7 +168,9 @@ class GroupViewModel(
                             .removePrefix("error: ")
                             .replaceFirstChar { it.uppercaseChar() }
                 }
-                is Result.Success -> Unit
+                // A kind:9000 (add / role change) is not reliably rendered in the
+                // timeline, so confirm the action to the admin who triggered it.
+                is Result.Success -> AppModule.postSystemMessage(successMessage)
             }
         }
     }
@@ -182,22 +186,22 @@ class GroupViewModel(
                             .removePrefix("error: ")
                             .replaceFirstChar { it.uppercaseChar() }
                 }
-                is Result.Success -> Unit
+                is Result.Success -> AppModule.postSystemMessage("User removed from the group")
             }
         }
     }
 
     fun promoteToAdmin(targetPubkey: String) {
-        addUser(targetPubkey, listOf("admin"))
+        addUser(targetPubkey, listOf("admin"), successMessage = "User promoted to admin")
     }
 
     fun demoteFromAdmin(targetPubkey: String) {
         // Re-add user without admin role to demote
-        addUser(targetPubkey, emptyList())
+        addUser(targetPubkey, emptyList(), successMessage = "Admin role removed")
     }
 
     fun approveJoinRequest(targetPubkey: String) {
-        addUser(targetPubkey)
+        addUser(targetPubkey, successMessage = "Join request approved")
     }
 
     fun rejectJoinRequest(joinRequestEventId: String) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -460,6 +460,7 @@ fun MessagesList(
                                             pubkey = item.pubkey,
                                             action = item.action,
                                             createdAt = item.createdAt,
+                                            type = item.type,
                                             metadata = userMetadata[item.pubkey],
                                             additionalUsers = item.additionalUsers,
                                             allUserMetadata = userMetadata,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
@@ -11,6 +11,17 @@ private const val MESSAGE_GROUP_WINDOW_SECONDS = 5 * 60
 private const val SYSTEM_EVENT_GROUP_WINDOW_SECONDS = 2 * 60
 
 /**
+ * Kind of system event, used to pick a distinct icon and color per moderation action
+ * instead of inferring it from the (translatable) action text.
+ */
+enum class SystemEventType {
+    JOINED, // kind 9021 — user joined
+    ROLE_CHANGED, // kind 9000 with role(s) — admin set/changed a member's role
+    REMOVED, // kind 9001 — admin removed a member
+    LEFT, // kind 9022 — user left
+}
+
+/**
  * Sealed class representing different types of chat items.
  * Marked as @Immutable for Compose stability to prevent unnecessary recompositions.
  */
@@ -35,6 +46,7 @@ sealed class ChatItem {
         val action: String,
         val createdAt: Long,
         val id: String,
+        val type: SystemEventType,
         val additionalUsers: List<String> = emptyList(), // Additional pubkeys for grouped events
     ) : ChatItem() {
         val totalUsers: Int get() = 1 + additionalUsers.size
@@ -86,12 +98,6 @@ fun buildChatItems(
     var newMessagesDividerInserted = false
 
     val sortedMessages = messages.sortedBy { it.createdAt }
-
-    // Map of pubkey → list of timestamps for join requests (kind 9021).
-    // Used to suppress kind 9000 that is just the relay auto-confirming a join.
-    val joinRequestTimestamps: Map<String, List<Long>> = sortedMessages
-        .filter { it.kind == 9021 }
-        .groupBy({ it.pubkey }, { it.createdAt })
 
     // Map of pubkey → list of timestamps for leave requests (kind 9022).
     // Used to suppress kind 9001 that is just the relay auto-confirming a leave.
@@ -203,21 +209,20 @@ fun buildChatItems(
                 lastMessagePubkey = null
                 lastMessageTime = null
             }
-            // kind 9000 (put-user): not shown in chat — entry is already
-            // covered by kind 9021 "joined the group". The relay emits 9000
-            // as an automatic confirmation; only kind 9001 (removal) is a
-            // meaningful moderation action to display.
             9000 -> {
-                // Show "was added" only when an admin manually added someone.
-                // Suppress if the target sent a kind 9021 join request within 5 min
-                // (that means the relay auto-confirmed the join, already shown as "joined").
-                val targetPubkey = message.tags.firstOrNull { it.firstOrNull() == "p" }?.getOrNull(1)
-                val hasRecentJoinRequest = targetPubkey != null &&
-                    joinRequestTimestamps[targetPubkey]?.any {
-                        kotlin.math.abs(message.createdAt - it) <= 5 * 60
-                    } == true
-                if (targetPubkey != null && !hasRecentJoinRequest) {
-                    val action = "was added to the group"
+                // kind 9000 (put-user) is reused both to add a member and to set/remove
+                // roles. Only a role *assignment* carries role names in the "p" tag
+                // (["p", <pubkey>, "<role>", ...]) and can be classified from the event
+                // alone, so we show "is now <role>" for those. A no-role 9000 is
+                // ambiguous (plain add vs. role removal) and the relay does not serve it
+                // back reliably, so it is suppressed to avoid lines that flicker or
+                // vanish on reload (issue #66).
+                val pTag = message.tags.firstOrNull { it.firstOrNull() == "p" }
+                val targetPubkey = pTag?.getOrNull(1)
+                val roles = pTag?.drop(2)?.filter { it.isNotBlank() } ?: emptyList()
+
+                if (targetPubkey != null && roles.isNotEmpty()) {
+                    val action = "is now ${roles.joinToString(", ")}"
                     val pending = pendingSystemEvent
 
                     if (pending != null &&
@@ -232,6 +237,7 @@ fun buildChatItems(
                             action = action,
                             createdAt = message.createdAt,
                             id = message.id,
+                            type = SystemEventType.ROLE_CHANGED,
                         )
                     }
 
@@ -264,6 +270,7 @@ fun buildChatItems(
                             action = action,
                             createdAt = message.createdAt,
                             id = message.id,
+                            type = SystemEventType.REMOVED,
                         )
                     }
 
@@ -290,6 +297,7 @@ fun buildChatItems(
                         action = action,
                         createdAt = message.createdAt,
                         id = message.id,
+                        type = SystemEventType.JOINED,
                     )
                 }
 
@@ -316,6 +324,7 @@ fun buildChatItems(
                         action = action,
                         createdAt = message.createdAt,
                         id = message.id,
+                        type = SystemEventType.LEFT,
                     )
                 }
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItemSystemEventTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItemSystemEventTest.kt
@@ -1,0 +1,143 @@
+package org.nostr.nostrord.ui.screens.group.model
+
+import org.nostr.nostrord.network.NostrGroupClient.NostrMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Covers the moderation-event classification in [buildChatItems] (issue #66):
+ * kind 9000 (put-user) must distinguish "added" from "role changed", and each
+ * moderation kind must map to its own [SystemEventType].
+ */
+class ChatItemSystemEventTest {
+    private var nextId = 0
+
+    private fun msg(
+        kind: Int,
+        pubkey: String = "author",
+        createdAt: Long,
+        tags: List<List<String>> = emptyList(),
+    ) = NostrMessage(
+        id = "id-${nextId++}",
+        pubkey = pubkey,
+        content = "",
+        createdAt = createdAt,
+        kind = kind,
+        tags = tags,
+    )
+
+    private fun systemEvents(messages: List<NostrMessage>) = buildChatItems(messages).filterIsInstance<ChatItem.SystemEvent>()
+
+    @Test
+    fun putUser_withRole_isRoleChange() {
+        val events = systemEvents(
+            listOf(msg(9000, createdAt = 1000, tags = listOf(listOf("p", "bob", "admin")))),
+        )
+        assertEquals(1, events.size)
+        assertEquals(SystemEventType.ROLE_CHANGED, events[0].type)
+        assertEquals("is now admin", events[0].action)
+        assertEquals("bob", events[0].pubkey)
+    }
+
+    @Test
+    fun putUser_withMultipleRoles_listsThem() {
+        val events = systemEvents(
+            listOf(msg(9000, createdAt = 1000, tags = listOf(listOf("p", "bob", "admin", "moderator")))),
+        )
+        assertEquals(SystemEventType.ROLE_CHANGED, events[0].type)
+        assertEquals("is now admin, moderator", events[0].action)
+    }
+
+    @Test
+    fun putUser_withoutRole_isSuppressed() {
+        // A no-role 9000 is ambiguous (plain add vs. role removal) and the relay does
+        // not serve it back reliably, so it is never displayed (issue #66).
+        val events = systemEvents(
+            listOf(msg(9000, createdAt = 1000, tags = listOf(listOf("p", "bob")))),
+        )
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun putUser_withoutRole_afterJoinRequest_isSuppressed() {
+        // The relay auto-confirms a join with a no-role kind 9000; only the kind 9021
+        // "joined" line should remain.
+        val events = systemEvents(
+            listOf(
+                msg(9021, pubkey = "bob", createdAt = 1000),
+                msg(9000, createdAt = 1010, tags = listOf(listOf("p", "bob"))),
+            ),
+        )
+        assertEquals(1, events.size)
+        assertEquals(SystemEventType.JOINED, events[0].type)
+    }
+
+    @Test
+    fun putUser_withRole_afterJoinRequest_isStillShown() {
+        // A role change is a real moderation action even right after a join.
+        val events = systemEvents(
+            listOf(
+                msg(9021, pubkey = "bob", createdAt = 1000),
+                msg(9000, createdAt = 1010, tags = listOf(listOf("p", "bob", "admin"))),
+            ),
+        )
+        assertEquals(SystemEventType.JOINED, events[0].type)
+        assertEquals(SystemEventType.ROLE_CHANGED, events[1].type)
+        assertEquals("is now admin", events[1].action)
+    }
+
+    @Test
+    fun removeUser_isRemoved() {
+        val events = systemEvents(
+            listOf(msg(9001, createdAt = 1000, tags = listOf(listOf("p", "bob")))),
+        )
+        assertEquals(SystemEventType.REMOVED, events[0].type)
+        assertEquals("was removed from the group", events[0].action)
+    }
+
+    @Test
+    fun joinRequest_isJoined() {
+        val events = systemEvents(listOf(msg(9021, pubkey = "bob", createdAt = 1000)))
+        assertEquals(SystemEventType.JOINED, events[0].type)
+        assertEquals("joined the group", events[0].action)
+        assertEquals("bob", events[0].pubkey)
+    }
+
+    @Test
+    fun leaveRequest_isLeft() {
+        val events = systemEvents(listOf(msg(9022, pubkey = "bob", createdAt = 1000)))
+        assertEquals(SystemEventType.LEFT, events[0].type)
+        assertEquals("left the group", events[0].action)
+    }
+
+    @Test
+    fun putUser_removingLastRole_showsOnlyTheAssignment() {
+        // Promote then demote: the demotion arrives as a no-role 9000 and is suppressed,
+        // so only the original "is now admin" remains (issue #66).
+        val events = systemEvents(
+            listOf(
+                msg(9000, createdAt = 1000, tags = listOf(listOf("p", "bob", "admin"))),
+                msg(9000, createdAt = 2000, tags = listOf(listOf("p", "bob"))),
+            ),
+        )
+        assertEquals(1, events.size)
+        assertEquals(SystemEventType.ROLE_CHANGED, events[0].type)
+        assertEquals("is now admin", events[0].action)
+    }
+
+    @Test
+    fun putUser_removingOneOfSeveralRoles_showsRemaining() {
+        // Removing one of several roles still carries the remaining role(s), so it is
+        // shown as a role assignment.
+        val events = systemEvents(
+            listOf(
+                msg(9000, createdAt = 1000, tags = listOf(listOf("p", "bob", "admin", "moderator"))),
+                msg(9000, createdAt = 2000, tags = listOf(listOf("p", "bob", "moderator"))),
+            ),
+        )
+        assertEquals("is now admin, moderator", events[0].action)
+        assertEquals(SystemEventType.ROLE_CHANGED, events[1].type)
+        assertEquals("is now moderator", events[1].action)
+    }
+}


### PR DESCRIPTION
Fixes #66 — a `nak group put-user` role change showed up as "user added", and the add / remove / role / left system events all shared the same gray Logout icon.

Kind 9000 (`put-user`) is reused both for adding a member and for setting/removing roles, so the action could not be told apart from the event alone. System events now carry an explicit type that drives a distinct icon and color. A 9000 that carries role names renders as "is now <role>"; a no-role 9000 is ambiguous (plain add vs. removing the last role) and NIP-29 relays do not serve it back reliably, so it is suppressed to avoid lines that flicker or vanish on reload (observed during testing). The admin who performs an add or role change now gets a snackbar confirmation instead.

| Event | Shown in timeline | Icon / color |
|---|---|---|
| 9021 join | "joined the group" | Login / green |
| 9000 with role | "is now {role}" | Shield / amber |
| 9000 no role | suppressed | — |
| 9001 remove | "was removed from the group" | PersonRemove / red |
| 9022 leave | "left the group" | Logout / gray |

Admin actions now confirmed via snackbar: user added, promoted to admin, admin role removed, join request approved, user removed. Covered by `ChatItemSystemEventTest`.

Commits:
- fix(group): distinguish NIP-29 role changes from member adds