### PR TITLE
fix(chat): mobile & web keyboard, scroll, and long-name fixes

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
@@ -11,3 +11,4 @@ actual fun getPlatform(): Platform = AndroidPlatform()
 actual val isAndroid: Boolean = true
 actual val isHandheldPlatform: Boolean = true
 actual val platformDisplayName: String = "Nostrord Android"
+actual val autoFocusTextInput: Boolean = false

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
@@ -23,3 +23,11 @@ expect val isHandheldPlatform: Boolean
  * (and revoke individually).
  */
 expect val platformDisplayName: String
+
+/**
+ * Whether the message input should grab focus automatically when a chat opens.
+ * True only in mouse + physical-keyboard environments (desktop, and desktop web).
+ * False on touch devices (Android, iOS, and coarse-pointer web) where auto-focus
+ * would pop the on-screen keyboard the moment a group is opened.
+ */
+expect val autoFocusTextInput: Boolean

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -392,8 +393,11 @@ fun MessageItem(
                                 text = displayName,
                                 color = Color.White,
                                 style = NostrordTypography.Username,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                                 modifier =
                                 Modifier
+                                    .weight(1f, fill = false)
                                     .clickable { currentOnUsernameClick(message.pubkey) }
                                     .pointerHoverIcon(PointerIcon.Hand),
                             )
@@ -402,6 +406,7 @@ fun MessageItem(
                                 text = formatTime(message.createdAt),
                                 color = NostrordColors.TextMuted,
                                 style = NostrordTypography.Timestamp,
+                                maxLines = 1,
                             )
                         }
                         Spacer(modifier = Modifier.height(Spacing.xs))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/SystemEventItem.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/chat/SystemEventItem.kt
@@ -115,41 +115,45 @@ fun SystemEventItem(
             Spacer(modifier = Modifier.width(8.dp))
         }
 
-        // Event text
-        Column {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                if (totalUsers == 1) {
-                    val displayName = metadata?.displayName ?: metadata?.name ?: pubkey.take(8) + "..."
-                    Text(
-                        text = displayName,
-                        color = Color.White,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = action,
-                        color = NostrordColors.TextMuted,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                } else {
-                    Text(
-                        text = "$totalUsers members",
-                        color = Color.White,
-                        style = MaterialTheme.typography.bodySmall,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = action,
-                        color = NostrordColors.TextMuted,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                }
+        // Event text — weighted (fill = false) so short rows stay centered while a
+        // long display name truncates instead of squeezing the action and timestamp.
+        Row(
+            modifier = Modifier.weight(1f, fill = false),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (totalUsers == 1) {
+                val displayName = metadata?.displayName ?: metadata?.name ?: pubkey.take(8) + "..."
+                Text(
+                    text = displayName,
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = action,
+                    color = NostrordColors.TextMuted,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                )
+            } else {
+                Text(
+                    text = "$totalUsers members",
+                    color = Color.White,
+                    style = MaterialTheme.typography.bodySmall,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = action,
+                    color = NostrordColors.TextMuted,
+                    style = MaterialTheme.typography.bodySmall,
+                    maxLines = 1,
+                )
             }
         }
 
@@ -160,6 +164,7 @@ fun SystemEventItem(
             text = formatTimestamp(createdAt),
             color = NostrordColors.TextMuted.copy(alpha = 0.6f),
             style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.launch
+import org.nostr.nostrord.autoFocusTextInput
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.getPlatform
 import org.nostr.nostrord.network.NostrGroupClient
@@ -118,9 +119,11 @@ fun MessageInput(
         !platform.startsWith("Android") && !platform.startsWith("iOS")
     }
 
-    // Auto-focus on desktop only — on Android this would open the keyboard immediately
+    // Auto-focus only where there's a physical keyboard (desktop, desktop web).
+    // On touch devices — Android, iOS, and coarse-pointer (mobile) web — this would
+    // pop the on-screen keyboard the instant a group opens, so it's skipped.
     LaunchedEffect(isJoined, groupName) {
-        if (isJoined && !getPlatform().name.startsWith("Android")) {
+        if (isJoined && autoFocusTextInput) {
             focusRequester.requestFocus()
         }
     }
@@ -171,8 +174,9 @@ fun MessageInput(
     LaunchedEffect(messageInput) {
         if (textFieldValue.text != messageInput) {
             textFieldValue = TextFieldValue(messageInput, TextRange(messageInput.length))
-            // Refocus after send (input cleared) on desktop
-            if (messageInput.isEmpty() && !getPlatform().name.startsWith("Android")) {
+            // Refocus after send (input cleared) only where auto-focus is wanted —
+            // skip touch/mobile web so a send doesn't re-pop the on-screen keyboard.
+            if (messageInput.isEmpty() && autoFocusTextInput) {
                 focusRequester.requestFocus()
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -116,6 +117,7 @@ fun MessagesList(
     val currentChatItems by rememberUpdatedState(chatItems)
 
     val coroutineScope = rememberCoroutineScope()
+    val focusManager = LocalFocusManager.current
     var reactingToMessageId by remember { mutableStateOf<String?>(null) }
     // Hoisted so only one message context menu can be open at a time
     var openContextMenuId by remember { mutableStateOf<String?>(null) }
@@ -498,7 +500,15 @@ fun MessagesList(
                                                         id == lastClosedMenuId &&
                                                             mark != null &&
                                                             mark.elapsedNow() < 350.milliseconds
-                                                    if (!recentlyClosed) openContextMenuId = id
+                                                    if (!recentlyClosed) {
+                                                        // Drop input focus before the focusable
+                                                        // menu Popup opens. Otherwise dismissing
+                                                        // it (e.g. Android back) returns focus to
+                                                        // the message field and re-shows the
+                                                        // keyboard instead of just closing the menu.
+                                                        focusManager.clearFocus(force = true)
+                                                        openContextMenuId = id
+                                                    }
                                                 } else if (openContextMenuId == id) {
                                                     closeContextMenu()
                                                 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ScrollPositionCache.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ScrollPositionCache.kt
@@ -163,33 +163,23 @@ fun <T> ScrollPositionEffect(
             }
     }
 
-    // Track when user scrolls away from bottom.
+    // Track whether the viewport is parked at the bottom. "Scrolled away" is a pure
+    // function of POSITION, not scroll direction. Direction-based tracking raced with
+    // the stick-to-bottom effect below: scrolling up to read history (or the IME
+    // open/close animation moving the list) could be misread as "returned to bottom",
+    // which then teleported the view to the newest message — including the
+    // "pagination loads and jumps to latest" symptom when older history pages in.
+    // Tolerance of 2 keeps a single appended message from briefly flipping the flag.
     LaunchedEffect(groupId, listState) {
         if (!initialScrollToEnd) return@LaunchedEffect
-        var prevFirstVisible = listState.firstVisibleItemIndex
         snapshotFlow {
-            val lastVisible =
-                listState.layoutInfo.visibleItemsInfo
-                    .lastOrNull()
-                    ?.index ?: -1
-            lastVisible to listState.firstVisibleItemIndex
+            val layoutInfo = listState.layoutInfo
+            val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+            val total = layoutInfo.totalItemsCount
+            lastVisible >= 0 && total > 0 && lastVisible >= total - 2
         }.distinctUntilChanged()
-            .collect { (lastVisible, firstVisible) ->
-                val size = currentItems.size
-                if (size > 0 && lastVisible >= 0) {
-                    val atBottom = lastVisible >= size - 1
-                    if (atBottom) {
-                        stateHolder.isScrolledAway = false
-                    } else {
-                        when {
-                            firstVisible > prevFirstVisible -> stateHolder.isScrolledAway = true
-                            firstVisible < prevFirstVisible -> stateHolder.isScrolledAway = false
-                        }
-                    }
-                    prevFirstVisible = firstVisible
-                } else {
-                    stateHolder.isScrolledAway = false
-                }
+            .collect { atBottom ->
+                stateHolder.isScrolledAway = !atBottom
             }
     }
 

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
@@ -11,3 +11,4 @@ actual fun getPlatform(): Platform = IOSPlatform()
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = true
 actual val platformDisplayName: String = "Nostrord iOS"
+actual val autoFocusTextInput: Boolean = false

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
@@ -9,3 +9,8 @@ actual fun getPlatform(): Platform = JsPlatform()
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = false
 actual val platformDisplayName: String = "Nostrord Web"
+
+// Desktop web (mouse) auto-focuses; mobile/touch web does not, to avoid popping
+// the on-screen keyboard on group entry. Mirrors messagesTextSelectionEnabled.
+actual val autoFocusTextInput: Boolean =
+    !org.nostr.nostrord.ui.components.chat.isCoarsePointer()

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
@@ -9,3 +9,4 @@ actual fun getPlatform(): Platform = JVMPlatform()
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = false
 actual val platformDisplayName: String = "Nostrord Desktop"
+actual val autoFocusTextInput: Boolean = true

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/Platform.wasmJs.kt
@@ -9,3 +9,8 @@ actual fun getPlatform(): Platform = WasmPlatform()
 actual val isAndroid: Boolean = false
 actual val isHandheldPlatform: Boolean = false
 actual val platformDisplayName: String = "Nostrord Web"
+
+// Desktop web (mouse) auto-focuses; mobile/touch web does not, to avoid popping
+// the on-screen keyboard on group entry. Mirrors messagesTextSelectionEnabled.
+actual val autoFocusTextInput: Boolean =
+    !org.nostr.nostrord.ui.components.chat.isCoarsePointer()


### PR DESCRIPTION
Conjunto de correções de UX do chat em mobile e web touch. O scroll deixa de pular para a última mensagem ao fechar o teclado ou ao paginar o histórico; o back no menu de contexto só fecha o menu (sem reabrir o teclado); o input não auto-foca em web touch (que abria o teclado ao entrar no grupo); e nomes longos truncam em vez de espremer o timestamp e o "joined the group". Tudo em commonMain, então vale para Android, desktop, web e iOS.

| Fix | Sintoma |
|---|---|
| scroll position | pulava para o fim ao fechar o teclado / paginar o histórico |
| context menu focus | back no menu de contexto reabria o teclado |
| touch-web auto-focus | teclado abria ao entrar no grupo (web touch) |
| long-name truncation | nome longo espremia data e "joined the group" |

Commits:
- dfda104 fix(chat): keep scroll position when paging history and closing the keyboard
- f609b72 fix(chat): don't reopen the keyboard when dismissing a message menu
- ad72681 fix(chat): stop auto-focusing the message input on touch web
- 942c8ca fix(chat): truncate long display names in message and system-event rows