### PR TITLE
feat: quoted-event card parity across web and native

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/Platform.android.kt
@@ -9,6 +9,7 @@ class AndroidPlatform : Platform {
 actual fun getPlatform(): Platform = AndroidPlatform()
 
 actual val isAndroid: Boolean = true
+actual val isLinuxDesktop: Boolean = false
 actual val isHandheldPlatform: Boolean = true
 actual val platformDisplayName: String = "Nostrord Android"
 actual val autoFocusTextInput: Boolean = false

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/Platform.kt
@@ -9,6 +9,13 @@ expect fun getPlatform(): Platform
 expect val isAndroid: Boolean
 
 /**
+ * True only on the Linux desktop. There, launching the default browser can't reliably bring
+ * its window to the front (GNOME/Wayland focus-stealing prevention), so callers prefer copying
+ * the link. macOS, Windows, mobile, and web all raise the browser fine.
+ */
+expect val isLinuxDesktop: Boolean
+
+/**
  * True on platforms where the window size IS the device size (phone, tablet). On these,
  * responsive breakpoints should look at the smallest dimension so rotation doesn't trigger
  * a layout class change. False on desktop / browser where the user resizes the window

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/TimeUtils.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/TimeUtils.kt
@@ -36,6 +36,14 @@ fun getDateLabel(timestamp: Long): String {
     }
 }
 
+/** Date label plus clock time, e.g. "Today 11:02", "23 May 11:02", "23 May 2025 11:02". */
+fun formatDateTime(timestamp: Long): String {
+    val dateTime = timestampToDateTime(timestamp)
+    val hour = dateTime.hour.toString().padStart(2, '0')
+    val minute = dateTime.minute.toString().padStart(2, '0')
+    return "${getDateLabel(timestamp)} $hour:$minute"
+}
+
 fun formatTime(timestamp: Long): String {
     val now = epochSeconds()
     val nowDateTime = timestampToDateTime(now)

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/Platform.ios.kt
@@ -9,6 +9,7 @@ class IOSPlatform : Platform {
 actual fun getPlatform(): Platform = IOSPlatform()
 
 actual val isAndroid: Boolean = false
+actual val isLinuxDesktop: Boolean = false
 actual val isHandheldPlatform: Boolean = true
 actual val platformDisplayName: String = "Nostrord iOS"
 actual val autoFocusTextInput: Boolean = false

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/Platform.js.kt
@@ -7,6 +7,7 @@ class JsPlatform : Platform {
 actual fun getPlatform(): Platform = JsPlatform()
 
 actual val isAndroid: Boolean = false
+actual val isLinuxDesktop: Boolean = false
 actual val isHandheldPlatform: Boolean = false
 actual val platformDisplayName: String = "Nostrord Web"
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/Platform.jvm.kt
@@ -7,6 +7,7 @@ class JVMPlatform : Platform {
 actual fun getPlatform(): Platform = JVMPlatform()
 
 actual val isAndroid: Boolean = false
+actual val isLinuxDesktop: Boolean = System.getProperty("os.name")?.lowercase()?.contains("linux") == true
 actual val isHandheldPlatform: Boolean = false
 actual val platformDisplayName: String = "Nostrord Desktop"
 actual val autoFocusTextInput: Boolean = true

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import androidx.compose.material.icons.filled.Apps
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.MusicNote
@@ -56,6 +59,8 @@ import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.isAndroid
+import org.nostr.nostrord.isLinuxDesktop
 import org.nostr.nostrord.network.CachedEvent
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.avatars.OptimizedUserAvatar
@@ -69,6 +74,7 @@ import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.ui.util.generateColorFromString
+import org.nostr.nostrord.utils.formatDateTime
 import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.utils.getImageUrl
 import org.nostr.nostrord.utils.isAnimatedImageUrl
@@ -384,6 +390,7 @@ fun MessageContent(
                                 currentGroupId = currentGroupId,
                                 currentRelayUrl = currentRelayUrl,
                                 onNavigateToGroup = onNavigateToGroup,
+                                onMentionClick = onMentionClick,
                             )
                             Spacer(modifier = Modifier.height(4.dp))
                         }
@@ -1139,6 +1146,7 @@ private fun QuotedEventBlock(
     currentGroupId: String? = null,
     currentRelayUrl: String? = null,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
+    onMentionClick: (String) -> Unit = {},
 ) {
     val entity = mention.reference.entity
 
@@ -1154,6 +1162,7 @@ private fun QuotedEventBlock(
                 currentGroupId = currentGroupId,
                 currentRelayUrl = currentRelayUrl,
                 onNavigateToGroup = onNavigateToGroup,
+                onMentionClick = onMentionClick,
             )
         }
         is Nip19.Entity.Note -> {
@@ -1167,6 +1176,7 @@ private fun QuotedEventBlock(
                 currentGroupId = currentGroupId,
                 currentRelayUrl = currentRelayUrl,
                 onNavigateToGroup = onNavigateToGroup,
+                onMentionClick = onMentionClick,
             )
         }
         is Nip19.Entity.Naddr -> {
@@ -1222,6 +1232,7 @@ fun ForwardedEventCard(
     onClick: () -> Unit,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
     modifier: Modifier = Modifier,
+    onMentionClick: (String) -> Unit = {},
 ) {
     val userMetadata by AppModule.nostrRepository.userMetadata.collectAsState()
     val cachedEvents by AppModule.nostrRepository.cachedEvents.collectAsState()
@@ -1445,7 +1456,7 @@ fun ForwardedEventCard(
 
             // Message content
             Spacer(modifier = Modifier.height(Spacing.sm))
-            QuotedEventContent(content = event.content, tags = event.tags)
+            QuotedEventContent(content = event.content, tags = event.tags, onMentionClick = onMentionClick)
         }
     }
 }
@@ -1536,6 +1547,7 @@ private fun QuotedEvent(
     currentGroupId: String? = null,
     currentRelayUrl: String? = null,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?) -> Unit = { _, _, _ -> },
+    onMentionClick: (String) -> Unit = {},
 ) {
     val cachedEvents by AppModule.nostrRepository.cachedEvents.collectAsState()
     val userMetadata by AppModule.nostrRepository.userMetadata.collectAsState()
@@ -1619,6 +1631,7 @@ private fun QuotedEvent(
                     onClick = onClick,
                     onNavigateToGroup = onNavigateToGroup,
                     modifier = modifier,
+                    onMentionClick = onMentionClick,
                 )
                 return
             }
@@ -1749,19 +1762,20 @@ private fun QuotedEvent(
         return
     }
 
-    // Default rendering for other event kinds (clickable)
+    // Default rendering for other event kinds
     val metadata = userMetadata[event.pubkey]
     val authorName = metadata?.displayName ?: metadata?.name ?: event.pubkey.take(8) + "..."
+    val uriHandler = LocalUriHandler.current
     val copyToClipboard = rememberClipboardWriter()
-    var showMenu by remember { mutableStateOf(false) }
+    // Linux desktop (GNOME/Wayland) can't reliably raise the browser to the front, so copy the
+    // link there instead of opening it. macOS, Windows, mobile and web all focus fine and open.
 
     Row(
         modifier =
         modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(NostrordShapes.radiusMedium))
-            .background(NostrordColors.Surface)
-            .clickable(onClick = onClick),
+            .widthIn(max = 420.dp)
+            .clip(RoundedCornerShape(NostrordShapes.radiusSmall))
+            .background(NostrordColors.InputBackground),
     ) {
         Column(
             modifier =
@@ -1775,65 +1789,83 @@ private fun QuotedEvent(
                     pubkey = event.pubkey,
                     displayName = authorName,
                     size = 24.dp,
+                    modifier =
+                    Modifier
+                        .clickable { onMentionClick(event.pubkey) }
+                        .pointerHoverIcon(PointerIcon.Hand),
                 )
                 Spacer(modifier = Modifier.width(Spacing.sm))
-                Text(
-                    text = authorName,
-                    color = NostrordColors.TextSecondary,
-                    style = NostrordTypography.Caption,
-                    fontWeight = FontWeight.Medium,
+                Row(
                     modifier = Modifier.weight(1f),
-                )
-                // 3-dot menu button - wrapped in DisableSelection to avoid hierarchy conflict
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = authorName,
+                        color = NostrordColors.TextPrimary,
+                        style = NostrordTypography.Caption,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1,
+                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                        modifier =
+                        Modifier
+                            .weight(1f, fill = false)
+                            .clickable { onMentionClick(event.pubkey) }
+                            .pointerHoverIcon(PointerIcon.Hand),
+                    )
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    Text(
+                        text = formatDateTime(event.createdAt),
+                        color = NostrordColors.TextMuted,
+                        style = NostrordTypography.Caption,
+                        maxLines = 1,
+                    )
+                }
+                Spacer(modifier = Modifier.width(Spacing.sm))
                 DisableSelection {
-                    Box {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        // Android only: open via the nostr: URI so the OS offers the user's
+                        // installed Nostr clients (desktop has no such handler).
+                        if (isAndroid) {
+                            Icon(
+                                imageVector = Icons.Filled.Apps,
+                                contentDescription = "Open in installed client",
+                                tint = NostrordColors.TextMuted,
+                                modifier =
+                                Modifier
+                                    .size(16.dp)
+                                    .clickable { onClick() }
+                                    .pointerHoverIcon(PointerIcon.Hand),
+                            )
+                            Spacer(modifier = Modifier.width(Spacing.md))
+                        }
+                        // Open the quoted event on the web (touch/web), or copy the link on
+                        // desktop where the browser can't be reliably brought to the front.
                         Icon(
-                            imageVector = Icons.Outlined.MoreVert,
-                            contentDescription = "More options",
+                            imageVector = if (isLinuxDesktop) Icons.Filled.ContentCopy else Icons.AutoMirrored.Filled.OpenInNew,
+                            contentDescription = if (isLinuxDesktop) "Copy link" else "Open on the web",
                             tint = NostrordColors.TextMuted,
                             modifier =
                             Modifier
-                                .size(20.dp)
-                                .clickable { showMenu = true }
+                                .size(16.dp)
+                                .clickable {
+                                    val url = "https://jumble.social/notes/${Nip19.encodeNote(event.id)}"
+                                    if (isLinuxDesktop) {
+                                        copyToClipboard(url)
+                                        AppModule.postSystemMessage("Link copied")
+                                    } else {
+                                        try {
+                                            uriHandler.openUri(url)
+                                        } catch (_: Exception) {
+                                        }
+                                    }
+                                }
                                 .pointerHoverIcon(PointerIcon.Hand),
                         )
-                        DropdownMenu(
-                            expanded = showMenu,
-                            onDismissRequest = { showMenu = false },
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text("Copy Event JSON") },
-                                onClick = {
-                                    val json =
-                                        buildJsonObject {
-                                            put("id", event.id)
-                                            put("pubkey", event.pubkey)
-                                            put("created_at", event.createdAt)
-                                            put("kind", event.kind)
-                                            put(
-                                                "tags",
-                                                buildJsonArray {
-                                                    event.tags.forEach { tag ->
-                                                        add(
-                                                            buildJsonArray {
-                                                                tag.forEach { add(JsonPrimitive(it)) }
-                                                            },
-                                                        )
-                                                    }
-                                                },
-                                            )
-                                            put("content", event.content)
-                                        }.toString()
-                                    copyToClipboard(json)
-                                    showMenu = false
-                                },
-                            )
-                        }
                     }
                 }
             }
             Spacer(modifier = Modifier.height(Spacing.sm))
-            QuotedEventContent(content = event.content, tags = event.tags)
+            QuotedEventContent(content = event.content, tags = event.tags, onMentionClick = onMentionClick)
         }
     }
 }
@@ -1846,12 +1878,26 @@ private fun QuotedEventContent(
     content: String,
     tags: List<List<String>> = emptyList(),
     modifier: Modifier = Modifier,
+    onMentionClick: (String) -> Unit = {},
 ) {
     // Extract custom emoji map from NIP-30 tags
     val emojiMap = remember(tags) { MessageContentParser.extractEmojiMap(tags) }
     val parts = remember(content, emojiMap) { parseContent(content, emojiMap) }
     val uriHandler = LocalUriHandler.current
     val userMetadata by AppModule.nostrRepository.userMetadata.collectAsState()
+
+    // Resolve names for pubkeys mentioned inside the quoted text (nostr:npub / nprofile),
+    // so they render as @name instead of a truncated key (matches the web card). Keyed on
+    // content only: re-keying on userMetadata would re-request forever for keys that never resolve.
+    LaunchedEffect(content) {
+        val pubkeysToFetch =
+            extractPubkeysFromContent(content)
+                .filter { !userMetadata.containsKey(it) }
+                .toSet()
+        if (pubkeysToFetch.isNotEmpty()) {
+            AppModule.nostrRepository.requestUserMetadata(pubkeysToFetch)
+        }
+    }
 
     // Image viewer modal state — use shared state from MessagesList
     val sharedImageViewerUrl = LocalImageViewerUrl.current
@@ -1923,6 +1969,7 @@ private fun QuotedEventContent(
                         } catch (_: Exception) {
                         }
                     },
+                    onMentionClick = onMentionClick,
                 )
             }
         }
@@ -1939,6 +1986,7 @@ private fun QuotedInlineContentGroup(
     userMetadata: Map<String, org.nostr.nostrord.network.UserMetadata>,
     onLinkClick: (String) -> Unit,
     modifier: Modifier = Modifier,
+    onMentionClick: (String) -> Unit = {},
 ) {
     // Check if this group contains any custom emojis
     val hasCustomEmojis =
@@ -2022,20 +2070,47 @@ private fun QuotedInlineContentGroup(
                         }
                         is MentionPart -> {
                             val displayText = getMentionDisplayText(part, userMetadata)
-                            withLink(
-                                LinkAnnotation.Url(
-                                    url = part.reference.uri,
-                                    styles =
-                                    TextLinkStyles(
-                                        style =
-                                        SpanStyle(
-                                            color = NostrordColors.MentionText,
-                                            fontWeight = FontWeight.Medium,
+                            // User mentions (npub/nprofile) open the profile; event/group refs have
+                            // no profile, so they keep the URL handler.
+                            val mentionPubkey =
+                                when (val mentionEntity = part.reference.entity) {
+                                    is Nip19.Entity.Npub -> mentionEntity.pubkey
+                                    is Nip19.Entity.Nprofile -> mentionEntity.pubkey
+                                    else -> null
+                                }
+                            if (mentionPubkey != null) {
+                                withLink(
+                                    LinkAnnotation.Clickable(
+                                        tag = "mention_$mentionPubkey",
+                                        styles =
+                                        TextLinkStyles(
+                                            style =
+                                            SpanStyle(
+                                                color = NostrordColors.MentionText,
+                                                fontWeight = FontWeight.Medium,
+                                            ),
+                                        ),
+                                        linkInteractionListener = { onMentionClick(mentionPubkey) },
+                                    ),
+                                ) {
+                                    append(displayText)
+                                }
+                            } else {
+                                withLink(
+                                    LinkAnnotation.Url(
+                                        url = part.reference.uri,
+                                        styles =
+                                        TextLinkStyles(
+                                            style =
+                                            SpanStyle(
+                                                color = NostrordColors.MentionText,
+                                                fontWeight = FontWeight.Medium,
+                                            ),
                                         ),
                                     ),
-                                ),
-                            ) {
-                                append(displayText)
+                                ) {
+                                    append(displayText)
+                                }
                             }
                         }
                         is CustomEmojiPart -> {
@@ -2058,7 +2133,6 @@ private fun QuotedInlineContentGroup(
                 color = NostrordColors.TextContent,
                 style = NostrordTypography.Caption,
                 inlineContent = inlineContentMap,
-                maxLines = 6,
                 modifier = modifier,
             )
         }
@@ -2067,7 +2141,6 @@ private fun QuotedInlineContentGroup(
             text = annotatedString,
             color = NostrordColors.TextContent,
             style = NostrordTypography.Caption,
-            maxLines = 6,
             modifier = modifier,
         )
     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/QuotedEventPreview.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/QuotedEventPreview.kt
@@ -32,6 +32,7 @@ import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.utils.formatDateTime
 
 /**
  * Data class representing a quoted event reference from a "q" tag.
@@ -132,7 +133,6 @@ fun QuotedEventPreview(
                 val processedContent =
                     remember(event.content, userMetadata) {
                         processMentionsInContent(event.content, userMetadata)
-                            .replace('\n', ' ')
                     }
 
                 // Author row with avatar
@@ -152,17 +152,22 @@ fun QuotedEventPreview(
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
+                    Spacer(modifier = Modifier.width(Spacing.sm))
+                    Text(
+                        text = formatDateTime(event.createdAt),
+                        color = NostrordColors.TextMuted,
+                        style = NostrordTypography.Caption,
+                        maxLines = 1,
+                    )
                 }
 
                 Spacer(modifier = Modifier.height(Spacing.xs))
 
-                // Content preview (truncated)
+                // Full event text, no truncation (mirrors the web quoted-event card)
                 Text(
                     text = processedContent,
                     color = NostrordColors.TextContent,
                     style = NostrordTypography.Quote,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis,
                 )
             } else {
                 // Loading state

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
@@ -69,7 +69,14 @@ val WebAvatar =
 
         div {
             className = ClassName("avatar-tile ${props.cls} avatar-stack" + if (kind == AvatarKind.GROUP) " group" else "")
-            props.onClick?.let { cb -> onClick = { cb() } }
+            // An avatar with its own handler opens the profile without also triggering the
+            // container it sits in (message row, quoted-event card).
+            props.onClick?.let { cb ->
+                onClick = { ev ->
+                    ev.stopPropagation()
+                    cb()
+                }
+            }
 
             // Fallback underneath while the photo loads. Removed once it has loaded so a
             // transparent avatar shows the tile's solid background instead of the

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -19,6 +19,7 @@ import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.formatDateTime
 import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.utils.formatTimestamp
 import org.nostr.nostrord.utils.normalizeForSearch
@@ -2645,6 +2646,8 @@ private fun ChildrenBuilder.renderEntities(
                         author = entity.author
                         localById = messagesById
                         onScrollTo = onEventRef
+                        this.onUser = onUser
+                        this.onGroupRef = onGroupRef
                     }
                 is Nip19.Entity.Note ->
                     QuotedEvent {
@@ -2653,6 +2656,8 @@ private fun ChildrenBuilder.renderEntities(
                         author = null
                         localById = messagesById
                         onScrollTo = onEventRef
+                        this.onUser = onUser
+                        this.onGroupRef = onGroupRef
                     }
                 is Nip19.Entity.Naddr ->
                     if (entity.kind == 39000) {
@@ -2692,6 +2697,8 @@ private external interface QuotedEventProps : Props {
     var author: String?
     var localById: Map<String, NostrGroupClient.NostrMessage>
     var onScrollTo: (String) -> Unit
+    var onUser: (String) -> Unit
+    var onGroupRef: (String, String?) -> Unit
 }
 
 /**
@@ -2709,6 +2716,8 @@ private val QuotedEvent =
         val cachedEv = cached[props.eventId]
         val pubkey = local?.pubkey ?: cachedEv?.pubkey ?: props.author
         val content = local?.content ?: cachedEv?.content
+        val createdAt = local?.createdAt ?: cachedEv?.createdAt
+        val quotedTags = local?.tags ?: cachedEv?.tags ?: emptyList()
 
         useEffectOnce {
             if (props.eventId !in cached && local == null) {
@@ -2721,10 +2730,32 @@ private val QuotedEvent =
                 launchApp { repo.requestUserMetadata(setOf(pk)) }
             }
         }
+        // Resolve names for pubkeys mentioned inside the quoted text (nostr:npub / nprofile).
+        useEffect(content) {
+            val c = content ?: return@useEffect
+            val missing =
+                NOSTR_URI_REGEX.findAll(c)
+                    .mapNotNull { m ->
+                        runCatching {
+                            when (val e = Nip19.decode(m.groupValues[1])) {
+                                is Nip19.Entity.Npub -> e.pubkey
+                                is Nip19.Entity.Nprofile -> e.pubkey
+                                else -> null
+                            }
+                        }.getOrNull()
+                    }
+                    .filter { userMetadata[it] == null }
+                    .toSet()
+            if (missing.isNotEmpty()) launchApp { repo.requestUserMetadata(missing) }
+        }
+
+        // Clickable only when the referenced event is a local message we can scroll to; an
+        // external nevent reference has nowhere to scroll, so it stays static (no pointer).
+        val scrollable = local != null
 
         div {
-            className = ClassName("quoted-event")
-            onClick = { props.onScrollTo(props.eventId) }
+            className = ClassName(if (scrollable) "quoted-event" else "quoted-event quoted-event-static")
+            if (scrollable) onClick = { props.onScrollTo(props.eventId) }
             if (content != null && pubkey != null) {
                 div {
                     className = ClassName("quoted-event-head")
@@ -2733,15 +2764,43 @@ private val QuotedEvent =
                         seed = pubkey
                         this.name = displayName(pubkey, userMetadata[pubkey])
                         cls = "quoted-event-avatar"
+                        onClick = { props.onUser(pubkey) }
                     }
                     span {
                         className = ClassName("quoted-event-author")
+                        onClick = { ev ->
+                            ev.stopPropagation()
+                            props.onUser(pubkey)
+                        }
                         +displayName(pubkey, userMetadata[pubkey])
+                    }
+                    if (createdAt != null) {
+                        span {
+                            className = ClassName("quoted-event-time")
+                            +formatDateTime(createdAt)
+                        }
+                    }
+                    a {
+                        className = ClassName("quoted-event-open")
+                        href = "https://jumble.social/notes/${Nip19.encodeNote(props.eventId)}"
+                        asDynamic().target = "_blank"
+                        rel = "noopener noreferrer"
+                        title = "Open in another client"
+                        onClick = { it.stopPropagation() }
+                        icon(Ic.OpenInNew)
                     }
                 }
                 div {
                     className = ClassName("quoted-event-content")
-                    +content.replace('\n', ' ').trim().take(280)
+                    renderMessageContent(
+                        content.trim(),
+                        quotedTags,
+                        userMetadata,
+                        props.localById,
+                        props.onUser,
+                        props.onScrollTo,
+                        props.onGroupRef,
+                    )
                 }
             } else {
                 span {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3240,12 +3240,17 @@ body {
     margin: 4px 0;
     padding: 8px 10px;
     background: var(--color-input);
-    border-left: 3px solid var(--color-primary);
     border-radius: 4px;
     cursor: pointer;
 }
 .quoted-event:hover {
     background: var(--color-surface-variant);
+}
+.quoted-event-static {
+    cursor: text;
+}
+.quoted-event-static:hover {
+    background: var(--color-input);
 }
 .quoted-event-head {
     display: flex;
@@ -3254,24 +3259,46 @@ body {
     margin-bottom: 4px;
 }
 .quoted-event-avatar {
-    width: 18px;
-    height: 18px;
+    width: 24px;
+    height: 24px;
     flex-shrink: 0;
-    font-size: 10px;
+    font-size: 12px;
     font-weight: 700;
+    border-radius: 50%;
+    cursor: pointer;
 }
 .quoted-event-author {
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 600;
     color: var(--color-text-primary);
+    cursor: pointer;
+}
+.quoted-event-author:hover {
+    text-decoration: underline;
+}
+.quoted-event-time {
+    font-size: 11px;
+    color: var(--color-text-muted);
+}
+.quoted-event-open {
+    display: flex;
+    align-items: center;
+    margin-left: auto;
+    color: var(--color-text-muted);
+    cursor: pointer;
+}
+.quoted-event-open:hover {
+    color: var(--color-text-primary);
+}
+.quoted-event-open .ico {
+    width: 16px;
+    height: 16px;
 }
 .quoted-event-content {
     font-size: 13px;
-    color: var(--color-text-secondary);
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
+    color: var(--color-text-content);
+    white-space: pre-wrap;
+    word-break: break-word;
 }
 .quoted-event-loading {
     font-size: 13px;


### PR DESCRIPTION
Brings the nevent/note quote card to parity on web (React) and native (Compose), plus a few correctness fixes uncovered along the way.

| Area | Change |
|---|---|
| Web content | Routes through `renderMessageContent`, so `nostr:npub`/`nprofile` render as clickable `@name` pills (with on-demand metadata fetch), and nested refs/URLs/emojis render too (was raw truncated text). |
| Native mentions | `QuotedInlineContentGroup` opens user mentions in the profile modal instead of the `nostr:` URI (fixed the desktop "Failed to show URI" error). `onMentionClick` threaded through the quote chain. |
| Avatar/author | Open the profile on both platforms; `WebAvatar` stops click propagation so it doesn't also trigger the card. |
| Content | Full event text (no `line-clamp`/`maxLines`); date+time header via shared `formatDateTime`. |
| Open in client | Web link + native `OpenInNew` to jumble.social; Android adds a `nostr:` chooser button; Linux desktop copies the link instead (GNOME can't raise the browser) via new `isLinuxDesktop`. |
| Styling | Round avatar, input background, no left border; external nevent cards are non-clickable (nowhere to scroll). |

🤖 Generated with [Claude Code](https://claude.com/claude-code)