### PR TITLE
fix(notifications): clear a group's notifications when its chat is read

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -426,6 +426,9 @@ object AppModule {
                     }
                 }
             },
+            // Drop a group's notifications from the feed the moment its unread
+            // badge is cleared, so opening/reading a chat clears both (issue #67).
+            onGroupRead = { groupId -> notificationHistoryStore.markReadForGroup(groupId) },
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -20,6 +20,9 @@ class UnreadManager(
     private val onReplyNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
     private val onMentionNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
     private val onReactionNotify: ((groupId: String, reaction: NostrGroupClient.NostrReaction) -> Unit)? = null,
+    // Called when a group is marked read so the notification feed can drop the
+    // group's entries in lockstep with the unread badge (issue #67).
+    private val onGroupRead: ((groupId: String) -> Unit)? = null,
 ) {
 
     private val _unreadCounts = MutableStateFlow<Map<String, Int>>(emptyMap())
@@ -97,6 +100,7 @@ class UnreadManager(
         SecureStorage.saveLastReadTimestamp(pubkey, groupId, epochSeconds())
         _unreadCounts.update { it + (groupId to 0) }
         persistEntries()
+        onGroupRead?.invoke(groupId)
     }
 
     fun getLastReadTimestamp(groupId: String): Long? = currentPubkey?.let { SecureStorage.getLastReadTimestamp(it, groupId) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
@@ -74,6 +74,22 @@ class NotificationHistoryStore {
         if (changed) persist()
     }
 
+    /** Mark every unread notification for [groupId] as read. No-op if none match. */
+    fun markReadForGroup(groupId: String) {
+        var changed = false
+        _entries.update { current ->
+            current.map {
+                if (it.groupId == groupId && !it.read) {
+                    changed = true
+                    it.copy(read = true)
+                } else {
+                    it
+                }
+            }
+        }
+        if (changed) persist()
+    }
+
     fun markAllRead() {
         _entries.update { current -> current.map { it.copy(read = true) } }
         persist()


### PR DESCRIPTION
Opening, reading, and even replying in a chat cleared its unread badge but left that chat's entries in the notification feed still marked unread — so a group you'd already read kept showing a pile of unread notifications (issue #67).

The unread badge and the notification feed are two systems: `UnreadManager.markAsRead(groupId)` zeroes the badge, but nothing told `NotificationHistoryStore` to drop the same group's entries. `NotificationEntry` already carries `groupId`, so the fix wires the two together — when a group is marked read (reaching the bottom, sending a message, or leaving the chat), its notifications are marked read in lockstep with the badge.

Entries stay in the feed as history (consistent with the screen's separate "Mark all as read" vs "Clear all" actions); they just stop counting as unread.

| File | Change |
|---|---|
| `NotificationHistoryStore.kt` | New `markReadForGroup(groupId)` — marks all of a group's unread entries read |
| `UnreadManager.kt` | New `onGroupRead` callback, invoked from `markAsRead` |
| `AppModule.kt` | Wires `onGroupRead` → `notificationHistoryStore.markReadForGroup` |

Verified with `./gradlew compileKotlinJvm`.

Commits:
- fix(notifications): mark a group's notifications read when its chat is read (#67)

Closes #67
