### PR TITLE
fix(groups): reliably load groups, messages and members after login (#88)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -585,6 +585,19 @@ class NostrGroupClient(
         // relay clients are active concurrently. The ID must be stable per relay
         // so the EOSE handler can map it back to the originating relay URL.
         val subId = "group-list-${relayUrl.hashCode().toUInt()}"
+        // CLOSE the sub id before re-REQ'ing. requestGroupsForIds() reuses this
+        // same id for the lazy joined-only (#d-filtered) fetch; sending an
+        // unfiltered REQ on a sub that is still open with a narrower filter is a
+        // re-REQ that some relays do not re-evaluate — they keep serving the old
+        // (#d) filter or treat it as already-EOSEd, so the OTHER GROUPS full
+        // fetch comes back empty (observed on hzrd149's relay). An explicit CLOSE
+        // guarantees the relay runs the widened filter as a fresh subscription.
+        sendJson(
+            buildJsonArray {
+                add("CLOSE")
+                add(subId)
+            },
+        )
         val req = buildJsonArray {
             add("REQ")
             add(subId)
@@ -612,6 +625,15 @@ class NostrGroupClient(
     suspend fun requestGroupsForIds(groupIds: List<String>) {
         if (groupIds.isEmpty()) return
         val subId = groupListSubscriptionId()
+        // CLOSE before re-REQ — see requestGroups(). This sub id is shared with
+        // the unfiltered full fetch; closing first guarantees the relay applies
+        // this #d filter as a fresh subscription instead of mishandling a re-REQ.
+        sendJson(
+            buildJsonArray {
+                add("CLOSE")
+                add(subId)
+            },
+        )
         val req = buildJsonArray {
             add("REQ")
             add(subId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -590,6 +590,12 @@ class NostrRepository(
             // for the same reason; the cold-start re-login path was the only
             // one missing it.
             connectionManager.loadSavedRelay()
+            // Seed the relay rail (kind:10009 set) from the per-account cache so
+            // ALL of the user's relays show immediately, exactly as initialize()
+            // does on cold boot. Without this, the rail showed only the current
+            // relay after re-login until the slow network kind:10009 fetch landed
+            // (or the user restarted the app).
+            outboxManager.seedFromCache(newPubkey)
             // Re-hydrate joined-group state from local storage, exactly as the
             // cold-boot path (initialize) does at lines 377-380. Previously this
             // re-login branch relied solely on the kind:10009 outbox fetch to

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -778,6 +778,13 @@ class NostrRepository(
             groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
             groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
             groupManager.loadRestrictedGroupsFromStorage(pubkey, allRelays)
+            // Point GroupManager's current-relay flow at the new primary so the
+            // derived joinedGroups (My Groups — sidebar AND homescreen) reflects
+            // this account immediately. applyActiveAccountChange.clear() nulled it,
+            // and the warm-swap path only re-sets it if reconnect() actually runs
+            // (non-blank relay + a live message handler) via resubscribeAllGroups
+            // — so without this, My Groups stayed empty after an account switch.
+            groupManager.restoreGroupsForRelay(primaryRelay)
             // The account had no persisted current relay — elect one so the
             // primary actually connects (and its cache-hit mux is set up) instead
             // of relying on a reconnect that no-ops against a blank current relay.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -282,6 +282,40 @@ class NostrRepository(
             }
         }
 
+        // Bunker (NIP-46) signer-ready recovery. On session restore / account-add
+        // the account is marked logged-in optimistically while the remote signer
+        // connects asynchronously (issue #85). connect() + NIP-42 AUTH for the
+        // group relays run before the signer can sign the AUTH event, so their
+        // group/mux REQs come back CLOSED "auth-required" and nothing retries —
+        // groups stuck on "No messages yet" / "Members 0" until app restart.
+        // When the signer transitions to ready, reconnect the group relays: fresh
+        // sockets -> fresh AUTH (now signable) -> resubscribe (messages+members).
+        // Interactive loginWithBunker connects the signer synchronously (verifying
+        // never goes true), so this never fires spuriously for a fresh login.
+        scope.launch {
+            var wasReady = sessionManager.isBunkerConnected.value &&
+                !sessionManager.isBunkerVerifying.value &&
+                sessionManager.isBunkerReady()
+            combine(
+                sessionManager.isBunkerConnected,
+                sessionManager.isBunkerVerifying,
+            ) { connected, verifying ->
+                connected && !verifying && sessionManager.isBunkerReady()
+            }.collect { ready ->
+                if (ready && !wasReady) {
+                    try {
+                        reconnect()
+                        ensureJoinedRelaysConnected(
+                            connectionManager.currentRelayUrl.value.takeIf { it.isNotBlank() },
+                        )
+                    } catch (e: Throwable) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                    }
+                }
+                wasReady = ready
+            }
+        }
+
         metadataManager.messageHandler = { msg, client -> enqueueToRelayPipeline(msg, client) }
 
         connectionManager.startNetworkMonitor()
@@ -728,13 +762,29 @@ class NostrRepository(
         // resolves, even for accounts that already have a persisted relay list.
         outboxManager.seedFromCache(pubkey)
 
-        if (activeRelay.isNotBlank()) {
-            groupManager.loadJoinedGroupsFromStorage(pubkey, activeRelay)
-        }
-        if (savedRelays.isNotEmpty()) {
-            groupManager.loadAllJoinedGroupsFromStorage(pubkey, savedRelays)
-            groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, savedRelays)
-            groupManager.loadRestrictedGroupsFromStorage(pubkey, savedRelays)
+        // Mirror initialize()/finishLoginInit's full relay+group bootstrap so a
+        // warm account swap establishes the SAME state as a cold start. The swap
+        // previously loaded joined groups but skipped prePopulateRelayList / the
+        // cursor + NIP-11 metadata bootstrap, and elected no primary when the new
+        // account had a blank current-relay slot — leaving it on empty groups /
+        // a one-relay rail / stale icons until the app was restarted.
+        val allRelays = (listOfNotNull(activeRelay.ifBlank { null }) + savedRelays).distinct()
+        val primaryRelay = activeRelay.ifBlank { allRelays.firstOrNull().orEmpty() }
+        if (primaryRelay.isNotBlank()) {
+            groupManager.prePopulateRelayList(allRelays)
+            liveCursorStore?.loadAll(allRelays)
+            _relayMetadataManager.fetchAll(allRelays)
+            groupManager.loadJoinedGroupsFromStorage(pubkey, primaryRelay)
+            groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
+            groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
+            groupManager.loadRestrictedGroupsFromStorage(pubkey, allRelays)
+            // The account had no persisted current relay — elect one so the
+            // primary actually connects (and its cache-hit mux is set up) instead
+            // of relying on a reconnect that no-ops against a blank current relay.
+            if (activeRelay.isBlank()) {
+                SecureStorage.saveCurrentRelayUrlFor(pubkey, primaryRelay)
+                connectionManager.loadSavedRelay()
+            }
         }
 
         initializeOutboxModel()
@@ -751,12 +801,12 @@ class NostrRepository(
         // until the next AUTH challenge; clear their mux tracker and reconnect
         // them so the new identity's AUTH runs before subs go out (matches
         // [ensureJoinedRelaysConnected] in the boot path).
-        if (activeRelay.isNotBlank()) {
+        if (primaryRelay.isNotBlank()) {
             triggerReconnect()
         }
         scope.launch {
             try {
-                ensureJoinedRelaysConnected(activeRelay.takeIf { it.isNotBlank() })
+                ensureJoinedRelaysConnected(primaryRelay.takeIf { it.isNotBlank() })
             } catch (_: Exception) {}
             // Safety net for the active relay and any joined relay not covered
             // above: applies the catch-up `since` set earlier so events missed

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -581,6 +581,30 @@ class NostrRepository(
             // for the same reason; the cold-start re-login path was the only
             // one missing it.
             connectionManager.loadSavedRelay()
+            // Re-hydrate joined-group state from local storage, exactly as the
+            // cold-boot path (initialize) does at lines 377-380. Previously this
+            // re-login branch relied solely on the kind:10009 outbox fetch to
+            // repopulate the group list; when that network fetch was slow or the
+            // bunker signer was unreachable (#85), nothing loaded the locally
+            // persisted groups as a fallback. The result (#88): every group was
+            // stuck on "No messages yet" and the relay's groups were never
+            // subscribed, intermittently, depending on outbox-fetch timing.
+            val activeRelay = connectionManager.currentRelayUrl.value
+            val savedRelays = SecureStorage.loadRelayListFor(newPubkey)
+            val allRelays = (listOfNotNull(activeRelay.ifBlank { null }) + savedRelays).distinct()
+            val primaryRelay = activeRelay.ifBlank { allRelays.firstOrNull().orEmpty() }
+            if (primaryRelay.isNotBlank()) {
+                groupManager.prePopulateRelayList(allRelays)
+                // Mirror the rest of initialize()'s sibling bootstrap, not just the
+                // joined-group loaders: without loadAll the first mux subscription
+                // has no persisted `since` cursor, and without fetchAll the relay
+                // rail shows stale NIP-11 icons/names after re-login.
+                liveCursorStore?.loadAll(allRelays)
+                _relayMetadataManager.fetchAll(allRelays)
+                groupManager.loadJoinedGroupsFromStorage(newPubkey, primaryRelay)
+                groupManager.loadAllJoinedGroupsFromStorage(newPubkey, allRelays)
+                groupManager.restoreJoinedGroupMetadataFromStorage(newPubkey, allRelays)
+            }
             unreadManager.initialize(newPubkey)
             notificationSettings?.initialize(newPubkey)
             notificationHistoryStore?.initialize(newPubkey)
@@ -592,6 +616,13 @@ class NostrRepository(
             if (!isNewIdentity) initializeOutboxModel()
             sessionManager.setLoggedIn(true)
             scope.launch { connect() }
+            // Open sockets for joined groups that live on secondary (non-primary)
+            // relays too. connect() only handles the primary; without this those
+            // groups stay on "No messages yet" until the user manually switches to
+            // their relay — the same #88 symptom, confined to non-primary relays.
+            if (primaryRelay.isNotBlank()) {
+                scope.launch { ensureJoinedRelaysConnected(primaryRelay) }
+            }
         }
         scope.launch { requestUserMetadata(setOf(newPubkey)) }
     }
@@ -939,11 +970,16 @@ class NostrRepository(
                     }
                 } else if (
                     SecureStorage.isGroupFetchLazy(relayUrl) &&
-                    !groupManager.hasFullGroupListBeenFetched(relayUrl) &&
+                    relayUrl.normalizeRelayUrl() !in groupManager.fullGroupListFetchedRelays.value &&
                     SecureStorage.getBooleanPref("sidebar_other_expanded_$relayUrl", default = true)
                 ) {
                     // Cache is fresh (partial, joined-only) but OTHER GROUPS is open and the full
-                    // list was never fetched. Trigger a full fetch now so the sidebar populates.
+                    // list was never fetched THIS SESSION. Trigger a full fetch now so the sidebar
+                    // populates automatically on connect — don't make the user click the homescreen
+                    // OTHER GROUPS tab. We check the in-memory set, not hasFullGroupListBeenFetched:
+                    // a stale persisted timestamp (or a previous session's full fetch) would
+                    // otherwise satisfy that guard while the cache holds only joined groups,
+                    // leaving OTHER GROUPS empty until a manual fetch.
                     groupManager.markPendingFullFetch(relayUrl)
                     groupManager.markRelayLoading(relayUrl)
                     client.requestGroups()
@@ -1060,14 +1096,16 @@ class NostrRepository(
                 requestGroupsForRelay(client, newRelayUrl)
             } else if (
                 SecureStorage.isGroupFetchLazy(newRelayUrl) &&
-                !groupManager.hasFullGroupListBeenFetched(newRelayUrl) &&
+                newRelayUrl.normalizeRelayUrl() !in groupManager.fullGroupListFetchedRelays.value &&
                 SecureStorage.getBooleanPref("sidebar_other_expanded_$newRelayUrl", default = true)
             ) {
                 // Cache holds only the joined-group subset (from a previous lazy
                 // fetch) but OTHER GROUPS is open and this session hasn't
                 // received a full EOSE — fire the full fetch so the sidebar
                 // populates instead of flashing "no other groups". Mirrors the
-                // equivalent branch in connect().
+                // equivalent branch in connect(). We check the in-memory session
+                // set rather than hasFullGroupListBeenFetched so a stale persisted
+                // timestamp can't suppress the auto-fetch on switching to a relay.
                 groupManager.markPendingFullFetch(newRelayUrl)
                 groupManager.markRelayLoading(newRelayUrl)
                 client.requestGroups()
@@ -2474,6 +2512,14 @@ class NostrRepository(
         if (connectionManager.getPrimaryClient() === client) {
             val now = epochSeconds()
             val lastAt = lastRequestGroupsAt[relayUrl] ?: 0L
+            // Any full-list result captured BEFORE auth is untrustworthy: an
+            // auth-required relay may answer the unauthenticated group-list REQ
+            // with an empty EOSE (rather than CLOSED auth-required), which marks
+            // the relay "fully fetched" and would make sessionFetched below skip
+            // this authed fetch — leaving OTHER GROUPS empty even when expanded
+            // (observed on hzrd149's relay). Drop that pre-auth marker so the
+            // post-auth fetch always runs once.
+            groupManager.invalidateFullGroupListFetch(relayUrl)
             // Bypass the 10s dedup when THIS SESSION hasn't received an EOSE for
             // the full group list yet. The previous REQ likely raced AUTH and was
             // CLOSED auth-required, so skipping the retry leaves OTHER GROUPS

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -996,6 +996,14 @@ class NostrRepository(
                 } else {
                     // Cache hit — no EOSE will arrive, so clear the early loading mark.
                     groupManager.markRelayLoaded(relayUrl)
+                    // No group-list REQ was sent, so the EOSE-driven mux setup
+                    // (handleEoseSuspend -> refreshMuxSubscriptionsForRelay) never
+                    // fires. Set up the live chat + metadata mux now, otherwise the
+                    // primary relay's groups show "No messages yet" and "Members 0"
+                    // until a re-AUTH or the 5-min periodic refresh. This path is hit
+                    // whenever login hydrates joined groups from storage (#88), which
+                    // makes the relay a cache hit and skips the group-list fetch.
+                    groupManager.refreshMuxSubscriptionsForRelay(relayUrl)
                 }
                 drainFullFetchRequest(client, relayUrl)
                 // After AUTH (or if no AUTH needed), request metadata for private
@@ -1122,6 +1130,11 @@ class NostrRepository(
             } else {
                 // Cache was restored — no EOSE will arrive, so unmark loading now.
                 groupManager.markRelayLoaded(newRelayUrl)
+                // As in connect(): a cache hit sends no group-list REQ, so the
+                // EOSE-driven mux setup won't fire. Refresh the chat + metadata mux
+                // for the new primary now so messages/members load instead of
+                // showing "No messages yet" / "Members 0".
+                groupManager.refreshMuxSubscriptionsForRelay(newRelayUrl)
             }
             drainFullFetchRequest(client, newRelayUrl)
             // Request metadata for private groups not in the cache (kind 10009 joined

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -94,6 +94,15 @@ class NostrRepository(
     private val lastRequestGroupsAt = mutableMapOf<String, Long>()
 
     /**
+     * Relays for which a post-AUTH group-list fetch has already been issued this
+     * session. resubscribeAfterAuth invalidates the (possibly pre-AUTH, empty-EOSE)
+     * full-list marker only on the FIRST auth completion per relay; thereafter the
+     * in-session marker is trustworthy, so subsequent re-AUTH challenges fall back
+     * to the normal 10s dedup instead of force-refetching the full list every time.
+     */
+    private val authedGroupListFetchedRelays = mutableSetOf<String>()
+
+    /**
      * Relays for which the UI requested the full OTHER GROUPS list while the
      * corresponding client wasn't yet primary/connected/AUTHed. Drained by
      * [drainFullFetchRequest] from connect()/switchRelay()/resubscribeAfterAuth
@@ -658,6 +667,7 @@ class NostrRepository(
         // mux/message refresh paths skip work for the new session, leaving
         // every group stuck on "No messages yet" until the user restarted.
         lastRequestGroupsAt.clear()
+        authedGroupListFetchedRelays.clear()
         lastGapDetectionAt.clear()
         pendingFullFetchMutex.withLock { pendingFullFetchRequests.clear() }
         _closedGroupSubscriptions.value = emptySet()
@@ -2512,14 +2522,19 @@ class NostrRepository(
         if (connectionManager.getPrimaryClient() === client) {
             val now = epochSeconds()
             val lastAt = lastRequestGroupsAt[relayUrl] ?: 0L
-            // Any full-list result captured BEFORE auth is untrustworthy: an
-            // auth-required relay may answer the unauthenticated group-list REQ
-            // with an empty EOSE (rather than CLOSED auth-required), which marks
-            // the relay "fully fetched" and would make sessionFetched below skip
-            // this authed fetch — leaving OTHER GROUPS empty even when expanded
-            // (observed on hzrd149's relay). Drop that pre-auth marker so the
-            // post-auth fetch always runs once.
-            groupManager.invalidateFullGroupListFetch(relayUrl)
+            val normalized = relayUrl.normalizeRelayUrl()
+            // On the FIRST auth completion for this relay this session, any full-list
+            // result captured so far is untrustworthy: an auth-required relay may
+            // answer the unauthenticated pre-AUTH group-list REQ with an empty EOSE
+            // (rather than CLOSED auth-required), which marks the relay "fully
+            // fetched" and would make sessionFetched below skip this authed fetch —
+            // leaving OTHER GROUPS empty even when expanded (observed on hzrd149's
+            // relay). Invalidate only once: after the first authed fetch the marker
+            // is trustworthy, so relays that re-issue AUTH periodically fall back to
+            // the 10s dedup instead of re-fetching the full list on every challenge.
+            if (normalized !in authedGroupListFetchedRelays) {
+                groupManager.invalidateFullGroupListFetch(relayUrl)
+            }
             // Bypass the 10s dedup when THIS SESSION hasn't received an EOSE for
             // the full group list yet. The previous REQ likely raced AUTH and was
             // CLOSED auth-required, so skipping the retry leaves OTHER GROUPS
@@ -2528,10 +2543,10 @@ class NostrRepository(
             // so a fresh re-login doesn't get fooled by the still-fresh persisted
             // cache from a previous session; that cache predates the auth-required
             // CLOSED on this socket.
-            val sessionFetched = relayUrl.normalizeRelayUrl() in
-                groupManager.fullGroupListFetchedRelays.value
+            val sessionFetched = normalized in groupManager.fullGroupListFetchedRelays.value
             if (!sessionFetched || now - lastAt > 10L) {
                 lastRequestGroupsAt[relayUrl] = now
+                authedGroupListFetchedRelays.add(normalized)
                 groupManager.markRelayLoading(relayUrl)
                 requestGroupsForRelay(client, relayUrl)
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -187,6 +187,16 @@ class GroupManager(
     private val _loadingRelays = MutableStateFlow<Set<String>>(emptySet())
     val loadingRelays: StateFlow<Set<String>> = _loadingRelays.asStateFlow()
 
+    // Safety-net timers so the sidebar skeleton can never spin forever. Every
+    // clear of [_loadingRelays] is otherwise event-driven (group-list EOSE,
+    // CLOSED, or a connection Error/Reconnecting). A relay that connects, accepts
+    // the REQ, then never sends EOSE nor CLOSED — common after a slow/flaky
+    // NIP-46 bunker AUTH where the 2s awaitAuthOrTimeout races the signer — would
+    // leave the relay stuck in _loadingRelays indefinitely (#88). Each
+    // markRelayLoading arms a per-relay watchdog; markRelayLoaded / EOSE cancel it.
+    private val loadingWatchdogs = mutableMapOf<String, Job>()
+    private val loadingWatchdogTimeoutMs = 15_000L
+
     // Relays for which requestGroups() (unfiltered, no #d tag) was sent this session but
     // EOSE hasn't arrived yet. Lets handleEoseSuspend() distinguish a full fetch from a
     // lazy (joined-only) fetch when the same sub ID is reused.
@@ -228,12 +238,47 @@ class GroupManager(
         return SecureStorage.isFullGroupListCacheFresh(normalized, epochSeconds())
     }
 
+    /**
+     * Discard any record that the FULL group list was fetched for [relayUrl] —
+     * both the in-memory session flag and the persisted freshness timestamp.
+     * Called when a relay completes NIP-42 AUTH: an auth-required relay answers
+     * the pre-AUTH unauthenticated group-list REQ with an EMPTY EOSE, which
+     * handleEoseSuspend records as "fully fetched", falsely satisfying the dedup
+     * in resubscribeAfterAuth and suppressing the real post-AUTH fetch — leaving
+     * OTHER GROUPS empty even when expanded (observed on hzrd149's relay).
+     */
+    fun invalidateFullGroupListFetch(relayUrl: String) {
+        val normalized = relayUrl.normalizeRelayUrl()
+        _fullGroupListFetchedRelays.update { it - normalized }
+        try {
+            SecureStorage.saveFullGroupListEoseTimestamp(normalized, 0L)
+        } catch (_: Exception) {}
+    }
+
     fun markRelayLoading(relayUrl: String) {
-        _loadingRelays.update { it + relayUrl.normalizeRelayUrl() }
+        val normalized = relayUrl.normalizeRelayUrl()
+        _loadingRelays.update { it + normalized }
+        // (Re)arm the watchdog: if no EOSE/CLOSED/error clears this relay within
+        // the grace period, force-clear it so the skeleton stops spinning.
+        loadingWatchdogs.remove(normalized)?.cancel()
+        loadingWatchdogs[normalized] = scope.launch {
+            delay(loadingWatchdogTimeoutMs)
+            _loadingRelays.update { it - normalized }
+            // Also release any stuck full-fetch marker. Otherwise hasPendingFullFetch
+            // stays true forever (the REQ got neither EOSE nor CLOSED), and the
+            // permanent dedup guard in requestFullGroupListForRelay silently drops
+            // every subsequent OTHER GROUPS expand — leaving the panel empty until
+            // app restart. Releasing it lets re-opening OTHER GROUPS retry the fetch.
+            pendingFullFetchRelays.remove(normalized)
+            pendingFetchSeenGroups.remove(normalized)
+            loadingWatchdogs.remove(normalized)
+        }
     }
 
     fun markRelayLoaded(relayUrl: String) {
-        _loadingRelays.update { it - relayUrl.normalizeRelayUrl() }
+        val normalized = relayUrl.normalizeRelayUrl()
+        _loadingRelays.update { it - normalized }
+        loadingWatchdogs.remove(normalized)?.cancel()
     }
 
     /**
@@ -1880,6 +1925,7 @@ class GroupManager(
             val normalizedRelay = sourceRelayUrl.normalizeRelayUrl()
             _completeGroupLoadRelays.update { it + normalizedRelay }
             _loadingRelays.update { it - normalizedRelay }
+            loadingWatchdogs.remove(normalizedRelay)?.cancel()
             val now = epochSeconds()
             val isFull = pendingFullFetchRelays.remove(normalizedRelay)
             if (isFull) {
@@ -3018,6 +3064,8 @@ class GroupManager(
         _completeGroupLoadRelays.value = emptySet()
         _fullGroupListFetchedRelays.value = emptySet()
         _loadingRelays.value = emptySet()
+        loadingWatchdogs.values.forEach { it.cancel() }
+        loadingWatchdogs.clear()
         // Without clearing this, an in-flight full fetch from the previous account
         // leaves the relay flagged as "pending", and the new account's expand of
         // OTHER GROUPS is silently skipped by requestFullGroupListForRelay's guard.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -195,19 +195,24 @@ class GroupManager(
     // leave the relay stuck in _loadingRelays indefinitely (#88). Each
     // markRelayLoading arms a per-relay watchdog; markRelayLoaded / EOSE cancel it.
     private val loadingWatchdogs = mutableMapOf<String, Job>()
-    private val loadingWatchdogTimeoutMs = 15_000L
+    private val loadingWatchdogTimeoutMs = 30_000L
 
     // Relays for which requestGroups() (unfiltered, no #d tag) was sent this session but
-    // EOSE hasn't arrived yet. Lets handleEoseSuspend() distinguish a full fetch from a
-    // lazy (joined-only) fetch when the same sub ID is reused.
-    private val pendingFullFetchRelays = mutableSetOf<String>()
+    // EOSE hasn't arrived yet, mapped to the epoch-seconds the REQ was sent. Lets
+    // handleEoseSuspend() distinguish a full fetch from a lazy (joined-only) fetch when
+    // the same sub ID is reused. The timestamp makes the dedup self-expiring: a REQ that
+    // never gets EOSE/CLOSED stops blocking retries after [pendingFullFetchStaleSeconds]
+    // without the loading watchdog having to erase the marker (which would mis-classify a
+    // genuinely slow EOSE that arrives later as a partial fetch).
+    private val pendingFullFetchRelays = mutableMapOf<String, Long>()
+    private val pendingFullFetchStaleSeconds = 30L
 
     // Group IDs seen during an in-flight full fetch; cleared on EOSE to prune stale groups.
     private val pendingFetchSeenGroups = mutableMapOf<String, MutableSet<String>>()
 
     fun markPendingFullFetch(relayUrl: String) {
         val normalized = relayUrl.normalizeRelayUrl()
-        pendingFullFetchRelays.add(normalized)
+        pendingFullFetchRelays[normalized] = epochSeconds()
         pendingFetchSeenGroups[normalized] = mutableSetOf()
     }
 
@@ -225,7 +230,12 @@ class GroupManager(
      * Used by [NostrRepository.requestFullGroupListForRelay] to skip a duplicate REQ when
      * [requestGroupsForRelay] already scheduled a full fetch on connect.
      */
-    fun hasPendingFullFetch(relayUrl: String): Boolean = relayUrl.normalizeRelayUrl() in pendingFullFetchRelays
+    fun hasPendingFullFetch(relayUrl: String): Boolean {
+        val sentAt = pendingFullFetchRelays[relayUrl.normalizeRelayUrl()] ?: return false
+        // A marker older than the stale window means the REQ got neither EOSE nor
+        // CLOSED; stop treating it as in-flight so a re-open of OTHER GROUPS can retry.
+        return epochSeconds() - sentAt < pendingFullFetchStaleSeconds
+    }
 
     // Relays whose FULL group list (unfiltered requestGroups()) EOSE was received this session.
     // Updated by handleEoseSuspend when the relay is in pendingFullFetchRelays.
@@ -239,39 +249,43 @@ class GroupManager(
     }
 
     /**
-     * Discard any record that the FULL group list was fetched for [relayUrl] —
-     * both the in-memory session flag and the persisted freshness timestamp.
-     * Called when a relay completes NIP-42 AUTH: an auth-required relay answers
-     * the pre-AUTH unauthenticated group-list REQ with an EMPTY EOSE, which
-     * handleEoseSuspend records as "fully fetched", falsely satisfying the dedup
-     * in resubscribeAfterAuth and suppressing the real post-AUTH fetch — leaving
-     * OTHER GROUPS empty even when expanded (observed on hzrd149's relay).
+     * Discard the IN-MEMORY record that the FULL group list was fetched for
+     * [relayUrl] this session. Called once per relay when it completes NIP-42
+     * AUTH: an auth-required relay answers the pre-AUTH unauthenticated
+     * group-list REQ with an EMPTY EOSE, which handleEoseSuspend records as
+     * "fully fetched", falsely satisfying the dedup in resubscribeAfterAuth and
+     * suppressing the real post-AUTH fetch — leaving OTHER GROUPS empty even when
+     * expanded (observed on hzrd149's relay). Deliberately does NOT touch the
+     * persisted freshness timestamp: that survives across sessions and clearing
+     * it on every auth would defeat the cross-session cache.
      */
     fun invalidateFullGroupListFetch(relayUrl: String) {
-        val normalized = relayUrl.normalizeRelayUrl()
-        _fullGroupListFetchedRelays.update { it - normalized }
-        try {
-            SecureStorage.saveFullGroupListEoseTimestamp(normalized, 0L)
-        } catch (_: Exception) {}
+        _fullGroupListFetchedRelays.update { it - relayUrl.normalizeRelayUrl() }
     }
 
     fun markRelayLoading(relayUrl: String) {
         val normalized = relayUrl.normalizeRelayUrl()
         _loadingRelays.update { it + normalized }
         // (Re)arm the watchdog: if no EOSE/CLOSED/error clears this relay within
-        // the grace period, force-clear it so the skeleton stops spinning.
+        // the grace period, force-clear ONLY the skeleton flag so it stops
+        // spinning. The pending-full-fetch dedup is released separately by the
+        // self-expiring timestamp in hasPendingFullFetch — the watchdog must not
+        // erase pendingFullFetchRelays, or a genuinely slow EOSE arriving after the
+        // timeout would be mis-classified as a partial fetch (isFull=false), skip
+        // pruning, and never mark the relay fully fetched.
         loadingWatchdogs.remove(normalized)?.cancel()
         loadingWatchdogs[normalized] = scope.launch {
-            delay(loadingWatchdogTimeoutMs)
-            _loadingRelays.update { it - normalized }
-            // Also release any stuck full-fetch marker. Otherwise hasPendingFullFetch
-            // stays true forever (the REQ got neither EOSE nor CLOSED), and the
-            // permanent dedup guard in requestFullGroupListForRelay silently drops
-            // every subsequent OTHER GROUPS expand — leaving the panel empty until
-            // app restart. Releasing it lets re-opening OTHER GROUPS retry the fetch.
-            pendingFullFetchRelays.remove(normalized)
-            pendingFetchSeenGroups.remove(normalized)
-            loadingWatchdogs.remove(normalized)
+            try {
+                delay(loadingWatchdogTimeoutMs)
+                _loadingRelays.update { it - normalized }
+            } finally {
+                // Remove self only if still the current watchdog for this relay, so a
+                // watchdog re-armed by a concurrent markRelayLoading isn't evicted
+                // (which would leave it uncancellable and able to clear a later fetch).
+                if (loadingWatchdogs[normalized] === coroutineContext[Job]) {
+                    loadingWatchdogs.remove(normalized)
+                }
+            }
         }
     }
 
@@ -1927,7 +1941,7 @@ class GroupManager(
             _loadingRelays.update { it - normalizedRelay }
             loadingWatchdogs.remove(normalizedRelay)?.cancel()
             val now = epochSeconds()
-            val isFull = pendingFullFetchRelays.remove(normalizedRelay)
+            val isFull = pendingFullFetchRelays.remove(normalizedRelay) != null
             if (isFull) {
                 // Save the dedicated full-list timestamp so hasFullGroupListBeenFetched()
                 // returns true after an app restart.
@@ -3064,7 +3078,9 @@ class GroupManager(
         _completeGroupLoadRelays.value = emptySet()
         _fullGroupListFetchedRelays.value = emptySet()
         _loadingRelays.value = emptySet()
-        loadingWatchdogs.values.forEach { it.cancel() }
+        // Snapshot before cancelling: a watchdog already past its delay may call
+        // loadingWatchdogs.remove() from its finally during iteration.
+        loadingWatchdogs.values.toList().forEach { it.cancel() }
         loadingWatchdogs.clear()
         // Without clearing this, an in-flight full fetch from the previous account
         // leaves the relay flagged as "pending", and the new account's expand of


### PR DESCRIPTION
Fixes #88. Groups, their messages and member lists intermittently failed to appear after login, and OTHER GROUPS often stayed empty even when expanded. Every cause turned out to be the same class of bug: an in-session login/connect path doesn't reach the full bootstrap that a cold boot (`initialize()`) does. State that's normally established via one trigger — the group-list EOSE, NIP-42 AUTH completion, a fresh socket, or a group-list REQ — is skipped on a sibling path (in-session re-login, NIP-46 bunker restore, account warm-swap, a cache hit), so the relevant subscription is never sent and the UI shows empty/stale data until the app is restarted.

The fixes make the re-login / bunker / account-switch paths mirror the cold-boot bootstrap, add a self-expiring loading watchdog, and make group-list fetching robust against AUTH timing and re-REQ on a reused subscription id.

| Symptom | Root cause | Fix |
|---|---|---|
| Groups missing / "No messages yet" after re-login | `finishLoginInit` re-login branch never re-hydrated joined groups from storage; relied solely on the network kind:10009 fetch | Re-hydrate joined groups + cursors + relay metadata from storage and connect secondary relays, like `initialize()` |
| Sidebar skeleton spins forever | Loading flag cleared only by EOSE/CLOSED/connection-error — no timeout | Per-relay watchdog in `GroupManager`; self-expiring pending-full-fetch marker |
| OTHER GROUPS empty after AUTH (hzrd149) | Auth-required relay answers the pre-AUTH group-list REQ with an empty EOSE, falsely marking it fully fetched | Invalidate the pre-AUTH marker on first auth completion per relay |
| OTHER GROUPS empty when opened | `requestGroups()` / `requestGroupsForIds()` re-REQ a widened filter on a still-open shared sub id, which some relays don't re-evaluate | CLOSE the sub before each REQ |
| OTHER GROUPS only loads via the homescreen tab | `connect()`/`switchRelay()` gated the lazy full-fetch on a stale persisted timestamp | Use the in-session fetched set instead |
| Group shows "No messages yet" / "Members 0" on a cache hit | Cache-hit connect sends no group-list REQ, so the EOSE-driven mux setup never fires | Refresh the mux explicitly in both cache-hit branches |
| Relay rail shows only one relay after re-login | `finishLoginInit` never seeded the rail (`kind:10009`) from cache | `seedFromCache` on re-login |
| Empty groups after NIP-46 bunker restore | Session marked ready while the signer connects async; AUTH for group relays can't be signed in time and nothing retries | Reconnect group relays on the signer-ready transition |
| Empty My Groups after switching accounts | Warm-swap reload never pointed GroupManager's current-relay flow at the new account; missing rail/cursor/metadata bootstrap | Mirror cold-boot bootstrap and `restoreGroupsForRelay(primary)` in `reloadForActiveAccount` |

Commits:
- 8414c45 reliably load joined and other groups after login
- 9c6d385 address code-review findings on group-list fetch and watchdog
- c2e111c set up live mux on cache-hit connect/switch so messages load
- bf9e2e1 seed the relay rail from cache on re-login
- e9e6236 recover groups on bunker signer-ready and on account warm-swap
- 3c86048 show My Groups by pointing GroupManager at the new primary

Verified green: `spotlessCheck`, `compileKotlinJvm`, `:composeApp:jvmTest`, plus `compileKotlinWasmJs`, `compileKotlinJs`, `compileDebugKotlinAndroid`. The bunker-restore and account-switch paths were also verified by hand in the desktop app.