### PR TITLE
fix(nip46): banner flicker, stuck reconnect, and MY GROUPS empty after switch

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -52,9 +52,15 @@ actual class Nip46Client actual constructor(
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
-                        client.waitForConnection()
-                        openResponseSubscription(client)
-                        client
+                        if (!client.waitForConnection()) {
+                            // WS never opened (timeout) — drop it so callers don't
+                            // treat a dead socket as a live relay connection.
+                            client.disconnect()
+                            null
+                        } else {
+                            openResponseSubscription(client)
+                            client
+                        }
                     } catch (e: Exception) {
                         null
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/AccountManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/AccountManager.kt
@@ -1,5 +1,7 @@
 package org.nostr.nostrord.auth
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.AuthManager
 import org.nostr.nostrord.nostr.KeyPair
@@ -13,11 +15,18 @@ import org.nostr.nostrord.utils.epochMillis
  *
  * The switch sequence is implemented (and documented inline) in [switchAccount];
  * a failed credential load leaves the current session intact.
+ *
+ * [scope] must outlive any Composable that triggers a switch — UI scopes from
+ * `rememberCoroutineScope()` get cancelled when the host Composable leaves
+ * composition (e.g. the account menu auto-dismissing after a successful swap),
+ * which kills [switchAccount]'s reloadForActiveAccount mid-flight and leaves
+ * the new account's joined-groups map unpopulated.
  */
 class AccountManager(
     private val accountStore: AccountStore,
     private val authManager: AuthManager,
     private val sessionFactory: AccountSessionFactory,
+    private val scope: CoroutineScope,
 ) {
     /**
      * Add a new local-key account WITHOUT switching to it.
@@ -93,6 +102,27 @@ class AccountManager(
         AppModule.nostrRepository.reloadForActiveAccount()
 
         return Result.success(Unit)
+    }
+
+    /**
+     * Fire [switchAccount] on the manager's long-lived [scope] so the swap
+     * completes even if the caller's Composable (e.g. an account menu) leaves
+     * composition mid-flight. UI callers MUST use this instead of launching
+     * [switchAccount] on a `rememberCoroutineScope` — that scope is cancelled
+     * on dismissal and the cancellation aborts [reloadForActiveAccount] in
+     * the middle of `liveCursorStore.loadAll`, leaving the new account's
+     * joined-groups map unpopulated. [onResult] runs on the manager's scope
+     * (not the UI thread), so state writes inside it must be thread-safe
+     * (MutableState / MutableStateFlow are fine).
+     */
+    fun switchAccountAsync(
+        accountId: String,
+        onResult: (Result<Unit>) -> Unit = {},
+    ) {
+        scope.launch {
+            val r = switchAccount(accountId)
+            onResult(r)
+        }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -92,7 +92,11 @@ object AppModule {
     }
 
     val accountManager: AccountManager by lazy {
-        AccountManager(accountStore, authManager, accountSessionFactory)
+        // appScope (long-lived) so a switchAccountAsync() survives the caller
+        // Composable being dismissed mid-swap — a rememberCoroutineScope would
+        // cancel reloadForActiveAccount in the middle and leave the new
+        // account's MY GROUPS empty.
+        AccountManager(accountStore, authManager, accountSessionFactory, appScope)
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -1,13 +1,21 @@
 package org.nostr.nostrord.network
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.auth.AccountStore
@@ -28,6 +36,18 @@ import org.nostr.nostrord.storage.saveBunkerClientPrivateKeyFor
 import org.nostr.nostrord.storage.saveBunkerUrlFor
 import org.nostr.nostrord.storage.savePrivateKeyFor
 import org.nostr.nostrord.utils.epochMillis
+
+// Interactive reconnect deadlines. Kept short so the banner's "Reconnect" button
+// fails fast with a precise reason instead of freezing on the old 120s RPC wait.
+// connectRelaysOnly's internal waitForConnection caps at 7s; backgroundConnect at
+// 10s — these are the safety nets just above those.
+private const val RELAY_CONNECT_TIMEOUT_MS = 8_000L
+private const val SIGNER_CONNECT_TIMEOUT_MS = 12_000L
+
+// Background auto-reconnect: capped exponential backoff, bounded attempts.
+private const val AUTO_RECONNECT_BASE_MS = 3_000L
+private const val AUTO_RECONNECT_MAX_MS = 60_000L
+private const val AUTO_RECONNECT_MAX_ATTEMPTS = 5
 
 /**
  * Manages authentication state and signing operations.
@@ -61,11 +81,27 @@ class AuthManager(
      */
     internal var onSessionInvalidated: (suspend (invalidatedPubkey: String?) -> Unit)? = null
 
-    private val _isBunkerConnected = MutableStateFlow(false)
-    val isBunkerConnected: StateFlow<Boolean> = _isBunkerConnected.asStateFlow()
+    // Single source of truth for the bunker connection lifecycle. The legacy
+    // isBunkerConnected boolean is derived from it so existing consumers keep
+    // working unchanged. isBunkerVerifying stays an independent flag because the
+    // App reuses it as a generic "show loading overlay" signal during cold-boot
+    // restore and logout — folding it in here would change those screens.
+    private val _bunkerState = MutableStateFlow<BunkerState>(BunkerState.Inactive)
+    val bunkerState: StateFlow<BunkerState> = _bunkerState.asStateFlow()
+
+    val isBunkerConnected: StateFlow<Boolean> =
+        _bunkerState
+            .map { it is BunkerState.Connected }
+            .stateIn(authScope, SharingStarted.Eagerly, false)
 
     private val _isBunkerVerifying = MutableStateFlow(false)
     val isBunkerVerifying: StateFlow<Boolean> = _isBunkerVerifying.asStateFlow()
+
+    // Capped-backoff background reconnect, started on entering Unreachable and
+    // cancelled once reconnected or the session ends. Serialized via the mutex
+    // so the banner button and the auto loop never reconnect concurrently.
+    private val reconnectMutex = Mutex()
+    private var autoReconnectJob: Job? = null
 
     private val _authUrl = MutableStateFlow<String?>(null)
     val authUrl: StateFlow<String?> = _authUrl.asStateFlow()
@@ -178,7 +214,8 @@ class AuthManager(
         SecureStorage.clearPrivateKey()
         registerAccountAfterLogin(userPubkey, AuthMethod.BUNKER)
 
-        _isBunkerConnected.value = true
+        _bunkerState.value = BunkerState.Connected
+        stopAutoReconnect()
         _authUrl.value = null
 
         return userPubkey
@@ -255,7 +292,8 @@ class AuthManager(
         SecureStorage.clearPrivateKey()
         registerAccountAfterLogin(userPubkey, AuthMethod.BUNKER)
 
-        _isBunkerConnected.value = true
+        _bunkerState.value = BunkerState.Connected
+        stopAutoReconnect()
         _authUrl.value = null
 
         return userPubkey
@@ -411,7 +449,8 @@ class AuthManager(
         isNip07Login = false
         nip07UserPubkey = null
         zeroAndClearKeyPair()
-        _isBunkerConnected.value = false
+        stopAutoReconnect()
+        _bunkerState.value = BunkerState.Inactive
 
         when (prepared) {
             is PreparedAccount.Local -> {
@@ -486,7 +525,7 @@ class AuthManager(
         _isLoggedIn.value = true
         // Optimistic: assume reachable. The async block below flips this to
         // false if the WebSocket open fails so the UI can show "Disconnected".
-        _isBunkerConnected.value = true
+        _bunkerState.value = BunkerState.Connected
         _isBunkerVerifying.value = true
 
         val savedClientPrivateKey =
@@ -500,7 +539,8 @@ class AuthManager(
                 } catch (_: Exception) {
                     if (nip46Client === client) {
                         _isBunkerVerifying.value = false
-                        _isBunkerConnected.value = false
+                        _bunkerState.value =
+                            BunkerState.Unreachable(BunkerUnreachableReason.Unknown)
                     }
                     return@launch
                 }
@@ -511,8 +551,8 @@ class AuthManager(
                 // surface the disconnected state. They can retry later;
                 // backgroundConnect below would just time out without sockets.
                 if (nip46Client === client) {
-                    _isBunkerConnected.value = false
                     _isBunkerVerifying.value = false
+                    enterUnreachable(BunkerUnreachableReason.RelaysUnreachable)
                 }
                 return@launch
             }
@@ -612,7 +652,7 @@ class AuthManager(
         // re-paste the bunker URI (issue #85).
         _isLoggedIn.value = true
         _isBunkerVerifying.value = true
-        _isBunkerConnected.value = true
+        _bunkerState.value = BunkerState.Connected
 
         if (savedClientPrivateKey == null) {
             SecureStorage.saveBunkerClientPrivateKey(newNip46Client.clientPrivateKey)
@@ -632,8 +672,8 @@ class AuthManager(
                 // Relay unreachable — keep the user signed in and surface the
                 // disconnected state so the UI can offer a one-tap reconnect.
                 if (nip46Client === newNip46Client) {
-                    _isBunkerConnected.value = false
                     _isBunkerVerifying.value = false
+                    enterUnreachable(BunkerUnreachableReason.RelaysUnreachable)
                 }
                 return@launch
             }
@@ -667,69 +707,147 @@ class AuthManager(
     }
 
     /**
-     * Reconnect bunker if disconnected
+     * Bring the bunker back online on demand (banner "Reconnect" button, or any
+     * caller that needs a live signer). Runs a single bounded attempt; if it
+     * fails, leaves background auto-reconnect running so recovery continues
+     * without further user action.
      */
     suspend fun ensureBunkerConnected(): Boolean {
         if (!isBunkerLogin) return true
-        if (nip46Client != null && _isBunkerConnected.value) return true
-
-        return reconnectBunker()
+        if (nip46Client != null && _bunkerState.value is BunkerState.Connected) return true
+        val ok = attemptReconnect()
+        if (!ok) startAutoReconnect()
+        return ok
     }
 
-    private suspend fun reconnectBunker(): Boolean {
+    /**
+     * One mutex-guarded reconnect attempt. Holds [BunkerState.Reconnecting] for
+     * the whole attempt so the banner spinner can never outlive it, then settles
+     * on [BunkerState.Connected] or [BunkerState.Unreachable] with a precise
+     * reason. Concurrent callers (button + auto loop) serialize here.
+     */
+    private suspend fun attemptReconnect(): Boolean = reconnectMutex.withLock {
+        if (!isBunkerLogin) return@withLock false
+        if (nip46Client != null && _bunkerState.value is BunkerState.Connected) {
+            return@withLock true
+        }
+
+        _bunkerState.value = BunkerState.Reconnecting
+        val reason = doReconnect()
+        if (reason == null) {
+            stopAutoReconnect()
+            _bunkerState.value = BunkerState.Connected
+            true
+        } else {
+            // Settle directly (not via enterUnreachable) so an attempt made
+            // from inside the auto loop doesn't restart the loop; the caller
+            // decides whether to keep retrying.
+            _bunkerState.value = BunkerState.Unreachable(reason)
+            false
+        }
+    }
+
+    /**
+     * Build a fresh client from the saved bunker URL and connect it in two
+     * bounded phases so a hang in either is short and distinguishable:
+     *  1. relays — [Nip46Client.connectRelaysOnly], capped at
+     *     [RELAY_CONNECT_TIMEOUT_MS]; failure ⇒ [BunkerUnreachableReason.RelaysUnreachable].
+     *  2. signer — [Nip46Client.backgroundConnect], capped at
+     *     [SIGNER_CONNECT_TIMEOUT_MS]; no ack ⇒ [BunkerUnreachableReason.SignerNotResponding].
+     * Returns null on success, otherwise the failure reason.
+     */
+    private suspend fun doReconnect(): BunkerUnreachableReason? {
         val activePubkey = bunkerUserPubkey
         val savedBunkerUrl =
             activePubkey?.let { SecureStorage.getBunkerUrlFor(it) }
                 ?: SecureStorage.getBunkerUrl()
-                ?: return false
+                ?: return BunkerUnreachableReason.Unknown
         val savedClientPrivateKey =
             activePubkey?.let { SecureStorage.getBunkerClientPrivateKeyFor(it) }
                 ?: SecureStorage.getBunkerClientPrivateKey()
-
-        try {
-            val bunkerInfo = parseBunkerUrl(savedBunkerUrl)
-
-            val newNip46Client =
-                if (savedClientPrivateKey != null) {
-                    Nip46Client(savedClientPrivateKey)
-                } else {
-                    Nip46Client()
-                }
-
-            newNip46Client.onAuthUrl = { url ->
-                _authUrl.value = url
-            }
-
+        val info =
             try {
-                newNip46Client.connect(
-                    remoteSignerPubkey = bunkerInfo.pubkey,
-                    relays = bunkerInfo.relays,
-                    secret = bunkerInfo.secret,
-                )
-            } catch (e: Exception) {
-                if (e.message?.contains("already connected", ignoreCase = true) == true) {
-                } else {
-                    throw e
-                }
+                parseBunkerUrl(savedBunkerUrl)
+            } catch (_: Exception) {
+                return BunkerUnreachableReason.Unknown
             }
 
-            nip46Client = newNip46Client
-            _isBunkerConnected.value = true
-
-            if (savedClientPrivateKey == null) {
-                SecureStorage.saveBunkerClientPrivateKey(newNip46Client.clientPrivateKey)
-                activePubkey?.let {
-                    SecureStorage.saveBunkerClientPrivateKeyFor(
-                        it,
-                        newNip46Client.clientPrivateKey,
-                    )
-                }
+        val client =
+            if (savedClientPrivateKey != null) {
+                Nip46Client(savedClientPrivateKey)
+            } else {
+                Nip46Client()
             }
+        client.onAuthUrl = { url -> _authUrl.value = url }
 
-            return true
-        } catch (e: Exception) {
-            return false
+        val relaysOk =
+            withTimeoutOrNull(RELAY_CONNECT_TIMEOUT_MS) {
+                try {
+                    client.connectRelaysOnly(info.pubkey, info.relays)
+                    true
+                } catch (_: Exception) {
+                    false
+                }
+            } ?: false
+        if (!relaysOk) {
+            client.disconnect()
+            return BunkerUnreachableReason.RelaysUnreachable
         }
+
+        val authorized = awaitSignerAuthorize(client, info.secret)
+        if (!authorized) {
+            client.disconnect()
+            return BunkerUnreachableReason.SignerNotResponding
+        }
+
+        nip46Client = client
+        if (savedClientPrivateKey == null) {
+            SecureStorage.saveBunkerClientPrivateKey(client.clientPrivateKey)
+            activePubkey?.let {
+                SecureStorage.saveBunkerClientPrivateKeyFor(it, client.clientPrivateKey)
+            }
+        }
+        return null
+    }
+
+    /**
+     * Fire the NIP-46 "connect" RPC and wait (bounded) for the signer to
+     * re-authorize. [Nip46Client.backgroundConnect] already self-times-out and
+     * reports back via callbacks; the outer deadline is a safety net.
+     */
+    private suspend fun awaitSignerAuthorize(
+        client: Nip46Client,
+        secret: String?,
+    ): Boolean {
+        val authorized = CompletableDeferred<Boolean>()
+        client.backgroundConnect(
+            secret = secret,
+            onSuccess = { authorized.complete(true) },
+            onRevoked = { authorized.complete(false) },
+        )
+        return withTimeoutOrNull(SIGNER_CONNECT_TIMEOUT_MS) { authorized.await() } ?: false
+    }
+
+    /** Start capped-backoff background reconnect (idempotent while already running). */
+    private fun startAutoReconnect() {
+        if (autoReconnectJob?.isActive == true) return
+        autoReconnectJob =
+            authScope.launch {
+                var delayMs = AUTO_RECONNECT_BASE_MS
+                repeat(AUTO_RECONNECT_MAX_ATTEMPTS) {
+                    delay(delayMs)
+                    if (!isBunkerLogin || _bunkerState.value is BunkerState.Connected) {
+                        return@launch
+                    }
+                    if (attemptReconnect()) return@launch
+                    delayMs = (delayMs * 2).coerceAtMost(AUTO_RECONNECT_MAX_MS)
+                }
+            }
+    }
+
+    private fun stopAutoReconnect() {
+        autoReconnectJob?.cancel()
+        autoReconnectJob = null
     }
 
     /**
@@ -740,7 +858,10 @@ class AuthManager(
      * inline auth state for the initial login flow, before the session is
      * activated.
      */
-    suspend fun signEvent(event: Event): Event {
+    suspend fun signEvent(
+        event: Event,
+        interactive: Boolean = true,
+    ): Event {
         val sessionSigner = ActiveAccountManager.session.value?.signer
         if (sessionSigner != null) {
             return try {
@@ -750,7 +871,11 @@ class AuthManager(
                     if (sessionSigner is NostrSigner.Bunker) {
                         // Can't tell an offline signer from a deleted connection
                         // apart — surface a reconnectable error, never log out.
-                        markSignerUnreachable()
+                        // Only a user-initiated sign raises the banner: background
+                        // NIP-42 AUTH (kind 22242) signs pass interactive=false, so a
+                        // transient relay/AUTH hiccup never flips the UI to "can't
+                        // reach your signer". (banner-flicker fix)
+                        if (interactive) markSignerUnreachable()
                         throw Exception("Couldn't reach your signer. Please reconnect.")
                     }
                     handlePermissionDenied()
@@ -762,7 +887,7 @@ class AuthManager(
         // Fallback: session not yet activated (e.g. initial login in progress).
         return when {
             isNip07Login -> signWithNip07(event)
-            isBunkerLogin -> signWithBunker(event)
+            isBunkerLogin -> signWithBunker(event, interactive)
             else -> signWithKeyPair(event)
         }
     }
@@ -773,16 +898,19 @@ class AuthManager(
         return parseSignedEvent(signedJson)
     }
 
-    private suspend fun signWithBunker(event: Event): Event {
+    private suspend fun signWithBunker(
+        event: Event,
+        interactive: Boolean = true,
+    ): Event {
         // Fast-fail when the bunker is known disconnected. Otherwise every
         // NIP-42 AUTH challenge from a NIP-29 relay piles up a 120s sign
         // attempt: N relays = N concurrent hung coroutines doing crypto on
         // the JS main thread, which freezes the browser tab.
-        if (!_isBunkerConnected.value) {
+        if (_bunkerState.value !is BunkerState.Connected) {
             throw Exception("Bunker not connected")
         }
         if (nip46Client == null) {
-            val reconnected = reconnectBunker()
+            val reconnected = attemptReconnect()
             if (!reconnected) {
                 throw Exception("Bunker not connected and reconnection failed")
             }
@@ -798,7 +926,7 @@ class AuthManager(
             if (isPermissionError(e)) {
                 // Can't tell an offline signer from a deleted connection apart —
                 // surface a reconnectable error, never log out (issue #85).
-                markSignerUnreachable()
+                if (interactive) markSignerUnreachable()
                 throw Exception("Couldn't reach your signer. Please reconnect.")
             }
             throw e
@@ -825,13 +953,21 @@ class AuthManager(
      * then explains the situation and lets the user choose to reconnect or log
      * out. (issue #85)
      */
-    private fun markSignerUnreachable() {
+    private fun markSignerUnreachable(
+        reason: BunkerUnreachableReason = BunkerUnreachableReason.SignerNotResponding,
+    ) {
         nip46Client?.disconnect()
         nip46Client = null
-        _isBunkerConnected.value = false
         _isBunkerVerifying.value = false
+        enterUnreachable(reason)
         // isBunkerLogin, bunkerUserPubkey, the stored bunker URL and isLoggedIn
-        // are left intact so reconnectBunker() can re-read the saved URL on retry.
+        // are left intact so the reconnect path can re-read the saved URL on retry.
+    }
+
+    /** Enter the Unreachable state and start capped-backoff background reconnect. */
+    private fun enterUnreachable(reason: BunkerUnreachableReason) {
+        _bunkerState.value = BunkerState.Unreachable(reason)
+        startAutoReconnect()
     }
 
     private fun handlePermissionDenied() {
@@ -841,7 +977,8 @@ class AuthManager(
 
         nip46Client?.disconnect()
         nip46Client = null
-        _isBunkerConnected.value = false
+        stopAutoReconnect()
+        _bunkerState.value = BunkerState.Inactive
         clearBunkerCredentials()
         isBunkerLogin = false
         bunkerUserPubkey = null
@@ -899,7 +1036,8 @@ class AuthManager(
         zeroAndClearKeyPair()
 
         _isLoggedIn.value = false
-        _isBunkerConnected.value = false
+        stopAutoReconnect()
+        _bunkerState.value = BunkerState.Inactive
         // Reset the verifying flag so a hung backgroundConnect does not keep
         // the UI stuck on "Reconnecting to signer..." after logout completes.
         _isBunkerVerifying.value = false
@@ -925,7 +1063,8 @@ class AuthManager(
         isBunkerLogin = false
         bunkerUserPubkey = null
         zeroAndClearKeyPair()
-        _isBunkerConnected.value = false
+        stopAutoReconnect()
+        _bunkerState.value = BunkerState.Inactive
         clearBunkerCredentials()
         SecureStorage.clearBunkerClientPrivateKey()
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/BunkerState.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/BunkerState.kt
@@ -1,0 +1,32 @@
+package org.nostr.nostrord.network
+
+/** Why the app currently can't sign through the active NIP-46 bunker. */
+enum class BunkerUnreachableReason {
+    /** Couldn't open a WebSocket to any of the bunker's relays (network / VPN / relay down). */
+    RelaysUnreachable,
+
+    /** Relays connected but the signer never answered (offline or connection revoked). */
+    SignerNotResponding,
+
+    /** Cause couldn't be determined (e.g. corrupt saved credentials). */
+    Unknown,
+}
+
+/**
+ * Lifecycle of the active account's NIP-46 bunker connection. Single source of
+ * truth in [AuthManager]; the legacy `isBunkerConnected` boolean is derived from
+ * it. Drives [org.nostr.nostrord.ui.components.BunkerStatusBanner].
+ */
+sealed interface BunkerState {
+    /** No bunker session (logged out, or a local / NIP-07 account is active). */
+    data object Inactive : BunkerState
+
+    /** Signer reachable and ready to sign. */
+    data object Connected : BunkerState
+
+    /** A reconnect attempt is in flight; the banner shows an inline spinner. */
+    data object Reconnecting : BunkerState
+
+    /** Signer unreachable; the banner explains [reason] and offers actions. */
+    data class Unreachable(val reason: BunkerUnreachableReason) : BunkerState
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -211,6 +211,7 @@ class NostrRepository(
     override val isLoggedIn: StateFlow<Boolean> = sessionManager.isLoggedIn
     override val isBunkerConnected: StateFlow<Boolean> = sessionManager.isBunkerConnected
     override val isBunkerVerifying: StateFlow<Boolean> = sessionManager.isBunkerVerifying
+    override val bunkerState: StateFlow<BunkerState> = sessionManager.bunkerState
     override val authUrl: StateFlow<String?> = sessionManager.authUrl
 
     // Expose metadata state

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -19,6 +19,7 @@ interface NostrRepositoryApi {
     val isLoggedIn: StateFlow<Boolean>
     val isBunkerVerifying: StateFlow<Boolean>
     val isBunkerConnected: StateFlow<Boolean>
+    val bunkerState: StateFlow<BunkerState>
     val authUrl: StateFlow<String?>
 
     // --- Connection state ---

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.AuthManager
+import org.nostr.nostrord.network.BunkerState
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip46Client
@@ -26,6 +27,7 @@ class SessionManager(
     val isLoggedIn: StateFlow<Boolean> = authManager.isLoggedIn
     val isBunkerConnected: StateFlow<Boolean> = authManager.isBunkerConnected
     val isBunkerVerifying: StateFlow<Boolean> = authManager.isBunkerVerifying
+    val bunkerState: StateFlow<BunkerState> = authManager.bunkerState
     val authUrl: StateFlow<String?> = authManager.authUrl
 
     /**
@@ -131,7 +133,10 @@ class SessionManager(
     /**
      * Sign an event
      */
-    suspend fun signEvent(event: Event): Event = authManager.signEvent(event)
+    suspend fun signEvent(
+        event: Event,
+        interactive: Boolean = true,
+    ): Event = authManager.signEvent(event, interactive)
 
     /**
      * Handle NIP-42 AUTH challenge from relay.
@@ -170,7 +175,9 @@ class SessionManager(
                 content = "",
             )
 
-            val signedEvent = signEvent(authEvent)
+            // interactive=false: a failed background AUTH sign must not flip the
+            // bunker banner to "can't reach your signer". (banner-flicker fix)
+            val signedEvent = signEvent(authEvent, interactive = false)
 
             val message = buildJsonArray {
                 add("AUTH")

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt
@@ -29,10 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -42,6 +39,8 @@ import kotlinx.coroutines.launch
 import org.nostr.nostrord.auth.ActiveAccountManager
 import org.nostr.nostrord.auth.NostrSigner
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.BunkerState
+import org.nostr.nostrord.network.BunkerUnreachableReason
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 
@@ -58,21 +57,44 @@ import org.nostr.nostrord.ui.theme.NostrordTypography
 fun BunkerStatusBanner(modifier: Modifier = Modifier) {
     val repo = AppModule.nostrRepository
     val loggedIn by repo.isLoggedIn.collectAsState()
-    val connected by repo.isBunkerConnected.collectAsState()
+    val state by repo.bunkerState.collectAsState()
+    // Cold-boot restore reuses the verifying flag + full-screen loader
+    // ("Reconnecting to signer..."), so suppress the banner then to avoid double UI.
     val verifying by repo.isBunkerVerifying.collectAsState()
-    // Follow the ACTIVE session's signer, not the inline auth flag: after "Log
-    // out" removes the bunker account and switches to another account, an active
-    // non-bunker signer hides the banner. Using isUsingBunker() (a stale inline
-    // flag) kept the banner up over the switched-in account.
+    // Follow the ACTIVE session's signer, not an inline auth flag: after "Log out"
+    // removes the bunker account and switches to another, an active non-bunker
+    // signer hides the banner.
     val session by ActiveAccountManager.session.collectAsState()
     val activeIsBunker = session?.signer is NostrSigner.Bunker
 
-    // Only when the active account signs through a bunker that's currently
-    // unreachable. While verifying, the startup loading screen already shows
-    // "Reconnecting to signer...", so suppress the banner to avoid double UI.
-    val show = loggedIn && !verifying && !connected && activeIsBunker
+    // Show for an active bunker account that is unreachable or actively
+    // reconnecting. The spinner is bound to the Reconnecting state, which
+    // AuthManager always resolves (mutex + short deadlines), so it can never get
+    // stuck on "Reconnecting…". (issue #85)
+    val reconnecting = state is BunkerState.Reconnecting
+    val show =
+        loggedIn &&
+            activeIsBunker &&
+            !verifying &&
+            (state is BunkerState.Unreachable || reconnecting)
 
-    var reconnecting by remember { mutableStateOf(false) }
+    val reason = (state as? BunkerState.Unreachable)?.reason
+    val title =
+        when {
+            reconnecting -> "Reconnecting to your signer…"
+            reason == BunkerUnreachableReason.RelaysUnreachable -> "Can't reach the bunker relays"
+            else -> "Can't reach your signer"
+        }
+    val body =
+        when {
+            reconnecting -> "Trying to restore the connection to your bunker…"
+            reason == BunkerUnreachableReason.RelaysUnreachable ->
+                "Your bunker's relays didn't respond. Check your internet or VPN, then reconnect."
+            else ->
+                "Your bunker didn't respond. It may be offline, or its connection was " +
+                    "removed. Reconnect to try again."
+        }
+
     val scope = rememberCoroutineScope()
 
     AnimatedVisibility(
@@ -104,16 +126,14 @@ fun BunkerStatusBanner(modifier: Modifier = Modifier) {
                     Spacer(Modifier.width(10.dp))
                     Column {
                         Text(
-                            text = "Can't reach your signer",
+                            text = title,
                             style = NostrordTypography.Caption,
                             color = NostrordColors.Warning,
                             fontWeight = FontWeight.SemiBold,
                         )
                         Spacer(Modifier.height(6.dp))
                         Text(
-                            text =
-                            "Your bunker didn't respond. It may be offline, or its " +
-                                "connection was removed. Reconnect to try again.",
+                            text = body,
                             style = NostrordTypography.Caption,
                             color = NostrordColors.TextContent,
                         )
@@ -157,16 +177,9 @@ fun BunkerStatusBanner(modifier: Modifier = Modifier) {
                         }
                         Spacer(Modifier.width(4.dp))
                         TextButton(
+                            enabled = !reconnecting,
                             onClick = {
-                                if (reconnecting) return@TextButton
-                                reconnecting = true
-                                scope.launch {
-                                    try {
-                                        repo.ensureBunkerConnected()
-                                    } finally {
-                                        reconnecting = false
-                                    }
-                                }
+                                scope.launch { repo.ensureBunkerConnected() }
                             },
                             contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
                         ) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
@@ -112,8 +112,12 @@ fun MeMenu(
         if (account.id != activeId && !isBusy) {
             isBusy = true
             pendingError = null
-            scope.launch {
-                val r = AppModule.accountManager.switchAccount(account.id)
+            // switchAccountAsync runs on the manager's long-lived scope, so
+            // onDismiss()-then-leave-composition can't cancel the in-flight
+            // reloadForActiveAccount mid-step. Using a rememberCoroutineScope
+            // here was killing the new account's MY GROUPS load with
+            // ForgottenCoroutineScopeException on JVM (account-switch fix).
+            AppModule.accountManager.switchAccountAsync(account.id) { r ->
                 isBusy = false
                 if (r.isFailure) {
                     pendingError = r.exceptionOrNull()?.message ?: "Switch failed"

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -75,6 +75,7 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val isLoggedIn: StateFlow<Boolean> = _isLoggedIn
     override val isBunkerVerifying: StateFlow<Boolean> = _isBunkerVerifying
     override val isBunkerConnected: StateFlow<Boolean> = _isBunkerConnected
+    override val bunkerState: StateFlow<BunkerState> = MutableStateFlow(BunkerState.Inactive)
     override val authUrl: StateFlow<String?> = _authUrl
     override val currentRelayUrl: StateFlow<String> = _currentRelayUrl
     override val connectionState: StateFlow<ConnectionManager.ConnectionState> = _connectionState

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -51,9 +51,15 @@ actual class Nip46Client actual constructor(
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
-                        client.waitForConnection()
-                        openResponseSubscription(client)
-                        client
+                        if (!client.waitForConnection()) {
+                            // WS never opened (timeout) — drop it so callers don't
+                            // treat a dead socket as a live relay connection.
+                            client.disconnect()
+                            null
+                        } else {
+                            openResponseSubscription(client)
+                            client
+                        }
                     } catch (_: Exception) {
                         null
                     }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -52,9 +52,15 @@ actual class Nip46Client actual constructor(
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
-                        client.waitForConnection()
-                        openResponseSubscription(client)
-                        client
+                        if (!client.waitForConnection()) {
+                            // WS never opened (timeout) — drop it so callers don't
+                            // treat a dead socket as a live relay connection.
+                            client.disconnect()
+                            null
+                        } else {
+                            openResponseSubscription(client)
+                            client
+                        }
                     } catch (e: Exception) {
                         null
                     }

--- a/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.wasmjs.kt
@@ -51,9 +51,15 @@ actual class Nip46Client actual constructor(
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
-                        client.waitForConnection()
-                        openResponseSubscription(client)
-                        client
+                        if (!client.waitForConnection()) {
+                            // WS never opened (timeout) — drop it so callers don't
+                            // treat a dead socket as a live relay connection.
+                            client.disconnect()
+                            null
+                        } else {
+                            openResponseSubscription(client)
+                            client
+                        }
                     } catch (_: Exception) {
                         null
                     }


### PR DESCRIPTION
Two NIP-46-adjacent bugs that surfaced together.

**Banner flicker + stuck "Reconnecting…"** (commit f14ec5e). The bunker status banner appeared on every transient AUTH failure and the Reconnect button could spin for up to two minutes before resolving. Three causes:

- Background NIP-42 AUTH signs (kind 22242) went through the same path as user-initiated signs; a permission-like failure called `markSignerUnreachable` and raised the banner. AUTH now passes `interactive=false`.
- Reconnect awaited the bunker "connect" RPC under a 120s timeout. Replaced with two short-bounded phases (relays 8s, signer 12s) under a mutex.
- `isBunkerConnected` was a single bool covering 5 distinct states. Replaced by `BunkerState` (Inactive / Connected / Reconnecting / Unreachable(reason)) so the banner shows a precise reason and the spinner is bound to \`Reconnecting\`, which always resolves. Adds capped-backoff auto-reconnect (3s → 60s, 5 attempts).

**MY GROUPS empty after switching to a bunker account on JVM** (commit fe82bf6). After switching from a local-key account to a bunker account, the new account's "MY GROUPS" section in sidebar and home stayed empty until the user manually toggled relays. Traced via println logs to a \`ForgottenCoroutineScopeException\` cancelling \`reloadForActiveAccount\` mid-flight: \`MeMenu\` launched \`switchAccount\` on \`rememberCoroutineScope()\`; the successful swap triggered \`onDismiss()\` which left composition, cancelling the scope and killing the reload before \`loadJoinedGroupsFromStorage\` for the primary relay could run. Web didn't reproduce because the swap completes before dismiss. Fix: route UI swaps through \`AccountManager.switchAccountAsync(accountId, onResult)\` that launches on a long-lived scope injected at construction.

| Area | Files |
|---|---|
| Bunker state machine + auto-reconnect | \`AuthManager.kt\`, new \`BunkerState.kt\` |
| Banner: typed state, reason text, deadline-bound spinner | \`BunkerStatusBanner.kt\` |
| AUTH non-interactive sign | \`SessionManager.kt\` |
| Repository contract | \`NostrRepository.kt\`, \`NostrRepositoryApi.kt\`, \`FakeNostrRepository.kt\` |
| Drop dead-client retention | \`Nip46Client.{android,js,jvm,wasmjs}.kt\` |
| Long-lived account swap | \`AccountManager.kt\`, \`AppModule.kt\`, \`MeMenu.kt\` |

Commits:
- f14ec5e fix(nip46): stop banner flicker and stuck "Reconnecting…" spinner
- fe82bf6 fix(account-switch): run switchAccount on a long-lived scope