### PR TITLE
feat(web): tap the nostrconnect QR to open the signer app

### DIFF
--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/BunkerQr.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/BunkerQr.kt
@@ -14,6 +14,7 @@ import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.qrDataUrl
 import react.FC
 import react.Props
+import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.img
@@ -127,11 +128,29 @@ val BunkerQr =
                         div { className = ClassName("qr-spinner") }
                     }
                 else ->
-                    img {
-                        className = ClassName("qr-img")
-                        src = qrDataUrl(uri)
-                        alt = "nostrconnect QR code"
+                    // The QR image itself is the deep link (matches native, where the
+                    // QR is clickable and calls uriHandler.openUri). On the same phone
+                    // you can't scan it, so tapping hands the nostrconnect:// URI to
+                    // the installed signer (Amber, etc.).
+                    a {
+                        className = ClassName("qr-link")
+                        href = uri
+                        img {
+                            className = ClassName("qr-img")
+                            src = qrDataUrl(uri)
+                            alt = "nostrconnect QR code"
+                        }
                     }
+            }
+
+            // Tap-to-open caption below the QR (matches native's "Tap to open in
+            // signer app", which it only shows on Android). Hidden on desktop and
+            // revealed on coarse-pointer devices via CSS.
+            if (uri != null) {
+                p {
+                    className = ClassName("bunker-tap-hint")
+                    +"Tap to open in signer app"
+                }
             }
 
             // URI + copy input (matches native OutlinedTextField with copy trailing icon).

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -511,6 +511,30 @@ body {
     font-size: 13px;
 }
 
+/* The QR image is itself a deep link to the installed signer (matches native,
+   where the QR is clickable). The anchor must not add underline/spacing around
+   the image. */
+.qr-link {
+    display: inline-flex;
+    text-decoration: none;
+}
+
+/* "Tap to open in signer app" caption under the QR. Only meaningful on a touch
+   device (you can't scan the QR on the same phone), so it is hidden by default
+   and revealed on coarse-pointer devices, mirroring native's Android-only hint. */
+.bunker-tap-hint {
+    display: none;
+    margin: 6px 0 0;
+    font-size: 11px;
+    color: var(--color-text-muted);
+}
+
+@media (pointer: coarse) {
+    .bunker-tap-hint {
+        display: block;
+    }
+}
+
 /* Trailing-icon button slot used by the URI copy, the add-relay +, and any
    other small affordance inside a .field-with-icon. */
 .field-action {


### PR DESCRIPTION
On the web bunker login, scanning the nostrconnect QR is impossible when you're already on the phone you'd scan with. This makes the QR itself a `nostrconnect://` deep link so a tap hands the URI to the installed signer (Amber, nsec.app, etc.), with a caption underneath, mirroring native `BunkerLoginTab.QrCodeLoginContent` (clickable QR + "Tap to open in signer app" hint).

| Aspect | Web (this PR) | Native parity |
|---|---|---|
| QR is the link | `<a href="nostrconnect://…">` wrapping the QR `<img>` | `Modifier.clickable { uriHandler.openUri(uri) }` |
| Caption | `Tap to open in signer app` below the QR | same string, shown on Android |
| Mobile gating | shown via `@media (pointer: coarse)` | native gates the hint to `isAndroid` |

The copy-URI field stays as the desktop affordance. No new icons or strings beyond the caption.

Compiled with `./gradlew compileKotlinJs`.

- d9542d2 feat(web): tap the nostrconnect QR to open the signer app