### PR TITLE
Show syncing indicator and lock composer on foreground resume

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -51,6 +51,11 @@ import org.nostr.nostrord.utils.epochSeconds
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.urlDecode
 
+// How long onForeground keeps [NostrRepository.isSyncing] true after issuing the
+// resume re-subscribe, giving freshly requested messages a window to stream in
+// before the composer re-enables (#104).
+private const val FOREGROUND_SYNC_SETTLE_MS = 1_200L
+
 /**
  * Repository for Nostr operations.
  * Coordinates between specialized managers for different concerns.
@@ -185,6 +190,13 @@ class NostrRepository(
     override val isDiscoveringRelays: StateFlow<Boolean> = _isDiscoveringRelays.asStateFlow()
     private val _pendingDeepLinkRelay = MutableStateFlow<String?>(null)
     override val pendingDeepLinkRelay: StateFlow<String?> = _pendingDeepLinkRelay.asStateFlow()
+
+    // True while a foreground-resume re-sync is in flight (set by onForeground,
+    // cleared after a brief settle). The group composer disables input and shows a
+    // "syncing" hint while this is true so a reply isn't written against a stale feed
+    // that is about to jump with newly arrived messages.
+    private val _isSyncing = MutableStateFlow(false)
+    override val isSyncing: StateFlow<Boolean> = _isSyncing.asStateFlow()
 
     // Expose group state
     override val groups: StateFlow<List<GroupMetadata>> = groupManager.groups
@@ -909,26 +921,35 @@ class NostrRepository(
      */
     override fun onForeground() {
         scope.launch {
-            val state = connectionManager.connectionState.value
-            when (state) {
-                // Only force reconnect if fully disconnected (no auto-reconnect running).
-                // Error state means auto-reconnect exhausted Phase 1 — force a fresh attempt.
-                is ConnectionManager.ConnectionState.Disconnected,
-                is ConnectionManager.ConnectionState.Error,
-                -> reconnect()
+            _isSyncing.value = true
+            try {
+                val state = connectionManager.connectionState.value
+                when (state) {
+                    // Only force reconnect if fully disconnected (no auto-reconnect running).
+                    // Error state means auto-reconnect exhausted Phase 1 — force a fresh attempt.
+                    is ConnectionManager.ConnectionState.Disconnected,
+                    is ConnectionManager.ConnectionState.Error,
+                    -> reconnect()
 
-                // Auto-reconnect or initial connect in progress — don't interrupt.
-                is ConnectionManager.ConnectionState.Reconnecting,
-                is ConnectionManager.ConnectionState.Connecting,
-                -> {
-                    reconnectDroppedNip29PoolRelays()
-                }
+                    // Auto-reconnect or initial connect in progress — don't interrupt.
+                    is ConnectionManager.ConnectionState.Reconnecting,
+                    is ConnectionManager.ConnectionState.Connecting,
+                    -> {
+                        reconnectDroppedNip29PoolRelays()
+                    }
 
-                // Already connected — refresh subscriptions and pool relays.
-                is ConnectionManager.ConnectionState.Connected -> {
-                    groupManager.refreshLiveSubscriptions()
-                    reconnectDroppedNip29PoolRelays()
+                    // Already connected — refresh subscriptions and pool relays.
+                    is ConnectionManager.ConnectionState.Connected -> {
+                        groupManager.refreshLiveSubscriptions()
+                        reconnectDroppedNip29PoolRelays()
+                    }
                 }
+                // Re-subscribe REQs are fire-and-forget; give freshly requested messages
+                // a brief window to stream in before clearing the flag, so the UI doesn't
+                // re-enable the composer the instant the REQ is sent (#104).
+                delay(FOREGROUND_SYNC_SETTLE_MS)
+            } finally {
+                _isSyncing.value = false
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -27,6 +27,13 @@ interface NostrRepositoryApi {
     val connectionState: StateFlow<ConnectionManager.ConnectionState>
     val isDiscoveringRelays: StateFlow<Boolean>
 
+    /**
+     * True while a foreground-resume re-sync is in flight. The group screen disables
+     * the composer and shows a syncing hint until it clears, so a reply isn't written
+     * against a feed that's about to jump with newly arrived messages.
+     */
+    val isSyncing: StateFlow<Boolean>
+
     /** Non-null when a deep link opened a relay not in the user's saved list. */
     val pendingDeepLinkRelay: StateFlow<String?>
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -79,6 +79,8 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val authUrl: StateFlow<String?> = _authUrl
     override val currentRelayUrl: StateFlow<String> = _currentRelayUrl
     override val connectionState: StateFlow<ConnectionManager.ConnectionState> = _connectionState
+    val _isSyncing = MutableStateFlow(false)
+    override val isSyncing: StateFlow<Boolean> = _isSyncing
     override val groups: StateFlow<List<GroupMetadata>> = _groups
     override val groupsByRelay: StateFlow<Map<String, List<GroupMetadata>>> = MutableStateFlow(emptyMap())
     override val messages: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> = _messages

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -15,6 +15,7 @@ class GroupViewModel(
 ) : ViewModel() {
     val messages = repo.messages
     val connectionState = repo.connectionState
+    val isSyncing = repo.isSyncing
     val joinedGroups = repo.joinedGroups
     val joinedGroupsByRelay = repo.joinedGroupsByRelay
     val groups = repo.groups

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -119,6 +119,11 @@ fun MessageInput(
         !platform.startsWith("Android") && !platform.startsWith("iOS")
     }
 
+    // While a foreground-resume re-sync is in flight, freshly arrived messages are
+    // about to push the feed; block the composer and surface a hint so a reply isn't
+    // written against a stale view (#104).
+    val isSyncing by AppModule.nostrRepository.isSyncing.collectAsState()
+
     // Auto-focus only where there's a physical keyboard (desktop, desktop web).
     // On touch devices — Android, iOS, and coarse-pointer (mobile) web — this would
     // pop the on-screen keyboard the instant a group opens, so it's skipped.
@@ -390,6 +395,29 @@ fun MessageInput(
         Column(
             modifier = Modifier.fillMaxWidth(),
         ) {
+            if (isSyncing) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(NostrordColors.SurfaceVariant)
+                        .padding(horizontal = Spacing.lg, vertical = Spacing.sm),
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        color = NostrordColors.Primary,
+                        strokeWidth = 2.dp,
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    Text(
+                        text = "Syncing new messages…",
+                        color = NostrordColors.TextMuted,
+                        style = NostrordTypography.Caption,
+                    )
+                }
+            }
+
             if (replyingToMessage != null) {
                 ReplyingToBar(
                     message = replyingToMessage,
@@ -478,9 +506,10 @@ fun MessageInput(
                         value = textFieldValue,
                         onValueChange = { handleTextFieldValueChange(it) },
                         interactionSource = textFieldInteractionSource,
+                        enabled = !isSyncing,
                         placeholder = {
                             Text(
-                                "Message ${groupName ?: selectedChannel}",
+                                if (isSyncing) "Syncing new messages…" else "Message ${groupName ?: selectedChannel}",
                                 style = NostrordTypography.InputPlaceholder,
                                 color = NostrordColors.TextMuted,
                             )
@@ -681,12 +710,12 @@ fun MessageInput(
 
                     IconButton(
                         onClick = {
-                            if (textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste) {
+                            if (textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste && !isSyncing) {
                                 showEmojiPicker = false
                                 onSendMessage()
                             }
                         },
-                        enabled = textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste,
+                        enabled = textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste && !isSyncing,
                         modifier = Modifier.size(40.dp),
                     ) {
                         if (isSending || isUploadingPaste) {


### PR DESCRIPTION
With the app open on both PC and Android, minimizing on mobile (group open) and restoring it gave no sign that messages were re-syncing. Because there's no background sync (intentional, to save battery), the feed reloads "all at once" on resume, so a user starts typing against a stale view and their reply ends up stranded out of context once the new messages land.

`onForeground()` now raises a `NostrRepository.isSyncing` flag for the duration of the resume re-subscribe plus a short settle window. The group composer observes it and, while syncing, disables the text field and send button and shows a "Syncing new messages…" hint, so a reply can't be written against a feed that's about to jump.

The other two asks were already handled by existing code: restore does not auto-jump to the latest (auto-scroll only follows the user's own messages, and the `lastReadSnapshot` divider marks where unread starts), and the jump-to-bottom FAB already shows a new-message count via `UnreadBadge`.

| File | Change |
|---|---|
| `network/NostrRepository.kt` | `isSyncing` flag, set/cleared around the `onForeground` re-sync (1.2s settle) |
| `network/NostrRepositoryApi.kt` | expose `isSyncing: StateFlow<Boolean>` |
| `ui/screens/group/GroupViewModel.kt` | pass through `isSyncing` |
| `ui/screens/group/components/MessageInput.kt` | disable composer + syncing banner/placeholder while syncing |
| `commonTest/.../FakeNostrRepository.kt` | fake `isSyncing` |

- feat(group): show syncing indicator and lock composer on foreground resume

Verified with `:composeApp:jvmTest` (BUILD SUCCESSFUL).
