### PR TITLE
feat(notifications): per-group notification levels with mute (#70)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -245,6 +245,12 @@ object AppModule {
             findMessageAuthor = { messageId ->
                 groupManager.findMessageByIdAcrossGroups(messageId)?.second?.pubkey
             },
+            shouldNotify = { groupId, isDirect ->
+                notificationSettings.shouldNotify(
+                    notificationSettings.effectiveLevelFor(groupId),
+                    isDirect,
+                )
+            },
             onUnreadIncrement = { groupId, message, _ ->
                 val selfPubkey = sessionManager.getPublicKey()
                 if (selfPubkey == null || message.pubkey != selfPubkey) {
@@ -453,6 +459,7 @@ object AppModule {
             liveCursorStore = liveCursorStore,
             connStats = connStats,
             notificationHistoryStore = notificationHistoryStore,
+            notificationSettings = notificationSettings,
             scope = appScope,
         )
     }
@@ -511,6 +518,7 @@ object AppModule {
         } catch (_: Throwable) {}
         groupManager.clear()
         unreadManager.clear()
+        notificationSettings.clear()
         notificationHistoryStore.clear()
         // OutboxManager owns the per-account kind:10009 relay list and the
         // user's NIP-65 relay list. Without clearing here, the previous
@@ -530,6 +538,7 @@ object AppModule {
             groupManager.setCurrentPubkey(account.pubkey)
             pendingEventManager.setCurrentPubkey(account.pubkey)
             unreadManager.initialize(account.pubkey)
+            notificationSettings.initialize(account.pubkey)
             notificationHistoryStore.initialize(account.pubkey)
             // Restore the new account's saved relay (no-op if they don't have
             // one yet — a freshly added account starts with a blank rail).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -67,6 +67,7 @@ class NostrRepository(
     private val liveCursorStore: LiveCursorStore? = null,
     private val connStats: ConnectionStats = ConnectionStats(),
     private val notificationHistoryStore: org.nostr.nostrord.notifications.NotificationHistoryStore? = null,
+    private val notificationSettings: org.nostr.nostrord.settings.NotificationSettings? = null,
     private val scope: CoroutineScope,
 ) : NostrRepositoryApi {
     private val json = Json { ignoreUnknownKeys = true }
@@ -321,6 +322,7 @@ class NostrRepository(
             if (activeRelay.isBlank() && savedRelays.isEmpty() && deepLinkRelay == null) {
                 if (pubkey != null) {
                     unreadManager.initialize(pubkey)
+                    notificationSettings?.initialize(pubkey)
                     notificationHistoryStore?.initialize(pubkey)
                     initializeOutboxModel()
                     scope.launch {
@@ -377,6 +379,7 @@ class NostrRepository(
                 groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
                 groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
                 unreadManager.initialize(pubkey)
+                notificationSettings?.initialize(pubkey)
                 notificationHistoryStore?.initialize(pubkey)
             }
             initializeOutboxModel()
@@ -577,6 +580,7 @@ class NostrRepository(
             // one missing it.
             connectionManager.loadSavedRelay()
             unreadManager.initialize(newPubkey)
+            notificationSettings?.initialize(newPubkey)
             notificationHistoryStore?.initialize(newPubkey)
             // Skip the outbox bootstrap for a freshly generated identity:
             // nothing has been published yet, so kind:10002 / kind:10009 fetches
@@ -602,6 +606,7 @@ class NostrRepository(
         outboxManager.clear()
         groupManager.clear()
         unreadManager.clear()
+        notificationSettings?.clear()
         notificationHistoryStore?.clear()
         liveCursorStore?.clear()
         relayPipelines.values.forEach { (_, pipeline) -> pipeline.close() }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -2066,6 +2066,20 @@ class GroupManager(
                 tags.add(listOf("p", pubkeyHex))
             }
 
+            // p-tag the author of the message being replied to (NIP-10/22). Without
+            // it the recipient is only classified as "replied to" when they happen
+            // to have the parent message cached locally, so replies silently miss
+            // the per-group "mentions & replies only" notification filter (#70).
+            if (replyToMessageId != null) {
+                val parentAuthor = findMessageByIdAcrossGroups(replyToMessageId)?.second?.pubkey
+                if (parentAuthor != null &&
+                    parentAuthor != pubKey &&
+                    tags.none { it.size >= 2 && it[0] == "p" && it[1] == parentAuthor }
+                ) {
+                    tags.add(listOf("p", parentAuthor))
+                }
+            }
+
             // Add extra tags (e.g. NIP-68 imeta tags from media uploads), dedup by content
             extraTags.forEach { tag -> if (tag !in tags) tags.add(tag) }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -16,6 +16,11 @@ class UnreadManager(
     private val isRestricted: (String) -> Boolean = { false },
     private val isAppFocused: () -> Boolean = { true },
     private val findMessageAuthor: (messageId: String) -> String? = { null },
+    // Per-group notification gate (issue #70). `isDirect` is true for replies,
+    // mentions and reactions to the user's own message. Returning false suppresses
+    // the notification callbacks below WITHOUT touching the unread badge — a muted
+    // or "mentions only" group still accumulates its unread count.
+    private val shouldNotify: (groupId: String, isDirect: Boolean) -> Boolean = { _, _ -> true },
     private val onUnreadIncrement: ((groupId: String, latestMessage: NostrGroupClient.NostrMessage, delta: Int) -> Unit)? = null,
     private val onReplyNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
     private val onMentionNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
@@ -153,12 +158,22 @@ class UnreadManager(
 
         // NIP-29 marks replies with a "q" (quote) tag; NIP-10 chats use "e".
         // Accept both so replies are classified correctly regardless of which
-        // client posted them.
+        // client posted them. A message counts as a reply to us when it is a
+        // reply event AND either we can confirm from cache that the parent is
+        // ours, or it directly p-tags us (set by the sender so we're notified
+        // even when the parent message isn't loaded locally — see #70).
         val latestReply = qualifying.filter { msg ->
-            msg.tags.any { tag ->
-                tag.size >= 2 &&
-                    (tag[0] == "q" || tag[0] == "e") &&
-                    findMessageAuthor(tag[1]) == pubkey
+            val isReplyEvent = msg.tags.any { it.size >= 2 && (it[0] == "q" || it[0] == "e") }
+            if (!isReplyEvent) {
+                false
+            } else {
+                val parentIsMine = msg.tags.any { tag ->
+                    tag.size >= 2 &&
+                        (tag[0] == "q" || tag[0] == "e") &&
+                        findMessageAuthor(tag[1]) == pubkey
+                }
+                val pTagsMe = msg.tags.any { it.size >= 2 && it[0] == "p" && it[1] == pubkey }
+                parentIsMine || pTagsMe
             }
         }.maxByOrNull { it.createdAt }
 
@@ -167,9 +182,14 @@ class UnreadManager(
         }.maxByOrNull { it.createdAt }
 
         when {
-            latestReply != null -> onReplyNotify?.invoke(groupId, latestReply)
-            latestMention != null -> onMentionNotify?.invoke(groupId, latestMention)
-            else -> onUnreadIncrement?.invoke(groupId, qualifying.maxBy { it.createdAt }, qualifying.size)
+            latestReply != null ->
+                if (shouldNotify(groupId, true)) onReplyNotify?.invoke(groupId, latestReply)
+            latestMention != null ->
+                if (shouldNotify(groupId, true)) onMentionNotify?.invoke(groupId, latestMention)
+            else ->
+                if (shouldNotify(groupId, false)) {
+                    onUnreadIncrement?.invoke(groupId, qualifying.maxBy { it.createdAt }, qualifying.size)
+                }
         }
     }
 
@@ -193,15 +213,28 @@ class UnreadManager(
             _latestMessageTimestamps.update { it + (groupId to reaction.createdAt) }
         }
 
+        // Mirror onMessagesFlushed's active/focus handling so reactions don't behave
+        // differently from messages for the group the user is looking at.
         val isActive = groupId == activeGroupId
-        if (!(isActive && isAppFocused())) {
+        // Active group + app focused: user is reading live — silent.
+        if (isActive && isAppFocused()) {
+            persistEntries()
+            return
+        }
+        // Only inactive groups bump the badge. An active-but-unfocused group still
+        // notifies below, but its badge stays clear — the group is open, so the
+        // reaction is seen on refocus (matches messages; fixes the relay count
+        // appearing for the group you're currently viewing).
+        if (!isActive) {
             _unreadCounts.update { current ->
                 current + (groupId to ((current[groupId] ?: 0) + 1))
             }
         }
         persistEntries()
 
-        onReactionNotify?.invoke(groupId, reaction)
+        // A reaction is always to the user's own message, so it counts as a
+        // direct interaction for the notification gate.
+        if (shouldNotify(groupId, true)) onReactionNotify?.invoke(groupId, reaction)
     }
 
     fun clear() {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
@@ -3,7 +3,24 @@ package org.nostr.nostrord.settings
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.loadGroupNotificationLevelsFor
+import org.nostr.nostrord.storage.saveGroupNotificationLevelsFor
+
+/**
+ * How noisy a group's notifications are. Applied per-group, falling back to the
+ * global default for groups the user hasn't overridden.
+ *
+ * - [ALL] — every message notifies (current default).
+ * - [MENTIONS_REPLIES] — only direct replies, @mentions and reactions to the
+ *   user's own messages notify. Ordinary chatter is silent.
+ * - [MUTED] — nothing notifies, not even direct mentions/replies.
+ *
+ * Unread badges are independent of this setting: a quiet or muted group still
+ * accumulates its unread count, it just doesn't fire the feed/sound/popup.
+ */
+enum class NotificationLevel { ALL, MENTIONS_REPLIES, MUTED }
 
 /**
  * User-facing notification preferences — toggled from Settings → Notifications.
@@ -11,6 +28,9 @@ import org.nostr.nostrord.storage.SecureStorage
  * Sound applies to every platform that has a NotificationSound actual (web/desktop/android).
  * System popups are gated on the per-platform [NotificationService.isSupported] check
  * inside the consumer; this flag just lets the user opt out even when supported.
+ *
+ * Per-group [NotificationLevel] overrides are account-scoped and reloaded on
+ * account switch via [initialize] / [clear].
  */
 class NotificationSettings {
     private val _soundEnabled =
@@ -25,6 +45,23 @@ class NotificationSettings {
         )
     val systemNotificationsEnabled: StateFlow<Boolean> = _systemNotificationsEnabled.asStateFlow()
 
+    // Global default applied to groups the user hasn't explicitly overridden.
+    private val _defaultLevel =
+        MutableStateFlow(
+            runCatching {
+                NotificationLevel.valueOf(
+                    SecureStorage.getStringPref(KEY_DEFAULT_LEVEL, NotificationLevel.ALL.name),
+                )
+            }.getOrDefault(NotificationLevel.ALL),
+        )
+    val defaultLevel: StateFlow<NotificationLevel> = _defaultLevel.asStateFlow()
+
+    // Per-account, per-group overrides. Reloaded on account switch.
+    private val _groupLevels = MutableStateFlow<Map<String, NotificationLevel>>(emptyMap())
+    val groupLevels: StateFlow<Map<String, NotificationLevel>> = _groupLevels.asStateFlow()
+
+    private var currentPubkey: String? = null
+
     fun setSoundEnabled(enabled: Boolean) {
         _soundEnabled.value = enabled
         SecureStorage.saveBooleanPref(KEY_SOUND_ENABLED, enabled)
@@ -35,8 +72,59 @@ class NotificationSettings {
         SecureStorage.saveBooleanPref(KEY_SYSTEM_ENABLED, enabled)
     }
 
+    fun setDefaultLevel(level: NotificationLevel) {
+        _defaultLevel.value = level
+        SecureStorage.saveStringPref(KEY_DEFAULT_LEVEL, level.name)
+    }
+
+    /** Load the active account's per-group overrides. Call on account activation. */
+    fun initialize(pubkey: String) {
+        currentPubkey = pubkey
+        _groupLevels.value =
+            SecureStorage.loadGroupNotificationLevelsFor(pubkey)
+                .mapNotNull { (id, name) ->
+                    runCatching { id to NotificationLevel.valueOf(name) }.getOrNull()
+                }
+                .toMap()
+    }
+
+    /** Drop the active account's overrides on logout / account switch. */
+    fun clear() {
+        currentPubkey = null
+        _groupLevels.value = emptyMap()
+    }
+
+    fun setGroupLevel(
+        groupId: String,
+        level: NotificationLevel,
+    ) {
+        val pubkey = currentPubkey ?: return
+        _groupLevels.update { it + (groupId to level) }
+        SecureStorage.saveGroupNotificationLevelsFor(
+            pubkey,
+            _groupLevels.value.mapValues { it.value.name },
+        )
+    }
+
+    fun effectiveLevelFor(groupId: String): NotificationLevel = _groupLevels.value[groupId] ?: _defaultLevel.value
+
+    /**
+     * Whether a notification should fire for a message of the given [level].
+     * [isDirect] is true for replies, @mentions and reactions to the user's own
+     * message; false for ordinary group chatter.
+     */
+    fun shouldNotify(
+        level: NotificationLevel,
+        isDirect: Boolean,
+    ): Boolean = when (level) {
+        NotificationLevel.ALL -> true
+        NotificationLevel.MENTIONS_REPLIES -> isDirect
+        NotificationLevel.MUTED -> false
+    }
+
     private companion object {
         const val KEY_SOUND_ENABLED = "notif_sound_enabled"
         const val KEY_SYSTEM_ENABLED = "notif_system_enabled"
+        const val KEY_DEFAULT_LEVEL = "notif_default_level"
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -677,6 +677,34 @@ fun SecureStorage.savePersistedNotifications(
     }
 }
 
+// Per-account, per-group notification level overrides (issue #70). Stored as a
+// groupId -> NotificationLevel.name map so each account keeps its own muting /
+// "mentions & replies only" choices. The settings layer maps the names back to
+// the enum; storing strings keeps this layer free of the settings dependency.
+private fun groupNotificationLevelsKey(pubkey: String): String = "group_notif_levels_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.loadGroupNotificationLevelsFor(pubkey: String): Map<String, String> {
+    if (pubkey.isBlank()) return emptyMap()
+    val raw = getStringPref(groupNotificationLevelsKey(pubkey), "")
+    if (raw.isBlank()) return emptyMap()
+    return try {
+        Json.decodeFromString(raw)
+    } catch (_: Exception) {
+        emptyMap()
+    }
+}
+
+fun SecureStorage.saveGroupNotificationLevelsFor(
+    pubkey: String,
+    levels: Map<String, String>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(groupNotificationLevelsKey(pubkey), Json.encodeToString<Map<String, String>>(levels))
+    } catch (_: Exception) {
+    }
+}
+
 // Per-account "last active" timestamp in Unix seconds. Written when the user
 // switches away from this account and as a periodic heartbeat while active so
 // it survives crashes. Used to compute the catch-up `since` for notification

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -340,6 +340,14 @@ fun GroupScreen(
         vm.markAsRead()
     }
 
+    // Re-mark the open group as read when the app regains focus: messages that
+    // arrived while active-but-unfocused are now on screen, so clear their
+    // notification-feed entries instead of leaving a stale count.
+    val isAppFocused by AppModule.focusTracker.isAppFocused.collectAsState()
+    LaunchedEffect(isAppFocused) {
+        if (isAppFocused) vm.markAsRead()
+    }
+
     LaunchedEffect(selectedChannel) {
         vm.requestGroupMessages(selectedChannel)
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupInfoModal.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupInfoModal.kt
@@ -9,9 +9,12 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.NotificationsOff
 import androidx.compose.material.icons.filled.Public
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -36,8 +39,10 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.ui.components.RichAboutText
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
@@ -171,6 +176,44 @@ fun GroupInfoModal(
                                 onMentionClick = onUserClick,
                             )
                         }
+
+                        // Notifications — per-group override of the global default.
+                        val notificationSettings = AppModule.notificationSettings
+                        val groupLevels by notificationSettings.groupLevels.collectAsState()
+                        val defaultLevel by notificationSettings.defaultLevel.collectAsState()
+                        val effectiveLevel = groupLevels[groupId] ?: defaultLevel
+
+                        Spacer(modifier = Modifier.height(Spacing.lg))
+
+                        Text(
+                            text = "NOTIFICATIONS",
+                            style = NostrordTypography.SectionHeader,
+                            color = NostrordColors.TextMuted,
+                        )
+
+                        Spacer(modifier = Modifier.height(Spacing.sm))
+
+                        NotificationLevelOption(
+                            icon = Icons.Default.Notifications,
+                            label = "All messages",
+                            description = "Notify for every message in this group.",
+                            selected = effectiveLevel == NotificationLevel.ALL,
+                            onClick = { notificationSettings.setGroupLevel(groupId, NotificationLevel.ALL) },
+                        )
+                        NotificationLevelOption(
+                            icon = Icons.Default.Notifications,
+                            label = "Mentions & replies only",
+                            description = "Notify on replies, @mentions, and reactions to your messages.",
+                            selected = effectiveLevel == NotificationLevel.MENTIONS_REPLIES,
+                            onClick = { notificationSettings.setGroupLevel(groupId, NotificationLevel.MENTIONS_REPLIES) },
+                        )
+                        NotificationLevelOption(
+                            icon = Icons.Default.NotificationsOff,
+                            label = "Muted",
+                            description = "Silence everything, including replies, mentions and reactions.",
+                            selected = effectiveLevel == NotificationLevel.MUTED,
+                            onClick = { notificationSettings.setGroupLevel(groupId, NotificationLevel.MUTED) },
+                        )
 
                         // Group ID
                         Spacer(modifier = Modifier.height(Spacing.lg))
@@ -384,6 +427,59 @@ private fun StatusBadge(
                 style = NostrordTypography.Caption,
                 color = color,
                 fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+/**
+ * Selectable row for a per-group [NotificationLevel] choice. Shows a check on
+ * the currently effective level.
+ */
+@Composable
+private fun NotificationLevelOption(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    description: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(vertical = Spacing.sm, horizontal = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = if (selected) NostrordColors.Primary else NostrordColors.TextSecondary,
+            modifier = Modifier.size(20.dp),
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                style = NostrordTypography.MessageBody,
+                color = if (selected) Color.White else NostrordColors.TextContent,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            )
+            Text(
+                text = description,
+                style = NostrordTypography.Caption,
+                color = NostrordColors.TextMuted,
+            )
+        }
+        if (selected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Selected",
+                tint = NostrordColors.Primary,
+                modifier = Modifier.size(18.dp),
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -52,6 +52,7 @@ import kotlinx.coroutines.delay
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
+import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.storage.PassphraseSettings
 import org.nostr.nostrord.ui.Screen
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
@@ -936,6 +937,7 @@ private fun NotificationsPanelContent() {
 
     val soundEnabled by settings.soundEnabled.collectAsState()
     val systemEnabled by settings.systemNotificationsEnabled.collectAsState()
+    val defaultLevel by settings.defaultLevel.collectAsState()
     val permission by notificationService.permission.collectAsState()
     val systemSupported = remember { notificationService.isSupported() }
 
@@ -969,6 +971,49 @@ private fun NotificationsPanelContent() {
                         Text("Test sound", color = NostrordColors.Primary, fontSize = 13.sp)
                     }
                 }
+            }
+        }
+
+        // ── Default notification level card ──
+        // Sets the fallback level for every group the user hasn't overridden via
+        // a group's own info screen (issue #70).
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = NostrordShapes.cardShape,
+            colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
+        ) {
+            Column(modifier = Modifier.padding(Spacing.xl)) {
+                Text(
+                    text = "Default for new groups",
+                    color = NostrordColors.TextContent,
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 15.sp,
+                )
+                Text(
+                    text = "Applied to groups you haven't set individually. Change a " +
+                        "single group from its info screen.",
+                    color = NostrordColors.TextSecondary,
+                    fontSize = 13.sp,
+                )
+                Spacer(Modifier.height(Spacing.md))
+                NotificationLevelRow(
+                    label = "All messages",
+                    description = "Notify for every message.",
+                    selected = defaultLevel == NotificationLevel.ALL,
+                    onClick = { settings.setDefaultLevel(NotificationLevel.ALL) },
+                )
+                NotificationLevelRow(
+                    label = "Mentions & replies only",
+                    description = "Notify on replies, @mentions, and reactions to your messages.",
+                    selected = defaultLevel == NotificationLevel.MENTIONS_REPLIES,
+                    onClick = { settings.setDefaultLevel(NotificationLevel.MENTIONS_REPLIES) },
+                )
+                NotificationLevelRow(
+                    label = "Muted",
+                    description = "Silence everything, including replies, mentions and reactions.",
+                    selected = defaultLevel == NotificationLevel.MUTED,
+                    onClick = { settings.setDefaultLevel(NotificationLevel.MUTED) },
+                )
             }
         }
 
@@ -1077,6 +1122,46 @@ private fun ToggleRow(
             ),
             modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
         )
+    }
+}
+
+@Composable
+private fun NotificationLevelRow(
+    label: String,
+    description: String,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(vertical = Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = label,
+                color = if (selected) NostrordColors.TextPrimary else NostrordColors.TextSecondary,
+                fontSize = 14.sp,
+                fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+            )
+            Text(
+                text = description,
+                style = NostrordTypography.Caption,
+                color = NostrordColors.TextMuted,
+            )
+        }
+        if (selected) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = "Selected",
+                tint = NostrordColors.Primary,
+                modifier = Modifier.size(18.dp),
+            )
+        }
     }
 }
 


### PR DESCRIPTION
Closes #70.

Not every group message should become a notification. This adds a per-group notification level with a global default, so you keep the loud groups loud and quiet the rest.

| Level | Plain message | Reply / @mention | Reaction to your message |
|---|---|---|---|
| All | notify | notify | notify |
| Mentions & replies only | silent | notify | notify |
| Muted | silent | silent | silent |

Set the default in Settings → Notifications; override per group from the group info screen. Levels persist per account and gate the in-app feed, sound and OS popup — unread badges are unaffected.

Also fixes related notification/unread issues found while testing:
- per-account settings now initialize on login/cold-start (not only on account switch), so per-group choices actually persist
- replies p-tag the parent author (and a reply that p-tags us is recognized), so replies notify reliably without the parent message cached locally
- reactions no longer bump the unread badge for the group you're actively viewing
- focusing the app while in a group clears its stale notification-feed count
