### PR TITLE
feat(auth): account chooser modal on sign-out with multiple accounts

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/App.kt
@@ -378,6 +378,13 @@ private fun AuthenticatedApp(
     var showSettings by remember { mutableStateOf(false) }
     var showMeMenu by remember { mutableStateOf(false) }
     var showAddAccount by remember { mutableStateOf(false) }
+    // Account chooser shown when signing out of the active account while others
+    // remain signed in. signOutChooserId is the account being signed out;
+    // signOutAfterAddId carries that account through the "add a new login" path
+    // so it is wiped only once the new account is active.
+    var showAccountChooser by remember { mutableStateOf(false) }
+    var signOutChooserId by remember { mutableStateOf<String?>(null) }
+    var signOutAfterAddId by remember { mutableStateOf<String?>(null) }
     val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
 
     // Bunker revoke / NIP-07 disconnect / other involuntary deauth events.
@@ -731,7 +738,7 @@ private fun AuthenticatedApp(
                         hideGroupsSidebar = currentScreen is Screen.Notifications,
                         modifier = Modifier.weight(1f),
                     ) {
-                        val hideAnimatedImages = showSettings || showCreateGroupModal || showAddRelayModal || showMeMenu || showAddAccount
+                        val hideAnimatedImages = showSettings || showCreateGroupModal || showAddRelayModal || showMeMenu || showAddAccount || showAccountChooser
                         CompositionLocalProvider(LocalAnimatedImageHidden provides hideAnimatedImages) {
                             DesktopContent(
                                 currentScreen = currentScreen,
@@ -847,7 +854,8 @@ private fun AuthenticatedApp(
                             showAddRelayModal ||
                             showSettings ||
                             showMeMenu ||
-                            showAddAccount
+                            showAddAccount ||
+                            showAccountChooser
                     CompositionLocalProvider(LocalAnimatedImageHidden provides hideAnimatedImages) {
                         // Left-edge swipe opens the drawer (issue #77). Detected on the Initial
                         // pass from an ancestor of the screen content so it pre-empts inner
@@ -953,12 +961,21 @@ private fun AuthenticatedApp(
                 onClose = { showSettings = false },
                 onNavigate = onNavigate,
                 onLogout = {
-                    scope.launch {
-                        val activeId = AppModule.accountStore.activeId.value
-                        if (activeId != null) {
-                            AppModule.accountManager.removeAccount(activeId)
-                        } else {
-                            AppModule.nostrRepository.logout()
+                    val activeId = AppModule.accountStore.activeId.value
+                    val hasOthers = AppModule.accountStore.accounts.value.size > 1
+                    if (activeId != null && hasOthers) {
+                        // Other accounts are signed in — let the user pick who to
+                        // continue as instead of silently switching.
+                        showSettings = false
+                        signOutChooserId = activeId
+                        showAccountChooser = true
+                    } else {
+                        scope.launch {
+                            if (activeId != null) {
+                                AppModule.accountManager.removeAccount(activeId)
+                            } else {
+                                AppModule.nostrRepository.logout()
+                            }
                         }
                     }
                 },
@@ -978,14 +995,44 @@ private fun AuthenticatedApp(
                 showMeMenu = false
                 showSettings = true
             },
+            onSignOutWithChoice = {
+                signOutChooserId = AppModule.accountStore.activeId.value
+                showAccountChooser = true
+            },
+        )
+
+        org.nostr.nostrord.ui.components.accounts.AccountChooserDialog(
+            visible = showAccountChooser,
+            signOutAccountId = signOutChooserId,
+            onDismiss = {
+                showAccountChooser = false
+                signOutChooserId = null
+            },
+            onNewLogin = { signOutId ->
+                showAccountChooser = false
+                signOutChooserId = null
+                // Defer wiping the old account until the new login is active.
+                signOutAfterAddId = signOutId
+                showAddAccount = true
+            },
         )
 
         org.nostr.nostrord.ui.components.accounts.AddAccountSheet(
             visible = showAddAccount,
-            onDismiss = { showAddAccount = false },
+            onDismiss = {
+                showAddAccount = false
+                // Cancelled before completing a login: keep the old account.
+                signOutAfterAddId = null
+            },
             onAdded = { displayLabel ->
                 showAddAccount = false
+                val toRemove = signOutAfterAddId
+                signOutAfterAddId = null
                 scope.launch {
+                    // The new account is now active; wipe the one being signed out.
+                    if (toRemove != null) {
+                        AppModule.accountManager.removeAccount(toRemove)
+                    }
                     snackbarHostState.showSnackbar("Switched to $displayLabel")
                 }
             },

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/AccountManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/AccountManager.kt
@@ -175,4 +175,31 @@ class AccountManager(
         AppModule.applyActiveAccountChange(null)
         return null
     }
+
+    /**
+     * Remove [accountId] but switch to a user-chosen [switchToId] instead of
+     * auto-picking a fallback. Backs the account chooser the UI shows on
+     * sign-out so the user controls which identity they land on rather than
+     * being silently dropped onto the most-recently-added one.
+     *
+     * Switches first (validate-before-teardown): if the chosen identity can't
+     * load, removal is aborted and the failure is returned, so the user is
+     * never left signed out when their pick is unusable. Once the switch
+     * succeeds, [accountId] is no longer active and its secrets are wiped the
+     * same way [removeAccount] handles a non-active account.
+     */
+    suspend fun removeAndSwitch(
+        accountId: String,
+        switchToId: String,
+    ): Result<Unit> {
+        val account = accountStore.get(accountId) ?: return Result.success(Unit)
+
+        val switchResult = switchAccount(switchToId)
+        if (switchResult.isFailure) return switchResult
+
+        SecureStorage.clearAllCredentialsForAccount(account.pubkey)
+        SecureStorage.clearPendingEvents(account.pubkey)
+        accountStore.remove(accountId)
+        return Result.success(Unit)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/AccountChooserDialog.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/AccountChooserDialog.kt
@@ -1,0 +1,264 @@
+package org.nostr.nostrord.ui.components.accounts
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.auth.Account
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
+import org.nostr.nostrord.ui.theme.NostrordColors
+
+/**
+ * Centered modal shown when the user signs out of the active account while other
+ * accounts are still signed in. Instead of silently dropping the user onto a
+ * fallback identity, it lists the remaining accounts (one-tap continue) and
+ * offers a new login. The active account is only wiped once the user picks where
+ * to go, so dismissing leaves them on the current account.
+ */
+@Composable
+fun AccountChooserDialog(
+    visible: Boolean,
+    signOutAccountId: String?,
+    onDismiss: () -> Unit,
+    onNewLogin: (signOutAccountId: String) -> Unit,
+) {
+    if (!visible || signOutAccountId == null) return
+
+    val accounts by AppModule.accountStore.accounts.collectAsState()
+    val userMetadata by AppModule.nostrRepository.userMetadata.collectAsState()
+    val scope = rememberCoroutineScope()
+
+    val current = accounts.firstOrNull { it.id == signOutAccountId }
+    val others = remember(accounts, signOutAccountId) { accounts.filter { it.id != signOutAccountId } }
+
+    var isBusy by remember { mutableStateOf(false) }
+    var pendingError by remember { mutableStateOf<String?>(null) }
+
+    // Fetch any account metadata not yet cached so rows show avatar/display name.
+    LaunchedEffect(accounts) {
+        val missing = accounts.map { it.pubkey }.filter { it !in userMetadata.keys }.toSet()
+        if (missing.isNotEmpty()) {
+            AppModule.nostrRepository.requestUserMetadata(missing)
+        }
+    }
+
+    // The account being signed out has gone away (e.g. removed elsewhere) or no
+    // alternatives remain — nothing left to choose, so close.
+    if (current == null || others.isEmpty()) {
+        LaunchedEffect(Unit) { onDismiss() }
+        return
+    }
+
+    val currentLabel = displayLabel(current, userMetadata[current.pubkey])
+
+    val onContinueAs: (Account) -> Unit = { account ->
+        if (!isBusy) {
+            isBusy = true
+            pendingError = null
+            scope.launch {
+                val r = AppModule.accountManager.removeAndSwitch(signOutAccountId, account.id)
+                isBusy = false
+                if (r.isFailure) {
+                    pendingError = r.exceptionOrNull()?.message ?: "Could not switch account"
+                } else {
+                    onDismiss()
+                }
+            }
+        }
+    }
+
+    Dialog(
+        onDismissRequest = { if (!isBusy) onDismiss() },
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = NostrordColors.Surface,
+            tonalElevation = 4.dp,
+            modifier = Modifier.widthIn(min = 280.dp, max = 340.dp),
+        ) {
+            Column {
+                Column(modifier = Modifier.fillMaxWidth().padding(20.dp)) {
+                    Text(
+                        "Choose an account",
+                        color = Color.White,
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        "Sign out of \"$currentLabel\" and continue as one of your other " +
+                            "accounts, or add a new login.",
+                        color = NostrordColors.TextSecondary,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                HorizontalDivider(color = NostrordColors.BackgroundDark)
+
+                pendingError?.let { msg ->
+                    Text(
+                        msg,
+                        color = NostrordColors.Error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    )
+                }
+
+                Column(
+                    modifier =
+                    Modifier
+                        .heightIn(max = 280.dp)
+                        .verticalScroll(rememberScrollState())
+                        .padding(vertical = 4.dp),
+                ) {
+                    others.forEach { account ->
+                        ChooserAccountRow(
+                            account = account,
+                            metadata = userMetadata[account.pubkey],
+                            isBusy = isBusy,
+                            onClick = { onContinueAs(account) },
+                        )
+                    }
+                }
+                HorizontalDivider(color = NostrordColors.BackgroundDark)
+                ChooserActionRow(
+                    icon = Icons.Default.PersonAdd,
+                    label = "Add a new login",
+                    isBusy = isBusy,
+                    onClick = { if (!isBusy) onNewLogin(signOutAccountId) },
+                )
+                HorizontalDivider(color = NostrordColors.BackgroundDark)
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(onClick = onDismiss, enabled = !isBusy) {
+                        Text("Cancel", color = NostrordColors.TextSecondary)
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChooserAccountRow(
+    account: Account,
+    metadata: UserMetadata?,
+    isBusy: Boolean,
+    onClick: () -> Unit,
+) {
+    val displayName = displayLabel(account, metadata)
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !isBusy, onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ProfileAvatar(
+            imageUrl = metadata?.picture?.takeIf { it.isNotBlank() },
+            displayName = displayName,
+            pubkey = account.pubkey,
+            size = 36.dp,
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                displayName,
+                color = Color.White,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                authMethodChooserLabel(account),
+                color = NostrordColors.TextMuted,
+                style = MaterialTheme.typography.labelSmall,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = NostrordColors.TextSecondary,
+            modifier = Modifier.size(20.dp),
+        )
+    }
+}
+
+@Composable
+private fun ChooserActionRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    isBusy: Boolean,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .clickable(enabled = !isBusy, onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
+        Spacer(Modifier.width(16.dp))
+        Text(label, color = Color.White, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+private fun displayLabel(
+    account: Account,
+    metadata: UserMetadata?,
+): String = metadata?.displayName?.takeIf { it.isNotBlank() }
+    ?: metadata?.name?.takeIf { it.isNotBlank() }
+    ?: account.label
+
+private fun authMethodChooserLabel(account: Account): String = when (account.authMethod) {
+    org.nostr.nostrord.auth.AuthMethod.LOCAL -> "Private key"
+    org.nostr.nostrord.auth.AuthMethod.BUNKER -> "Bunker (NIP-46)"
+    org.nostr.nostrord.auth.AuthMethod.NIP07 -> "Browser extension (NIP-07)"
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
@@ -81,6 +81,7 @@ fun MeMenu(
     onDismiss: () -> Unit,
     onAddAccount: () -> Unit,
     onSettings: () -> Unit,
+    onSignOutWithChoice: () -> Unit,
 ) {
     if (!visible) return
 
@@ -128,6 +129,18 @@ fun MeMenu(
         }
     }
 
+    // Signing out of the active account while others are signed in routes to
+    // the account chooser instead of auto-switching. Removing a non-active
+    // account (or the last one) keeps the plain confirmation dialog.
+    val requestRemove: (Account) -> Unit = { account ->
+        if (account.id == activeId && accounts.size > 1) {
+            onDismiss()
+            onSignOutWithChoice()
+        } else {
+            removeTarget = account
+        }
+    }
+
     val content: @Composable ColumnScope.() -> Unit = {
         if (activeAccount != null) {
             MeHeader(account = activeAccount, metadata = userMetadata[activeAccount.pubkey])
@@ -154,7 +167,7 @@ fun MeMenu(
                     isBusy = isBusy,
                     unreadCount = unread,
                     onClick = { onSwitchAccount(account) },
-                    onRemove = { removeTarget = account },
+                    onRemove = { requestRemove(account) },
                 )
             }
         }
@@ -181,7 +194,7 @@ fun MeMenu(
             icon = Icons.AutoMirrored.Filled.Logout,
             label = "Sign out",
             tint = NostrordColors.Error,
-            onClick = { activeAccount?.let { removeTarget = it } },
+            onClick = { activeAccount?.let { requestRemove(it) } },
         )
         Spacer(Modifier.height(8.dp))
     }


### PR DESCRIPTION
Signing out of the active account while others are still signed in used to silently switch to the most-recently-added fallback (`pickFirstSuccess` inside `AccountManager.removeAccount`). The user never picked who they continued as. Now a centered modal opens listing the remaining accounts (tap to continue) plus an "Add a new login" action; Cancel keeps the current account active.

The current account is only wiped once the user picks where to go — `AccountManager.removeAndSwitch` switches first (validate-before-teardown) and only then drops the old account's secrets, so a broken pick can never strand the user signed out. The "Add a new login" branch defers the wipe via `signOutAfterAddId` until the new login warm-swaps in.

Triggers: Settings → *Log Out*, and `MeMenu`'s Sign-out action / trash icon on the active row — but only when there is more than one account. Removing a non-active account keeps the existing confirmation dialog, and the single-account logout still goes straight to the login screen.

| File | Change |
|---|---|
| `ui/components/accounts/AccountChooserDialog.kt` | New centered `Dialog` modal listing remaining accounts + Add a new login + Cancel |
| `auth/AccountManager.kt` | New `removeAndSwitch(accountId, switchToId)` — switch first, wipe second |
| `ui/components/accounts/MeMenu.kt` | New `onSignOutWithChoice` callback; active-account sign-out routes through the chooser when others are signed in |
| `App.kt` | Hosts the chooser; `onLogout` and the AddAccountSheet wiring honor `signOutAfterAddId` |

Commits:
- `3dc19be` feat(auth): account chooser modal on sign-out with multiple accounts