### PR TITLE
Unify the message context menu across platforms

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.android.kt
@@ -2,8 +2,9 @@ package org.nostr.nostrord.ui.components.chat
 
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.pointerInput
 
-actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier = Modifier.pointerInput(onRightClick) {
-    detectTapGestures(onTap = { onRightClick() })
+actual fun rightClickContextMenuModifier(onRightClick: (Offset) -> Unit): Modifier = Modifier.pointerInput(onRightClick) {
+    detectTapGestures(onTap = { offset -> onRightClick(offset) })
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/emoji/QuickReactions.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/components/emoji/QuickReactions.kt
@@ -1,0 +1,11 @@
+package org.nostr.nostrord.ui.components.emoji
+
+/**
+ * The small set of one-tap reactions shown as a horizontal row on top of the
+ * message context menu (Telegram-style). Picking one sends that reaction
+ * immediately; the trailing "open picker" affordance reaches the full set.
+ *
+ * Shared by the native (Compose) and web (React) context menus so both
+ * platforms offer the same quick reactions.
+ */
+val QuickReactions: List<String> = listOf("👍", "❤️", "😂", "😮", "😢", "🙏")

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.ios.kt
@@ -1,12 +1,15 @@
 package org.nostr.nostrord.ui.components.chat
 
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.pointerInput
 
 /**
- * iOS implementation: No-op, context menu is accessed via "More" button.
- * Touch devices don't have a secondary button.
+ * iOS implementation: single tap opens the context menu at the tap position
+ * (same as Android). Touch devices have no secondary button, and there is no
+ * longer a hover "More" button, so tap is the entry point.
  */
-actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier {
-    // No-op on iOS - users access context menu via the "More" button
-    return Modifier
+actual fun rightClickContextMenuModifier(onRightClick: (Offset) -> Unit): Modifier = Modifier.pointerInput(onRightClick) {
+    detectTapGestures(onTap = { offset -> onRightClick(offset) })
 }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.jvm.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.ui.components.chat
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.isSecondaryPressed
 import androidx.compose.ui.input.pointer.pointerInput
@@ -11,12 +12,13 @@ import androidx.compose.ui.input.pointer.pointerInput
  * Desktop implementation: Detects right-click via secondary button press
  */
 @OptIn(ExperimentalComposeUiApi::class)
-actual fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier = Modifier.pointerInput(Unit) {
+actual fun rightClickContextMenuModifier(onRightClick: (Offset) -> Unit): Modifier = Modifier.pointerInput(Unit) {
     awaitEachGesture {
         val event = awaitPointerEvent()
         // Check if secondary (right) mouse button is pressed
         if (event.type == PointerEventType.Press && event.buttons.isSecondaryPressed) {
-            onRightClick()
+            val position = event.changes.firstOrNull()?.position ?: Offset.Zero
+            onRightClick(position)
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -1,18 +1,21 @@
 package org.nostr.nostrord.ui.components.chat
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Reply
@@ -33,22 +36,32 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.window.PopupProperties
+import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.theme.NostrordAnimation
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.utils.supportsNativeShare
 
 /**
@@ -64,6 +77,9 @@ import org.nostr.nostrord.utils.supportsNativeShare
  */
 sealed class MessageContextAction {
     data object AddReaction : MessageContextAction()
+
+    /** One-tap reaction from the quick-reactions row on top of the menu. */
+    data class QuickReact(val emoji: String) : MessageContextAction()
 
     data object Reply : MessageContextAction()
 
@@ -101,6 +117,8 @@ fun MessageContextMenu(
     visible: Boolean,
     onDismiss: () -> Unit,
     onAction: (MessageContextAction) -> Unit,
+    anchorOffsetPx: Offset? = null,
+    anchorWidthPx: Int = 0,
     isAuthor: Boolean = false,
     isAdmin: Boolean = false,
     canZap: Boolean = false,
@@ -108,9 +126,19 @@ fun MessageContextMenu(
 ) {
     // Only render Popup when visible to avoid layout participation
     if (visible) {
+        val marginPx = with(LocalDensity.current) { 8.dp.roundToPx() }
+        // Open at the click position (web parity); fall back to the row's
+        // top-right when there's no cursor anchor (the hover More button).
+        val positionProvider =
+            remember(anchorOffsetPx, anchorWidthPx, marginPx) {
+                MessageMenuPositionProvider(anchorOffsetPx, anchorWidthPx, marginPx)
+            }
+        // Grow from the cursor (top-left) when opened at a click, from the
+        // top-right when hung off the More button.
+        val transformOrigin =
+            if (anchorOffsetPx != null) TransformOrigin(0f, 0f) else TransformOrigin(1f, 0f)
         Popup(
-            alignment = Alignment.TopEnd,
-            offset = IntOffset(x = -8, y = 0),
+            popupPositionProvider = positionProvider,
             onDismissRequest = onDismiss,
             properties =
             PopupProperties(
@@ -132,13 +160,13 @@ fun MessageContextMenu(
                         scaleIn(
                             animationSpec = tween(NostrordAnimation.popupEnter),
                             initialScale = 0.9f,
-                            transformOrigin = TransformOrigin(1f, 0f),
+                            transformOrigin = transformOrigin,
                         ),
                     exit =
                     fadeOut(animationSpec = tween(NostrordAnimation.popupExit)) +
                         scaleOut(
                             animationSpec = tween(NostrordAnimation.popupExit),
-                            transformOrigin = TransformOrigin(1f, 0f),
+                            transformOrigin = transformOrigin,
                         ),
                 ) {
                     ContextMenuContent(
@@ -151,6 +179,43 @@ fun MessageContextMenu(
                 }
             }
         }
+    }
+}
+
+/**
+ * Positions the context-menu popup at the click point, flipping it back into the
+ * viewport when it would overflow. Mirrors the web menu's positioning effect:
+ * a cursor anchor opens rightward/downward from the click; a null anchor (the
+ * hover More button) hangs the menu off the row's right edge (opens leftward).
+ */
+private class MessageMenuPositionProvider(
+    private val anchorOffsetPx: Offset?,
+    private val anchorWidthPx: Int,
+    private val marginPx: Int,
+) : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize,
+    ): IntOffset {
+        val w = popupContentSize.width
+        val h = popupContentSize.height
+
+        var x =
+            if (anchorOffsetPx != null) {
+                anchorBounds.left + anchorOffsetPx.x.toInt()
+            } else {
+                anchorBounds.left + anchorWidthPx - w
+            }
+        if (x + w > windowSize.width - marginPx) x = (windowSize.width - marginPx - w).coerceAtLeast(marginPx)
+        if (x < marginPx) x = marginPx
+
+        var y = anchorBounds.top + (anchorOffsetPx?.y?.toInt() ?: 0)
+        if (y + h > windowSize.height - marginPx) y = (y - h).coerceAtLeast(marginPx)
+        if (y < marginPx) y = marginPx
+
+        return IntOffset(x, y)
     }
 }
 
@@ -168,29 +233,38 @@ private fun ContextMenuContent(
     Column(
         modifier =
         Modifier
-            .width(Spacing.channelSidebarWidth * 0.75f) // ~180dp
+            // 210dp + 6dp padding + 1dp border, mirroring the web `.ctx-menu`.
+            .width(210.dp)
             .shadow(
-                elevation = 8.dp,
-                shape = NostrordShapes.menuShape,
-                ambientColor = Color.Black.copy(alpha = 0.3f),
-                spotColor = Color.Black.copy(alpha = 0.3f),
-            ).clip(NostrordShapes.menuShape)
+                elevation = 12.dp,
+                shape = NostrordShapes.shapeMedium,
+                ambientColor = Color.Black.copy(alpha = 0.4f),
+                spotColor = Color.Black.copy(alpha = 0.4f),
+            ).clip(NostrordShapes.shapeMedium)
             .background(NostrordColors.Surface)
-            .padding(vertical = Spacing.xs)
+            .border(
+                width = Spacing.dividerThickness,
+                color = NostrordColors.Divider,
+                shape = NostrordShapes.shapeMedium,
+            ).padding(6.dp)
             // Consume pointer events to prevent them from reaching underlying content
             .pointerInput(Unit) {
                 detectTapGestures { /* consume */ }
             },
     ) {
-        // Add Reaction
-        ContextMenuItem(
-            icon = Icons.Outlined.EmojiEmotions,
-            label = "Add Reaction",
-            onClick = {
+        // Quick reactions row (one tap to react) + an affordance to open the full picker.
+        QuickReactionsRow(
+            onQuickReact = { emoji ->
+                onAction(MessageContextAction.QuickReact(emoji))
+                onDismiss()
+            },
+            onOpenPicker = {
                 onAction(MessageContextAction.AddReaction)
                 onDismiss()
             },
         )
+
+        ContextMenuDivider()
 
         // Reply
         ContextMenuItem(
@@ -211,6 +285,7 @@ private fun ContextMenuContent(
                     onAction(MessageContextAction.ZapMessage)
                     onDismiss()
                 },
+                isZap = true,
             )
         }
 
@@ -290,6 +365,74 @@ private fun ContextMenuContent(
 }
 
 /**
+ * Horizontal row of one-tap reactions on top of the menu, ending in an
+ * affordance that opens the full emoji picker. Mirrors the web menu's
+ * `.ctx-reactions` row.
+ */
+@Composable
+private fun QuickReactionsRow(
+    onQuickReact: (String) -> Unit,
+    onOpenPicker: () -> Unit,
+) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .padding(vertical = Spacing.xxs),
+        // Spread the buttons across the full width and let them shrink to fit,
+        // matching the web `.ctx-reactions` flex row.
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // NotoColorEmoji so the glyphs render in color on Skia (desktop/iOS);
+        // the system SansSerif lacks color emoji. Same as ReactionBadges.
+        val emojiFont = rememberEmojiFontFamily()
+        QuickReactions.forEach { emoji ->
+            QuickReactionButton(onClick = { onQuickReact(emoji) }) {
+                Text(text = emoji, fontFamily = emojiFont, fontSize = 18.sp)
+            }
+        }
+        QuickReactionButton(onClick = onOpenPicker) {
+            Icon(
+                imageVector = Icons.Outlined.EmojiEmotions,
+                contentDescription = "Add Reaction",
+                tint = NostrordColors.TextSecondary,
+                modifier = Modifier.size(Spacing.iconMd - Spacing.xs),
+            )
+        }
+    }
+}
+
+/**
+ * A single 30dp quick-reaction button. Mirrors the web `.ctx-reaction`: it
+ * tints its background and scales to 1.15x on hover.
+ */
+@Composable
+private fun QuickReactionButton(
+    onClick: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+    val scale by animateFloatAsState(targetValue = if (isHovered) 1.15f else 1f)
+
+    Box(
+        modifier =
+        Modifier
+            .size(26.dp)
+            .scale(scale)
+            .clip(RoundedCornerShape(6.dp))
+            .background(if (isHovered) NostrordColors.HoverBackground else Color.Transparent)
+            .hoverable(interactionSource)
+            .clickable(onClick = onClick)
+            .pointerHoverIcon(PointerIcon.Hand),
+        contentAlignment = Alignment.Center,
+    ) {
+        content()
+    }
+}
+
+/**
  * Individual context menu item.
  */
 @Composable
@@ -298,6 +441,7 @@ private fun ContextMenuItem(
     label: String,
     onClick: () -> Unit,
     isDestructive: Boolean = false,
+    isZap: Boolean = false,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
@@ -305,12 +449,15 @@ private fun ContextMenuItem(
     val textColor =
         when {
             isDestructive -> NostrordColors.Error
+            // Zap highlights amber on hover, matching the hover toolbar's zap button.
+            isZap && isHovered -> NostrordColors.Warning
             else -> NostrordColors.TextContent
         }
 
     val iconColor =
         when {
             isDestructive -> NostrordColors.Error
+            isZap && isHovered -> NostrordColors.Warning
             else -> NostrordColors.TextSecondary
         }
 
@@ -320,12 +467,15 @@ private fun ContextMenuItem(
         modifier =
         Modifier
             .fillMaxWidth()
+            // Rounded, inset hover highlight (web `.ctx-item` has border-radius 4px
+            // inside the menu's 6px padding).
+            .clip(NostrordShapes.menuShape)
             .height(Spacing.channelItemHeight + Spacing.xs) // 36dp
             .background(backgroundColor)
             .hoverable(interactionSource)
             .clickable(onClick = onClick)
             .pointerHoverIcon(PointerIcon.Hand)
-            .padding(horizontal = Spacing.sm),
+            .padding(horizontal = Spacing.md - Spacing.xxs), // 10dp
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
@@ -335,7 +485,7 @@ private fun ContextMenuItem(
             modifier = Modifier.size(Spacing.iconMd - Spacing.xs), // 20dp
         )
 
-        Spacer(modifier = Modifier.width(Spacing.sm))
+        Spacer(modifier = Modifier.width(Spacing.md - Spacing.xxs)) // 10dp gap
 
         Text(
             text = label,
@@ -351,7 +501,8 @@ private fun ContextMenuItem(
 @Composable
 private fun ContextMenuDivider() {
     HorizontalDivider(
-        modifier = Modifier.padding(vertical = Spacing.xs),
+        // Web `.ctx-divider` has margin 6px 4px.
+        modifier = Modifier.padding(horizontal = Spacing.xs, vertical = 6.dp),
         thickness = Spacing.dividerThickness,
         color = NostrordColors.Divider,
     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -1,12 +1,9 @@
 package org.nostr.nostrord.ui.components.chat
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.snap
 import androidx.compose.animation.core.tween
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitEachGesture
@@ -17,17 +14,11 @@ import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.Reply
-import androidx.compose.material.icons.outlined.Bolt
-import androidx.compose.material.icons.outlined.EmojiEmotions
-import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.Icon
-import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -40,16 +31,19 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -60,9 +54,7 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.zap.ZapBadge
 import org.nostr.nostrord.ui.components.zap.ZapController
-import org.nostr.nostrord.ui.theme.NostrordAnimation
 import org.nostr.nostrord.ui.theme.NostrordColors
-import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.utils.formatTime
@@ -70,11 +62,11 @@ import kotlin.math.abs
 import kotlin.math.roundToInt
 
 /**
- * Enhanced message item with grouping support and hover actions.
+ * Enhanced message item with grouping support.
  *
  * Interaction behavior:
- * - Desktop: hover shows action toolbar; right-click opens context menu
- * - Mobile (Android / touch web): single tap opens the context menu directly
+ * - Desktop: right-click opens the context menu at the cursor
+ * - Mobile (Android / touch): single tap opens the context menu; swipe left to reply
  *
  * Spacing:
  * - 72dp total left column (16dp padding + 40dp avatar + 16dp gap)
@@ -99,7 +91,6 @@ fun MessageItem(
     onReplyClick: () -> Unit = {},
     onReactionClick: () -> Unit = {},
     onReactionBadgeClick: (emoji: String) -> Unit = {},
-    onMoreClick: () -> Unit = {},
     onCopyText: () -> Unit = {},
     onCopyLink: () -> Unit = {},
     onShareLink: () -> Unit = {},
@@ -118,6 +109,7 @@ fun MessageItem(
     val currentOnUsernameClick by rememberUpdatedState(onUsernameClick)
     val currentOnReplyClick by rememberUpdatedState(onReplyClick)
     val currentOnReactionClick by rememberUpdatedState(onReactionClick)
+    val currentOnReactionBadgeClick by rememberUpdatedState(onReactionBadgeClick)
     val currentOnCopyText by rememberUpdatedState(onCopyText)
     val currentOnCopyLink by rememberUpdatedState(onCopyLink)
     val currentOnShareLink by rememberUpdatedState(onShareLink)
@@ -205,20 +197,11 @@ fun MessageItem(
     val isHovered by interactionSource.collectIsHoveredAsState()
     val isPressed by interactionSource.collectIsPressedAsState()
 
-    // Delayed hover state for actions toolbar (50ms delay). This is a desktop-only
-    // pointer affordance: on touch/compact layouts (Android, iOS, narrow web) a tap
-    // would otherwise register as a press and trip it. Those layouts use tap (context
-    // menu) and swipe (reply) instead, so the toolbar is suppressed there — gated by
-    // swipeToReplyEnabled, the same compact-layout signal.
-    var showActions by remember { mutableStateOf(false) }
-    LaunchedEffect(isHovered, isPressed, swipeToReplyEnabled) {
-        if (!swipeToReplyEnabled && (isHovered || isPressed)) {
-            delay(NostrordAnimation.hoverActionsDelay.toLong())
-            showActions = true
-        } else {
-            showActions = false
-        }
-    }
+    // Where to open the context menu, in px relative to this row's top-left.
+    // Set from the right-click / tap position so the menu appears at the cursor (web parity).
+    var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
+    // Row size in px, so the position provider can offset relative to the row.
+    var rowSizePx by remember { mutableStateOf(IntSize.Zero) }
 
     var highlightActive by remember(isHighlighted) { mutableStateOf(isHighlighted) }
     LaunchedEffect(isHighlighted) {
@@ -264,12 +247,13 @@ fun MessageItem(
             modifier =
             Modifier
                 .fillMaxWidth()
+                .onGloballyPositioned { rowSizePx = it.size }
                 .hoverable(interactionSource)
                 // Tap (mobile) / right-click (desktop) opens the context menu directly.
                 // Closing is handled by the menu's full-screen scrim (see MessageContextMenu).
                 .then(
-                    rightClickContextMenuModifier {
-                        showActions = false // Hide hover actions immediately
+                    rightClickContextMenuModifier { clickOffset ->
+                        menuAnchorPx = clickOffset // open at the cursor (web parity)
                         onContextMenuOpenChange(true)
                     },
                 ).then(
@@ -461,42 +445,17 @@ fun MessageItem(
                 }
             }
 
-            // Overlay layer for hover actions - uses matchParentSize to not affect layout
-            // This Box matches parent size exactly, then positions content inside
-            Box(
-                modifier =
-                Modifier
-                    .matchParentSize() // Critical: doesn't affect parent measurement
-                    .padding(end = Spacing.sm),
-                contentAlignment = Alignment.TopEnd,
-            ) {
-                // Hover actions - fade in/out without affecting layout
-                androidx.compose.animation.AnimatedVisibility(
-                    visible = showActions && !isContextMenuOpen,
-                    enter = fadeIn(animationSpec = tween(NostrordAnimation.actionsAppear)),
-                    exit = fadeOut(animationSpec = tween(NostrordAnimation.actionsDisappear)),
-                ) {
-                    // DisableSelection prevents toolbar from being part of text selection
-                    DisableSelection {
-                        MessageActions(
-                            onReplyClick = currentOnReplyClick,
-                            onReactionClick = currentOnReactionClick,
-                            onMoreClick = { onContextMenuOpenChange(true) },
-                            canZap = canZap,
-                            onZapClick = { ZapController.request(message.pubkey, message.id) },
-                        )
-                    }
-                }
-            }
-
-            // Context menu - appears on right-click or "More" click
+            // Context menu - appears on right-click (desktop) or tap (touch)
             // This is a Popup so it floats outside the layout tree
             MessageContextMenu(
                 visible = isContextMenuOpen,
+                anchorOffsetPx = menuAnchorPx,
+                anchorWidthPx = rowSizePx.width,
                 onDismiss = { onContextMenuOpenChange(false) },
                 onAction = { action ->
                     when (action) {
                         MessageContextAction.AddReaction -> currentOnReactionClick()
+                        is MessageContextAction.QuickReact -> currentOnReactionBadgeClick(action.emoji)
                         MessageContextAction.Reply -> currentOnReplyClick()
                         MessageContextAction.CopyText -> currentOnCopyText()
                         MessageContextAction.CopyMessageLink -> currentOnCopyLink()
@@ -511,113 +470,6 @@ fun MessageItem(
                 isAdmin = isAdmin,
                 canZap = canZap,
             )
-        }
-    }
-}
-
-/**
- * Hover actions toolbar for messages.
- *
- * Behavior:
- * - Positioned at top-right, overlapping message slightly
- * - Appears with 100ms fade in after 50ms hover delay
- * - Disappears immediately (50ms fade out)
- * - Order: Reaction, Reply, More
- */
-@Composable
-private fun MessageActions(
-    onReplyClick: () -> Unit,
-    onReactionClick: () -> Unit,
-    onMoreClick: () -> Unit,
-    canZap: Boolean,
-    onZapClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier =
-        modifier
-            .padding(end = Spacing.sm)
-            .clip(NostrordShapes.messageActionsShape)
-            .background(NostrordColors.SurfaceVariant)
-            .padding(horizontal = Spacing.xs),
-        horizontalArrangement = Arrangement.spacedBy(0.dp),
-    ) {
-        // 1. Add Reaction (emoji)
-        ActionButton(
-            icon = {
-                Icon(
-                    Icons.Outlined.EmojiEmotions,
-                    contentDescription = "React",
-                    modifier = Modifier.size(Spacing.iconSm + Spacing.xs), // 16dp
-                )
-            },
-            onClick = onReactionClick,
-        )
-        // 2. Reply
-        ActionButton(
-            icon = {
-                Icon(
-                    Icons.AutoMirrored.Outlined.Reply,
-                    contentDescription = "Reply",
-                    modifier = Modifier.size(Spacing.iconSm + Spacing.xs), // 16dp
-                )
-            },
-            onClick = onReplyClick,
-        )
-        // 3. Zap (when the author has a Lightning address) — highlights amber on hover
-        if (canZap) {
-            ActionButton(
-                icon = { isHovered ->
-                    Icon(
-                        Icons.Outlined.Bolt,
-                        contentDescription = "Zap",
-                        tint = if (isHovered) NostrordColors.Warning else NostrordColors.TextSecondary,
-                        modifier = Modifier.size(Spacing.iconSm + Spacing.xs), // 16dp
-                    )
-                },
-                onClick = onZapClick,
-            )
-        }
-        // 4. More (three dots)
-        ActionButton(
-            icon = {
-                Icon(
-                    Icons.Outlined.MoreVert,
-                    contentDescription = "More options",
-                    modifier = Modifier.size(Spacing.iconSm + Spacing.xs), // 16dp
-                )
-            },
-            onClick = onMoreClick,
-        )
-    }
-}
-
-/**
- * Individual action button in the hover toolbar.
- */
-@Composable
-private fun ActionButton(
-    icon: @Composable (isHovered: Boolean) -> Unit,
-    onClick: () -> Unit,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    val isHovered by interactionSource.collectIsHoveredAsState()
-
-    Box(
-        modifier =
-        Modifier
-            .size(Spacing.messageActionButtonSize)
-            .clip(NostrordShapes.channelItemShape)
-            .background(if (isHovered) NostrordColors.HoverBackground else Color.Transparent)
-            .hoverable(interactionSource)
-            .clickable(onClick = onClick)
-            .pointerHoverIcon(PointerIcon.Hand),
-        contentAlignment = Alignment.Center,
-    ) {
-        CompositionLocalProvider(
-            LocalContentColor provides if (isHovered) NostrordColors.TextPrimary else NostrordColors.TextSecondary,
-        ) {
-            icon(isHovered)
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/RightClickModifier.kt
@@ -1,9 +1,13 @@
 package org.nostr.nostrord.ui.components.chat
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 
 /**
  * Returns a Modifier that opens the context menu via the platform's secondary interaction.
+ *
+ * [onRightClick] receives the local click position (px, relative to the modified
+ * element's top-left) so the menu can open at the cursor rather than a fixed corner.
  *
  * Platform behavior:
  * - Desktop (JVM): right-click via PointerEvent secondary button
@@ -11,4 +15,4 @@ import androidx.compose.ui.Modifier
  * - iOS: no-op (context menu accessed via "More" button)
  * - Web (JS/WasmJS): contextmenu event
  */
-expect fun rightClickContextMenuModifier(onRightClick: () -> Unit): Modifier
+expect fun rightClickContextMenuModifier(onRightClick: (Offset) -> Unit): Modifier

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -403,6 +403,16 @@ fun GroupScreen(
         vm.requestGroupMessages(selectedChannel)
     }
 
+    // Fetch kind:0 for every message author (plus members), mirroring the web
+    // ChatScreen. The repository auto-requests metadata for members, reactors and
+    // quoted events, but not plain message authors who aren't members. Without
+    // their profile the Zap action (gated on lud16/lud06) never appears for them,
+    // so the native menu was missing Zap where the web one showed it.
+    LaunchedEffect(groupId, messages.size, memberPubkeys.size) {
+        val pubkeys = (memberPubkeys + messages.map { it.pubkey }).toSet()
+        if (pubkeys.isNotEmpty()) AppModule.nostrRepository.requestUserMetadata(pubkeys)
+    }
+
     // Re-request messages when connection is restored so the open group reloads after
     // a reconnect, even if it wasn't in the joined list or messages cache.
     LaunchedEffect(connectionState) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -713,6 +713,11 @@ val ChatScreen =
         // silently so the user thought the message was deleted when it
         // wasn't.
         val (deleteError, setDeleteError) = useState<String?> { null }
+        // Relay rejected a kind:7 reaction (e.g., "kind 7 not allowed", or an
+        // "unknown member" needing to join). Mirrors native's reactionError flow
+        // (GroupViewModel.kt:148-157 + GroupScreen.kt:620-665) — the web used to
+        // swallow it, so the reaction just blinked away with no explanation.
+        val (reactionError, setReactionError) = useState<String?> { null }
 
         // Scroll/pagination bookkeeping (refs so they don't trigger re-render).
         //
@@ -1311,7 +1316,20 @@ val ChatScreen =
                                                 onUser = { setProfilePubkey(it) }
                                                 onReply = { setReplyingToId(message.id) }
                                                 onReact = { emoji ->
-                                                    repo.sendReaction(group.id, message.id, message.pubkey, emoji)
+                                                    // Surface a relay rejection (e.g. "kind 7 not allowed")
+                                                    // instead of letting the reaction silently blink away.
+                                                    when (val result = repo.sendReaction(group.id, message.id, message.pubkey, emoji)) {
+                                                        is Result.Error -> {
+                                                            val raw = result.error.cause?.message ?: result.error.toString()
+                                                            setReactionError(
+                                                                raw
+                                                                    .removePrefix("blocked: ")
+                                                                    .removePrefix("error: ")
+                                                                    .replaceFirstChar { it.uppercaseChar() },
+                                                            )
+                                                        }
+                                                        is Result.Success -> Unit
+                                                    }
                                                 }
                                                 onDelete = { setMessageToDelete(message.id) }
                                             }
@@ -1580,6 +1598,19 @@ val ChatScreen =
             deleteError?.let { error ->
                 deleteMessageErrorDialog(error) { setDeleteError(null) }
             }
+            // Relay rejected the kind:7 reaction — explain it instead of the
+            // reaction just blinking away. Mirrors native's "Cannot React" /
+            // "Join Required" dialog (GroupScreen.kt:620-665).
+            reactionError?.let { error ->
+                reactionErrorDialog(
+                    message = error,
+                    onDismiss = { setReactionError(null) },
+                    onJoin = {
+                        setReactionError(null)
+                        join()
+                    },
+                )
+            }
         }
     }
 
@@ -1606,6 +1637,58 @@ private fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss:
                     className = ClassName("btn-primary")
                     onClick = { onDismiss() }
                     +"OK"
+                }
+            }
+        }
+    }
+}
+
+/** Dialog shown when the relay rejects a kind:7 reaction. Mirrors the native
+ *  AlertDialog at GroupScreen.kt:620-665: a "Join Required" variant (offers Join)
+ *  when the relay says we're an unknown member, otherwise "Cannot React" + OK. */
+private fun ChildrenBuilder.reactionErrorDialog(message: String, onDismiss: () -> Unit, onJoin: () -> Unit) {
+    val isUnknownMember = message.contains("unknown member", ignoreCase = true)
+    div {
+        className = ClassName("modal-overlay")
+        onClick = { onDismiss() }
+        div {
+            className = ClassName("modal-card sm")
+            onClick = { it.stopPropagation() }
+            div {
+                className = ClassName("modal-title")
+                +(if (isUnknownMember) "Join Required" else "Cannot React")
+            }
+            div {
+                className = ClassName("modal-subtitle tight")
+                if (isUnknownMember) {
+                    +"You need to join this group before you can react to messages."
+                } else {
+                    div { +"This relay does not support reactions." }
+                    div {
+                        className = ClassName("modal-reason")
+                        +message
+                    }
+                }
+            }
+            div {
+                className = ClassName("modal-footer")
+                if (isUnknownMember) {
+                    button {
+                        className = ClassName("btn-text")
+                        onClick = { onDismiss() }
+                        +"Cancel"
+                    }
+                    button {
+                        className = ClassName("btn-primary")
+                        onClick = { onJoin() }
+                        +"Join Group"
+                    }
+                } else {
+                    button {
+                        className = ClassName("btn-primary")
+                        onClick = { onDismiss() }
+                        +"OK"
+                    }
                 }
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -15,6 +15,7 @@ import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
 import org.nostr.nostrord.utils.formatTime
@@ -1719,6 +1720,9 @@ private val MessageRow =
         }
         // Anchor (viewport x,y) for the context menu; positioned/flipped by the effect below.
         val (menuAt, setMenuAt) = useState<Pair<Int, Int>?> { null }
+        // Right-click opens the menu to the right of the cursor; the ⋯ button hangs it
+        // off the button's right edge (opens leftward). Drives the flip math below.
+        val (menuFromCursor, setMenuFromCursor) = useState { false }
         val menuRef = useRef<HTMLDivElement>(null)
 
         // Swipe-to-reply (touch): drag the row left past a threshold to reply (mirrors native).
@@ -1742,9 +1746,11 @@ private val MessageRow =
             val h = el.offsetHeight as Int
             val vw = window.innerWidth
             val vh = window.innerHeight
-            var left = anchor.first - w
-            if (left < 8) left = 8
+            // Cursor anchor opens rightward (left = x); button anchor opens leftward
+            // (left = x - w). Either way, clamp into the viewport with an 8px margin.
+            var left = if (menuFromCursor) anchor.first else anchor.first - w
             if (left + w > vw - 8) left = (vw - 8 - w).coerceAtLeast(8)
+            if (left < 8) left = 8
             var top = anchor.second
             if (top + h > vh - 8) top = (anchor.second - h).coerceAtLeast(8)
             el.style.left = "${left}px"
@@ -1761,10 +1767,20 @@ private val MessageRow =
                         (if (props.highlighted) " highlight" else ""),
                 )
             ref = rowRef
-            // Right-click is left to the browser's default menu (copy / inspect /
-            // etc.) — feels foreign to override it on a web page. The .msg-actions
-            // toolbar's ⋯ More button still opens the same .ctx-menu, so the
-            // moderation actions stay reachable from the hover toolbar.
+            // Two-stage right-click (Telegram-style): the first right-click on a
+            // message opens our app menu at the cursor and suppresses the browser's
+            // native menu. A second right-click escapes to the native menu, handled
+            // by the .ctx-overlay below (which does not preventDefault). Right-click
+            // off any message keeps the browser default untouched.
+            onContextMenu = { event ->
+                if (!menuOpen) {
+                    event.preventDefault()
+                    setReactOpen(false)
+                    setMenuAt(event.clientX.toInt() to event.clientY.toInt())
+                    setMenuFromCursor(true)
+                    setMenuOpen(true)
+                }
+            }
             onTouchStart = { event ->
                 val t = event.asDynamic().touches[0]
                 touchStartX.current = t.clientX as Double
@@ -1967,60 +1983,50 @@ private val MessageRow =
                 }
             }
 
-            // Hover action toolbar (top-right)
-            div {
-                className = ClassName("msg-actions")
-                button {
-                    className = ClassName("msg-action-btn")
-                    title = "Add reaction"
-                    onClick = { setReactOpen(true) }
-                    icon(Ic.EmojiEmotions)
-                }
-                button {
-                    className = ClassName("msg-action-btn")
-                    title = "Reply"
-                    onClick = { props.onReply() }
-                    icon(Ic.Reply)
-                }
-                if (props.canZap) {
-                    button {
-                        className = ClassName("msg-action-btn zap")
-                        title = "Zap"
-                        onClick = { props.onZap() }
-                        icon(Ic.Bolt)
-                    }
-                }
-                button {
-                    className = ClassName("msg-action-btn")
-                    title = "More"
-                    onClick = { event ->
-                        val r = event.currentTarget.getBoundingClientRect()
-                        setMenuAt(r.right.toInt() to r.bottom.toInt())
-                        setMenuOpen(!menuOpen)
-                    }
-                    icon(Ic.MoreVert)
-                }
-            }
-
-            // Context menu (right-click or the ⋯ button)
+            // Context menu (right-click / long-press)
             if (menuOpen) {
                 div {
                     className = ClassName("ctx-overlay")
                     onClick = { setMenuOpen(false) }
+                    // Second right-click (this overlay is now on top): close our menu
+                    // and let the browser show its native menu, since we don't
+                    // preventDefault here. Matches Telegram's two-stage behavior.
+                    onContextMenu = { setMenuOpen(false) }
                 }
                 div {
                     ref = menuRef
                     className = ClassName("ctx-menu")
-                    ctxItem(Ic.EmojiEmotions, "Add Reaction") {
-                        setMenuOpen(false)
-                        setReactOpen(true)
+                    // Quick-reactions row (one tap to react) + an affordance to open
+                    // the full picker. Mirrors the native menu's QuickReactionsRow.
+                    div {
+                        className = ClassName("ctx-reactions")
+                        for (emoji in QuickReactions) {
+                            button {
+                                className = ClassName("ctx-reaction")
+                                onClick = {
+                                    react(emoji)
+                                    setMenuOpen(false)
+                                }
+                                +emoji
+                            }
+                        }
+                        button {
+                            className = ClassName("ctx-reaction ctx-reaction-more")
+                            title = "Add reaction"
+                            onClick = {
+                                setMenuOpen(false)
+                                setReactOpen(true)
+                            }
+                            icon(Ic.EmojiEmotions)
+                        }
                     }
+                    div { className = ClassName("ctx-divider") }
                     ctxItem(Ic.Reply, "Reply") {
                         props.onReply()
                         setMenuOpen(false)
                     }
                     if (props.canZap) {
-                        ctxItem(Ic.Bolt, "Zap") {
+                        ctxItem(Ic.Bolt, "Zap", zap = true) {
                             props.onZap()
                             setMenuOpen(false)
                         }
@@ -2064,9 +2070,16 @@ private val MessageRow =
         }
     }
 
-private fun ChildrenBuilder.ctxItem(ic: Ic, label: String, danger: Boolean = false, onSelect: () -> Unit) {
+private fun ChildrenBuilder.ctxItem(ic: Ic, label: String, danger: Boolean = false, zap: Boolean = false, onSelect: () -> Unit) {
     div {
-        className = ClassName(if (danger) "ctx-item danger" else "ctx-item")
+        className =
+            ClassName(
+                when {
+                    danger -> "ctx-item danger"
+                    zap -> "ctx-item zap"
+                    else -> "ctx-item"
+                },
+            )
         onClick = { onSelect() }
         span {
             className = ClassName("ctx-item-icon")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -1736,6 +1736,16 @@ private val MessageRow =
         val touchStartY = useRef(0.0)
         val swiping = useRef(false)
         val swipeArmed = useRef(false)
+        // Long-press to open the context menu on touch (mirrors the Android app). The
+        // menu opens when the finger is LIFTED after a stationary hold — not mid-hold —
+        // so the page never jumps and the ensuing synthesized click can be suppressed
+        // (otherwise it lands on the overlay and instantly closes the menu).
+        val longPressTimer = useRef(0)
+        // True once the press has been held long enough (and hasn't moved) to count as
+        // a long-press; the menu opens on touchend while this is set.
+        val longPressReady = useRef(false)
+        // Timestamp (ms) of a touch-opened menu, to swallow the trailing ghost click.
+        val menuOpenedAt = useRef(0.0)
 
         // Place the fixed context menu at its anchor, flipping left/up when it would overflow.
         useEffect(menuOpen) {
@@ -1773,9 +1783,13 @@ private val MessageRow =
             // by the .ctx-overlay below (which does not preventDefault). Right-click
             // off any message keeps the browser default untouched.
             onContextMenu = { event ->
+                // Always suppress the browser's native menu/callout on a message; open
+                // ours at the cursor when none is open yet. (When our menu is open the
+                // .ctx-overlay sits on top, so this only fires while it's closed.)
+                event.preventDefault()
                 if (!menuOpen) {
-                    event.preventDefault()
                     setReactOpen(false)
+                    menuOpenedAt.current = 0.0 // mouse/right-click: no ghost click to swallow
                     setMenuAt(event.clientX.toInt() to event.clientY.toInt())
                     setMenuFromCursor(true)
                     setMenuOpen(true)
@@ -1787,11 +1801,28 @@ private val MessageRow =
                 touchStartY.current = t.clientY as Double
                 swiping.current = false
                 swipeArmed.current = false
+                longPressReady.current = false
+                window.clearTimeout(longPressTimer.current ?: 0)
+                // Arm the long-press after a stationary hold; the menu itself opens on
+                // touchend (below) so the page can't jump while the finger is down. A
+                // light haptic signals that releasing now will open the menu.
+                longPressTimer.current = window.setTimeout({
+                    if (swiping.current != true) {
+                        longPressReady.current = true
+                        val nav = window.navigator.asDynamic()
+                        if (nav.vibrate != null) nav.vibrate(15)
+                    }
+                }, 380)
             }
             onTouchMove = { event ->
                 val t = event.asDynamic().touches[0]
                 val dx = (t.clientX as Double) - (touchStartX.current ?: 0.0)
                 val dy = (t.clientY as Double) - (touchStartY.current ?: 0.0)
+                // Any real movement means this is a scroll/swipe, not a long-press.
+                if (abs(dx) > 10.0 || abs(dy) > 10.0) {
+                    window.clearTimeout(longPressTimer.current ?: 0)
+                    longPressReady.current = false
+                }
                 if (swiping.current != true && abs(dx) > 10.0 && abs(dx) > abs(dy)) {
                     swiping.current = true
                 }
@@ -1818,28 +1849,55 @@ private val MessageRow =
                     }
                 }
             }
-            onTouchEnd = {
-                val el = rowRef.current?.asDynamic()
-                if (el != null) {
-                    el.style.transition = "transform 0.15s ease"
-                    el.style.transform = "translateX(0)"
-                    window.setTimeout({
-                        el.style.transition = ""
-                        el.style.transform = ""
-                    }, 180)
+            onTouchEnd = { event ->
+                window.clearTimeout(longPressTimer.current ?: 0)
+                // Open the menu at the finger if the press was a stationary long-press
+                // and didn't land on something interactive (link, avatar, badge, ...).
+                val tgt = event.target.asDynamic()
+                val onInteractive = tgt != null &&
+                    tgt.closest("a, button, img, video, input, textarea, .clickable, .mention") != null
+                val openMenu = longPressReady.current == true &&
+                    swiping.current != true &&
+                    !onInteractive &&
+                    !menuOpen
+                if (openMenu) {
+                    // Suppress the synthesized mouse/click sequence so it can't hit the
+                    // overlay and immediately close the menu we're about to open.
+                    event.preventDefault()
+                    setReactOpen(false)
+                    menuOpenedAt.current = kotlin.js.Date.now()
+                    setMenuAt((touchStartX.current ?: 0.0).toInt() to (touchStartY.current ?: 0.0).toInt())
+                    setMenuFromCursor(true)
+                    setMenuOpen(true)
                 }
-                val iconStyle = swipeIconRef.current?.asDynamic()?.style
-                if (iconStyle != null) {
-                    iconStyle.transition = "opacity 0.15s ease, transform 0.15s ease"
-                    iconStyle.opacity = "0"
-                    iconStyle.transform = "translateY(-50%) scale(1.0)"
-                    window.setTimeout({
-                        iconStyle.transition = ""
-                    }, 180)
+                // Animate the row back ONLY if it was actually swiped. Giving the row a
+                // transform otherwise (even translateX(0)) makes it the containing block
+                // for the position:fixed context menu, which would yank the menu out of
+                // place the moment it opens.
+                if (swiping.current == true) {
+                    val el = rowRef.current?.asDynamic()
+                    if (el != null) {
+                        el.style.transition = "transform 0.15s ease"
+                        el.style.transform = "translateX(0)"
+                        window.setTimeout({
+                            el.style.transition = ""
+                            el.style.transform = ""
+                        }, 180)
+                    }
+                    val iconStyle = swipeIconRef.current?.asDynamic()?.style
+                    if (iconStyle != null) {
+                        iconStyle.transition = "opacity 0.15s ease, transform 0.15s ease"
+                        iconStyle.opacity = "0"
+                        iconStyle.transform = "translateY(-50%) scale(1.0)"
+                        window.setTimeout({
+                            iconStyle.transition = ""
+                        }, 180)
+                    }
                 }
-                if (swipeArmed.current == true) props.onReply()
+                if (!openMenu && swipeArmed.current == true) props.onReply()
                 swiping.current = false
                 swipeArmed.current = false
+                longPressReady.current = false
             }
 
             // Swipe-to-reply icon (revealed under the row as it slides left). Sits
@@ -1987,7 +2045,16 @@ private val MessageRow =
             if (menuOpen) {
                 div {
                     className = ClassName("ctx-overlay")
-                    onClick = { setMenuOpen(false) }
+                    // Don't let overlay/menu touches reach the row's swipe + long-press
+                    // handlers (they would transform the row and yank this fixed menu).
+                    onTouchStart = { it.stopPropagation() }
+                    onTouchMove = { it.stopPropagation() }
+                    onTouchEnd = { it.stopPropagation() }
+                    onClick = {
+                        // Ignore the synthesized click that trails a touch-open
+                        // (it would otherwise close the menu the instant it opens).
+                        if (kotlin.js.Date.now() - (menuOpenedAt.current ?: 0.0) > 400.0) setMenuOpen(false)
+                    }
                     // Second right-click (this overlay is now on top): close our menu
                     // and let the browser show its native menu, since we don't
                     // preventDefault here. Matches Telegram's two-stage behavior.
@@ -1996,6 +2063,9 @@ private val MessageRow =
                 div {
                     ref = menuRef
                     className = ClassName("ctx-menu")
+                    onTouchStart = { it.stopPropagation() }
+                    onTouchMove = { it.stopPropagation() }
+                    onTouchEnd = { it.stopPropagation() }
                     // Quick-reactions row (one tap to react) + an affordance to open
                     // the full picker. Mirrors the native menu's QuickReactionsRow.
                     div {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2788,45 +2788,6 @@ body {
     height: 18px;
 }
 
-/* Hover action toolbar (top-right of a message) */
-.msg-actions {
-    position: absolute;
-    top: -10px;
-    right: 16px;
-    display: none;
-    gap: 2px;
-    padding: 2px;
-    background: var(--color-surface);
-    border: 1px solid var(--color-divider);
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-    z-index: 2;
-}
-
-.msg:hover .msg-actions,
-.msg.menu-open .msg-actions {
-    display: flex;
-}
-
-.msg-action-btn {
-    width: 30px;
-    height: 30px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 15px;
-    color: var(--color-text-secondary);
-    background: transparent;
-    border: none;
-    border-radius: 6px;
-    cursor: pointer;
-}
-
-.msg-action-btn:hover {
-    background: var(--color-hover);
-    color: var(--color-text-primary);
-}
-
 /* Message context menu */
 .ctx-overlay {
     position: fixed;
@@ -2871,6 +2832,11 @@ body {
     background: rgba(237, 66, 69, 0.15);
 }
 
+/* Zap highlights amber on hover. */
+.ctx-item.zap:hover {
+    color: var(--color-warning-orange);
+}
+
 .ctx-item-icon {
     width: 18px;
     text-align: center;
@@ -2881,6 +2847,40 @@ body {
     height: 1px;
     margin: 6px 4px;
     background: var(--color-divider);
+}
+
+/* Quick-reactions row on top of the context menu (Telegram-style one-tap reactions). */
+.ctx-reactions {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding: 2px;
+}
+
+.ctx-reaction {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    font-size: 18px;
+    line-height: 1;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background 0.1s ease, transform 0.1s ease;
+}
+
+.ctx-reaction:hover {
+    background: var(--color-hover);
+    transform: scale(1.15);
+}
+
+.ctx-reaction-more {
+    color: var(--color-text-muted);
+    font-size: 14px;
 }
 
 /* Hairline above each grouped (same-author) message, aligned with content (after the gutter). */
@@ -6221,10 +6221,6 @@ body {
 .zap-badge-bolt {
     font-size: 12px;
 }
-.msg-action-btn.zap:hover {
-    color: var(--color-warning-orange);
-}
-
 /* ===== Emoji picker ===== */
 .emoji-overlay {
     position: fixed;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2764,6 +2764,17 @@ body {
     background: var(--color-message-hover);
 }
 
+/* On touch devices, press-and-hold opens the context menu (Android parity), so
+   suppress the native text-selection / long-press callout on a message. Desktop
+   keeps normal text selection. Copy Text lives in the menu. */
+@media (hover: none) {
+    .msg {
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        user-select: none;
+    }
+}
+
 /* Reply icon revealed under the row during swipe-to-reply. Sits absolutely on
    the right edge; the .msg's flex children render *on top* of it because they
    come later in the DOM, so the row slides left over the icon as in native. */

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -1819,6 +1819,12 @@ body {
     margin-bottom: 16px;
 }
 
+/* The relay's raw rejection reason, shown under the main explanation line. */
+.modal-reason {
+    margin-top: 8px;
+    color: var(--color-text-secondary);
+}
+
 .modal-close {
     flex-shrink: 0;
     width: 32px;


### PR DESCRIPTION
Brings the native (Compose) and web (React) message context menus to parity, retires the hover action toolbar now that the menu covers every action, and fixes the touch interactions surfaced while testing on the web.

The menu opens at the click/tap point on every platform, the quick-reactions row and Zap match between web and native (including the amber hover tint and color emoji rendering), and reaction rejections now explain themselves instead of silently blinking away.

| Area | Change |
|---|---|
| Positioning | Menu opens at the cursor/tap (cursor-aware `PopupPositionProvider` on native, viewport-flipping on web) instead of a fixed corner |
| Native style | Bordered 210dp menu, rounded inset items, animated quick reactions, NotoColorEmoji glyphs |
| Zap | Appears for any author with a Lightning address (native now fetches author kind:0 like web), amber hover tint on both |
| Hover toolbar | Removed (`MessageActions` native + `.msg-actions` web); iOS opens the menu via tap like Android |
| Web touch | Long-press opens the menu on release with the ghost click suppressed; tap follows links, drag swipes/scrolls |
| Reaction errors | Web shows a "Cannot React" / "Join Required" dialog with the relay's reason instead of a silent blink |

Commits:
- feat(chat): unify the message context menu across platforms
- feat(web): long-press to open the context menu on touch (Android parity)
- fix(web): show a dialog when the relay rejects a reaction

Verified with `compileKotlinJvm`, `compileDebugKotlinAndroid`, and `compileKotlinJs`. Touch behavior checked on the Android emulator.