### PR TITLE
Composer, upload and reply parity (web + native) + native desktop file picker

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -152,6 +152,23 @@ kotlin {
             // native-library matrix that JavaFX Media relies on.
             implementation("javazoom:jlayer:1.0.1")
             implementation("com.github.javakeyring:java-keyring:1.0.3")
+            // Native file picker (zenity/kdialog subprocess on Linux) via LWJGL tinyfd.
+            // Chosen over java.awt.FileDialog (GNOME focus-stealing on repeat opens) and
+            // over FileKit (its dbus-java 5.x clashes with java-keyring's Secret Service
+            // dbus-java 3.x, breaking the OS keychain). tinyfd pulls no dbus-java.
+            val lwjglVersion = "3.3.4"
+            val osArch = System.getProperty("os.arch")
+            val lwjglNatives =
+                when {
+                    os.isLinux -> if (osArch.startsWith("aarch64")) "natives-linux-arm64" else "natives-linux"
+                    os.isMacOsX -> if (osArch.startsWith("aarch64")) "natives-macos-arm64" else "natives-macos"
+                    os.isWindows -> "natives-windows"
+                    else -> "natives-linux"
+                }
+            implementation("org.lwjgl:lwjgl:$lwjglVersion")
+            implementation("org.lwjgl:lwjgl-tinyfd:$lwjglVersion")
+            runtimeOnly("org.lwjgl:lwjgl:$lwjglVersion:$lwjglNatives")
+            runtimeOnly("org.lwjgl:lwjgl-tinyfd:$lwjglVersion:$lwjglNatives")
         }
 
         jsMain.dependencies {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
@@ -86,50 +86,22 @@ object NostrBuildUploader {
         buildAuthHeader: suspend (url: String, method: String) -> String?,
     ): Result<UploadResult> {
         val isCached = isBlobRef(filename)
-        val displayName = if (isCached) filename.split("|").getOrNull(2) ?: filename else filename
-        val sizeDesc =
-            if (isCached) {
-                "clipboard cache"
-            } else {
-                val kb = bytes.size / 1024
-                "${bytes.size}B (${kb / 1024}.${((kb % 1024) * 100 / 1024).toString().padStart(2, '0')}MB)"
-            }
-        println("[Upload] START  file=$displayName  size=$sizeDesc  mime=$mimeType  url=$UPLOAD_URL")
 
-        val authHeader = buildAuthHeader(UPLOAD_URL, "POST")
-        if (authHeader == null) {
-            println("[Upload] ERROR  auth header is null – not authenticated")
-            return Result.Error(AppError.Auth.NotAuthenticated)
-        }
-        println("[Upload] AUTH   header obtained (length=${authHeader.length})")
+        val authHeader =
+            buildAuthHeader(UPLOAD_URL, "POST")
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
 
         // Blob-ref uploads can't be retried — the JS cache entry is consumed on first use
         val maxAttempts = if (isCached) 1 else 3
         var lastException: Throwable? = null
         repeat(maxAttempts) { attempt ->
-            println("[Upload] ATTEMPT ${attempt + 1}/$maxAttempts  file=$displayName")
             try {
-                val result = doUpload(bytes, filename, mimeType, authHeader)
-                println(
-                    "[Upload] DONE   file=$displayName  result=${
-                        when (result) {
-                            is Result.Success -> "SUCCESS url=${result.data.url}"
-                            is Result.Error -> "SERVER_ERROR ${result.error.message}"
-                        }
-                    }",
-                )
-                return result
+                return doUpload(bytes, filename, mimeType, authHeader)
             } catch (e: Throwable) {
-                println("[Upload] EXCEPTION attempt=${attempt + 1}  type=${e::class.simpleName}  msg=${e.message}")
-                e.cause?.let { println("[Upload]   cause: ${it::class.simpleName}: ${it.message}") }
                 lastException = e
-                if (attempt < maxAttempts - 1) {
-                    println("[Upload] RETRY in 500ms…")
-                    delay(500)
-                }
+                if (attempt < maxAttempts - 1) delay(500)
             }
         }
-        println("[Upload] FAILED after $maxAttempts attempts  file=$displayName  lastError=${lastException?.message}")
         return Result.Error(AppError.Unknown("Upload failed: ${lastException?.message}", lastException))
     }
 
@@ -141,11 +113,7 @@ object NostrBuildUploader {
         mimeType: String,
         authHeader: String,
     ): Result<UploadResult> {
-        println("[Upload] SEND   submitting multipart to $UPLOAD_URL")
         val (statusCode, text) = executeUpload(UPLOAD_URL, bytes, filename, mimeType, authHeader)
-
-        println("[Upload] RESPONSE  status=$statusCode")
-        println("[Upload] BODY  (${text.length} chars): ${text.take(500)}${if (text.length > 500) "…" else ""}")
 
         if (statusCode !in 200..299) {
             val msg =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
@@ -18,6 +18,13 @@ const val SUPPORTED_FORMATS_MESSAGE =
 
 internal fun isBlobRef(s: String) = s.startsWith("nostrord-blob|")
 
+/** Still-image extensions (avatars / banners). Single source for native pickers. */
+internal val SUPPORTED_IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "gif", "webp", "avif")
+
+/** All upload extensions (image + video + audio). Keep in sync with mimeTypeForFilename. */
+internal val SUPPORTED_MEDIA_EXTENSIONS =
+    SUPPORTED_IMAGE_EXTENSIONS + setOf("mp4", "mov", "webm", "mp3", "ogg", "wav", "flac", "m4a", "aac", "opus")
+
 internal val SUPPORTED_UPLOAD_MIMES =
     setOf(
         "image/jpeg",

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -70,8 +70,15 @@ actual fun rememberMediaPickerLauncher(
                         }
                     else -> {
                         withContext(Dispatchers.Main) { currentOnPickStart.value() }
-                        val bytes = file.readBytes()
-                        withContext(Dispatchers.Main) { currentOnFilePicked.value(bytes, file.name) }
+                        // readBytes can throw (file vanished, permission, special file). Surface
+                        // it via onError so the caller's busy/spinner state is reset (onPickStart
+                        // already flipped it on) instead of leaving the attach button stuck.
+                        try {
+                            val bytes = file.readBytes()
+                            withContext(Dispatchers.Main) { currentOnFilePicked.value(bytes, file.name) }
+                        } catch (e: Throwable) {
+                            withContext(Dispatchers.Main) { currentOnError.value("Could not read the selected file.") }
+                        }
                     }
                 }
             }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -17,13 +17,6 @@ actual class MediaPickerLauncher(
     actual fun launch() = doLaunch()
 }
 
-private val IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "gif", "webp", "avif")
-private val ALL_EXTENSIONS =
-    IMAGE_EXTENSIONS + setOf(
-        "mp4", "mov", "webm",
-        "mp3", "ogg", "wav", "flac", "m4a", "aac", "opus",
-    )
-
 /**
  * Native file picker via LWJGL tinyfd, which on Linux shells out to zenity/kdialog as a
  * subprocess. That subprocess window is managed by the WM independently of the JVM, so it
@@ -46,8 +39,8 @@ actual fun rememberMediaPickerLauncher(
     val currentOnFilePicked = rememberUpdatedState(onFilePicked)
     val allowedSet =
         when (accept) {
-            MediaAccept.Images -> IMAGE_EXTENSIONS
-            MediaAccept.ImagesVideosAudio -> ALL_EXTENSIONS
+            MediaAccept.Images -> SUPPORTED_IMAGE_EXTENSIONS
+            MediaAccept.ImagesVideosAudio -> SUPPORTED_MEDIA_EXTENSIONS
         }
 
     return remember {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -7,12 +7,9 @@ import androidx.compose.runtime.rememberUpdatedState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.awt.FileDialog
-import java.awt.Frame
-import java.awt.KeyboardFocusManager
+import org.lwjgl.system.MemoryStack
+import org.lwjgl.util.tinyfd.TinyFileDialogs
 import java.io.File
-import java.io.FilenameFilter
-import javax.swing.SwingUtilities
 
 actual class MediaPickerLauncher(
     private val doLaunch: () -> Unit,
@@ -20,18 +17,19 @@ actual class MediaPickerLauncher(
     actual fun launch() = doLaunch()
 }
 
-private val IMAGE_EXTENSIONS = arrayOf("jpg", "jpeg", "png", "gif", "webp", "avif")
-private val AUDIO_EXTENSIONS = arrayOf("mp3", "ogg", "wav", "flac", "m4a", "aac", "opus")
-private val ALL_EXTENSIONS = IMAGE_EXTENSIONS + arrayOf("mp4", "mov", "webm") + AUDIO_EXTENSIONS
-private val ALL_EXTENSIONS_SET = ALL_EXTENSIONS.toSet()
-private val IMAGE_EXTENSIONS_SET = IMAGE_EXTENSIONS.toSet()
+private val IMAGE_EXTENSIONS = setOf("jpg", "jpeg", "png", "gif", "webp", "avif")
+private val ALL_EXTENSIONS =
+    IMAGE_EXTENSIONS + setOf(
+        "mp4", "mov", "webm",
+        "mp3", "ogg", "wav", "flac", "m4a", "aac", "opus",
+    )
 
 /**
- * Uses the native [FileDialog] (GTK file chooser on Linux) owned by the Compose window.
- * The OS manages the dialog, so it can't fall behind the app and focus returns to the
- * owner window on close — unlike a Swing JFileChooser in a throwaway JDialog, which left
- * focus on a background window on some Linux WMs. Extension filtering is best-effort via
- * FilenameFilter; the selection is validated again after the dialog closes.
+ * Native file picker via LWJGL tinyfd, which on Linux shells out to zenity/kdialog as a
+ * subprocess. That subprocess window is managed by the WM independently of the JVM, so it
+ * always opens in front and focus returns to the app on close — no AWT `_NET_WM_USER_TIME`
+ * focus-stealing dance (java.awt.FileDialog) and no dbus-java on the classpath (FileKit),
+ * which would clash with java-keyring's Secret Service and break the OS keychain.
  */
 @Composable
 actual fun rememberMediaPickerLauncher(
@@ -41,68 +39,59 @@ actual fun rememberMediaPickerLauncher(
     onFilePicked: (ByteArray, String) -> Unit,
 ): MediaPickerLauncher {
     val scope = rememberCoroutineScope()
-    // The launcher is remembered once, so capture the latest callbacks via
-    // rememberUpdatedState (like the Android picker). Without this the picker keeps
-    // the first composition's onFilePicked, which closes over a stale textFieldValue
-    // state — the upload then writes the URL to an orphaned field and the visible
-    // input never updates after a recomposition (e.g. switching groups).
+    // Capture the latest callbacks: the launcher is remembered once, and a stale
+    // onFilePicked would write the uploaded URL into an orphaned composer field.
     val currentOnPickStart = rememberUpdatedState(onPickStart)
     val currentOnError = rememberUpdatedState(onError)
     val currentOnFilePicked = rememberUpdatedState(onFilePicked)
     val allowedSet =
         when (accept) {
-            MediaAccept.Images -> IMAGE_EXTENSIONS_SET
-            MediaAccept.ImagesVideosAudio -> ALL_EXTENSIONS_SET
+            MediaAccept.Images -> IMAGE_EXTENSIONS
+            MediaAccept.ImagesVideosAudio -> ALL_EXTENSIONS
         }
+
     return remember {
         MediaPickerLauncher {
-            SwingUtilities.invokeLater {
-                // The dialog owner is what focus should return to on close. activeWindow is
-                // usually the Compose window; fall back to the first showing app frame so we
-                // never pass null (a null owner lets the WM hand focus to a background window).
-                val owner =
-                    (KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow as? Frame)
-                        ?: Frame.getFrames().firstOrNull { it.isShowing && it.isFocusableWindow }
-
-                val dialog =
-                    FileDialog(owner, "Select File", FileDialog.LOAD).apply {
-                        isMultipleMode = false
-                        // Honored by the GTK chooser; ignored on some platforms, where the
-                        // post-selection extension check below enforces the same rule.
-                        filenameFilter =
-                            FilenameFilter { _, name ->
-                                name.substringAfterLast('.', "").lowercase() in allowedSet
-                            }
-                    }
-
-                // Do NOT toFront/requestFocus/alwaysOnTop the app window before or after the
-                // dialog. AWT issues those activations with a zero _NET_WM_USER_TIME, which
-                // resets the app's user-activity association so GNOME/Mutter then treats the
-                // NEXT dialog as a focus-steal and opens it behind with a "ready" notice.
-                // Each open is user-initiated (the click), so Mutter raises it on its own.
-                dialog.isVisible = true // blocks the EDT until the native dialog closes
-
-                val name = dialog.file ?: return@invokeLater // cancelled
-                val dir = dialog.directory ?: return@invokeLater
-                val file = File(dir, name)
+            // tinyfd blocks (waits on the zenity subprocess), so run it off the UI thread.
+            scope.launch(Dispatchers.IO) {
+                val path = openNativeFileDialog(allowedSet) ?: return@launch // cancelled
+                val file = File(path)
                 val ext = file.extension.lowercase()
-
                 when {
                     ext !in allowedSet ->
-                        currentOnError.value(
-                            "\".${ext.ifEmpty { "unknown" }}\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE",
-                        )
-                    file.length() > MAX_UPLOAD_BYTES ->
-                        currentOnError.value("File is too large. The maximum upload size is 20 MB.")
-                    else -> {
-                        currentOnPickStart.value()
-                        scope.launch(Dispatchers.IO) {
-                            val bytes = file.readBytes()
-                            withContext(Dispatchers.Main) { currentOnFilePicked.value(bytes, file.name) }
+                        withContext(Dispatchers.Main) {
+                            currentOnError.value(
+                                "\".${ext.ifEmpty { "unknown" }}\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE",
+                            )
                         }
+                    file.length() > MAX_UPLOAD_BYTES ->
+                        withContext(Dispatchers.Main) {
+                            currentOnError.value("File is too large. The maximum upload size is 20 MB.")
+                        }
+                    else -> {
+                        withContext(Dispatchers.Main) { currentOnPickStart.value() }
+                        val bytes = file.readBytes()
+                        withContext(Dispatchers.Main) { currentOnFilePicked.value(bytes, file.name) }
                     }
                 }
             }
         }
+    }
+}
+
+/** Open the native single-file picker, restricted to [allowedSet] extensions. Returns the
+ *  chosen path, or null if cancelled. Blocks until the dialog closes. */
+private fun openNativeFileDialog(allowedSet: Set<String>): String? {
+    MemoryStack.stackPush().use { stack ->
+        val patterns = stack.mallocPointer(allowedSet.size)
+        allowedSet.forEach { patterns.put(stack.UTF8("*.$it")) }
+        patterns.flip()
+        return TinyFileDialogs.tinyfd_openFileDialog(
+            "Select File",
+            null,
+            patterns,
+            "Images, videos & audio",
+            false,
+        )
     }
 }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.network.upload
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -46,6 +47,14 @@ actual fun rememberMediaPickerLauncher(
     onFilePicked: (ByteArray, String) -> Unit,
 ): MediaPickerLauncher {
     val scope = rememberCoroutineScope()
+    // The launcher is remembered once, so capture the latest callbacks via
+    // rememberUpdatedState (like the Android picker). Without this the picker keeps
+    // the first composition's onFilePicked, which closes over a stale textFieldValue
+    // state — the upload then writes the URL to an orphaned field and the visible
+    // input never updates after a recomposition (e.g. switching groups).
+    val currentOnPickStart = rememberUpdatedState(onPickStart)
+    val currentOnError = rememberUpdatedState(onError)
+    val currentOnFilePicked = rememberUpdatedState(onFilePicked)
     return remember {
         MediaPickerLauncher {
             val deferred = CompletableDeferred<Pair<ByteArray, String>?>()
@@ -147,10 +156,10 @@ actual fun rememberMediaPickerLauncher(
 
                     val selected = chooser.selectedFile
                     if (selected != null && selected.extension.lowercase() in allowedSet) {
-                        scope.launch { onPickStart() }
+                        scope.launch { currentOnPickStart.value() }
                         if (selected.length() > MAX_UPLOAD_BYTES) {
                             deferred.complete(null)
-                            scope.launch { onError("File is too large. The maximum upload size is 20 MB.") }
+                            scope.launch { currentOnError.value("File is too large. The maximum upload size is 20 MB.") }
                         } else {
                             scope.launch(Dispatchers.IO) {
                                 deferred.complete(selected.readBytes() to selected.name)
@@ -160,7 +169,7 @@ actual fun rememberMediaPickerLauncher(
                         deferred.complete(null)
                         if (selected != null) {
                             val ext = selected.extension.ifEmpty { "unknown" }
-                            scope.launch { onError("\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE") }
+                            scope.launch { currentOnError.value("\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE") }
                         }
                     }
                 } finally {
@@ -173,7 +182,7 @@ actual fun rememberMediaPickerLauncher(
                 try {
                     val result = deferred.await()
                     if (result != null) {
-                        withContext(Dispatchers.Main) { onFilePicked(result.first, result.second) }
+                        withContext(Dispatchers.Main) { currentOnFilePicked.value(result.first, result.second) }
                     }
                 } catch (_: Throwable) {
                 }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -67,11 +67,6 @@ actual fun rememberMediaPickerLauncher(
                 val dialog =
                     FileDialog(owner, "Select File", FileDialog.LOAD).apply {
                         isMultipleMode = false
-                        // Always-on-top so the picker opens in front of the app even right
-                        // after a previous pick (the focus-restore toggle below briefly
-                        // raises the app window, which otherwise let the next dialog open
-                        // behind it).
-                        isAlwaysOnTop = true
                         // Honored by the GTK chooser; ignored on some platforms, where the
                         // post-selection extension check below enforces the same rule.
                         filenameFilter =
@@ -80,18 +75,12 @@ actual fun rememberMediaPickerLauncher(
                             }
                     }
 
+                // Do NOT toFront/requestFocus/alwaysOnTop the app window before or after the
+                // dialog. AWT issues those activations with a zero _NET_WM_USER_TIME, which
+                // resets the app's user-activity association so GNOME/Mutter then treats the
+                // NEXT dialog as a focus-steal and opens it behind with a "ready" notice.
+                // Each open is user-initiated (the click), so Mutter raises it on its own.
                 dialog.isVisible = true // blocks the EDT until the native dialog closes
-
-                // Gently re-assert the app window after the dialog closes. Toggling the app
-                // window's always-on-top here was forceful enough to make GNOME/Mutter flag
-                // the NEXT dialog as a focus-steal (it then opened behind with a "ready"
-                // notification), so keep it to a plain toFront + requestFocus.
-                owner?.let { w ->
-                    SwingUtilities.invokeLater {
-                        w.toFront()
-                        w.requestFocus()
-                    }
-                }
 
                 val name = dialog.file ?: return@invokeLater // cancelled
                 val dir = dialog.directory ?: return@invokeLater

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -57,10 +57,12 @@ actual fun rememberMediaPickerLauncher(
     return remember {
         MediaPickerLauncher {
             SwingUtilities.invokeLater {
+                // The dialog owner is what focus should return to on close. activeWindow is
+                // usually the Compose window; fall back to the first showing app frame so we
+                // never pass null (a null owner lets the WM hand focus to a background window).
                 val owner =
-                    KeyboardFocusManager
-                        .getCurrentKeyboardFocusManager()
-                        .activeWindow as? Frame
+                    (KeyboardFocusManager.getCurrentKeyboardFocusManager().activeWindow as? Frame)
+                        ?: Frame.getFrames().firstOrNull { it.isShowing && it.isFocusableWindow }
 
                 val dialog =
                     FileDialog(owner, "Select File", FileDialog.LOAD).apply {
@@ -74,6 +76,19 @@ actual fun rememberMediaPickerLauncher(
                     }
 
                 dialog.isVisible = true // blocks the EDT until the native dialog closes
+
+                // Some Linux WMs hand focus to the launching terminal (or another background
+                // window) after a native dialog closes. Re-assert the app window: toFront +
+                // requestFocus alone is often dropped, so a brief always-on-top toggle forces
+                // the WM to raise and refocus it. Posted after the dialog teardown.
+                owner?.let { w ->
+                    SwingUtilities.invokeLater {
+                        w.toFront()
+                        w.requestFocus()
+                        w.isAlwaysOnTop = true
+                        w.isAlwaysOnTop = false
+                    }
+                }
 
                 val name = dialog.file ?: return@invokeLater // cancelled
                 val dir = dialog.directory ?: return@invokeLater

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -67,6 +67,11 @@ actual fun rememberMediaPickerLauncher(
                 val dialog =
                     FileDialog(owner, "Select File", FileDialog.LOAD).apply {
                         isMultipleMode = false
+                        // Always-on-top so the picker opens in front of the app even right
+                        // after a previous pick (the focus-restore toggle below briefly
+                        // raises the app window, which otherwise let the next dialog open
+                        // behind it).
+                        isAlwaysOnTop = true
                         // Honored by the GTK chooser; ignored on some platforms, where the
                         // post-selection extension check below enforces the same rule.
                         filenameFilter =

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -174,7 +174,15 @@ actual fun rememberMediaPickerLauncher(
                     }
                 } finally {
                     anchor.dispose()
-                    appWindow?.requestFocus()
+                    // Return input focus to the Compose window after the modal + anchor
+                    // are fully torn down. A synchronous requestFocus() here is often
+                    // dropped by Linux window managers (focus stays on the file manager),
+                    // so re-post on the EDT and raise the window with toFront() once the
+                    // teardown has been processed.
+                    SwingUtilities.invokeLater {
+                        appWindow?.toFront()
+                        appWindow?.requestFocus()
+                    }
                 }
             }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -82,16 +82,14 @@ actual fun rememberMediaPickerLauncher(
 
                 dialog.isVisible = true // blocks the EDT until the native dialog closes
 
-                // Some Linux WMs hand focus to the launching terminal (or another background
-                // window) after a native dialog closes. Re-assert the app window: toFront +
-                // requestFocus alone is often dropped, so a brief always-on-top toggle forces
-                // the WM to raise and refocus it. Posted after the dialog teardown.
+                // Gently re-assert the app window after the dialog closes. Toggling the app
+                // window's always-on-top here was forceful enough to make GNOME/Mutter flag
+                // the NEXT dialog as a focus-steal (it then opened behind with a "ready"
+                // notification), so keep it to a plain toFront + requestFocus.
                 owner?.let { w ->
                     SwingUtilities.invokeLater {
                         w.toFront()
                         w.requestFocus()
-                        w.isAlwaysOnTop = true
-                        w.isAlwaysOnTop = false
                     }
                 }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/network/upload/MediaPickerLauncher.jvm.kt
@@ -4,21 +4,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.awt.Dialog
+import java.awt.FileDialog
+import java.awt.Frame
 import java.awt.KeyboardFocusManager
-import java.awt.Rectangle
-import java.awt.Toolkit
-import java.awt.Window
-import javax.swing.JDialog
-import javax.swing.JFileChooser
-import javax.swing.JFrame
+import java.io.File
+import java.io.FilenameFilter
 import javax.swing.SwingUtilities
-import javax.swing.UIManager
-import javax.swing.filechooser.FileNameExtensionFilter
 
 actual class MediaPickerLauncher(
     private val doLaunch: () -> Unit,
@@ -32,12 +26,12 @@ private val ALL_EXTENSIONS = IMAGE_EXTENSIONS + arrayOf("mp4", "mov", "webm") + 
 private val ALL_EXTENSIONS_SET = ALL_EXTENSIONS.toSet()
 private val IMAGE_EXTENSIONS_SET = IMAGE_EXTENSIONS.toSet()
 
-// UIManager is global state — apply system L&F only once.
-private var systemLafApplied = false
-
 /**
- * Uses JFileChooser inside a JDialog(APPLICATION_MODAL) so the JVM's EDT blocks
- * input to all other app windows, preventing z-order issues on Linux.
+ * Uses the native [FileDialog] (GTK file chooser on Linux) owned by the Compose window.
+ * The OS manages the dialog, so it can't fall behind the app and focus returns to the
+ * owner window on close — unlike a Swing JFileChooser in a throwaway JDialog, which left
+ * focus on a background window on some Linux WMs. Extension filtering is best-effort via
+ * FilenameFilter; the selection is validated again after the dialog closes.
  */
 @Composable
 actual fun rememberMediaPickerLauncher(
@@ -55,144 +49,51 @@ actual fun rememberMediaPickerLauncher(
     val currentOnPickStart = rememberUpdatedState(onPickStart)
     val currentOnError = rememberUpdatedState(onError)
     val currentOnFilePicked = rememberUpdatedState(onFilePicked)
+    val allowedSet =
+        when (accept) {
+            MediaAccept.Images -> IMAGE_EXTENSIONS_SET
+            MediaAccept.ImagesVideosAudio -> ALL_EXTENSIONS_SET
+        }
     return remember {
         MediaPickerLauncher {
-            val deferred = CompletableDeferred<Pair<ByteArray, String>?>()
-
             SwingUtilities.invokeLater {
-                if (!systemLafApplied) {
-                    runCatching { UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName()) }
-                    systemLafApplied = true
-                }
-
-                val appWindow: Window? =
+                val owner =
                     KeyboardFocusManager
                         .getCurrentKeyboardFocusManager()
-                        .activeWindow
+                        .activeWindow as? Frame
 
-                val appBounds: Rectangle =
-                    appWindow?.bounds
-                        ?: Toolkit
-                            .getDefaultToolkit()
-                            .screenSize
-                            .let { Rectangle(0, 0, it.width, it.height) }
-
-                val monitorBounds: Rectangle =
-                    appWindow
-                        ?.graphicsConfiguration
-                        ?.bounds
-                        ?: appBounds
-
-                val anchor =
-                    JFrame().apply {
-                        isUndecorated = true
-                        isAlwaysOnTop = true
-                        setSize(1, 1)
-                        setLocation(
-                            appBounds.x + appBounds.width / 2,
-                            appBounds.y + appBounds.height / 2,
-                        )
-                        isVisible = true
-                    }
-
-                val (filterDesc, extensions, allowedSet) =
-                    when (accept) {
-                        MediaAccept.Images ->
-                            Triple("Images (jpg, png, gif, webp, avif)", IMAGE_EXTENSIONS, IMAGE_EXTENSIONS_SET)
-                        MediaAccept.ImagesVideosAudio ->
-                            Triple(
-                                "Images, Videos & Audio (jpg, png, gif, webp, avif, mp4, mov, webm, mp3, ogg, wav, flac, m4a, aac, opus)",
-                                ALL_EXTENSIONS,
-                                ALL_EXTENSIONS_SET,
-                            )
-                    }
-
-                val chooser =
-                    JFileChooser().apply {
-                        dialogTitle = "Select File"
-                        fileFilter = FileNameExtensionFilter(filterDesc, *extensions)
-                        isMultiSelectionEnabled = false
-                        fileSelectionMode = JFileChooser.FILES_ONLY
-                    }
-
-                val pickerDialog =
-                    JDialog(
-                        anchor,
-                        "Select File",
-                        Dialog.ModalityType.APPLICATION_MODAL,
-                    ).apply {
-                        isAlwaysOnTop = true
-                        defaultCloseOperation = JDialog.DISPOSE_ON_CLOSE
-                        contentPane.add(chooser)
-                        pack()
-
-                        val dw = width
-                        val dh = height
-                        var dx = appBounds.x + (appBounds.width - dw) / 2
-                        var dy = appBounds.y + (appBounds.height - dh) / 2
-                        dx =
-                            dx.coerceIn(
-                                monitorBounds.x,
-                                monitorBounds.x + (monitorBounds.width - dw).coerceAtLeast(0),
-                            )
-                        dy =
-                            dy.coerceIn(
-                                monitorBounds.y,
-                                monitorBounds.y + (monitorBounds.height - dh).coerceAtLeast(0),
-                            )
-                        setLocation(dx, dy)
-                    }
-
-                chooser.addActionListener { e ->
-                    when (e.actionCommand) {
-                        JFileChooser.APPROVE_SELECTION,
-                        JFileChooser.CANCEL_SELECTION,
-                        -> pickerDialog.dispose()
-                    }
-                }
-
-                try {
-                    pickerDialog.isVisible = true // blocks EDT until dialog is disposed
-
-                    val selected = chooser.selectedFile
-                    if (selected != null && selected.extension.lowercase() in allowedSet) {
-                        scope.launch { currentOnPickStart.value() }
-                        if (selected.length() > MAX_UPLOAD_BYTES) {
-                            deferred.complete(null)
-                            scope.launch { currentOnError.value("File is too large. The maximum upload size is 20 MB.") }
-                        } else {
-                            scope.launch(Dispatchers.IO) {
-                                deferred.complete(selected.readBytes() to selected.name)
+                val dialog =
+                    FileDialog(owner, "Select File", FileDialog.LOAD).apply {
+                        isMultipleMode = false
+                        // Honored by the GTK chooser; ignored on some platforms, where the
+                        // post-selection extension check below enforces the same rule.
+                        filenameFilter =
+                            FilenameFilter { _, name ->
+                                name.substringAfterLast('.', "").lowercase() in allowedSet
                             }
-                        }
-                    } else {
-                        deferred.complete(null)
-                        if (selected != null) {
-                            val ext = selected.extension.ifEmpty { "unknown" }
-                            scope.launch { currentOnError.value("\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE") }
-                        }
                     }
-                } finally {
-                    anchor.dispose()
-                    // Return input focus to the Compose window after the modal + anchor
-                    // are fully torn down. A synchronous requestFocus() here is often
-                    // dropped by Linux window managers (focus stays on the file manager),
-                    // so re-post on the EDT and raise the window with toFront() once the
-                    // teardown has been processed.
-                    SwingUtilities.invokeLater {
-                        appWindow?.toFront()
-                        appWindow?.requestFocus()
-                    }
-                }
-            }
 
-            scope.launch {
-                try {
-                    val result = deferred.await()
-                    if (result != null) {
-                        withContext(Dispatchers.Main) { currentOnFilePicked.value(result.first, result.second) }
+                dialog.isVisible = true // blocks the EDT until the native dialog closes
+
+                val name = dialog.file ?: return@invokeLater // cancelled
+                val dir = dialog.directory ?: return@invokeLater
+                val file = File(dir, name)
+                val ext = file.extension.lowercase()
+
+                when {
+                    ext !in allowedSet ->
+                        currentOnError.value(
+                            "\".${ext.ifEmpty { "unknown" }}\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE",
+                        )
+                    file.length() > MAX_UPLOAD_BYTES ->
+                        currentOnError.value("File is too large. The maximum upload size is 20 MB.")
+                    else -> {
+                        currentOnPickStart.value()
+                        scope.launch(Dispatchers.IO) {
+                            val bytes = file.readBytes()
+                            withContext(Dispatchers.Main) { currentOnFilePicked.value(bytes, file.name) }
+                        }
                     }
-                } catch (_: Throwable) {
                 }
             }
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
@@ -33,10 +33,14 @@ import org.nostr.nostrord.utils.Result
 fun MessageUploadButton(
     onUploadComplete: (UploadResult) -> Unit,
     modifier: Modifier = Modifier,
+    // Upload owned by the caller (paste / drag-and-drop) that doesn't go through
+    // this button's picker. When true, the spinner shows here on the attach icon.
+    externalBusy: Boolean = false,
 ) {
     val scope = rememberCoroutineScope()
     var isUploading by remember { mutableStateOf(false) }
     var uploadError by remember { mutableStateOf<String?>(null) }
+    val busy = isUploading || externalBusy
 
     val picker =
         rememberMediaPickerLauncher(
@@ -83,13 +87,13 @@ fun MessageUploadButton(
 
     IconButton(
         onClick = { picker.launch() },
-        enabled = !isUploading,
+        enabled = !busy,
         modifier =
         modifier
             .size(40.dp)
             .pointerHoverIcon(PointerIcon.Hand),
     ) {
-        if (isUploading) {
+        if (busy) {
             CircularProgressIndicator(
                 modifier = Modifier.size(20.dp),
                 color = NostrordColors.Primary,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui.components.upload
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
@@ -45,6 +46,7 @@ fun MessageUploadButton(
     val busy = isUploading || externalBusy
     val interaction = remember { MutableInteractionSource() }
     val isHovered by interaction.collectIsHoveredAsState()
+    val isPressed by interaction.collectIsPressedAsState()
 
     val picker =
         rememberMediaPickerLauncher(
@@ -108,8 +110,13 @@ fun MessageUploadButton(
             Icon(
                 imageVector = Icons.Default.AttachFile,
                 contentDescription = "Attach image",
-                // Hover brightens to TextContent (web .composer-btn:hover).
-                tint = if (isHovered) NostrordColors.TextContent else NostrordColors.TextMuted,
+                // Press shows white (tap feedback on Android, which has no hover);
+                // hover brightens to TextContent (web .composer-btn:hover).
+                tint = when {
+                    isPressed -> NostrordColors.TextPrimary
+                    isHovered -> NostrordColors.TextContent
+                    else -> NostrordColors.TextMuted
+                },
                 modifier = Modifier.size(20.dp),
             )
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
@@ -1,5 +1,7 @@
 package org.nostr.nostrord.ui.components.upload
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachFile
@@ -41,6 +43,8 @@ fun MessageUploadButton(
     var isUploading by remember { mutableStateOf(false) }
     var uploadError by remember { mutableStateOf<String?>(null) }
     val busy = isUploading || externalBusy
+    val interaction = remember { MutableInteractionSource() }
+    val isHovered by interaction.collectIsHoveredAsState()
 
     val picker =
         rememberMediaPickerLauncher(
@@ -88,6 +92,7 @@ fun MessageUploadButton(
     IconButton(
         onClick = { picker.launch() },
         enabled = !busy,
+        interactionSource = interaction,
         modifier =
         modifier
             .size(32.dp)
@@ -103,7 +108,8 @@ fun MessageUploadButton(
             Icon(
                 imageVector = Icons.Default.AttachFile,
                 contentDescription = "Attach image",
-                tint = NostrordColors.TextMuted,
+                // Hover brightens to TextContent (web .composer-btn:hover).
+                tint = if (isHovered) NostrordColors.TextContent else NostrordColors.TextMuted,
                 modifier = Modifier.size(20.dp),
             )
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
@@ -90,7 +90,7 @@ fun MessageUploadButton(
         enabled = !busy,
         modifier =
         modifier
-            .size(40.dp)
+            .size(32.dp)
             .pointerHoverIcon(PointerIcon.Hand),
     ) {
         if (busy) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -197,6 +197,7 @@ fun GroupScreenDesktop(
                     pendingReactions = pendingReactions,
                     currentUserPubkey = currentUserPubkey,
                     isJoined = isJoined,
+                    isReplying = replyingToMessage != null,
                     isInitialLoading = isInitialLoading,
                     isPendingApproval = isPendingApproval,
                     isGroupRestricted = isGroupRestricted,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -249,6 +249,7 @@ fun GroupScreenMobile(
                             pendingReactions = pendingReactions,
                             currentUserPubkey = currentUserPubkey,
                             isJoined = isJoined,
+                            isReplying = replyingToMessage != null,
                             isInitialLoading = isInitialLoading,
                             isPendingApproval = isPendingApproval,
                             isGroupRestricted = isGroupRestricted,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.selection.TextSelectionColors
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Close
@@ -20,6 +20,7 @@ import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
@@ -523,7 +524,7 @@ fun MessageInput(
                         },
                     )
 
-                    TextField(
+                    BasicTextField(
                         value = textFieldValue,
                         onValueChange = { handleTextFieldValueChange(it) },
                         // Typing is locked while a send is in flight inside
@@ -532,16 +533,9 @@ fun MessageInput(
                         // behaves inconsistently across platforms. The handler is
                         // the single source of truth for the in-flight lock.
                         interactionSource = textFieldInteractionSource,
-                        placeholder = {
-                            Text(
-                                "Message ${groupName ?: selectedChannel}",
-                                style = NostrordTypography.InputPlaceholder,
-                                color = NostrordColors.TextMuted,
-                            )
-                        },
+                        cursorBrush = SolidColor(Color.White),
                         modifier = Modifier
                             .weight(1f)
-                            .clip(NostrordShapes.inputShape)
                             .focusRequester(focusRequester)
                             .onFocusChanged { focusState ->
                                 // On Android the focus transiently drops while the IME
@@ -688,28 +682,29 @@ fun MessageInput(
                                     else -> false
                                 }
                             },
-                        colors = TextFieldDefaults.colors(
-                            // Transparent so the input blends into the single composer
-                            // pill (web parity), instead of a separate inner input box.
-                            focusedContainerColor = Color.Transparent,
-                            unfocusedContainerColor = Color.Transparent,
-                            focusedTextColor = Color.White,
-                            unfocusedTextColor = Color.White,
-                            cursorColor = Color.White,
-                            selectionColors = TextSelectionColors(
-                                handleColor = Color.White,
-                                backgroundColor = Color.White.copy(alpha = 0.3f),
-                            ),
-                            focusedPlaceholderColor = NostrordColors.TextMuted,
-                            unfocusedPlaceholderColor = NostrordColors.TextMuted,
-                            focusedIndicatorColor = Color.Transparent,
-                            unfocusedIndicatorColor = Color.Transparent,
-                        ),
-                        textStyle = NostrordTypography.Input,
-                        shape = NostrordShapes.inputShape,
+                        textStyle = NostrordTypography.Input.copy(color = Color.White),
                         singleLine = false,
                         maxLines = 4,
                         visualTransformation = mentionVisualTransformation,
+                        decorationBox = { innerTextField ->
+                            // BasicTextField has no built-in placeholder/container; show
+                            // the placeholder when empty and let the small vertical padding
+                            // drive a compact one-line height (web parity) instead of the
+                            // Material TextField's fixed ~56dp minimum.
+                            Box(
+                                contentAlignment = Alignment.CenterStart,
+                                modifier = Modifier.padding(vertical = 4.dp),
+                            ) {
+                                if (textFieldValue.text.isEmpty()) {
+                                    Text(
+                                        "Message ${groupName ?: selectedChannel}",
+                                        style = NostrordTypography.InputPlaceholder,
+                                        color = NostrordColors.TextMuted,
+                                    )
+                                }
+                                innerTextField()
+                            }
+                        },
                     )
 
                     if (showEmojiButton) {
@@ -718,7 +713,7 @@ fun MessageInput(
                                 showEmojiPicker = !showEmojiPicker
                                 if (showEmojiPicker) showMentionPopup = false
                             },
-                            modifier = Modifier.size(40.dp),
+                            modifier = Modifier.size(32.dp),
                         ) {
                             Icon(
                                 Icons.Outlined.EmojiEmotions,
@@ -738,7 +733,7 @@ fun MessageInput(
                         // Disabled while a paste upload finishes (its URL must land in
                         // the draft first), but the spinner now shows on the attach icon.
                         enabled = textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste,
-                        modifier = Modifier.size(40.dp),
+                        modifier = Modifier.size(32.dp),
                     ) {
                         if (isSending) {
                             CircularProgressIndicator(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -506,6 +506,7 @@ fun MessageInput(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     MessageUploadButton(
+                        externalBusy = isUploadingPaste,
                         onUploadComplete = { uploadResult ->
                             val url = uploadResult.url
                             val current = textFieldValue.text
@@ -726,10 +727,12 @@ fun MessageInput(
 
                     IconButton(
                         onClick = { submit() },
+                        // Disabled while a paste upload finishes (its URL must land in
+                        // the draft first), but the spinner now shows on the attach icon.
                         enabled = textFieldValue.text.isNotBlank() && !isSending && !isUploadingPaste,
                         modifier = Modifier.size(40.dp),
                     ) {
-                        if (isSending || isUploadingPaste) {
+                        if (isSending) {
                             CircularProgressIndicator(
                                 modifier = Modifier.size(Spacing.iconMd),
                                 color = NostrordColors.Primary,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -577,6 +577,13 @@ fun MessageInput(
                                         groupMentionQuery = ""
                                         true
                                     }
+                                    // Esc exits reply mode once no popup/picker is open (desktop).
+                                    event.type == KeyEventType.KeyDown &&
+                                        event.key == Key.Escape &&
+                                        replyingToMessage != null -> {
+                                        onCancelReply()
+                                        true
+                                    }
                                     event.type == KeyEventType.KeyDown &&
                                         event.key == Key.DirectionUp &&
                                         showMentionPopup &&

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -510,6 +510,7 @@ fun MessageInput(
                         .clip(NostrordShapes.inputShape)
                         .background(NostrordColors.SurfaceVariant)
                         .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     MessageUploadButton(
@@ -723,7 +724,7 @@ fun MessageInput(
                                 } else {
                                     NostrordColors.TextMuted
                                 },
-                                modifier = Modifier.size(Spacing.iconMd),
+                                modifier = Modifier.size(20.dp),
                             )
                         }
                     }
@@ -737,7 +738,7 @@ fun MessageInput(
                     ) {
                         if (isSending) {
                             CircularProgressIndicator(
-                                modifier = Modifier.size(Spacing.iconMd),
+                                modifier = Modifier.size(20.dp),
                                 color = NostrordColors.Primary,
                                 strokeWidth = 2.dp,
                             )
@@ -750,7 +751,7 @@ fun MessageInput(
                                 } else {
                                     NostrordColors.TextMuted
                                 },
-                                modifier = Modifier.size(Spacing.iconMd),
+                                modifier = Modifier.size(20.dp),
                             )
                         }
                     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.ui.screens.group.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
@@ -22,6 +23,8 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.*
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -709,20 +712,26 @@ fun MessageInput(
                     )
 
                     if (showEmojiButton) {
+                        val emojiInteraction = remember { MutableInteractionSource() }
+                        val emojiHovered by emojiInteraction.collectIsHoveredAsState()
                         IconButton(
                             onClick = {
                                 showEmojiPicker = !showEmojiPicker
                                 if (showEmojiPicker) showMentionPopup = false
                             },
-                            modifier = Modifier.size(32.dp),
+                            interactionSource = emojiInteraction,
+                            modifier = Modifier
+                                .size(32.dp)
+                                .pointerHoverIcon(PointerIcon.Hand),
                         ) {
                             Icon(
                                 Icons.Outlined.EmojiEmotions,
                                 contentDescription = "Emoji picker",
-                                tint = if (showEmojiPicker) {
-                                    NostrordColors.Primary
-                                } else {
-                                    NostrordColors.TextMuted
+                                // Hover brightens to TextContent (web .composer-btn:hover).
+                                tint = when {
+                                    showEmojiPicker -> NostrordColors.Primary
+                                    emojiHovered -> NostrordColors.TextContent
+                                    else -> NostrordColors.TextMuted
                                 },
                                 modifier = Modifier.size(20.dp),
                             )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -496,13 +496,19 @@ fun MessageInput(
             }
 
             Box(
-                modifier = Modifier.fillMaxWidth(),
+                // Inset the composer from the window edges and round it into a single
+                // surface "pill" (web .composer parity: margin 0 16px 16px, radius 8px).
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = Spacing.lg)
+                    .padding(bottom = Spacing.lg),
             ) {
                 Row(
                     modifier = Modifier
                         .fillMaxWidth()
+                        .clip(NostrordShapes.inputShape)
                         .background(NostrordColors.SurfaceVariant)
-                        .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+                        .padding(horizontal = Spacing.md, vertical = Spacing.sm),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     MessageUploadButton(
@@ -683,8 +689,10 @@ fun MessageInput(
                                 }
                             },
                         colors = TextFieldDefaults.colors(
-                            focusedContainerColor = NostrordColors.InputBackground,
-                            unfocusedContainerColor = NostrordColors.InputBackground,
+                            // Transparent so the input blends into the single composer
+                            // pill (web parity), instead of a separate inner input box.
+                            focusedContainerColor = Color.Transparent,
+                            unfocusedContainerColor = Color.Transparent,
                             focusedTextColor = Color.White,
                             unfocusedTextColor = Color.White,
                             cursorColor = Color.White,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -267,17 +267,27 @@ fun MessagesList(
         internalScrollTarget = null
     }
 
-    // Entering reply mode grows the composer with the reply bar; if the feed was
-    // pinned at the bottom, re-scroll so the replied-to last message stays visible
-    // instead of sliding behind the bar (web parity).
+    // Whether the feed is pinned at the bottom, tracked continuously and ignoring transient
+    // empty layouts (during recomposition layoutInfo can be momentarily empty). Reading
+    // layoutInfo at the instant reply mode toggles was racy — an empty read skipped the
+    // re-pin and let the bar hide the last message. This holds the last known-good state.
+    val pinnedAtBottom = remember { mutableStateOf(true) }
+    LaunchedEffect(listState) {
+        snapshotFlow {
+            val info = listState.layoutInfo
+            val last = info.visibleItemsInfo.lastOrNull()?.index
+            val total = info.totalItemsCount
+            if (last == null || total == 0) null else last >= total - 2
+        }.collect { atBottom -> if (atBottom != null) pinnedAtBottom.value = atBottom }
+    }
+
+    // Entering reply mode grows the composer with the reply bar; if the feed was pinned at
+    // the bottom, re-scroll so the replied-to last message stays visible instead of sliding
+    // behind the bar (web parity). Uses the tracked flag, not a one-shot layoutInfo read.
     LaunchedEffect(isReplying) {
-        if (!isReplying) return@LaunchedEffect
-        val layoutInfo = listState.layoutInfo
-        val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
-        val total = layoutInfo.totalItemsCount
-        if (total > 0 && lastVisible >= total - 2) {
-            listState.animateScrollToItem(total - 1)
-        }
+        if (!isReplying || !pinnedAtBottom.value) return@LaunchedEffect
+        val total = listState.layoutInfo.totalItemsCount
+        if (total > 0) listState.animateScrollToItem(total - 1)
     }
 
     // hasMoreMessages and isLoadingMore are keys so the effect re-fires on the

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -98,6 +98,9 @@ fun MessagesList(
     isInitialLoading: Boolean = false,
     isPendingApproval: Boolean = false,
     isGroupRestricted: Boolean = false,
+    // True while the composer is in reply mode; entering it re-pins the feed to the
+    // bottom so the reply bar doesn't hide the last message.
+    isReplying: Boolean = false,
     isLoadingMore: Boolean = false,
     hasMoreMessages: Boolean = true,
     onLoadMore: () -> Unit = {},
@@ -262,6 +265,19 @@ fun MessagesList(
             listState.animateScrollToItem(idx)
         }
         internalScrollTarget = null
+    }
+
+    // Entering reply mode grows the composer with the reply bar; if the feed was
+    // pinned at the bottom, re-scroll so the replied-to last message stays visible
+    // instead of sliding behind the bar (web parity).
+    LaunchedEffect(isReplying) {
+        if (!isReplying) return@LaunchedEffect
+        val layoutInfo = listState.layoutInfo
+        val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+        val total = layoutInfo.totalItemsCount
+        if (total > 0 && lastVisible >= total - 2) {
+            listState.animateScrollToItem(total - 1)
+        }
     }
 
     // hasMoreMessages and isLoadingMore are keys so the effect re-fires on the

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
@@ -36,6 +36,13 @@ external interface UploadButtonProps : Props {
 
     /** Idle icon shown when not uploading. */
     var icon: Ic
+
+    /**
+     * Optional external busy flag. When the caller owns an upload that does not go
+     * through this button's file input (paste / drag-and-drop), set this true so the
+     * spinner shows here on the attach icon instead of elsewhere.
+     */
+    var busy: Boolean?
 }
 
 /**
@@ -47,7 +54,10 @@ external interface UploadButtonProps : Props {
  */
 val UploadButton =
     FC<UploadButtonProps> { props ->
-        val (busy, setBusy) = useState { false }
+        val (picking, setPicking) = useState { false }
+        // Either an in-progress file pick (owned here) or a paste/drop upload the
+        // caller signals via props.busy shows the spinner on this attach icon.
+        val busy = picking || (props.busy == true)
 
         label {
             className = ClassName(props.cls)
@@ -66,7 +76,7 @@ val UploadButton =
                     val fileList = target.asDynamic().files
                     val f = if (fileList != null && (fileList.length as Int) > 0) fileList[0] else null
                     if (f != null) {
-                        setBusy(true)
+                        setPicking(true)
                         launchApp {
                             try {
                                 when (val r = uploadBlob(f)) {
@@ -74,7 +84,7 @@ val UploadButton =
                                     is Result.Error -> props.onError(r.error.message)
                                 }
                             } finally {
-                                setBusy(false)
+                                setPicking(false)
                                 target.asDynamic().value = ""
                             }
                         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
@@ -43,6 +43,19 @@ external interface UploadButtonProps : Props {
      * spinner shows here on the attach icon instead of elsewhere.
      */
     var busy: Boolean?
+
+    /**
+     * Optional callback fired with true when a file-pick upload starts and false when it
+     * settles. Lets the caller block its send button while a picked file is uploading (the
+     * picked URL hasn't landed in the draft yet) — paste/drop already do this via uploadCount.
+     */
+    var onBusyChange: ((Boolean) -> Unit)?
+
+    /**
+     * Restrict to still images only (avatars / banners / group pictures), matching native's
+     * MediaAccept.Images. Defaults to the full image/video/audio set used by the composer.
+     */
+    var imagesOnly: Boolean?
 }
 
 /**
@@ -69,7 +82,7 @@ val UploadButton =
             input {
                 className = ClassName("upload-file-input")
                 type = InputType.file
-                accept = "image/*,video/*,audio/*"
+                accept = if (props.imagesOnly == true) "image/*" else "image/*,video/*,audio/*"
                 disabled = busy
                 onChange = { event ->
                     val target = event.currentTarget
@@ -77,14 +90,16 @@ val UploadButton =
                     val f = if (fileList != null && (fileList.length as Int) > 0) fileList[0] else null
                     if (f != null) {
                         setPicking(true)
+                        props.onBusyChange?.invoke(true)
                         launchApp {
                             try {
-                                when (val r = uploadBlob(f)) {
+                                when (val r = uploadBlob(f, props.imagesOnly == true)) {
                                     is Result.Success -> props.onUploaded(r.data)
                                     is Result.Error -> props.onError(r.error.message)
                                 }
                             } finally {
                                 setPicking(false)
+                                props.onBusyChange?.invoke(false)
                                 target.asDynamic().value = ""
                             }
                         }
@@ -101,7 +116,7 @@ val UploadButton =
  * [UploadResult] (URL + NIP-68 metadata) so callers can build imeta tags, or a
  * [Result.Error] to surface. Reusable by the file picker and Ctrl+V paste / drag-and-drop.
  */
-suspend fun uploadBlob(file: dynamic): Result<UploadResult> {
+suspend fun uploadBlob(file: dynamic, imagesOnly: Boolean = false): Result<UploadResult> {
     val name = (file.name.unsafeCast<String?>())?.takeIf { it.isNotBlank() } ?: "file"
     val size = (file.size.unsafeCast<Double?>())?.toLong() ?: 0L
     if (size > MAX_UPLOAD_BYTES) {
@@ -116,9 +131,17 @@ suspend fun uploadBlob(file: dynamic): Result<UploadResult> {
         } else {
             (file.type.unsafeCast<String?>())?.takeIf { it.isNotBlank() } ?: "application/octet-stream"
         }
-    if (!isSupportedUploadMime(mime)) {
+    // imagesOnly callers (avatars / banners) accept still images only, matching native.
+    val supported = isSupportedUploadMime(mime) && (!imagesOnly || mime.startsWith("image/"))
+    if (!supported) {
         val ext = name.substringAfterLast('.', "").ifEmpty { "unknown" }
-        return Result.Error(AppError.Unknown("\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE"))
+        val message =
+            if (imagesOnly) {
+                "\".$ext\" files are not supported.\nChoose an image: jpg, png, gif, webp, avif."
+            } else {
+                "\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE"
+            }
+        return Result.Error(AppError.Unknown(message))
     }
     val bytes = readFileBytes(file)
     if (bytes.isEmpty()) return Result.Error(AppError.Unknown("Could not read the selected file."))

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
@@ -16,6 +16,7 @@ import react.FC
 import react.Props
 import react.dom.html.ReactHTML.input
 import react.dom.html.ReactHTML.label
+import react.dom.html.ReactHTML.span
 import react.useState
 import web.cssom.ClassName
 import web.html.InputType
@@ -50,7 +51,11 @@ val UploadButton =
 
         label {
             className = ClassName(props.cls)
-            if (busy) +"…" else icon(props.icon)
+            if (busy) {
+                span { className = ClassName("upload-spinner") }
+            } else {
+                icon(props.icon)
+            }
             input {
                 className = ClassName("upload-file-input")
                 type = InputType.file

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
@@ -4,7 +4,12 @@ import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.get
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.upload.MAX_UPLOAD_BYTES
 import org.nostr.nostrord.network.upload.NostrBuildUploader
+import org.nostr.nostrord.network.upload.SUPPORTED_FORMATS_MESSAGE
+import org.nostr.nostrord.network.upload.UploadResult
+import org.nostr.nostrord.network.upload.isSupportedUploadMime
+import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.web.bridge.launchApp
 import react.FC
@@ -19,8 +24,11 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
 external interface UploadButtonProps : Props {
-    /** Called with the uploaded media URL on success. */
-    var onUploaded: (String) -> Unit
+    /** Called with the upload result (URL + NIP-68 metadata) on success. */
+    var onUploaded: (UploadResult) -> Unit
+
+    /** Called with a user-facing message when validation or the upload fails. */
+    var onError: (String) -> Unit
 
     /** Class for the clickable label (e.g. "composer-btn" / "upload-btn"). */
     var cls: String
@@ -30,9 +38,11 @@ external interface UploadButtonProps : Props {
 }
 
 /**
- * Upload button — a styled `<label>` wrapping a hidden file input. On pick it reads the
- * file bytes and uploads to nostr.build (NIP-98 auth via the repository), then hands back
- * the resulting URL. Shows "…" while in flight.
+ * Upload button — a styled `<label>` wrapping a hidden file input. On pick it validates
+ * and reads the file bytes, uploads to nostr.build (NIP-98 auth via the repository), then
+ * hands back the full result. Shows "…" while in flight. Failures (too large, unsupported
+ * format, auth/server/network) are reported via [UploadButtonProps.onError] instead of
+ * being swallowed silently, matching the native picker.
  */
 val UploadButton =
     FC<UploadButtonProps> { props ->
@@ -44,7 +54,7 @@ val UploadButton =
             input {
                 className = ClassName("upload-file-input")
                 type = InputType.file
-                accept = "image/*"
+                accept = "image/*,video/*,audio/*"
                 disabled = busy
                 onChange = { event ->
                     val target = event.currentTarget
@@ -54,8 +64,10 @@ val UploadButton =
                         setBusy(true)
                         launchApp {
                             try {
-                                val url = uploadBlob(f)
-                                if (url != null) props.onUploaded(url)
+                                when (val r = uploadBlob(f)) {
+                                    is Result.Success -> props.onUploaded(r.data)
+                                    is Result.Error -> props.onError(r.error.message)
+                                }
                             } finally {
                                 setBusy(false)
                                 target.asDynamic().value = ""
@@ -68,22 +80,39 @@ val UploadButton =
     }
 
 /**
- * Upload a picked/pasted File (or Blob) to nostr.build (NIP-98 auth via the repository).
- * Returns the media URL, or null on failure. Reusable by the file picker and Ctrl+V paste.
+ * Validate and upload a picked/pasted File (or Blob) to nostr.build (NIP-98 auth via the
+ * repository). Mirrors the native picker's checks: the 20 MB cap and the supported
+ * image/video/audio formats, with the same user-facing messages. Returns the full
+ * [UploadResult] (URL + NIP-68 metadata) so callers can build imeta tags, or a
+ * [Result.Error] to surface. Reusable by the file picker and Ctrl+V paste / drag-and-drop.
  */
-suspend fun uploadBlob(file: dynamic): String? {
+suspend fun uploadBlob(file: dynamic): Result<UploadResult> {
+    val name = (file.name.unsafeCast<String?>())?.takeIf { it.isNotBlank() } ?: "file"
+    val size = (file.size.unsafeCast<Double?>())?.toLong() ?: 0L
+    if (size > MAX_UPLOAD_BYTES) {
+        return Result.Error(AppError.Unknown("File is too large. The maximum upload size is 20 MB."))
+    }
+    // Prefer the extension-derived mime (parity with native); fall back to the
+    // browser-provided type for pasted blobs that arrive without a real filename.
+    val byName = NostrBuildUploader.mimeTypeForFilename(name)
+    val mime =
+        if (byName != "application/octet-stream") {
+            byName
+        } else {
+            (file.type.unsafeCast<String?>())?.takeIf { it.isNotBlank() } ?: "application/octet-stream"
+        }
+    if (!isSupportedUploadMime(mime)) {
+        val ext = name.substringAfterLast('.', "").ifEmpty { "unknown" }
+        return Result.Error(AppError.Unknown("\".$ext\" files are not supported.\n\n$SUPPORTED_FORMATS_MESSAGE"))
+    }
     val bytes = readFileBytes(file)
-    if (bytes.isEmpty()) return null
-    val mime = (file.type.unsafeCast<String?>())?.takeIf { it.isNotBlank() } ?: "image/jpeg"
-    val name = (file.name.unsafeCast<String?>())?.takeIf { it.isNotBlank() } ?: "image"
-    val result =
-        NostrBuildUploader.upload(
-            bytes,
-            name,
-            mime,
-            AppModule.nostrRepository::buildNip98AuthHeader,
-        )
-    return if (result is Result.Success) result.data.url else null
+    if (bytes.isEmpty()) return Result.Error(AppError.Unknown("Could not read the selected file."))
+    return NostrBuildUploader.upload(
+        bytes,
+        name,
+        mime,
+        AppModule.nostrRepository::buildNip98AuthHeader,
+    )
 }
 
 /** Read a picked file's bytes via the Blob arrayBuffer() promise. */

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt
@@ -227,6 +227,7 @@ val CreateGroupModal =
                     UploadButton {
                         cls = "upload-btn"
                         icon = Ic.Upload
+                        imagesOnly = true
                         onUploaded = { setPicture(it.url) }
                         onError = { setError(it) }
                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt
@@ -227,7 +227,8 @@ val CreateGroupModal =
                     UploadButton {
                         cls = "upload-btn"
                         icon = Ic.Upload
-                        onUploaded = { setPicture(it) }
+                        onUploaded = { setPicture(it.url) }
+                        onError = { setError(it) }
                     }
                 }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/EditGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/EditGroupModal.kt
@@ -130,7 +130,8 @@ val EditGroupModal =
                     UploadButton {
                         cls = "upload-btn"
                         icon = Ic.Upload
-                        onUploaded = { setPicture(it) }
+                        onUploaded = { setPicture(it.url) }
+                        onError = { setError(it) }
                     }
                 }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/EditGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/EditGroupModal.kt
@@ -130,6 +130,7 @@ val EditGroupModal =
                     UploadButton {
                         cls = "upload-btn"
                         icon = Ic.Upload
+                        imagesOnly = true
                         onUploaded = { setPicture(it.url) }
                         onError = { setError(it) }
                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2030,8 +2030,11 @@ private val MessageRow =
                         // read as a snap rather than a colour change in isolation.
                         // Keep the translateY(-50%) from the base CSS or the icon
                         // jumps off vertical center when the JS overrides transform.
-                        iconStyle.transform =
-                            if (armed) "translateY(-50%) scale(1.15)" else "translateY(-50%) scale(1.0)"
+                        // The icon is a child of the row, so the row's translateX would
+                        // drag it left with the content; counter-translate by -off so it
+                        // stays pinned to the right edge as the row slides (Android parity).
+                        val scale = if (armed) "scale(1.15)" else "scale(1.0)"
+                        iconStyle.transform = "translateX(${-off}px) translateY(-50%) $scale"
                     }
                 }
             }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -14,6 +14,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.utils.Result
@@ -54,6 +55,7 @@ import react.ChildrenBuilder
 import react.FC
 import react.Props
 import react.dom.html.ReactHTML.a
+import react.dom.html.ReactHTML.br
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.code
 import react.dom.html.ReactHTML.div
@@ -249,6 +251,13 @@ private val ChatComposer =
         // Active media uploads in flight (paste / drag-and-drop). The send button
         // shows a spinner instead of the Send icon while > 0.
         val (uploadCount, setUploadCount) = useState { 0 }
+        // Successful uploads pending attachment. Their NIP-68 imeta tags ride along
+        // on the next sendMessage so dimensions / sha256 / video poster propagate
+        // (parity with native GroupScreen.pendingUploads).
+        val (pendingUploads, setPendingUploads) = useState<List<UploadResult>> { emptyList() }
+        // Last upload failure (too large, unsupported, auth/server). Shown in a
+        // dialog instead of being swallowed silently, matching the native picker.
+        val (uploadError, setUploadError) = useState<String?> { null }
         // Composer emoji picker open state.
         val (emojiOpen, setEmojiOpen) = useState { false }
         // Active @user / %group mention being typed in the composer.
@@ -340,9 +349,13 @@ private val ChatComposer =
             setUploadCount { it + 1 }
             launchApp {
                 try {
-                    val url = uploadBlob(file)
-                    if (url != null) {
-                        setDraft { prev -> if (prev.isBlank()) url else "$prev $url" }
+                    when (val r = uploadBlob(file)) {
+                        is Result.Success -> {
+                            val url = r.data.url
+                            setDraft { prev -> if (prev.isBlank()) url else "$prev $url" }
+                            setPendingUploads { it + r.data }
+                        }
+                        is Result.Error -> setUploadError(r.error.message)
                     }
                 } finally {
                     setUploadCount { it - 1 }
@@ -357,15 +370,25 @@ private val ChatComposer =
             // @user mentions are resolved by repo.sendMessage from the mentions map (+ p-tag).
             groupMentions.forEach { (name, ref) -> text = text.replace("%$name", ref) }
             val replyId = props.replyingToId
+            // NIP-68 imeta for any media uploaded into this draft (native parity).
+            val imetaTags = pendingUploads.map { it.toImetaTag() }
             setSending(true)
             launchApp {
-                val result = repo.sendMessage(props.groupId, text, mentions = mentions, replyToMessageId = replyId)
+                val result =
+                    repo.sendMessage(
+                        props.groupId,
+                        text,
+                        mentions = mentions,
+                        replyToMessageId = replyId,
+                        extraTags = imetaTags,
+                    )
                 setSending(false)
                 if (result is Result.Success) {
                     // Clear only after publish succeeded so a cancel/reject keeps the draft.
                     setDraft("")
                     setMentions(emptyMap())
                     setGroupMentions(emptyMap())
+                    setPendingUploads(emptyList())
                     props.onSent()
                 }
             }
@@ -425,7 +448,12 @@ private val ChatComposer =
                 UploadButton {
                     cls = "composer-btn"
                     icon = Ic.AttachFile
-                    onUploaded = { url -> setDraft { prev -> if (prev.isBlank()) url else "$prev $url" } }
+                    onUploaded = { upload ->
+                        val url = upload.url
+                        setDraft { prev -> if (prev.isBlank()) url else "$prev $url" }
+                        setPendingUploads { it + upload }
+                    }
+                    onError = { setUploadError(it) }
                 }
                 div {
                     className = ClassName("composer-input-wrap")
@@ -585,6 +613,9 @@ private val ChatComposer =
                         }
                     }
                 }
+            }
+            uploadError?.let { error ->
+                uploadErrorDialog(error) { setUploadError(null) }
             }
         }
     }
@@ -1630,6 +1661,40 @@ private fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss:
             div {
                 className = ClassName("modal-subtitle tight")
                 +message
+            }
+            div {
+                className = ClassName("modal-footer")
+                button {
+                    className = ClassName("btn-primary")
+                    onClick = { onDismiss() }
+                    +"OK"
+                }
+            }
+        }
+    }
+}
+
+/** Error dialog shown when a media upload is rejected (too large, unsupported
+ *  format, or an auth/server failure). Single OK button — mirrors the native
+ *  "Upload Failed" AlertDialog at MessageUploadButton.kt:70-82. The message can
+ *  carry newlines (the supported-formats list), so render it line by line. */
+private fun ChildrenBuilder.uploadErrorDialog(message: String, onDismiss: () -> Unit) {
+    div {
+        className = ClassName("modal-overlay")
+        onClick = { onDismiss() }
+        div {
+            className = ClassName("modal-card sm")
+            onClick = { it.stopPropagation() }
+            div {
+                className = ClassName("modal-title")
+                +"Upload Failed"
+            }
+            div {
+                className = ClassName("modal-subtitle tight")
+                message.split("\n").forEachIndexed { i, line ->
+                    if (i > 0) br {}
+                    +line
+                }
             }
             div {
                 className = ClassName("modal-footer")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -460,6 +460,9 @@ private val ChatComposer =
                     // Paste / drag-and-drop uploads run through handleMediaFile and are
                     // tracked by uploadCount; surface their spinner on the attach icon.
                     busy = uploadCount > 0
+                    // Count a file-pick upload in uploadCount too, so the send button is
+                    // disabled until the picked URL lands in the draft (it isn't sent empty).
+                    onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
                     onUploaded = { upload ->
                         val url = upload.url
                         setDraft { prev -> if (prev.isBlank()) url else "$prev $url" }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -217,9 +217,11 @@ private external interface ChatComposerProps : Props {
     var relayUrl: String
     var relayPubkey: String?
 
-    /** Id of the message being replied to (null = no reply), plus the parent's display name for the banner. */
+    /** Id of the message being replied to (null = no reply), plus the parent's display name and a
+     *  content preview for the banner (native ReplyingToBar shows both). */
     var replyingToId: String?
     var replyParentName: String?
+    var replyParentContent: String?
     var onCancelReply: () -> Unit
 
     /** Cleared after a successful publish so the parent can drop the reply target. */
@@ -427,11 +429,18 @@ private val ChatComposer =
             if (props.replyingToId != null && parentName != null) {
                 div {
                     className = ClassName("composer-reply")
-                    span {
-                        +"Replying to "
-                        span {
+                    div { className = ClassName("composer-reply-bar") }
+                    div {
+                        className = ClassName("composer-reply-body")
+                        div {
                             className = ClassName("composer-reply-name")
-                            +parentName
+                            +"Replying to $parentName"
+                        }
+                        props.replyParentContent?.takeIf { it.isNotBlank() }?.let { preview ->
+                            div {
+                                className = ClassName("composer-reply-text")
+                                +preview
+                            }
                         }
                     }
                     button {
@@ -1424,6 +1433,12 @@ val ChatScreen =
                     this.replyingToId = replyingToId
                     this.replyParentName =
                         replyingToId?.let { id -> messagesById[id]?.let { p -> displayName(p.pubkey, userMetadata[p.pubkey]) } }
+                    this.replyParentContent =
+                        replyingToId?.let { id ->
+                            messagesById[id]?.let { p ->
+                                processMentions(p.content, userMetadata).replace('\n', ' ').trim().take(80)
+                            }
+                        }
                     this.onCancelReply = { setReplyingToId(null) }
                     this.onSent = { setReplyingToId(null) }
                     this.onJoin = { join() }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -448,6 +448,9 @@ private val ChatComposer =
                 UploadButton {
                     cls = "composer-btn"
                     icon = Ic.AttachFile
+                    // Paste / drag-and-drop uploads run through handleMediaFile and are
+                    // tracked by uploadCount; surface their spinner on the attach icon.
+                    busy = uploadCount > 0
                     onUploaded = { upload ->
                         val url = upload.url
                         setDraft { prev -> if (prev.isBlank()) url else "$prev $url" }
@@ -592,13 +595,15 @@ private val ChatComposer =
                 }
                 button {
                     val uploading = uploadCount > 0
-                    val busy = uploading || sending
+                    // The upload spinner now lives on the attach icon; the send button
+                    // only spins for an in-flight send, but stays disabled while a paste
+                    // upload finishes so its URL can land in the draft first.
                     className = ClassName(
-                        if (draft.isNotBlank() || busy) "composer-send active" else "composer-send",
+                        if (draft.isNotBlank() || sending) "composer-send active" else "composer-send",
                     )
                     disabled = (draft.isBlank() && !uploading) || sending || uploading
                     onClick = { send() }
-                    if (busy) {
+                    if (sending) {
                         span { className = ClassName("btn-spinner") }
                     } else {
                         icon(Ic.Send)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -781,6 +781,15 @@ val ChatScreen =
         val (scrollKey, setScrollKey) = useState<String?> { null }
         val (jumpNonce, setJumpNonce) = useState { 0 }
 
+        // Entering reply mode grows the composer with the reply banner; if the feed
+        // was at the bottom, the last message would slide behind it. Re-pin to the
+        // bottom so the replied-to message stays visible (native parity).
+        useEffect(replyingToId) {
+            if (replyingToId != null && atBottom.current == true) {
+                setJumpNonce { it + 1 }
+            }
+        }
+
         // "New messages" divider snapshot. Captured once on group entry, then
         // cleared the first time the user scrolls up and back down to the bottom
         // (issue #83 — divider sticks around after the user has clearly read them).

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -111,8 +111,7 @@ private fun parentMessageOf(message: org.nostr.nostrord.network.NostrGroupClient
 
 /** Plain-text preview of a parent message for a reply chip/banner: mentions resolved,
  *  newlines flattened, trimmed, and capped at [max] chars. */
-private fun replyPreviewText(content: String, userMetadata: Map<String, UserMetadata>, max: Int): String =
-    processMentions(content, userMetadata).replace('\n', ' ').trim().take(max)
+private fun replyPreviewText(content: String, userMetadata: Map<String, UserMetadata>, max: Int): String = processMentions(content, userMetadata).replace('\n', ' ').trim().take(max)
 
 /** Reply-preview payload: author name, plain-text body, and the parent event's tags for emoji resolution. */
 data class ReplyPreviewData(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -523,6 +523,10 @@ private val ChatComposer =
                                     event.preventDefault()
                                     setMention(null)
                                 }
+                                props.replyingToId != null && event.key == "Escape" -> {
+                                    event.preventDefault()
+                                    props.onCancelReply()
+                                }
                                 event.key == "Enter" && !event.shiftKey -> {
                                     event.preventDefault()
                                     send()

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -94,13 +94,25 @@ external interface ChatScreenProps : Props {
 // Window (seconds) for grouping consecutive messages from the same author.
 private const val GROUP_WINDOW = 5 * 60
 
-/** Parent message id of a reply — the "q" tag with a 64-char hex event id (kind 9 only). */
+/**
+ * Parent message id of a reply (kind 9 only). Nostrord tags replies with "q"; other clients
+ * may use the NIP-10 reply marker ["e", id, relay?, "reply"], which native also honors
+ * (getReplyParentId). The plain unmarked "e" fallback is intentionally not used here — it is
+ * ambiguous (root vs mention vs inline quote) without the content embed-check native does.
+ */
 private fun parentMessageOf(message: org.nostr.nostrord.network.NostrGroupClient.NostrMessage): String? {
     if (message.kind != 9) return null
+    fun isHexId(s: String) = s.length == 64 && s.all { it.isLetterOrDigit() }
+    message.tags.firstOrNull { it.size >= 2 && it[0] == "q" && isHexId(it[1]) }?.let { return it[1] }
     return message.tags
-        .firstOrNull { it.size >= 2 && it[0] == "q" && it[1].length == 64 && it[1].all { c -> c.isLetterOrDigit() } }
+        .firstOrNull { it.size >= 4 && it[0] == "e" && it[3] == "reply" && isHexId(it[1]) }
         ?.get(1)
 }
+
+/** Plain-text preview of a parent message for a reply chip/banner: mentions resolved,
+ *  newlines flattened, trimmed, and capped at [max] chars. */
+private fun replyPreviewText(content: String, userMetadata: Map<String, UserMetadata>, max: Int): String =
+    processMentions(content, userMetadata).replace('\n', ' ').trim().take(max)
 
 /** Reply-preview payload: author name, plain-text body, and the parent event's tags for emoji resolution. */
 data class ReplyPreviewData(
@@ -1336,10 +1348,7 @@ val ChatScreen =
                                                 parent?.let {
                                                     ReplyPreviewData(
                                                         author = displayName(it.pubkey, userMetadata[it.pubkey]),
-                                                        content = processMentions(it.content, userMetadata)
-                                                            .replace('\n', ' ')
-                                                            .trim()
-                                                            .take(120),
+                                                        content = replyPreviewText(it.content, userMetadata, 120),
                                                         tags = it.tags,
                                                     )
                                                 }
@@ -1451,9 +1460,7 @@ val ChatScreen =
                         replyingToId?.let { id -> messagesById[id]?.let { p -> displayName(p.pubkey, userMetadata[p.pubkey]) } }
                     this.replyParentContent =
                         replyingToId?.let { id ->
-                            messagesById[id]?.let { p ->
-                                processMentions(p.content, userMetadata).replace('\n', ' ').trim().take(80)
-                            }
+                            messagesById[id]?.let { p -> replyPreviewText(p.content, userMetadata, 80) }
                         }
                     this.onCancelReply = { setReplyingToId(null) }
                     this.onSent = { setReplyingToId(null) }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -589,7 +589,9 @@ private val ChatComposer =
                     }
                 }
                 button {
-                    className = ClassName(if (emojiOpen) "composer-btn active" else "composer-btn")
+                    // composer-emoji is hidden on touch/mobile (CSS @media pointer:coarse),
+                    // where the OS keyboard already provides emoji (native parity).
+                    className = ClassName(if (emojiOpen) "composer-btn composer-emoji active" else "composer-btn composer-emoji")
                     onClick = { setEmojiOpen(!emojiOpen) }
                     icon(Ic.EmojiEmotions)
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -732,6 +732,7 @@ private fun react.ChildrenBuilder.settingsUploadField(
             UploadButton {
                 cls = "upload-btn"
                 icon = Ic.Upload
+                imagesOnly = true
                 onUploaded = { onChange(it.url) }
                 this.onError = onError
             }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -217,6 +217,7 @@ private val ProfilePanel =
         val (lud16, setLud16) = useState { meta?.lud16 ?: "" }
         val (website, setWebsite) = useState { meta?.website ?: "" }
         val (busy, setBusy) = useState { false }
+        val (uploadError, setUploadError) = useState<String?> { null }
         val (saved, setSaved) = useState { false }
 
         div {
@@ -243,8 +244,14 @@ private val ProfilePanel =
                 setSaved(false)
             }
             settingsTextarea("About", "Tell us about yourself", about) { setAbout(it) }
-            settingsUploadField("Avatar URL", "https://example.com/avatar.jpg", picture) { setPicture(it) }
-            settingsUploadField("Banner URL", "https://example.com/banner.jpg", banner) { setBanner(it) }
+            settingsUploadField("Avatar URL", "https://example.com/avatar.jpg", picture, { setPicture(it) }) { setUploadError(it) }
+            settingsUploadField("Banner URL", "https://example.com/banner.jpg", banner, { setBanner(it) }) { setUploadError(it) }
+            uploadError?.let { err ->
+                div {
+                    className = ClassName("settings-status-line error")
+                    +err
+                }
+            }
             settingsField("Nostr Address (NIP-05)", "you@example.com", nip05) { setNip05(it) }
             settingsField("Lightning Address", "you@walletofsatoshi.com", lud16) { setLud16(it) }
             settingsField("Website", "https://example.com", website) { setWebsite(it) }
@@ -706,6 +713,7 @@ private fun react.ChildrenBuilder.settingsUploadField(
     placeholder: String,
     value: String,
     onChange: (String) -> Unit,
+    onError: (String) -> Unit,
 ) {
     div {
         className = ClassName("settings-field")
@@ -724,7 +732,8 @@ private fun react.ChildrenBuilder.settingsUploadField(
             UploadButton {
                 cls = "upload-btn"
                 icon = Ic.Upload
-                onUploaded = onChange
+                onUploaded = { onChange(it.url) }
+                this.onError = onError
             }
         }
     }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -284,6 +284,20 @@ body {
     flex-shrink: 0;
 }
 
+/* Spinner for the attach/upload button. Inherits the button's text color via
+   currentColor so it stays visible on the muted/transparent backgrounds where
+   the white .btn-spinner would vanish (native CircularProgressIndicator parity). */
+.upload-spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid currentColor;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: app-spin 0.8s linear infinite;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
 .login-primary:disabled {
     opacity: 0.5;
     cursor: default;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3687,7 +3687,10 @@ body {
     position: absolute;
     inset: 0;
     z-index: 0;
-    padding: 4px 0;
+    /* 5.5px keeps a single line's box at 32px (21px line + 11px), matching the
+       button height so the text optically centers with the icons. Must equal
+       .composer-input's padding so the mirror stays glyph-aligned. */
+    padding: 5.5px 0;
     line-height: 1.4;
     font-size: 15px;
     font-family: inherit;
@@ -3713,9 +3716,12 @@ body {
     display: block;
     width: 100%;
     min-width: 0;
-    min-height: 22px;
+    /* 32px one-line box + 5.5px vertical padding centers the text against the
+       32px buttons (the row is align-items:flex-end). Keep in sync with
+       .composer-highlight's padding. */
+    min-height: 32px;
     max-height: 140px;
-    padding: 4px 0;
+    padding: 5.5px 0;
     line-height: 1.4;
     background: transparent;
     border: none;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3542,7 +3542,7 @@ body {
 .composer-reply {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    gap: 8px;
     margin: 0 16px;
     padding: 6px 12px;
     font-size: 13px;
@@ -3552,9 +3552,32 @@ body {
     border-bottom: 1px solid var(--color-background);
 }
 
+/* Accent bar mirroring the native ReplyingToBar. */
+.composer-reply-bar {
+    flex-shrink: 0;
+    width: 3px;
+    align-self: stretch;
+    min-height: 24px;
+    background: var(--color-primary);
+    border-radius: 2px;
+}
+
+.composer-reply-body {
+    flex: 1;
+    min-width: 0;
+}
+
 .composer-reply-name {
-    color: var(--color-text-primary);
+    color: var(--color-primary);
     font-weight: 600;
+}
+
+/* Single-line content preview of the message being replied to. */
+.composer-reply-text {
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .composer-reply-close {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3707,6 +3707,10 @@ body {
        caret-color keeps the cursor visible. */
     position: relative;
     z-index: 1;
+    /* block (not the textarea default inline-block) removes the baseline
+       descender gap that made the wrap taller than the textarea and pushed
+       the absolute .composer-highlight mirror out of vertical alignment. */
+    display: block;
     width: 100%;
     min-width: 0;
     min-height: 22px;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3673,6 +3673,15 @@ body {
     color: var(--color-text-content);
 }
 
+/* On touch / mobile the OS keyboard provides emoji, so hide the in-app emoji
+   picker button (the native composer hides it on Android / iOS for the same
+   reason). display:none also collapses its flex slot, so no gap is left. */
+@media (pointer: coarse) {
+    .composer-emoji {
+        display: none;
+    }
+}
+
 /* Holds the textarea and its colored mirror so @mentions can be tinted gold
    (a plain textarea can't style part of its text). */
 .composer-input-wrap {


### PR DESCRIPTION
Brings the web and native composer in line and rounds out media upload + reply UX. The web file attach now accepts image/video/audio (was images only), surfaces upload errors and carries NIP-68 imeta like native, and the native composer was restyled into the same single rounded pill. Also replaces the desktop file picker, which fought GNOME/Mutter focus-stealing prevention.

| Area | Changes |
|---|---|
| Upload | web accepts image/video/audio; size + format validation with surfaced errors; NIP-68 imeta (dimensions, sha256, video poster thumb) on sent media; spinner on the attach icon for file-pick and paste/drop; dropped verbose `[Upload]` logging |
| Composer (style) | native restyled to the web's single rounded inset pill with a transparent input (BasicTextField, compact height); 32dp icons with 8dp gaps and hover/press color; emoji hidden on touch/mobile; web text/highlight-mirror vertical alignment |
| Reply | web reply banner shows the replied message preview + accent bar; Esc exits reply mode on desktop (web + native); the replied-to last message stays visible (no longer hidden behind the reply bar); swipe-to-reply icon pinned to the right edge on web mobile |
| Desktop picker | swapped `java.awt.FileDialog` for **LWJGL tinyfd** (zenity/kdialog subprocess) — opens in front and returns focus on every open, and pulls no dbus-java so the OS keychain (java-keyring Secret Service) is untouched |

Native picker also gained `rememberUpdatedState` callbacks (a stale-callback fix that was dropping the uploaded URL after a recomposition).

Commits:
- feat(web): match native upload error handling and attach imeta
- fix(web): show a spinner on the attach button while uploading
- fix(chat): show paste upload spinner on the attach icon, not send
- chore(upload): drop the verbose [Upload] debug logging
- feat(native): match the web composer's single rounded pill
- feat(native): make the composer compact like the web
- fix(native): match composer icon spacing and right-icon size to web
- fix(native): add hover color to the composer attach/emoji buttons
- fix(native): white attach icon while pressed (Android tap feedback)
- fix(web): hide the composer emoji button on touch/mobile
- fix(web): align the composer highlight mirror with the textarea
- fix(web): vertically center the composer text with the action icons
- fix(web): show the replied message preview in the composer reply banner
- feat(desktop): Esc exits reply mode (web + native)
- fix(chat): keep the last message visible when replying to it
- fix(web): pin the swipe-to-reply icon to the right edge on mobile
- fix(desktop): use rememberUpdatedState for the file picker callbacks
- feat(desktop): native file picker via LWJGL tinyfd (zenity subprocess)

Desktop picker requires zenity or kdialog on Linux (standard on GNOME/KDE); native dialogs on Windows/macOS need no extra setup.