### PR TITLE
fix(auth): keep bunker users signed in when the signer is unreachable

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -46,6 +46,7 @@ import org.nostr.nostrord.storage.clearLastGroupForRelay
 import org.nostr.nostrord.storage.getLastGroupForRelay
 import org.nostr.nostrord.storage.saveLastGroupForRelay
 import org.nostr.nostrord.ui.Screen
+import org.nostr.nostrord.ui.components.BunkerStatusBanner
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.components.layout.DesktopShell
 import org.nostr.nostrord.ui.components.layout.responsiveDimension
@@ -987,9 +988,17 @@ private fun AuthenticatedApp(
             },
         )
 
-        // Floating prompt to enable desktop notifications. Mounted at the root so it
-        // persists across navigation; renders only when supported + permission Default.
-        NotificationPermissionBanner(modifier = Modifier.align(Alignment.TopCenter))
+        // Floating root-level banners, mounted here so they persist across
+        // navigation. Stacked in a column so they never overlap when both show.
+        Column(
+            modifier = Modifier.align(Alignment.TopCenter),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            // Bunker (NIP-46) signer offline → one-tap reconnect (issue #85).
+            BunkerStatusBanner()
+            // Prompt to enable desktop notifications (supported + permission Default).
+            NotificationPermissionBanner()
+        }
 
         androidx.compose.material3.SnackbarHost(
             hostState = snackbarHostState,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -538,11 +538,9 @@ class AuthManager(
                 },
                 onRevoked = {
                     if (nip46Client !== client) return@backgroundConnect
-                    handlePermissionDenied()
-                    authScope.launch {
-                        delay(1500)
-                        _isBunkerVerifying.value = false
-                    }
+                    // Couldn't reach or verify the signer — keep the user signed
+                    // in and let the banner offer a retry instead of logging out.
+                    markSignerUnreachable()
                 },
             )
         }
@@ -570,64 +568,85 @@ class AuthManager(
         bunkerUrl: String,
         savedUserPubkey: String,
     ): Boolean {
-        try {
-            val bunkerInfo = parseBunkerUrl(bunkerUrl)
-            val savedClientPrivateKey =
-                SecureStorage.getBunkerClientPrivateKeyFor(savedUserPubkey)
-                    ?: SecureStorage.getBunkerClientPrivateKey()
-
-            val newNip46Client =
-                if (savedClientPrivateKey != null) {
-                    Nip46Client(savedClientPrivateKey)
-                } else {
-                    Nip46Client()
-                }
-
-            bunkerUserPubkey = savedUserPubkey
-            isBunkerLogin = true
-
-            newNip46Client.onAuthUrl = { url ->
-                _authUrl.value = url
+        val bunkerInfo =
+            try {
+                parseBunkerUrl(bunkerUrl)
+            } catch (_: Exception) {
+                // A corrupt/unparseable stored URL is the only restore failure
+                // that genuinely logs out — there is nothing to reconnect to.
+                _isLoggedIn.value = false
+                _isBunkerVerifying.value = false
+                clearBunkerCredentials()
+                return false
             }
 
-            // Set logged-in and verifying states BEFORE the slow relay connection so the UI
-            // immediately shows "Reconnecting to signer..." instead of a blank spinner.
-            _isLoggedIn.value = true
-            _isBunkerVerifying.value = true
+        val savedClientPrivateKey =
+            SecureStorage.getBunkerClientPrivateKeyFor(savedUserPubkey)
+                ?: SecureStorage.getBunkerClientPrivateKey()
 
-            newNip46Client.connectRelaysOnly(bunkerInfo.pubkey, bunkerInfo.relays)
+        val newNip46Client =
+            if (savedClientPrivateKey != null) {
+                Nip46Client(savedClientPrivateKey)
+            } else {
+                Nip46Client()
+            }
+
+        bunkerUserPubkey = savedUserPubkey
+        isBunkerLogin = true
+        newNip46Client.onAuthUrl = { url ->
+            _authUrl.value = url
+        }
+        nip46Client = newNip46Client
+
+        // Stay logged in immediately; the relay connection below is best-effort.
+        // The UI shows "Reconnecting to signer..." while verifying. If the bunker
+        // relay is offline we keep the user on this account and only mark the
+        // signer disconnected — dropping the session here would force the user to
+        // re-paste the bunker URI (issue #85).
+        _isLoggedIn.value = true
+        _isBunkerVerifying.value = true
+        _isBunkerConnected.value = true
+
+        if (savedClientPrivateKey == null) {
+            SecureStorage.saveBunkerClientPrivateKey(newNip46Client.clientPrivateKey)
+            SecureStorage.saveBunkerClientPrivateKeyFor(
+                savedUserPubkey,
+                newNip46Client.clientPrivateKey,
+            )
+        }
+
+        // The slow relay connect + identity verification run async so a hung or
+        // offline bunker never blocks startup or tears down the session. Mirrors
+        // installBunkerClient (the multi-account path).
+        authScope.launch {
+            try {
+                newNip46Client.connectRelaysOnly(bunkerInfo.pubkey, bunkerInfo.relays)
+            } catch (_: Exception) {
+                // Relay unreachable — keep the user signed in and surface the
+                // disconnected state so the UI can offer a one-tap reconnect.
+                if (nip46Client === newNip46Client) {
+                    _isBunkerConnected.value = false
+                    _isBunkerVerifying.value = false
+                }
+                return@launch
+            }
             newNip46Client.backgroundConnect(
                 secret = bunkerInfo.secret,
-                onSuccess = { _isBunkerVerifying.value = false },
+                onSuccess = {
+                    if (nip46Client === newNip46Client) _isBunkerVerifying.value = false
+                },
                 onRevoked = {
-                    // Set isLoggedIn=false FIRST (keeps loading screen visible, prevents auth flash),
-                    // then delay briefly to show "Logging out..." before releasing the loading screen.
-                    handlePermissionDenied()
-                    authScope.launch {
-                        delay(1500)
-                        _isBunkerVerifying.value = false
-                    }
+                    // Couldn't reach or verify the signer on restore — stay
+                    // logged in and let the banner offer a retry. We can't tell
+                    // an offline signer from a deleted connection apart, so we
+                    // never drop the session here (issue #85).
+                    if (nip46Client !== newNip46Client) return@backgroundConnect
+                    markSignerUnreachable()
                 },
             )
-
-            nip46Client = newNip46Client
-            _isBunkerConnected.value = true
-
-            if (savedClientPrivateKey == null) {
-                SecureStorage.saveBunkerClientPrivateKey(newNip46Client.clientPrivateKey)
-                SecureStorage.saveBunkerClientPrivateKeyFor(
-                    savedUserPubkey,
-                    newNip46Client.clientPrivateKey,
-                )
-            }
-
-            return true
-        } catch (e: Exception) {
-            _isLoggedIn.value = false
-            _isBunkerVerifying.value = false
-            clearBunkerCredentials()
-            return false
         }
+
+        return true
     }
 
     private fun restorePrivateKeySession(privateKeyHex: String): Boolean = try {
@@ -721,6 +740,12 @@ class AuthManager(
                 sessionSigner.signEvent(event)
             } catch (e: NostrSigner.SigningException) {
                 if (isPermissionError(e)) {
+                    if (sessionSigner is NostrSigner.Bunker) {
+                        // Can't tell an offline signer from a deleted connection
+                        // apart — surface a reconnectable error, never log out.
+                        markSignerUnreachable()
+                        throw Exception("Couldn't reach your signer. Please reconnect.")
+                    }
                     handlePermissionDenied()
                     throw Exception("Signing permission denied. Please login again.")
                 }
@@ -764,8 +789,10 @@ class AuthManager(
             return parseSignedEvent(signedEventJson)
         } catch (e: Exception) {
             if (isPermissionError(e)) {
-                handlePermissionDenied()
-                throw Exception("Signing permission denied. Please login again.")
+                // Can't tell an offline signer from a deleted connection apart —
+                // surface a reconnectable error, never log out (issue #85).
+                markSignerUnreachable()
+                throw Exception("Couldn't reach your signer. Please reconnect.")
             }
             throw e
         }
@@ -781,6 +808,23 @@ class AuthManager(
         return msg.contains("no permission") ||
             msg.contains("not authorized") ||
             msg.contains("permission denied")
+    }
+
+    /**
+     * The bunker signer can't be reached or refused a request. The app cannot
+     * tell "signer offline" from "connection deleted on the signer" apart — both
+     * surface as a timeout or an error — so this NEVER logs the user out or wipes
+     * credentials. It only marks the signer disconnected; [BunkerStatusBanner]
+     * then explains the situation and lets the user choose to reconnect or log
+     * out. (issue #85)
+     */
+    private fun markSignerUnreachable() {
+        nip46Client?.disconnect()
+        nip46Client = null
+        _isBunkerConnected.value = false
+        _isBunkerVerifying.value = false
+        // isBunkerLogin, bunkerUserPubkey, the stored bunker URL and isLoggedIn
+        // are left intact so reconnectBunker() can re-read the saved URL on retry.
     }
 
     private fun handlePermissionDenied() {
@@ -851,8 +895,6 @@ class AuthManager(
         _isBunkerConnected.value = false
         // Reset the verifying flag so a hung backgroundConnect does not keep
         // the UI stuck on "Reconnecting to signer..." after logout completes.
-        // The delay(1500) clearer in installBunkerClient / restoreBunkerSession
-        // is best-effort; this is the deterministic path.
         _isBunkerVerifying.value = false
 
         SecureStorage.clearPrivateKey()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt
@@ -1,0 +1,200 @@
+package org.nostr.nostrord.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.auth.ActiveAccountManager
+import org.nostr.nostrord.auth.NostrSigner
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordTypography
+
+/**
+ * Floating warning shown when the active account signs through a NIP-46 bunker
+ * the app currently can't reach. The app can't tell an offline signer from a
+ * connection that was deleted on the signer side, so it never logs the user out
+ * (see [org.nostr.nostrord.network.AuthManager.markSignerUnreachable]). This
+ * banner explains the situation and lets the user choose: "Reconnect" re-reads
+ * the saved bunker URL from storage via [ensureBunkerConnected] (no re-paste),
+ * or "Log out" to sign in differently. (issue #85)
+ */
+@Composable
+fun BunkerStatusBanner(modifier: Modifier = Modifier) {
+    val repo = AppModule.nostrRepository
+    val loggedIn by repo.isLoggedIn.collectAsState()
+    val connected by repo.isBunkerConnected.collectAsState()
+    val verifying by repo.isBunkerVerifying.collectAsState()
+    // Follow the ACTIVE session's signer, not the inline auth flag: after "Log
+    // out" removes the bunker account and switches to another account, an active
+    // non-bunker signer hides the banner. Using isUsingBunker() (a stale inline
+    // flag) kept the banner up over the switched-in account.
+    val session by ActiveAccountManager.session.collectAsState()
+    val activeIsBunker = session?.signer is NostrSigner.Bunker
+
+    // Only when the active account signs through a bunker that's currently
+    // unreachable. While verifying, the startup loading screen already shows
+    // "Reconnecting to signer...", so suppress the banner to avoid double UI.
+    val show = loggedIn && !verifying && !connected && activeIsBunker
+
+    var reconnecting by remember { mutableStateOf(false) }
+    val scope = rememberCoroutineScope()
+
+    AnimatedVisibility(
+        visible = show,
+        enter = expandVertically(),
+        exit = shrinkVertically(),
+        modifier = modifier,
+    ) {
+        Card(
+            modifier =
+            Modifier
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .widthIn(max = 520.dp),
+            shape = RoundedCornerShape(12.dp),
+            colors =
+            CardDefaults.cardColors(
+                containerColor = NostrordColors.SurfaceVariant,
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+        ) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.Warning,
+                        contentDescription = null,
+                        tint = NostrordColors.Warning,
+                        modifier = Modifier.size(20.dp),
+                    )
+                    Spacer(Modifier.width(10.dp))
+                    Column {
+                        Text(
+                            text = "Can't reach your signer",
+                            style = NostrordTypography.Caption,
+                            color = NostrordColors.Warning,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Spacer(Modifier.height(6.dp))
+                        Text(
+                            text =
+                            "Your bunker didn't respond. It may be offline, or its " +
+                                "connection was removed. Reconnect to try again.",
+                            style = NostrordTypography.Caption,
+                            color = NostrordColors.TextContent,
+                        )
+                    }
+                }
+                Spacer(Modifier.height(6.dp))
+                // Collapse the buttons' 48dp minimum touch target so the action
+                // row hugs its content. Otherwise the reserved height adds slack
+                // below the text, making the card's bottom padding look larger
+                // than the top.
+                CompositionLocalProvider(
+                    LocalMinimumInteractiveComponentSize provides Dp.Unspecified,
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        TextButton(
+                            onClick = {
+                                scope.launch {
+                                    // Mirror the explicit-logout flow used by Settings:
+                                    // remove the active account if registered, else a
+                                    // plain logout. Routes the UI back to login.
+                                    val activeId = AppModule.accountStore.activeId.value
+                                    if (activeId != null) {
+                                        AppModule.accountManager.removeAccount(activeId)
+                                    } else {
+                                        repo.logout()
+                                    }
+                                }
+                            },
+                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                        ) {
+                            Text(
+                                text = "Log out",
+                                style = NostrordTypography.Caption,
+                                color = NostrordColors.TextContent,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                        Spacer(Modifier.width(4.dp))
+                        TextButton(
+                            onClick = {
+                                if (reconnecting) return@TextButton
+                                reconnecting = true
+                                scope.launch {
+                                    try {
+                                        repo.ensureBunkerConnected()
+                                    } finally {
+                                        reconnecting = false
+                                    }
+                                }
+                            },
+                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                        ) {
+                            if (reconnecting) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(14.dp),
+                                    color = NostrordColors.Warning,
+                                    strokeWidth = 2.dp,
+                                )
+                            } else {
+                                Icon(
+                                    Icons.Default.Refresh,
+                                    contentDescription = null,
+                                    tint = NostrordColors.Warning,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                            Spacer(Modifier.width(4.dp))
+                            Text(
+                                text = if (reconnecting) "Reconnecting…" else "Reconnect",
+                                style = NostrordTypography.Caption,
+                                color = NostrordColors.Warning,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
A NIP-46 (bunker) account whose signer was offline — or whose connection was deleted on the signer side — got dropped to the login screen, and the stored bunker URL was wiped so the user had to re-paste it. The app can't distinguish "signer offline" from "connection revoked" (both surface as a timeout or error), so every unreachable-signer case is now handled the same way: stay signed in, keep credentials, and show a banner letting the user reconnect or log out.

| Scenario | Before | After |
|---|---|---|
| Bunker offline at cold start | logout + bunker URL wiped | stays signed in, banner offers Reconnect |
| Signer connection deleted mid-session | logout + bunker URL wiped | stays signed in, banner offers Reconnect / Log out |
| Signer identity mismatch (security) | logout | logout (unchanged) |

Reconnect re-reads the saved bunker URL from storage (no re-paste). The banner follows the active session's signer, so it hides after Log out switches to another account.

Closes #85

Commits:
- fix(auth): keep bunker users signed in when the signer is unreachable (#85)