### PR TITLE
feat(zap): NIP-57 Lightning Zaps for messages and profiles

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -55,6 +55,7 @@ import org.nostr.nostrord.ui.components.navigation.NavigationToolbar
 import org.nostr.nostrord.ui.components.navigation.ServerRail
 import org.nostr.nostrord.ui.components.notifications.NotificationPermissionBanner
 import org.nostr.nostrord.ui.components.sidebars.GroupsNavSidebar
+import org.nostr.nostrord.ui.components.zap.ZapModalHost
 import org.nostr.nostrord.ui.navigation.BrowserNavigationHandler
 import org.nostr.nostrord.ui.navigation.NavEntry
 import org.nostr.nostrord.ui.navigation.NavigationHistory
@@ -169,6 +170,8 @@ fun App() {
                         deepLinkInviteCode = startupState.deepLinkInviteCode,
                         deepLinkMessageId = startupState.deepLinkMessageId,
                     )
+                    // NIP-57 zap modal overlay — opened from anywhere via ZapController.
+                    ZapModalHost()
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -25,6 +25,7 @@ import org.nostr.nostrord.network.managers.PendingEventManager
 import org.nostr.nostrord.network.managers.RelayMetadataManager
 import org.nostr.nostrord.network.managers.SessionManager
 import org.nostr.nostrord.network.managers.UnreadManager
+import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.EventDeduplicator
 import org.nostr.nostrord.network.outbox.RelayListManager
 import org.nostr.nostrord.nostr.Nip19
@@ -210,6 +211,15 @@ object AppModule {
 
     val metadataManager: MetadataManager by lazy {
         MetadataManager(
+            connectionManager = connectionManager,
+            outboxManager = outboxManager,
+            scope = appScope,
+        )
+    }
+
+    val zapManager: ZapManager by lazy {
+        ZapManager(
+            metadataManager = metadataManager,
             connectionManager = connectionManager,
             outboxManager = outboxManager,
             scope = appScope,
@@ -453,6 +463,7 @@ object AppModule {
             groupManager = groupManager,
             metadataManager = metadataManager,
             outboxManager = outboxManager,
+            zapManager = zapManager,
             unreadManager = unreadManager,
             pendingEventManager = pendingEventManager,
             relayMetadataManager = relayMetadataManager,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -112,6 +112,8 @@ data class UserMetadata(
     val nip05: String?,
     val banner: String? = null,
     val lud16: String? = null,
+    /** LNURL-pay bech32 (`lnurl1...`) — NIP-57 fallback when lud16 is absent. */
+    val lud06: String? = null,
     val website: String? = null,
     /** Original kind:0 content JSON — preserved so updates can merge without losing unknown fields. */
     val rawContentJson: String? = null,
@@ -724,9 +726,53 @@ class NostrGroupClient(
                         buildJsonArray {
                             add(7)
                             add(9321)
+                            add(9735) // NIP-57 zap receipts
                         },
                     )
                     put("#e", buildJsonArray { messageIds.forEach { add(it) } })
+                },
+            )
+        }.toString()
+        send(subscription)
+        return subId
+    }
+
+    /**
+     * Fetch NIP-57 zap receipts (kind 9735) for specific event IDs. Used against
+     * general-purpose relays: zap receipts carry no `h` tag, so NIP-29 group relays do
+     * not serve them — they live on the relays named in the zap request's `relays` tag.
+     */
+    suspend fun requestZapReceipts(eventIds: List<String>): String? {
+        if (eventIds.isEmpty()) return null
+        val subId = "zaps_${epochMillis()}"
+        val subscription = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(
+                buildJsonObject {
+                    putJsonArray("kinds") { add(9735) }
+                    put("#e", buildJsonArray { eventIds.forEach { add(it) } })
+                },
+            )
+        }.toString()
+        send(subscription)
+        return subId
+    }
+
+    /**
+     * Fetch recent zap receipts (kind 9735) addressed to [recipientPubkey] (`#p`). Used to
+     * confirm a profile zap, which carries no zapped-event id.
+     */
+    suspend fun requestZapReceiptsForRecipient(recipientPubkey: String, limit: Int = 20): String? {
+        val subId = "zaps_${epochMillis()}"
+        val subscription = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(
+                buildJsonObject {
+                    putJsonArray("kinds") { add(9735) }
+                    put("#p", buildJsonArray { add(recipientPubkey) })
+                    put("limit", limit)
                 },
             )
         }.toString()
@@ -1241,6 +1287,7 @@ class NostrGroupClient(
                     nip05 = metadata["nip05"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
                     banner = metadata["banner"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
                     lud16 = metadata["lud16"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
+                    lud06 = metadata["lud06"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
                     website = metadata["website"]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() },
                     rawContentJson = content,
                 ),

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -14,6 +15,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -31,6 +33,7 @@ import org.nostr.nostrord.network.managers.RelayMetadataManager
 import org.nostr.nostrord.network.managers.RelayReconnectScheduler
 import org.nostr.nostrord.network.managers.SessionManager
 import org.nostr.nostrord.network.managers.UnreadManager
+import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.startup.StartupResolver
@@ -61,6 +64,7 @@ class NostrRepository(
     private val groupManager: GroupManager,
     private val metadataManager: MetadataManager,
     private val outboxManager: OutboxManager,
+    private val zapManager: ZapManager,
     private val unreadManager: UnreadManager,
     private val pendingEventManager: org.nostr.nostrord.network.managers.PendingEventManager? = null,
     private val relayMetadataManager: RelayMetadataManager? = null,
@@ -85,6 +89,10 @@ class NostrRepository(
      */
     private val GAP_DETECTION_COOLDOWN_S = 30L
     private val lastGapDetectionAt = mutableMapOf<String, Long>()
+
+    /** How long the zap modal waits for a payment confirmation, and the receipt poll cadence. */
+    private val ZAP_PAYMENT_WATCH_MS = 90_000L
+    private val ZAP_PAYMENT_POLL_MS = 3_000L
 
     /**
      * Epoch-seconds of the last requestGroups() call per relay.
@@ -181,6 +189,9 @@ class NostrRepository(
     override val isLoadingMore: StateFlow<Map<String, Boolean>> = groupManager.isLoadingMore
     override val hasMoreMessages: StateFlow<Map<String, Boolean>> = groupManager.hasMoreMessages
     override val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = groupManager.reactions
+
+    // NIP-57 zap totals per zapped event id.
+    override val zaps: StateFlow<Map<String, ZapManager.ZapInfo>> = zapManager.zaps
     override val groupMembers: StateFlow<Map<String, List<String>>> = groupManager.groupMembers
     override val groupAdmins: StateFlow<Map<String, List<String>>> = groupManager.groupAdmins
     override val groupRoles: StateFlow<Map<String, List<RoleDefinition>>> = groupManager.groupRoles
@@ -1596,6 +1607,68 @@ class NostrRepository(
         )
     }
 
+    override suspend fun requestZapInvoice(
+        recipientPubkey: String,
+        amountSats: Long,
+        comment: String,
+        eventId: String?,
+    ): Result<ZapManager.ZapInvoice> {
+        val pubKey = sessionManager.getPublicKey()
+            ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        return zapManager.requestInvoice(
+            recipientPubkey = recipientPubkey,
+            amountSats = amountSats,
+            comment = comment,
+            eventId = eventId,
+            senderPubkey = pubKey,
+            signEvent = { sessionManager.signEvent(it) },
+        )
+    }
+
+    override suspend fun watchZapPayment(
+        bolt11: String,
+        recipientPubkey: String,
+        eventId: String?,
+    ): Boolean {
+        // Poll the receipt relays for the matching kind:9735 while awaiting the flow.
+        val matched = withTimeoutOrNull(ZAP_PAYMENT_WATCH_MS) {
+            coroutineScope {
+                val poller = launch {
+                    while (isActive) {
+                        pollZapReceipts(recipientPubkey, eventId)
+                        delay(ZAP_PAYMENT_POLL_MS)
+                    }
+                }
+                try {
+                    zapManager.paidInvoices.first { it.equals(bolt11, ignoreCase = true) }
+                } finally {
+                    poller.cancel()
+                }
+            }
+        }
+        return matched != null
+    }
+
+    /** One poll cycle: re-request the zap receipt from connected + general relays. */
+    private suspend fun pollZapReceipts(recipientPubkey: String, eventId: String?) {
+        // Same relays the receipt was asked to be published to (see ZapManager.receiptRelays).
+        zapManager.receiptRelays().forEach { url ->
+            try {
+                val client = connectionManager.getClientForRelay(url)
+                    ?: connectionManager.getOrConnectRelay(url) { msg, c -> enqueueToRelayPipeline(msg, c) }
+                if (client != null && client.isConnected()) {
+                    if (eventId != null) {
+                        client.requestZapReceipts(listOf(eventId))
+                    } else {
+                        client.requestZapReceiptsForRecipient(recipientPubkey)
+                    }
+                }
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+            }
+        }
+    }
+
     override fun getMessagesForGroup(groupId: String): List<NostrGroupClient.NostrMessage> = groupManager.getMessagesForGroup(groupId)
 
     // Unread message operations
@@ -1913,6 +1986,29 @@ class NostrRepository(
      * Fix: both initializeOutboxModel and connectToRelayBackground now use this unified
      * handler so the first-connection handler always handles both NIP-29 and outbox events.
      */
+    /**
+     * Fetch NIP-57 zap receipts (kind 9735) for [messageIds] from general-purpose relays.
+     * NIP-29 group relays don't serve zap receipts (they carry no `h` tag), so we query
+     * connected outbox/bootstrap relays — connecting a couple if none are open. Responses
+     * route through the relay pipeline → kind 9735 → ZapManager aggregation.
+     */
+    private fun fetchZapReceiptsFromGeneralRelays(messageIds: List<String>) {
+        if (messageIds.isEmpty()) return
+        scope.launch {
+            // Query the exact relays the zap request asked the receipt to be published to —
+            // not the NIP-29 group relay, which rejects the (h-less) 9735.
+            zapManager.receiptRelays().forEach { url ->
+                try {
+                    val client = connectionManager.getClientForRelay(url)
+                        ?: connectionManager.getOrConnectRelay(url) { msg, c -> enqueueToRelayPipeline(msg, c) }
+                    if (client != null && client.isConnected()) client.requestZapReceipts(messageIds)
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                }
+            }
+        }
+    }
+
     private fun handleUnifiedMessage(msg: String, client: NostrGroupClient) {
         // Parse once — every downstream handler reuses this JsonArray.
         val arr = try {
@@ -2036,6 +2132,9 @@ class NostrRepository(
                                     // Will be closed when its own EOSE arrives via reactions_ prefix
                                 }
                             } catch (_: Exception) {}
+                            // Zap receipts (kind 9735) carry no `h` tag, so they live on
+                            // general relays, not the NIP-29 group relay — fetch them there.
+                            fetchZapReceiptsFromGeneralRelays(messageIds)
                         }
                     }
                     // Close one-shot subs after EOSE so the relay slot is freed.
@@ -2046,6 +2145,7 @@ class NostrRepository(
                         subId.startsWith("e_") ||
                         subId.startsWith("a_") ||
                         subId.startsWith("reactions_") ||
+                        subId.startsWith("zaps_") ||
                         subId.startsWith("event_")
                     ) {
                         try {
@@ -2218,6 +2318,11 @@ class NostrRepository(
                     0 -> {
                         val parsed = client.parseUserMetadata(event) ?: return
                         metadataManager.handleMetadataEvent(parsed.pubkey, parsed.metadata, parsed.createdAt)
+                    }
+
+                    9735 -> {
+                        // NIP-57 zap receipt — aggregate per zapped event id for UI totals.
+                        zapManager.handleZapReceipt(event)
                     }
 
                     7 -> {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.network
 import kotlinx.coroutines.flow.StateFlow
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip46Client
@@ -44,6 +45,9 @@ interface NostrRepositoryApi {
     val isLoadingMore: StateFlow<Map<String, Boolean>>
     val hasMoreMessages: StateFlow<Map<String, Boolean>>
     val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>>
+
+    /** NIP-57 zap totals keyed by zapped event id. */
+    val zaps: StateFlow<Map<String, ZapManager.ZapInfo>>
     val groupMembers: StateFlow<Map<String, List<String>>>
     val groupAdmins: StateFlow<Map<String, List<String>>>
     val groupRoles: StateFlow<Map<String, List<RoleDefinition>>>
@@ -347,6 +351,28 @@ interface NostrRepositoryApi {
         targetPubkey: String,
         emoji: String,
     ): Result<Unit>
+
+    /**
+     * Resolve [recipientPubkey]'s LNURL-pay endpoint and fetch a bolt11 invoice for a
+     * NIP-57 zap of [amountSats]. The returned invoice must be paid with an external
+     * wallet. [eventId] is the zapped message, or null for a profile zap.
+     */
+    suspend fun requestZapInvoice(
+        recipientPubkey: String,
+        amountSats: Long,
+        comment: String,
+        eventId: String?,
+    ): Result<ZapManager.ZapInvoice>
+
+    /**
+     * Suspend until a zap receipt settling [bolt11] is observed (returns true), or a timeout
+     * elapses (returns false). Polls the relays named in the zap request while waiting.
+     */
+    suspend fun watchZapPayment(
+        bolt11: String,
+        recipientPubkey: String,
+        eventId: String?,
+    ): Boolean
 
     fun getMessagesForGroup(groupId: String): List<NostrGroupClient.NostrMessage>
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -411,6 +411,7 @@ class MetadataManager(
         nip05.isNullOrBlank() &&
         banner.isNullOrBlank() &&
         lud16.isNullOrBlank() &&
+        lud06.isNullOrBlank() &&
         website.isNullOrBlank()
 
     fun handleCachedEvent(event: CachedEvent) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ZapManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ZapManager.kt
@@ -1,0 +1,222 @@
+package org.nostr.nostrord.network.managers
+
+import io.ktor.client.request.get
+import io.ktor.client.request.url
+import io.ktor.client.statement.bodyAsText
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import org.nostr.nostrord.network.createHttpClient
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.Nip57
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.LruCache
+import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.epochMillis
+
+/**
+ * NIP-57 Lightning Zaps orchestration.
+ *
+ * Sending side: resolves the recipient's LNURL-pay endpoint, builds and signs a zap
+ * request (kind 9734), and fetches a bolt11 invoice from the LNURL callback. Paying the
+ * invoice is delegated to an external wallet — this manager never moves funds.
+ *
+ * Receiving side: aggregates incoming zap receipts (kind 9735, published by the
+ * recipient's LNURL server) into [zaps], keyed by the zapped event id, so the UI can show
+ * per-message zap totals.
+ */
+class ZapManager(
+    private val metadataManager: MetadataManager,
+    private val connectionManager: ConnectionManager,
+    private val outboxManager: OutboxManager,
+    @Suppress("unused") private val scope: CoroutineScope,
+) {
+    private val http = createHttpClient()
+
+    companion object {
+        private const val HTTP_TIMEOUT_MS = 15_000L
+        private const val MAX_RECEIPT_RELAYS = 6
+        private val DEFAULT_RELAYS =
+            listOf("wss://relay.damus.io", "wss://nos.lol", "wss://relay.nostr.band")
+    }
+
+    /** Aggregated zaps for a target event id: total amount + distinct zappers. */
+    data class ZapInfo(
+        val totalMsats: Long,
+        val zappers: Set<String>,
+        val count: Int,
+    )
+
+    /** A ready-to-pay invoice produced by [requestInvoice]. */
+    data class ZapInvoice(
+        val bolt11: String,
+        val amountMsats: Long,
+        val recipientPubkey: String,
+        val eventId: String?,
+        val comment: String,
+    )
+
+    // eventId -> aggregated zaps. Deduped by receipt id so relay echoes don't double count.
+    private val _zaps = MutableStateFlow<Map<String, ZapInfo>>(emptyMap())
+    val zaps: StateFlow<Map<String, ZapInfo>> = _zaps.asStateFlow()
+
+    // Emits the bolt11 of every settled zap as its receipt arrives, so an open zap modal
+    // can confirm payment. Buffered so emissions aren't dropped between poll cycles.
+    private val _paidInvoices = MutableSharedFlow<String>(extraBufferCapacity = 64)
+    val paidInvoices: SharedFlow<String> = _paidInvoices.asSharedFlow()
+
+    private val seenReceiptIds = LruCache<String, Boolean>(4000)
+
+    /**
+     * Resolve the recipient's LNURL-pay endpoint, build + sign a zap request (kind 9734),
+     * and fetch a bolt11 invoice from the callback. The returned invoice must be paid by
+     * an external wallet — this method does not pay it.
+     *
+     * @param amountSats whole-satoshi amount to zap.
+     * @param eventId    the chat message being zapped, or null for a profile zap.
+     */
+    suspend fun requestInvoice(
+        recipientPubkey: String,
+        amountSats: Long,
+        comment: String,
+        eventId: String?,
+        senderPubkey: String,
+        signEvent: suspend (Event) -> Event,
+    ): Result<ZapInvoice> {
+        if (amountSats <= 0L) {
+            return Result.Error(AppError.Unknown("Enter an amount greater than zero"))
+        }
+
+        val metadata = metadataManager.getMetadata(recipientPubkey)
+        val endpoint = Nip57.resolvePayEndpoint(metadata?.lud16, metadata?.lud06)
+            ?: return Result.Error(AppError.Unknown("This user has no Lightning address set"))
+        val (lnurlUrl, lnurlBech32) = endpoint
+        val amountMsats = amountSats * 1_000L
+
+        return try {
+            withTimeout(HTTP_TIMEOUT_MS) {
+                // 1. Fetch the LNURL-pay service description.
+                val params = Nip57.parseLnurlPayParams(http.get(lnurlUrl).bodyAsText())
+                    ?: return@withTimeout Result.Error(AppError.Unknown("Invalid Lightning address"))
+                if (!params.allowsNostr || params.nostrPubkey.isNullOrBlank()) {
+                    return@withTimeout Result.Error(
+                        AppError.Unknown("This user's wallet does not support zaps"),
+                    )
+                }
+                if (amountMsats < params.minSendableMsats) {
+                    return@withTimeout Result.Error(
+                        AppError.Unknown("Minimum is ${params.minSendableMsats / 1000} sats"),
+                    )
+                }
+                if (amountMsats > params.maxSendableMsats) {
+                    return@withTimeout Result.Error(
+                        AppError.Unknown("Maximum is ${params.maxSendableMsats / 1000} sats"),
+                    )
+                }
+
+                // 2. Build + sign the zap request (kind 9734). Not published to a relay.
+                val cappedComment = if (params.commentAllowed > 0) comment.take(params.commentAllowed) else ""
+                val request = Nip57.buildZapRequest(
+                    senderPubkey = senderPubkey,
+                    recipientPubkey = recipientPubkey,
+                    amountMsats = amountMsats,
+                    relays = receiptRelays(),
+                    lnurlBech32 = lnurlBech32,
+                    comment = cappedComment,
+                    eventId = eventId,
+                    createdAt = epochMillis() / 1000,
+                )
+                val signed = signEvent(request)
+
+                // 3. Hit the callback with amount + the signed request to get the invoice.
+                val callbackBody = http.get(params.callback) {
+                    url {
+                        parameters.append("amount", amountMsats.toString())
+                        parameters.append("nostr", signed.toJsonString())
+                        parameters.append("lnurl", lnurlBech32)
+                    }
+                }.bodyAsText()
+
+                Nip57.parseCallbackError(callbackBody)?.let {
+                    return@withTimeout Result.Error(AppError.Unknown(it))
+                }
+                val bolt11 = Nip57.parseInvoiceFromCallback(callbackBody)
+                    ?: return@withTimeout Result.Error(AppError.Unknown("Wallet did not return an invoice"))
+
+                Result.Success(
+                    ZapInvoice(
+                        bolt11 = bolt11,
+                        amountMsats = amountMsats,
+                        recipientPubkey = recipientPubkey,
+                        eventId = eventId,
+                        comment = cappedComment,
+                    ),
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.Error(AppError.Unknown("Could not reach the Lightning service: ${e.message}", e))
+        }
+    }
+
+    /** Aggregate an incoming zap receipt (kind 9735) into [zaps], keyed by zapped event id. */
+    fun handleZapReceipt(event: JsonObject) {
+        val receiptId = event["id"]?.jsonPrimitive?.contentOrNull ?: return
+        if (seenReceiptIds.get(receiptId) != null) return
+        val parsed = Nip57.parseZapReceipt(event) ?: return
+        seenReceiptIds.put(receiptId, true)
+
+        // Confirm payment to any open zap modal (covers profile zaps too, which have no
+        // zapped event id and aren't aggregated below).
+        parsed.bolt11?.let { _paidInvoices.tryEmit(it) }
+
+        // Aggregate per zapped event for the badge totals (needs an event id + amount).
+        val target = parsed.zappedEventId ?: return
+        val amount = parsed.amountMsats ?: return
+        _zaps.update { current ->
+            val existing = current[target]
+            val zappers = parsed.zapperPubkey
+                ?.let { (existing?.zappers ?: emptySet()) + it }
+                ?: (existing?.zappers ?: emptySet())
+            current + (
+                target to ZapInfo(
+                    totalMsats = (existing?.totalMsats ?: 0L) + amount,
+                    zappers = zappers,
+                    count = (existing?.count ?: 0) + 1,
+                )
+                )
+        }
+    }
+
+    fun clear() {
+        _zaps.value = emptyMap()
+        seenReceiptIds.clear()
+    }
+
+    /**
+     * Relays to request the zap receipt be published to (the 9734 `relays` tag): the active
+     * group relay first (where the zapped message lives and where we read it back), then the
+     * account's NIP-65/NIP-29 relays, then well-known general relays for redundancy.
+     *
+     * Also the canonical set to read receipts back from — they are published here, not to the
+     * NIP-29 group relay (which rejects events without an `h` tag).
+     */
+    fun receiptRelays(): List<String> {
+        val relays = LinkedHashSet<String>()
+        connectionManager.currentRelayUrl.value.takeIf { it.isNotBlank() }?.let { relays.add(it) }
+        relays.addAll(outboxManager.kind10009Relays.value)
+        relays.addAll(DEFAULT_RELAYS)
+        return relays.take(MAX_RECEIPT_RELAYS).toList()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip57.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip57.kt
@@ -1,0 +1,228 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * NIP-57 — Lightning Zaps.
+ *
+ * Pure, platform-agnostic helpers for the zap flow:
+ *
+ *  1. Resolve a recipient's LNURL-pay endpoint from their kind:0 `lud16`/`lud06`.
+ *  2. Parse the LNURL-pay service description.
+ *  3. Build the **zap request** (kind 9734) — this is signed by us and sent as a
+ *     query param to the LNURL callback, NOT published to a relay.
+ *  4. Extract the bolt11 invoice from the callback response.
+ *  5. Parse incoming **zap receipts** (kind 9735) — created and published by the
+ *     recipient's LNURL server; we only read these to display zap totals.
+ */
+object Nip57 {
+    private val lenientJson = Json { ignoreUnknownKeys = true }
+
+    /** Parsed LNURL-pay service description (the GET to the lnurlp URL). */
+    data class LnurlPayParams(
+        val callback: String,
+        val minSendableMsats: Long,
+        val maxSendableMsats: Long,
+        val allowsNostr: Boolean,
+        val nostrPubkey: String?,
+        val commentAllowed: Int,
+    )
+
+    /** Parsed zap receipt (kind 9735). Amounts are in millisatoshis. */
+    data class ZapReceipt(
+        val zappedEventId: String?,
+        val recipientPubkey: String?,
+        val zapperPubkey: String?,
+        val amountMsats: Long?,
+        /** The paid invoice — uniquely identifies which zap request this settles. */
+        val bolt11: String?,
+    )
+
+    /**
+     * Convert a lightning address (`lud16`, `name@domain`) to its LNURL-pay https URL
+     * per LUD-16. Returns null if the address is malformed.
+     */
+    fun lightningAddressToUrl(address: String): String? {
+        val trimmed = address.trim()
+        val at = trimmed.indexOf('@')
+        if (at <= 0 || at >= trimmed.length - 1) return null
+        val name = trimmed.substring(0, at)
+        val domain = trimmed.substring(at + 1)
+        if (name.isBlank() || domain.isBlank() || '/' in domain || '@' in domain) return null
+        return "https://$domain/.well-known/lnurlp/$name"
+    }
+
+    /** Decode a bech32 `lnurl1...` (`lud06`) into its https URL. */
+    fun decodeLnurl(lnurl: String): String? {
+        val decoded = Bech32.decode(lnurl.trim()) ?: return null
+        if (!decoded.first.equals("lnurl", ignoreCase = true)) return null
+        return decoded.second.decodeToString().takeIf { it.startsWith("http") }
+    }
+
+    /** Bech32-encode an https URL as an `lnurl1...` string (the zap request `lnurl` tag). */
+    fun encodeLnurl(url: String): String = Bech32.encode("lnurl", url.encodeToByteArray())
+
+    /**
+     * Resolve a recipient's LNURL-pay endpoint from their kind:0 fields. Prefers
+     * `lud16` (lightning address); falls back to `lud06` (bech32 lnurl).
+     *
+     * @return `(lnurlPayUrl, lnurlBech32)` or null if neither field is usable.
+     */
+    fun resolvePayEndpoint(lud16: String?, lud06: String?): Pair<String, String>? {
+        lud16?.takeIf { it.isNotBlank() }?.let { addr ->
+            lightningAddressToUrl(addr)?.let { url -> return url to encodeLnurl(url) }
+        }
+        lud06?.takeIf { it.isNotBlank() }?.let { raw ->
+            decodeLnurl(raw)?.let { url -> return url to raw.trim().lowercase() }
+        }
+        return null
+    }
+
+    /** Parse an LNURL-pay service description, or null if it is not a pay request. */
+    fun parseLnurlPayParams(body: String): LnurlPayParams? = try {
+        val obj = lenientJson.parseToJsonElement(body).jsonObject
+        val callback = obj["callback"]?.jsonPrimitive?.contentOrNull
+        if (callback.isNullOrBlank()) {
+            null
+        } else {
+            LnurlPayParams(
+                callback = callback,
+                minSendableMsats = obj["minSendable"]?.jsonPrimitive?.longOrNull ?: 1_000L,
+                maxSendableMsats = obj["maxSendable"]?.jsonPrimitive?.longOrNull ?: Long.MAX_VALUE,
+                allowsNostr = obj["allowsNostr"]?.jsonPrimitive?.booleanOrNull ?: false,
+                nostrPubkey = obj["nostrPubkey"]?.jsonPrimitive?.contentOrNull,
+                commentAllowed = obj["commentAllowed"]?.jsonPrimitive?.intOrNull ?: 0,
+            )
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    /** Extract the bolt11 invoice (`pr`) from an LNURL-pay callback response. */
+    fun parseInvoiceFromCallback(body: String): String? = try {
+        lenientJson.parseToJsonElement(body).jsonObject["pr"]?.jsonPrimitive?.contentOrNull
+            ?.takeIf { it.isNotBlank() }
+    } catch (_: Exception) {
+        null
+    }
+
+    /** Return the callback's error reason if it responded with `status: "ERROR"`, else null. */
+    fun parseCallbackError(body: String): String? = try {
+        val obj = lenientJson.parseToJsonElement(body).jsonObject
+        if (obj["status"]?.jsonPrimitive?.contentOrNull?.equals("ERROR", ignoreCase = true) == true) {
+            obj["reason"]?.jsonPrimitive?.contentOrNull ?: "LNURL service rejected the request"
+        } else {
+            null
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    /**
+     * Build an unsigned zap request (kind 9734). The signed, JSON-serialized form is
+     * sent to the LNURL callback `nostr` param — it is never published to a relay.
+     *
+     * @param eventId when zapping a specific event (e.g. a chat message); null for a profile zap.
+     */
+    fun buildZapRequest(
+        senderPubkey: String,
+        recipientPubkey: String,
+        amountMsats: Long,
+        relays: List<String>,
+        lnurlBech32: String,
+        comment: String,
+        eventId: String?,
+        createdAt: Long,
+    ): Event {
+        val tags = buildList {
+            if (relays.isNotEmpty()) add(listOf("relays") + relays)
+            add(listOf("amount", amountMsats.toString()))
+            add(listOf("lnurl", lnurlBech32))
+            add(listOf("p", recipientPubkey))
+            if (!eventId.isNullOrBlank()) add(listOf("e", eventId))
+        }
+        return Event(
+            pubkey = senderPubkey,
+            createdAt = createdAt,
+            kind = 9734,
+            tags = tags,
+            content = comment,
+        )
+    }
+
+    /**
+     * Parse a zap receipt (kind 9735). The receipt embeds the original zap request in its
+     * `description` tag — that is the source of truth for the zapper and amount. Falls back
+     * to the receipt's own `amount`/`bolt11` tags when the description is absent.
+     */
+    fun parseZapReceipt(event: JsonObject): ZapReceipt? = try {
+        if (event["kind"]?.jsonPrimitive?.intOrNull != 9735) {
+            null
+        } else {
+            val tags = event["tags"]?.jsonArray
+                ?.mapNotNull { t -> runCatching { t.jsonArray.map { it.jsonPrimitive.content } }.getOrNull() }
+                ?: emptyList()
+            fun tag(name: String) = tags.firstOrNull { it.firstOrNull() == name }?.getOrNull(1)
+
+            val request = tag("description")
+                ?.let { runCatching { lenientJson.parseToJsonElement(it).jsonObject }.getOrNull() }
+            val reqTags = request?.get("tags")?.jsonArray
+                ?.mapNotNull { t -> runCatching { t.jsonArray.map { it.jsonPrimitive.content } }.getOrNull() }
+                ?: emptyList()
+            fun reqTag(name: String) = reqTags.firstOrNull { it.firstOrNull() == name }?.getOrNull(1)
+
+            val amountMsats = reqTag("amount")?.toLongOrNull()
+                ?: tag("amount")?.toLongOrNull()
+                ?: tag("bolt11")?.let { decodeBolt11AmountMsats(it) }
+            val zapper = request?.get("pubkey")?.jsonPrimitive?.contentOrNull ?: tag("P")
+            val zappedEvent = tag("e") ?: reqTag("e")
+
+            ZapReceipt(
+                zappedEventId = zappedEvent,
+                recipientPubkey = tag("p") ?: reqTag("p"),
+                zapperPubkey = zapper,
+                amountMsats = amountMsats,
+                bolt11 = tag("bolt11"),
+            )
+        }
+    } catch (_: Exception) {
+        null
+    }
+
+    /**
+     * Decode the amount encoded in a bolt11 invoice's human-readable part, in millisats.
+     * Returns null for amountless invoices or malformed input.
+     */
+    fun decodeBolt11AmountMsats(invoice: String): Long? {
+        val s = invoice.trim().lowercase()
+        if (!s.startsWith("ln")) return null
+        // The bech32 separator is the last '1' — the data charset never contains '1',
+        // and the amount precedes the separator.
+        val sep = s.lastIndexOf('1')
+        if (sep <= 2) return null
+        var hrp = s.substring(2, sep) // strip "ln"; e.g. "bc2500u"
+        val currency = listOf("bcrt", "bc", "tb", "sb").firstOrNull { hrp.startsWith(it) } ?: return null
+        hrp = hrp.substring(currency.length) // e.g. "2500u" (or "" if amountless)
+        if (hrp.isEmpty()) return null
+        val multChar = hrp.last()
+        val hasMultiplier = multChar in "munp"
+        val digits = (if (hasMultiplier) hrp.dropLast(1) else hrp).toLongOrNull() ?: return null
+        // amount(BTC) = digits * multiplier; 1 BTC = 100_000_000_000 msats.
+        return when (if (hasMultiplier) multChar else ' ') {
+            ' ' -> digits * 100_000_000_000L
+            'm' -> digits * 100_000_000L
+            'u' -> digits * 100_000L
+            'n' -> digits * 100L
+            'p' -> digits / 10L
+            else -> null
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Reply
+import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Delete
@@ -66,6 +67,8 @@ sealed class MessageContextAction {
 
     data object Reply : MessageContextAction()
 
+    data object ZapMessage : MessageContextAction()
+
     data object CopyText : MessageContextAction()
 
     data object CopyMessageLink : MessageContextAction()
@@ -100,6 +103,7 @@ fun MessageContextMenu(
     onAction: (MessageContextAction) -> Unit,
     isAuthor: Boolean = false,
     isAdmin: Boolean = false,
+    canZap: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     // Only render Popup when visible to avoid layout participation
@@ -142,6 +146,7 @@ fun MessageContextMenu(
                         onDismiss = onDismiss,
                         isAuthor = isAuthor,
                         isAdmin = isAdmin,
+                        canZap = canZap,
                     )
                 }
             }
@@ -158,6 +163,7 @@ private fun ContextMenuContent(
     onDismiss: () -> Unit,
     isAuthor: Boolean,
     isAdmin: Boolean,
+    canZap: Boolean,
 ) {
     Column(
         modifier =
@@ -195,6 +201,18 @@ private fun ContextMenuContent(
                 onDismiss()
             },
         )
+
+        // Zap (only when the author has a Lightning address and zaps are enabled)
+        if (canZap) {
+            ContextMenuItem(
+                icon = Icons.Outlined.Bolt,
+                label = "Zap",
+                onClick = {
+                    onAction(MessageContextAction.ZapMessage)
+                    onDismiss()
+                },
+            )
+        }
 
         ContextMenuDivider()
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Reply
+import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Icon
@@ -56,6 +57,8 @@ import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
+import org.nostr.nostrord.ui.components.zap.ZapBadge
+import org.nostr.nostrord.ui.components.zap.ZapController
 import org.nostr.nostrord.ui.theme.NostrordAnimation
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
@@ -131,6 +134,13 @@ fun MessageItem(
 
     // Collect cached events from repository for parent message lookup
     val cachedEvents by AppModule.nostrRepository.cachedEvents.collectAsState()
+
+    // NIP-57 zaps: offer the action when the author has a Lightning address (and isn't
+    // the current user), and surface the running total for this message.
+    val zapTotals by AppModule.nostrRepository.zaps.collectAsState()
+    val zapInfo = zapTotals[message.id]
+    val canZap = message.pubkey != currentUserPubkey &&
+        (!metadata?.lud16.isNullOrBlank() || !metadata?.lud06.isNullOrBlank())
 
     // Look up parent via caller-provided resolver, then in cachedEvents
     val parentMessage =
@@ -431,6 +441,16 @@ fun MessageItem(
                             onReactionClick = onReactionBadgeClick,
                         )
                     }
+
+                    // Zap total badge
+                    if (zapInfo != null && zapInfo.totalMsats > 0) {
+                        ZapBadge(
+                            totalMsats = zapInfo.totalMsats,
+                            count = zapInfo.count,
+                            zappedByMe = currentUserPubkey != null && currentUserPubkey in zapInfo.zappers,
+                            onClick = { if (canZap) ZapController.request(message.pubkey, message.id) },
+                        )
+                    }
                 }
             }
 
@@ -455,6 +475,8 @@ fun MessageItem(
                             onReplyClick = currentOnReplyClick,
                             onReactionClick = currentOnReactionClick,
                             onMoreClick = { onContextMenuOpenChange(true) },
+                            canZap = canZap,
+                            onZapClick = { ZapController.request(message.pubkey, message.id) },
                         )
                     }
                 }
@@ -475,10 +497,12 @@ fun MessageItem(
                         MessageContextAction.CopyEventJson -> currentOnCopyJson()
                         MessageContextAction.PinMessage -> currentOnPinMessage()
                         MessageContextAction.DeleteMessage -> currentOnDeleteMessage()
+                        MessageContextAction.ZapMessage -> ZapController.request(message.pubkey, message.id)
                     }
                 },
                 isAuthor = isAuthor,
                 isAdmin = isAdmin,
+                canZap = canZap,
             )
         }
     }
@@ -498,6 +522,8 @@ private fun MessageActions(
     onReplyClick: () -> Unit,
     onReactionClick: () -> Unit,
     onMoreClick: () -> Unit,
+    canZap: Boolean,
+    onZapClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -531,7 +557,21 @@ private fun MessageActions(
             },
             onClick = onReplyClick,
         )
-        // 3. More (three dots)
+        // 3. Zap (when the author has a Lightning address) — highlights amber on hover
+        if (canZap) {
+            ActionButton(
+                icon = { isHovered ->
+                    Icon(
+                        Icons.Outlined.Bolt,
+                        contentDescription = "Zap",
+                        tint = if (isHovered) NostrordColors.Warning else NostrordColors.TextSecondary,
+                        modifier = Modifier.size(Spacing.iconSm + Spacing.xs), // 16dp
+                    )
+                },
+                onClick = onZapClick,
+            )
+        }
+        // 4. More (three dots)
         ActionButton(
             icon = {
                 Icon(
@@ -550,7 +590,7 @@ private fun MessageActions(
  */
 @Composable
 private fun ActionButton(
-    icon: @Composable () -> Unit,
+    icon: @Composable (isHovered: Boolean) -> Unit,
     onClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
@@ -570,7 +610,7 @@ private fun ActionButton(
         CompositionLocalProvider(
             LocalContentColor provides if (isHovered) NostrordColors.TextPrimary else NostrordColors.TextSecondary,
         ) {
-            icon()
+            icon(isHovered)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/zap/Zap.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/zap/Zap.kt
@@ -1,0 +1,482 @@
+package org.nostr.nostrord.ui.components.zap
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.outlined.Bolt
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.managers.ZapManager
+import org.nostr.nostrord.ui.components.QrCode
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.utils.Result
+
+/**
+ * App-wide entry point for opening the zap modal from anywhere (message context menu,
+ * zap badge, profile button) without threading modal state through every screen.
+ * A single [ZapModalHost] placed at the app root renders whatever target is active.
+ */
+object ZapController {
+    data class Target(val recipientPubkey: String, val eventId: String?)
+
+    private val _active = MutableStateFlow<Target?>(null)
+    val active: StateFlow<Target?> = _active.asStateFlow()
+
+    /** Open the zap modal for [recipientPubkey]; [eventId] is the zapped message, or null for a profile zap. */
+    fun request(recipientPubkey: String, eventId: String? = null) {
+        _active.value = Target(recipientPubkey, eventId)
+    }
+
+    fun dismiss() {
+        _active.value = null
+    }
+}
+
+/** Place once at the app root. Renders the zap modal whenever [ZapController] has an active target. */
+@Composable
+fun ZapModalHost() {
+    val target by ZapController.active.collectAsState()
+    target?.let {
+        ZapModal(
+            recipientPubkey = it.recipientPubkey,
+            eventId = it.eventId,
+            onDismiss = { ZapController.dismiss() },
+        )
+    }
+}
+
+private val PRESET_SATS = listOf(21L, 100L, 500L, 1_000L, 5_000L, 21_000L)
+
+@Composable
+private fun ZapModal(
+    recipientPubkey: String,
+    eventId: String?,
+    onDismiss: () -> Unit,
+) {
+    val scope = rememberCoroutineScope()
+    val uriHandler = LocalUriHandler.current
+    val clipboard = LocalClipboardManager.current
+
+    val metadataMap by AppModule.nostrRepository.userMetadata.collectAsState()
+    val metadata = metadataMap[recipientPubkey]
+    val recipientName = metadata?.displayName ?: metadata?.name ?: (recipientPubkey.take(8) + "…")
+
+    LaunchedEffect(recipientPubkey) {
+        if (metadataMap[recipientPubkey] == null) {
+            AppModule.nostrRepository.requestUserMetadata(setOf(recipientPubkey))
+        }
+    }
+
+    var amountText by remember { mutableStateOf("21") }
+    var comment by remember { mutableStateOf("") }
+    var loading by remember { mutableStateOf(false) }
+    var error by remember { mutableStateOf<String?>(null) }
+    var invoice by remember { mutableStateOf<ZapManager.ZapInvoice?>(null) }
+    var paid by remember { mutableStateOf(false) }
+
+    val amountSats = amountText.toLongOrNull() ?: 0L
+
+    // Once an invoice exists, watch the relays for its zap receipt to confirm payment.
+    LaunchedEffect(invoice?.bolt11) {
+        val inv = invoice ?: return@LaunchedEffect
+        if (AppModule.nostrRepository.watchZapPayment(inv.bolt11, recipientPubkey, eventId)) {
+            paid = true
+        }
+    }
+    // Auto-close shortly after a confirmed payment.
+    LaunchedEffect(paid) {
+        if (paid) {
+            delay(2_000)
+            onDismiss()
+        }
+    }
+
+    fun send() {
+        if (loading) return
+        scope.launch {
+            loading = true
+            error = null
+            when (val r = AppModule.nostrRepository.requestZapInvoice(recipientPubkey, amountSats, comment, eventId)) {
+                is Result.Success -> invoice = r.data
+                is Result.Error -> error = r.error.message
+            }
+            loading = false
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.7f))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) { onDismiss() }
+                .safeDrawingPadding(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Card(
+                modifier = Modifier
+                    .widthIn(max = 440.dp)
+                    .fillMaxWidth(0.92f)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { /* consume */ },
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
+            ) {
+                Column(
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(Spacing.xxl),
+                ) {
+                    // Header
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                imageVector = Icons.Outlined.Bolt,
+                                contentDescription = null,
+                                tint = NostrordColors.Warning,
+                                modifier = Modifier.size(22.dp),
+                            )
+                            Spacer(Modifier.width(Spacing.sm))
+                            Text(
+                                text = "Zap $recipientName",
+                                color = NostrordColors.TextPrimary,
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.Bold,
+                            )
+                        }
+                        IconButton(
+                            onClick = onDismiss,
+                            modifier = Modifier.size(32.dp).clip(CircleShape),
+                        ) {
+                            Icon(Icons.Default.Close, contentDescription = "Close", tint = NostrordColors.TextSecondary)
+                        }
+                    }
+
+                    Spacer(Modifier.height(Spacing.lg))
+
+                    val readyInvoice = invoice
+                    when {
+                        readyInvoice == null -> ZapAmountStep(
+                            amountText = amountText,
+                            onAmountChange = { amountText = it.filter { c -> c.isDigit() } },
+                            comment = comment,
+                            onCommentChange = { comment = it },
+                            loading = loading,
+                            error = error,
+                            onSend = ::send,
+                            sendEnabled = amountSats > 0L,
+                        )
+
+                        paid -> ZapSuccessStep(amountMsats = readyInvoice.amountMsats)
+
+                        else -> ZapInvoiceStep(
+                            invoice = readyInvoice,
+                            onOpenWallet = {
+                                runCatching { uriHandler.openUri("lightning:${readyInvoice.bolt11}") }
+                                    .onFailure { error = "No Lightning wallet found. Scan the QR or copy the invoice." }
+                            },
+                            onCopy = { clipboard.setText(AnnotatedString(readyInvoice.bolt11)) },
+                            onDone = onDismiss,
+                            error = error,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ZapAmountStep(
+    amountText: String,
+    onAmountChange: (String) -> Unit,
+    comment: String,
+    onCommentChange: (String) -> Unit,
+    loading: Boolean,
+    error: String?,
+    onSend: () -> Unit,
+    sendEnabled: Boolean,
+) {
+    Text(
+        text = "Amount (sats)",
+        color = NostrordColors.TextSecondary,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
+    Spacer(Modifier.height(Spacing.sm))
+
+    // Preset chips, two rows of three.
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        PRESET_SATS.chunked(3).forEach { row ->
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm), modifier = Modifier.fillMaxWidth()) {
+                row.forEach { preset ->
+                    val selected = amountText == preset.toString()
+                    OutlinedButton(
+                        onClick = { onAmountChange(preset.toString()) },
+                        modifier = Modifier.weight(1f),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            containerColor = if (selected) NostrordColors.Primary.copy(alpha = 0.18f) else Color.Transparent,
+                            contentColor = if (selected) NostrordColors.Primary else NostrordColors.TextPrimary,
+                        ),
+                    ) {
+                        Text("$preset", fontSize = 13.sp)
+                    }
+                }
+            }
+        }
+    }
+
+    Spacer(Modifier.height(Spacing.md))
+
+    OutlinedTextField(
+        value = amountText,
+        onValueChange = onAmountChange,
+        label = { Text("Custom amount") },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    Spacer(Modifier.height(Spacing.md))
+
+    OutlinedTextField(
+        value = comment,
+        onValueChange = onCommentChange,
+        label = { Text("Comment (optional)") },
+        singleLine = false,
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    if (error != null) {
+        Spacer(Modifier.height(Spacing.md))
+        Text(text = error, color = NostrordColors.Error, fontSize = 13.sp)
+    }
+
+    Spacer(Modifier.height(Spacing.lg))
+
+    Button(
+        onClick = onSend,
+        enabled = sendEnabled && !loading,
+        modifier = Modifier.fillMaxWidth().height(48.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = NostrordColors.Primary),
+    ) {
+        if (loading) {
+            CircularProgressIndicator(modifier = Modifier.size(20.dp), color = Color.White, strokeWidth = 2.dp)
+        } else {
+            Icon(Icons.Outlined.Bolt, contentDescription = null, modifier = Modifier.size(18.dp))
+            Spacer(Modifier.width(Spacing.sm))
+            Text("Get invoice", fontWeight = FontWeight.SemiBold)
+        }
+    }
+}
+
+@Composable
+private fun ZapInvoiceStep(
+    invoice: ZapManager.ZapInvoice,
+    onOpenWallet: () -> Unit,
+    onCopy: () -> Unit,
+    onDone: () -> Unit,
+    error: String?,
+) {
+    Text(
+        text = "${invoice.amountMsats / 1000} sats invoice ready",
+        color = NostrordColors.TextPrimary,
+        fontSize = 15.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
+    Spacer(Modifier.height(Spacing.xs))
+    Text(
+        text = "Pay with your Lightning wallet to complete the zap.",
+        color = NostrordColors.TextSecondary,
+        fontSize = 13.sp,
+    )
+
+    Spacer(Modifier.height(Spacing.lg))
+
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        QrCode(data = "lightning:${invoice.bolt11}", size = 220.dp)
+    }
+
+    if (error != null) {
+        Spacer(Modifier.height(Spacing.md))
+        Text(text = error, color = NostrordColors.Error, fontSize = 13.sp)
+    }
+
+    Spacer(Modifier.height(Spacing.lg))
+
+    Button(
+        onClick = onOpenWallet,
+        modifier = Modifier.fillMaxWidth().height(48.dp),
+        colors = ButtonDefaults.buttonColors(containerColor = NostrordColors.Primary),
+    ) {
+        Icon(Icons.Outlined.Bolt, contentDescription = null, modifier = Modifier.size(18.dp))
+        Spacer(Modifier.width(Spacing.sm))
+        Text("Open in wallet", fontWeight = FontWeight.SemiBold)
+    }
+
+    Spacer(Modifier.height(Spacing.sm))
+
+    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm), modifier = Modifier.fillMaxWidth()) {
+        OutlinedButton(
+            onClick = onCopy,
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = NostrordColors.TextPrimary),
+        ) {
+            Text("Copy invoice", fontSize = 13.sp)
+        }
+        OutlinedButton(
+            onClick = onDone,
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = NostrordColors.TextPrimary),
+        ) {
+            Text("Done", fontSize = 13.sp)
+        }
+    }
+
+    Spacer(Modifier.height(Spacing.md))
+
+    // Live confirmation indicator — flips to ZapSuccessStep when the receipt arrives.
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(14.dp),
+            color = NostrordColors.TextSecondary,
+            strokeWidth = 2.dp,
+        )
+        Spacer(Modifier.width(Spacing.sm))
+        Text("Waiting for payment…", color = NostrordColors.TextSecondary, fontSize = 12.sp)
+    }
+}
+
+@Composable
+private fun ZapSuccessStep(amountMsats: Long) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Bolt,
+            contentDescription = null,
+            tint = NostrordColors.Warning,
+            modifier = Modifier.size(48.dp),
+        )
+        Spacer(Modifier.height(Spacing.md))
+        Text(
+            text = "Zap received",
+            color = NostrordColors.TextPrimary,
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+        )
+        Spacer(Modifier.height(Spacing.xs))
+        Text(
+            text = "${amountMsats / 1000} sats paid ⚡",
+            color = NostrordColors.TextSecondary,
+            fontSize = 13.sp,
+        )
+    }
+}
+
+/** Compact zap-total chip shown under a message, mirroring reaction badges. */
+@Composable
+fun ZapBadge(
+    totalMsats: Long,
+    count: Int,
+    zappedByMe: Boolean,
+    onClick: () -> Unit,
+) {
+    val sats = totalMsats / 1000
+    val container = if (zappedByMe) NostrordColors.Warning.copy(alpha = 0.18f) else NostrordColors.InputBackground
+    val tint = if (zappedByMe) NostrordColors.Warning else NostrordColors.TextSecondary
+    Row(
+        modifier = Modifier
+            .padding(top = Spacing.xs)
+            .clip(RoundedCornerShape(12.dp))
+            .background(container)
+            .clickable(onClick = onClick)
+            .padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Bolt,
+            contentDescription = "Zaps",
+            tint = tint,
+            modifier = Modifier.size(14.dp),
+        )
+        Spacer(Modifier.width(Spacing.xs))
+        Text(
+            text = if (count > 1) "${formatSatsShort(sats)} · $count" else formatSatsShort(sats),
+            color = tint,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+private fun formatSatsShort(sats: Long): String = when {
+    sats >= 1_000_000 -> "${sats / 1_000_000}M"
+    sats >= 10_000 -> "${sats / 1_000}k"
+    else -> sats.toString()
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material.icons.outlined.Bolt
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -25,6 +26,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import coil3.compose.AsyncImage
@@ -37,6 +39,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.RichAboutText
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
+import org.nostr.nostrord.ui.components.zap.ZapController
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
@@ -64,6 +67,8 @@ fun UserProfileModal(
     val copyToClipboard = rememberClipboardWriter()
     val npub = remember(pubkey) { Nip19.encodeNpub(pubkey) }
     val displayName = metadata?.displayName ?: metadata?.name ?: pubkey.take(8) + "..."
+
+    val canZap = !metadata?.lud16.isNullOrBlank() || !metadata?.lud06.isNullOrBlank()
     val username = metadata?.name
 
     Dialog(
@@ -124,21 +129,62 @@ fun UserProfileModal(
                     ) {
                         Spacer(modifier = Modifier.height(Spacing.md))
 
-                        // Display name
-                        Text(
-                            text = displayName,
-                            style = NostrordTypography.ServerHeader,
-                            color = Color.White,
-                            fontWeight = FontWeight.Bold,
-                        )
+                        // Name on the left, Zap pill aligned right just below the banner.
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Column(modifier = Modifier.weight(1f)) {
+                                // Display name
+                                Text(
+                                    text = displayName,
+                                    style = NostrordTypography.ServerHeader,
+                                    color = Color.White,
+                                    fontWeight = FontWeight.Bold,
+                                )
 
-                        // Username (if different from display name)
-                        if (username != null && username != displayName) {
-                            Text(
-                                text = "@$username",
-                                style = NostrordTypography.Caption,
-                                color = NostrordColors.TextSecondary,
-                            )
+                                // Username (if different from display name)
+                                if (username != null && username != displayName) {
+                                    Text(
+                                        text = "@$username",
+                                        style = NostrordTypography.Caption,
+                                        color = NostrordColors.TextSecondary,
+                                    )
+                                }
+                            }
+
+                            // Zap button — a discreet pill (when the user has a Lightning address)
+                            if (canZap) {
+                                Spacer(modifier = Modifier.width(Spacing.sm))
+                                Surface(
+                                    onClick = {
+                                        ZapController.request(pubkey, null)
+                                        onDismiss()
+                                    },
+                                    shape = RoundedCornerShape(10.dp),
+                                    color = NostrordColors.SurfaceVariant,
+                                    modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
+                                ) {
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Outlined.Bolt,
+                                            contentDescription = null,
+                                            tint = NostrordColors.Warning,
+                                            modifier = Modifier.size(16.dp),
+                                        )
+                                        Spacer(modifier = Modifier.width(Spacing.xs))
+                                        Text(
+                                            text = "Zap",
+                                            color = NostrordColors.TextPrimary,
+                                            fontWeight = FontWeight.SemiBold,
+                                            fontSize = 13.sp,
+                                        )
+                                    }
+                                }
+                            }
                         }
 
                         Spacer(modifier = Modifier.height(Spacing.sm))

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.update
 import org.nostr.nostrord.network.RoleDefinition
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip46Client
@@ -378,6 +379,29 @@ class FakeNostrRepository : NostrRepositoryApi {
         targetPubkey: String,
         emoji: String,
     ): Result<Unit> = Result.Success(Unit)
+
+    override val zaps: StateFlow<Map<String, ZapManager.ZapInfo>> = MutableStateFlow(emptyMap())
+
+    override suspend fun requestZapInvoice(
+        recipientPubkey: String,
+        amountSats: Long,
+        comment: String,
+        eventId: String?,
+    ): Result<ZapManager.ZapInvoice> = Result.Success(
+        ZapManager.ZapInvoice(
+            bolt11 = "lnbc10n1fake",
+            amountMsats = amountSats * 1_000L,
+            recipientPubkey = recipientPubkey,
+            eventId = eventId,
+            comment = comment,
+        ),
+    )
+
+    override suspend fun watchZapPayment(
+        bolt11: String,
+        recipientPubkey: String,
+        eventId: String?,
+    ): Boolean = false
 
     override suspend fun publishRelayList(relays: List<Nip65Relay>): Result<Unit> = Result.Success(Unit)
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip57Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip57Test.kt
@@ -1,0 +1,230 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class Nip57Test {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // -------------------------------------------------------------------------
+    // lightningAddressToUrl
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `lightning address maps to well-known lnurlp url`() {
+        assertEquals(
+            "https://walletofsatoshi.com/.well-known/lnurlp/alice",
+            Nip57.lightningAddressToUrl("alice@walletofsatoshi.com"),
+        )
+    }
+
+    @Test
+    fun `lightning address trims and is case-preserving on name`() {
+        assertEquals(
+            "https://getalby.com/.well-known/lnurlp/Bob",
+            Nip57.lightningAddressToUrl("  Bob@getalby.com "),
+        )
+    }
+
+    @Test
+    fun `malformed lightning addresses return null`() {
+        assertNull(Nip57.lightningAddressToUrl("noatsign.com"))
+        assertNull(Nip57.lightningAddressToUrl("@domain.com"))
+        assertNull(Nip57.lightningAddressToUrl("name@"))
+        assertNull(Nip57.lightningAddressToUrl("a@b@c.com"))
+    }
+
+    // -------------------------------------------------------------------------
+    // lnurl encode / decode round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `lnurl encode then decode round-trips the url`() {
+        val url = "https://example.com/.well-known/lnurlp/alice"
+        val encoded = Nip57.encodeLnurl(url)
+        assertTrue(encoded.startsWith("lnurl1"), "expected lnurl hrp, got $encoded")
+        assertEquals(url, Nip57.decodeLnurl(encoded))
+    }
+
+    @Test
+    fun `decodeLnurl rejects non-lnurl bech32`() {
+        // An npub is valid bech32 but the wrong hrp.
+        assertNull(Nip57.decodeLnurl("npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6"))
+    }
+
+    // -------------------------------------------------------------------------
+    // resolvePayEndpoint
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `resolvePayEndpoint prefers lud16 over lud06`() {
+        val lud06 = Nip57.encodeLnurl("https://other.com/.well-known/lnurlp/x")
+        val (url, _) = Nip57.resolvePayEndpoint(lud16 = "a@b.com", lud06 = lud06)!!
+        assertEquals("https://b.com/.well-known/lnurlp/a", url)
+    }
+
+    @Test
+    fun `resolvePayEndpoint falls back to lud06 when lud16 missing`() {
+        val lnurl = Nip57.encodeLnurl("https://c.com/.well-known/lnurlp/y")
+        val (url, bech) = Nip57.resolvePayEndpoint(lud16 = null, lud06 = lnurl)!!
+        assertEquals("https://c.com/.well-known/lnurlp/y", url)
+        assertEquals(lnurl, bech)
+    }
+
+    @Test
+    fun `resolvePayEndpoint returns null when neither usable`() {
+        assertNull(Nip57.resolvePayEndpoint(lud16 = null, lud06 = null))
+        assertNull(Nip57.resolvePayEndpoint(lud16 = "", lud06 = ""))
+    }
+
+    // -------------------------------------------------------------------------
+    // parseLnurlPayParams
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `parseLnurlPayParams reads zap-capable service`() {
+        val body = """
+            {"callback":"https://x.com/cb","minSendable":1000,"maxSendable":100000000,
+             "allowsNostr":true,"nostrPubkey":"abc123","commentAllowed":255,"tag":"payRequest"}
+        """.trimIndent()
+        val p = Nip57.parseLnurlPayParams(body)!!
+        assertEquals("https://x.com/cb", p.callback)
+        assertEquals(1000L, p.minSendableMsats)
+        assertEquals(100_000_000L, p.maxSendableMsats)
+        assertTrue(p.allowsNostr)
+        assertEquals("abc123", p.nostrPubkey)
+        assertEquals(255, p.commentAllowed)
+    }
+
+    @Test
+    fun `parseLnurlPayParams defaults allowsNostr false`() {
+        val p = Nip57.parseLnurlPayParams("""{"callback":"https://x.com/cb","minSendable":1000,"maxSendable":2000}""")!!
+        assertTrue(!p.allowsNostr)
+        assertNull(p.nostrPubkey)
+    }
+
+    @Test
+    fun `parseLnurlPayParams returns null without callback`() {
+        assertNull(Nip57.parseLnurlPayParams("""{"status":"ERROR","reason":"not found"}"""))
+    }
+
+    // -------------------------------------------------------------------------
+    // callback parsing
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `parseInvoiceFromCallback extracts pr`() {
+        assertEquals("lnbc100n1xyz", Nip57.parseInvoiceFromCallback("""{"pr":"lnbc100n1xyz","routes":[]}"""))
+    }
+
+    @Test
+    fun `parseCallbackError surfaces reason`() {
+        assertEquals("amount too low", Nip57.parseCallbackError("""{"status":"ERROR","reason":"amount too low"}"""))
+        assertNull(Nip57.parseCallbackError("""{"pr":"lnbc1"}"""))
+    }
+
+    // -------------------------------------------------------------------------
+    // buildZapRequest
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `buildZapRequest produces a kind 9734 with required tags`() {
+        val ev = Nip57.buildZapRequest(
+            senderPubkey = "sender",
+            recipientPubkey = "recipient",
+            amountMsats = 21_000L,
+            relays = listOf("wss://relay.one", "wss://relay.two"),
+            lnurlBech32 = "lnurl1abc",
+            comment = "thanks!",
+            eventId = "evt123",
+            createdAt = 1_700_000_000L,
+        )
+        assertEquals(9734, ev.kind)
+        assertEquals("thanks!", ev.content)
+        assertEquals(listOf("amount", "21000"), ev.getTag("amount"))
+        assertEquals(listOf("p", "recipient"), ev.getTag("p"))
+        assertEquals(listOf("e", "evt123"), ev.getTag("e"))
+        assertEquals(listOf("lnurl", "lnurl1abc"), ev.getTag("lnurl"))
+        assertEquals(listOf("relays", "wss://relay.one", "wss://relay.two"), ev.getTag("relays"))
+    }
+
+    @Test
+    fun `buildZapRequest omits e tag for profile zaps`() {
+        val ev = Nip57.buildZapRequest(
+            senderPubkey = "s",
+            recipientPubkey = "r",
+            amountMsats = 1000L,
+            relays = emptyList(),
+            lnurlBech32 = "lnurl1abc",
+            comment = "",
+            eventId = null,
+            createdAt = 1L,
+        )
+        assertNull(ev.getTag("e"))
+        assertNull(ev.getTag("relays"))
+    }
+
+    // -------------------------------------------------------------------------
+    // parseZapReceipt
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `parseZapReceipt reads amount and zapper from embedded request`() {
+        val description = """
+            {"pubkey":"zapperpk","kind":9734,"tags":[["amount","50000"],["e","msg1"],["p","authorpk"]],"content":"gg"}
+        """.trimIndent().replace("\n", "")
+        val receipt = """
+            {"kind":9735,"pubkey":"lnurlserverpk","tags":[
+              ["p","authorpk"],["e","msg1"],
+              ["bolt11","lnbc500n1xyz"],
+              ["description","${description.replace("\"", "\\\"")}"]
+            ],"content":""}
+        """.trimIndent().replace("\n", "")
+        val obj = json.parseToJsonElement(receipt).jsonObject
+        val parsed = Nip57.parseZapReceipt(obj)
+        assertNotNull(parsed)
+        assertEquals("msg1", parsed.zappedEventId)
+        assertEquals("authorpk", parsed.recipientPubkey)
+        assertEquals("zapperpk", parsed.zapperPubkey)
+        assertEquals(50_000L, parsed.amountMsats)
+    }
+
+    @Test
+    fun `parseZapReceipt falls back to bolt11 amount`() {
+        val receipt = """
+            {"kind":9735,"pubkey":"srv","tags":[["e","m"],["p","a"],["bolt11","lnbc10u1pxyz"]],"content":""}
+        """.trimIndent().replace("\n", "")
+        val parsed = Nip57.parseZapReceipt(json.parseToJsonElement(receipt).jsonObject)!!
+        assertEquals(1_000_000L, parsed.amountMsats) // 10u = 10 micro-BTC = 1_000_000 msats
+    }
+
+    @Test
+    fun `parseZapReceipt rejects wrong kind`() {
+        assertNull(Nip57.parseZapReceipt(json.parseToJsonElement("""{"kind":1,"tags":[]}""").jsonObject))
+    }
+
+    // -------------------------------------------------------------------------
+    // decodeBolt11AmountMsats
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `decodeBolt11AmountMsats handles multipliers`() {
+        // 2500u = 2500 micro-BTC = 0.0025 BTC = 250_000 sats = 250_000_000 msats
+        assertEquals(250_000_000L, Nip57.decodeBolt11AmountMsats("lnbc2500u1pvjluezpp5..."))
+        // 20m = 20 milli-BTC = 0.02 BTC = 2_000_000 sats = 2_000_000_000 msats
+        assertEquals(2_000_000_000L, Nip57.decodeBolt11AmountMsats("lnbc20m1pvjluez..."))
+        // 1n = 1 nano-BTC = 100 msats
+        assertEquals(100L, Nip57.decodeBolt11AmountMsats("lnbc1n1pxyz"))
+    }
+
+    @Test
+    fun `decodeBolt11AmountMsats returns null for amountless or garbage`() {
+        assertNull(Nip57.decodeBolt11AmountMsats("lnbc1pvjluez...")) // amountless
+        assertNull(Nip57.decodeBolt11AmountMsats("not-an-invoice"))
+    }
+}


### PR DESCRIPTION
Adds Lightning Zaps (NIP-57) so users can zap group chat messages (kind 9) and user profiles. The recipient's LNURL-pay endpoint is resolved from their kind:0 `lud16`/`lud06`, the zap request (kind 9734) is built and signed locally and sent to the LNURL callback, and the returned bolt11 invoice is handed off to an external Lightning wallet (`lightning:` deeplink, with QR + copy fallbacks for desktop/web). While the invoice is shown, the modal polls for the matching kind 9735 receipt (matched on `bolt11`) and flips to a confirmed state on payment.

Received zaps are aggregated per event and rendered as a total badge under each message. Receipts are read from the relays named in the request's `relays` tag (group relay + account relays + a few general relays) — not the NIP-29 group relay, which rejects the h-less 9735. Entry points are gated on the author having a Lightning address: a zap action in the message hover toolbar and the context menu, plus a discreet zap pill on the profile modal.

The whole flow is driven from `ZapController` into a single app-root `ZapModalHost`, so no per-screen modal plumbing is needed. Payment uses the existing Compose `LocalUriHandler` rather than new per-platform `expect/actual`. In-app payment (NIP-47 NWC) and anonymous zaps are intentionally out of scope.

| Area | Change |
|---|---|
| Protocol | `Nip57` helper — LNURL resolve (lud16/lud06), pay-params + callback parsing, 9734 build, 9735 parse, bolt11 amount decode (unit-tested) |
| Orchestration | `ZapManager` — invoice fetch, receipt aggregation (`zaps` flow), paid-invoice flow for live confirmation |
| Repository | `requestZapInvoice` / `watchZapPayment` on the facade; kind 9735 routed to aggregation; receipt fetch on message load |
| Model | `UserMetadata.lud06` added + parsed |
| UI | `ZapModal` (amount/comment → invoice QR/handoff → "Zap received"), zap badge, hover-toolbar + context-menu actions, profile pill |

Verification: `compileKotlinJvm`, `compileDebugKotlinAndroid`, `compileKotlinJs`, `compileKotlinWasmJs`, `:composeApp:jvmTest` (incl. `Nip57Test`), and `spotlessCheck` all pass. iOS shares the same commonMain (no iOS-specific code added).

Commits:
- feat(zap): NIP-57 Lightning Zaps for messages and profiles