### PR TITLE
fix(web): route notification clicks through the SW and fix browser history

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
@@ -183,6 +183,23 @@ fun String.toRelayUrl(): String {
     return "$scheme://$trimmed"
 }
 
+/**
+ * Build the web deep-link query for a group: `?relay=host&group=id[&e=eventId]`.
+ *
+ * Single source of truth for the deep-link contract shared by the web notification
+ * payload (jsMain), the in-app URL writer (`searchFor`), the cold-boot history seed,
+ * and the query parser. `host` is the relay authority with the ws(s):// scheme stripped,
+ * matching what the URL-sync effect writes and what the parser reads back. The optional
+ * `eventId` is a transient scroll target, not part of the canonical (shareable) URL, so
+ * callers that own the address bar omit it.
+ */
+fun groupDeepLinkQuery(relayUrl: String, groupId: String, eventId: String? = null): String {
+    val host = relayUrl.removePrefix("wss://").removePrefix("ws://")
+    val sb = StringBuilder("?relay=").append(host).append("&group=").append(groupId)
+    if (!eventId.isNullOrBlank()) sb.append("&e=").append(eventId)
+    return sb.toString()
+}
+
 fun isValidRelayUrl(url: String): Boolean {
     val trimmed = url.trim()
     val afterScheme = when {

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationService.js.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import org.nostr.nostrord.utils.groupDeepLinkQuery
 
 private fun jsSupported(): Boolean = js("typeof Notification !== 'undefined'").unsafeCast<Boolean>()
 
@@ -34,30 +35,80 @@ private fun jsObservePermissionChanges(cb: (String) -> Unit) {
     )
 }
 
-private fun jsShowNotification(
-    title: String,
-    body: String,
-    tag: String,
-    iconUrl: String,
-    onClick: () -> Unit,
-): dynamic {
+private fun jsBuildOptions(body: String, tag: String, iconUrl: String, deepLink: String): dynamic {
     val opts = js("({})")
     opts.body = body
     opts.tag = tag
     if (iconUrl.isNotEmpty()) opts.icon = iconUrl
+    // The service-worker notificationclick handler reads data.url to route the click.
+    val data = js("({})")
+    data.url = deepLink
+    opts.data = data
+    return opts
+}
+
+// Prefer the service worker: notifications it shows survive in the OS tray and their
+// clicks are handled by sw.js, which focuses an existing tab (or opens one) at the
+// deep link. onUnavailable runs the page-context fallback when no SW is ready.
+private fun jsShowViaServiceWorker(title: String, opts: dynamic, onUnavailable: () -> Unit) {
+    val ready = js("(typeof navigator !== 'undefined' && navigator.serviceWorker && navigator.serviceWorker.ready) ? navigator.serviceWorker.ready : null")
+    if (ready == null) {
+        onUnavailable()
+        return
+    }
+    ready.then({ reg: dynamic ->
+        if (reg != null && reg.showNotification != null) {
+            reg.showNotification(title, opts)
+        } else {
+            onUnavailable()
+        }
+        null
+    }).catch({ _: dynamic ->
+        onUnavailable()
+        null
+    })
+}
+
+// Fallback for browsers without an active service worker: a page-context
+// Notification. Its click can only act on this tab, so it focuses and emits a
+// NotificationClick that the web UI consumes to navigate in place.
+private fun jsShowPageNotification(title: String, opts: dynamic, onClick: () -> Unit): dynamic = try {
     val notification = js("new Notification(title, opts)")
     notification.onclick = {
-        js("window.focus()")
+        js("try { window.focus(); } catch (e) {}")
         notification.close()
         onClick()
     }
-    return notification
+    notification
+} catch (_: Throwable) {
+    null
 }
 
 private fun jsCloseNotification(handle: dynamic) {
     try {
         handle.close()
     } catch (_: Throwable) {}
+}
+
+// Close service-worker notifications whose tag is in [tags] (an array passed to JS as-is).
+private fun jsCloseServiceWorkerNotifications(tags: Array<String>) {
+    js(
+        """
+        try {
+            if (typeof navigator !== 'undefined' && navigator.serviceWorker && navigator.serviceWorker.ready) {
+                navigator.serviceWorker.ready.then(function(reg) {
+                    if (reg && reg.getNotifications) {
+                        reg.getNotifications().then(function(list) {
+                            list.forEach(function(n) {
+                                if (tags.indexOf(n.tag) !== -1) { try { n.close(); } catch (e) {} }
+                            });
+                        });
+                    }
+                });
+            }
+        } catch (e) {}
+        """,
+    )
 }
 
 actual class NotificationService actual constructor() {
@@ -72,6 +123,11 @@ actual class NotificationService actual constructor() {
     // without limit; oldest entries fall off when the list crosses MAX_TRACKED.
     private val activeNotifications = ArrayDeque<dynamic>()
     private val MAX_TRACKED = 100
+
+    // Tags of notifications shown via the service worker (which returns no closable
+    // handle). cancelAllPending closes only these on account switch, so it never reaches
+    // across to notifications another account/tab posted through the shared registration.
+    private val swNotificationTags = ArrayDeque<String>()
 
     init {
         if (jsSupported()) {
@@ -94,21 +150,37 @@ actual class NotificationService actual constructor() {
     actual fun notify(request: NotificationRequest) {
         if (!jsSupported()) return
         if (_permission.value != NotificationPermission.Granted) return
-        val handle = jsShowNotification(
-            request.title,
-            request.body,
-            request.tag,
-            request.iconUrl ?: "",
-        ) { _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId, request.messageId)) }
-        activeNotifications.addLast(handle)
-        while (activeNotifications.size > MAX_TRACKED) activeNotifications.removeFirst()
+        val opts = jsBuildOptions(request.body, request.tag, request.iconUrl ?: "", buildDeepLink(request))
+        // Track the tag up front: the SW path shows asynchronously and returns no handle,
+        // so this is the only record cancelAllPending can use to close it later.
+        swNotificationTags.addLast(request.tag)
+        while (swNotificationTags.size > MAX_TRACKED) swNotificationTags.removeFirst()
+        jsShowViaServiceWorker(request.title, opts) {
+            val handle = jsShowPageNotification(request.title, opts) {
+                _clicks.tryEmit(NotificationClick(request.relayUrl, request.groupId, request.messageId))
+            }
+            if (handle != null) {
+                activeNotifications.addLast(handle)
+                while (activeNotifications.size > MAX_TRACKED) activeNotifications.removeFirst()
+            }
+        }
     }
+
+    // Deep link the sw.js notificationclick handler routes to. Uses the shared
+    // groupDeepLinkQuery contract so the payload, in-app URL writer, and parser never drift.
+    private fun buildDeepLink(request: NotificationRequest): String = groupDeepLinkQuery(request.relayUrl, request.groupId, request.messageId)
 
     actual fun cancelAllPending() {
         if (!jsSupported()) return
         val snapshot = activeNotifications.toList()
         activeNotifications.clear()
         snapshot.forEach { jsCloseNotification(it) }
+        // Close service-worker notifications we showed (e.g. on account switch), scoped to
+        // our own tags so we don't close notifications another account/tab posted through the
+        // shared registration.
+        val tags = swNotificationTags.toTypedArray()
+        swNotificationTags.clear()
+        if (tags.isNotEmpty()) jsCloseServiceWorkerNotifications(tags)
     }
 
     private fun readPermission(): NotificationPermission {

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.js.kt
@@ -4,8 +4,14 @@ actual fun playNotificationSound() {
     try {
         val audio = js("new Audio('message-incoming.mp3')")
         audio.volume = 0.6
-        audio.play()
+        // play() returns a Promise that REJECTS when autoplay is blocked (no user
+        // gesture yet). A try/catch can't see that rejection, so swallow it here or
+        // it surfaces as an uncaught-in-promise runtime error.
+        val result = audio.play()
+        if (result != null && result.then != null) {
+            result.catch({ _: dynamic -> null })
+        }
     } catch (_: Throwable) {
-        // Autoplay may be blocked before the user interacts with the page — ignore.
+        // Older browsers where play() throws synchronously.
     }
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppShell.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppShell.kt
@@ -17,6 +17,7 @@ import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.clearLastGroupForRelay
 import org.nostr.nostrord.storage.getLastGroupForRelay
 import org.nostr.nostrord.storage.saveLastGroupForRelay
+import org.nostr.nostrord.utils.groupDeepLinkQuery
 import org.nostr.nostrord.utils.toRelayUrl
 import org.nostr.nostrord.web.auth.WebAuth
 import org.nostr.nostrord.web.bridge.launchApp
@@ -63,14 +64,11 @@ private fun authMethodLabel(method: AuthMethod): String = when (method) {
 }
 
 /** Build the URL query that reflects the current navigation (round-trips with main.kt). */
-private fun searchFor(relay: String, groupId: String?, notifications: Boolean): String {
-    val host = relay.removePrefix("wss://").removePrefix("ws://")
-    return when {
-        notifications -> "?view=notifications"
-        groupId != null && relay.isNotBlank() -> "?relay=$host&group=$groupId"
-        relay.isNotBlank() -> "?relay=$host"
-        else -> ""
-    }
+private fun searchFor(relay: String, groupId: String?, notifications: Boolean): String = when {
+    notifications -> "?view=notifications"
+    groupId != null && relay.isNotBlank() -> groupDeepLinkQuery(relay, groupId)
+    relay.isNotBlank() -> "?relay=${relay.removePrefix("wss://").removePrefix("ws://")}"
+    else -> ""
 }
 
 private fun parseSearch(search: String): Map<String, String> = search.removePrefix("?").split("&").filter { it.isNotEmpty() }.associate { part ->
@@ -213,6 +211,12 @@ val AppShell =
         // Groups sidebar search query (filters My Groups + Other Groups by name/id, like native).
         val (groupQuery, setGroupQuery) = useState { "" }
         val firstNav = useRef(true)
+        // Set while a browser back/forward (popstate) settles. The browser already owns the
+        // target entry, so the URL-sync effect must NOT write history during the async
+        // relay/group catch-up (any push/replace then would add a phantom forward entry or
+        // overwrite the popstate target). It clears itself once the settled state matches the
+        // current URL, so it cannot get stuck and corrupt a later genuine navigation.
+        val suppressSync = useRef(false)
         // Native saves the last-active group per relay (SecureStorage.saveLastGroupForRelay)
         // so cold-booting onto a bare URL restores the user where they left off. The web
         // wasn't doing this — entering localhost:8080/ landed on the relay home even when
@@ -267,12 +271,33 @@ val AppShell =
                 is ExternalLaunchContext.OpenRelay ->
                     launchApp { repo.switchRelay(ctx.relayUrl) }
                 is ExternalLaunchContext.OpenGroup -> {
-                    launchApp {
-                        ctx.relayUrl?.let { repo.switchRelay(it) }
-                        if (!ctx.inviteCode.isNullOrBlank()) repo.joinGroup(ctx.groupId, ctx.inviteCode)
+                    val relayUrl = ctx.relayUrl
+                    val gid = ctx.groupId
+                    val msg = ctx.messageId?.takeIf { it.isNotBlank() }
+                    val invite = ctx.inviteCode
+                    // Seed a same-document back target (the relay home) SYNCHRONOUSLY, before
+                    // the async switchRelay. Without this the deep-link load is the only
+                    // history entry, so Back leaves the document — a full reload that lands on
+                    // Login while the session re-initializes. Seeding here (not after
+                    // switchRelay) guarantees the back target exists immediately, even if the
+                    // relay is slow to connect. suppressSync holds the URL-sync effect off the
+                    // address bar until the (relay, group) state settles to match this seed, so
+                    // the in-flight transient (persisted relay / null group) can't push a bogus
+                    // entry over it; firstNav is cleared so the first genuine nav still pushes.
+                    relayUrl?.let { url ->
+                        val path = window.location.pathname
+                        val host = url.removePrefix("wss://").removePrefix("ws://")
+                        window.history.replaceState(null, "", "$path?relay=$host")
+                        window.history.pushState(null, "", path + groupDeepLinkQuery(url, gid))
+                        firstNav.current = false
+                        suppressSync.current = true
                     }
-                    setSelectedGroupId(ctx.groupId)
-                    ctx.messageId?.takeIf { it.isNotBlank() }?.let { setScrollToEventId(it) }
+                    setSelectedGroupId(gid)
+                    msg?.let { setScrollToEventId(it) }
+                    launchApp {
+                        relayUrl?.let { repo.switchRelay(it) }
+                        if (!invite.isNullOrBlank()) repo.joinGroup(gid, invite)
+                    }
                 }
                 is ExternalLaunchContext.OpenNotifications -> {
                     ctx.relayUrl?.let { url -> launchApp { repo.switchRelay(url) } }
@@ -323,9 +348,31 @@ val AppShell =
         }
 
         // Keep the URL in sync with navigation so it's shareable and back/forward works.
-        useEffect(activeRelay, selectedGroupId, notificationsOpen) {
+        useEffect(activeRelay, selectedGroupId, notificationsOpen, groups) {
             val target = window.location.pathname + searchFor(activeRelay, selectedGroupId, notificationsOpen)
             val current = window.location.pathname + window.location.search
+
+            // Back/forward in flight: the browser already owns the target entry. Don't write
+            // history during the async relay/group catch-up (that would add a phantom forward
+            // entry or overwrite the popstate target). Release once the settled state matches
+            // the current URL — which compares group ids by value, so it never strands on a
+            // group whose metadata hasn't loaded.
+            if (suppressSync.current == true) {
+                if (target == current) suppressSync.current = false
+                return@useEffect
+            }
+
+            // Genuine in-app navigation. Skip the async cross-relay window where activeRelay
+            // has flipped to the new relay but selectedGroupId still points at the previous
+            // relay's group: writing then would record a group that doesn't live on this relay
+            // and corrupt Back. Detect it precisely (the id resolves on a DIFFERENT relay) so a
+            // not-yet-loaded group on the active relay still updates the URL instead of
+            // stranding it. `groups`/`groupsByRelay` are deps so this reconciles as lists load.
+            val staleFromOtherRelay = selectedGroupId != null &&
+                groups.none { it.id == selectedGroupId } &&
+                groupsByRelay.any { (relay, list) -> relay != activeRelay && list.any { it.id == selectedGroupId } }
+            if (staleFromOtherRelay) return@useEffect
+
             if (target != current) {
                 if (firstNav.current == true) {
                     window.history.replaceState(null, "", target)
@@ -336,19 +383,74 @@ val AppShell =
             firstNav.current = false
         }
 
-        // Browser back/forward → apply the URL to state.
+        // Apply a URL search string (?relay=&group=&e= / ?view=notifications) to in-app
+        // navigation state. Shared by browser back/forward and by service-worker
+        // notification clicks that focus this already-open tab. We never push history
+        // here: the URL-sync effect owns the address bar, so it produces exactly one
+        // clean entry per navigation and the back button keeps working. Crossing relays
+        // mirrors the relay-rail order (switchRelay first, then setSelectedGroupId) so
+        // neither the URL-sync nor the last-group save effect ever fires with the stale
+        // (oldRelay, newGroup) pair — the cause of "back lands on the previous relay
+        // still carrying the new group id". `e` (scroll target) stays out of the URL;
+        // it's transient intent, cleared once the message is reached.
+        val applyNavFromSearch: (String) -> Unit = { search ->
+            val params = parseSearch(search)
+            if (params["view"] == "notifications") {
+                setNotificationsOpen(true)
+            } else {
+                setNotificationsOpen(false)
+                val group = params["group"]?.takeIf { it.isNotBlank() }
+                val eventId = params["e"]?.takeIf { it.isNotBlank() }
+                val relay = params["relay"]?.takeIf { it.isNotBlank() }?.toRelayUrl()
+                if (relay != null && relay != repo.currentRelayUrl.value) {
+                    launchApp {
+                        repo.switchRelay(relay)
+                        setSelectedGroupId(group)
+                        eventId?.let { setScrollToEventId(it) }
+                    }
+                } else {
+                    setSelectedGroupId(group)
+                    eventId?.let { setScrollToEventId(it) }
+                }
+            }
+        }
+
+        // Browser back/forward → apply the URL to state. Mark suppressSync so the resulting
+        // async state change does NOT write history (the browser already owns this entry);
+        // suppressSync self-releases once state matches the URL.
         useEffectOnce {
             window.asDynamic().addEventListener("popstate") {
-                val params = parseSearch(window.location.search)
-                if (params["view"] == "notifications") {
-                    setNotificationsOpen(true)
-                } else {
-                    setNotificationsOpen(false)
-                    val relay = params["relay"]?.takeIf { it.isNotBlank() }?.toRelayUrl()
-                    if (relay != null && relay != repo.currentRelayUrl.value) {
-                        launchApp { repo.switchRelay(relay) }
+                suppressSync.current = true
+                applyNavFromSearch(window.location.search)
+            }
+        }
+
+        // Desktop-notification clicks: the service worker focuses this already-open tab
+        // and posts the deep link here so we route in place (correct relay + group)
+        // instead of reloading the page or letting a duplicate tab open.
+        useEffectOnce {
+            val sw = js("(typeof navigator !== 'undefined' && navigator.serviceWorker) ? navigator.serviceWorker : null")
+            if (sw != null) {
+                sw.addEventListener("message") { event: dynamic ->
+                    val msg = event.data
+                    val type = msg?.type as? String
+                    val url = msg?.url as? String
+                    if (type == "notification-click" && url != null) {
+                        val query = url.substringAfter("?", "")
+                        applyNavFromSearch(if (query.isEmpty()) "" else "?$query")
                     }
-                    setSelectedGroupId(params["group"]?.takeIf { it.isNotBlank() })
+                }
+            }
+        }
+
+        // Fallback path for browsers without an active service worker: NotificationService
+        // shows a page-context Notification whose click emits a NotificationClick instead of
+        // routing through sw.js. Route those the same way (one in-app pushState via the
+        // URL-sync effect) so the no-SW click still navigates rather than only focusing.
+        useEffectOnce {
+            launchApp {
+                AppModule.notificationService.notificationClicks.collect { click ->
+                    applyNavFromSearch(groupDeepLinkQuery(click.relayUrl, click.groupId, click.messageId))
                 }
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/WebApp.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/WebApp.kt
@@ -31,6 +31,7 @@ val WebApp =
         val repo = AppModule.nostrRepository
         val initialized = useStateFlow(repo.isInitialized)
         val loggedIn = useStateFlow(repo.isLoggedIn)
+        val verifyingBunker = useStateFlow(repo.isBunkerVerifying)
 
         useEffectOnce {
             // Track tab focus so notifications/unread are suppressed while the app is visible
@@ -70,6 +71,14 @@ val WebApp =
             // and only fades out once data-app-ready is set above.
             !initialized -> null
             loggedIn -> AppShell()
+            // A bunker signer is still being (re)connected on cold start: hold the loading
+            // shell instead of flashing LoginScreen during the async handshake. This is the
+            // only restore path that completes after isInitialized (local/NIP-07 restore
+            // flips isLoggedIn before initialize() returns). isBunkerVerifying flips false
+            // when the signer connects (-> loggedIn -> AppShell) or fails (-> LoginScreen),
+            // so unlike gating on persisted-account existence it can never strand the user
+            // on a permanent spinner after logout or a failed restore.
+            verifyingBunker -> null
             else -> LoginScreen()
         }
     }

--- a/composeApp/src/webMain/resources/sw.js
+++ b/composeApp/src/webMain/resources/sw.js
@@ -78,6 +78,40 @@ self.addEventListener('activate', (event) => {
     );
 });
 
+// Notification click - reuse an already-open app tab when possible.
+// Notifications are shown via registration.showNotification with a deep link in
+// data.url (?relay=&group=&e=). On click we focus an existing tab and post the
+// deep link to it so the SPA routes in place; only when no tab exists do we open
+// a new one. This avoids the "wrong tab / duplicate tab / never navigates" bugs
+// of page-context Notification + window.focus().
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+    const data = event.notification.data || {};
+    const targetUrl = new URL(data.url || '', self.registration.scope).href;
+    const scopePath = new URL(self.registration.scope).pathname;
+
+    event.waitUntil((async () => {
+        const allClients = await self.clients.matchAll({ type: 'window', includeUncontrolled: true });
+        // Only reuse tabs that belong to this app (handles GitHub Pages subpaths).
+        const appClients = allClients.filter(c => new URL(c.url).pathname.startsWith(scopePath));
+        // matchAll order is not focus/recency ordered, so with several app tabs open prefer
+        // the focused one, then a visible one, else the first — don't yank an arbitrary tab.
+        const client = appClients.find(c => c.focused) ||
+                       appClients.find(c => c.visibilityState === 'visible') ||
+                       appClients[0];
+        if (client) {
+            client.postMessage({ type: 'notification-click', url: targetUrl });
+            if ('focus' in client) {
+                await client.focus();
+            }
+            return;
+        }
+        if (self.clients.openWindow) {
+            await self.clients.openWindow(targetUrl);
+        }
+    })());
+});
+
 // Fetch event - route requests to appropriate cache strategy
 self.addEventListener('fetch', (event) => {
     const url = new URL(event.request.url);


### PR DESCRIPTION
Clicking a web desktop notification was landing on the wrong tab, opening a duplicate tab, or not reaching the target group, and browser back/forward in the React web shell was unreliable (Back felt stuck after a notification jump, deep links reloaded the page onto Login). This routes notification clicks through the service worker and rebuilds the history handling around a single URL writer, restoring the deterministic back/forward the pre-React `BrowserNavigationHandler` had.

Notification clicks are shown via `registration.showNotification` with a deep link in `data.url`; a `notificationclick` handler focuses an existing app tab (preferring focused, then visible) and posts the link so the SPA routes in place, only opening a new tab when none exists. History is owned by one sync effect: `popstate` sets `suppressSync` so the async relay/group catch-up never writes a phantom forward entry (it self-releases when state matches the URL), a cross-relay guard skips only the genuine stale-pointer transient (a not-yet-loaded group still updates the URL), and cold-boot deep links seed a same-document relay-home back target so Back is a soft in-app nav instead of a reload onto Login. The boot gate holds the loading shell only while `isBunkerVerifying`, so Login never flashes during a bunker reconnect and the user can't get stranded on a spinner after logout.

| Area | Change |
|---|---|
| `sw.js` | `notificationclick` handler: reuse focused/visible app tab, else open one |
| `NotificationService.js.kt` | show via SW with deep-link `data.url`; tag-scoped cancel; shared deep-link helper |
| `NotificationSound.js.kt` | swallow the autoplay-blocked `play()` promise rejection |
| `AppShell.kt` | `suppressSync` + cross-relay guard URL sync, cold-boot history seed, SW message listener, no-SW fallback collector |
| `WebApp.kt` | gate the boot Login flash on `isBunkerVerifying` (self-releasing) |
| `StringUtils.kt` | shared `groupDeepLinkQuery` used by payload, URL writer, and parser |

- fix(web): route notification clicks through the SW and fix browser history

Verified on JVM desktop and the web dev server; `compileKotlinJs`, `compileKotlinJvm`, and `:composeApp:jvmTest` all pass.