### PR TITLE
fix: route group sends to the group's own relay, never the primary

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -345,6 +345,7 @@ class NostrRepository(
         }
 
         metadataManager.messageHandler = { msg, client -> enqueueToRelayPipeline(msg, client) }
+        groupManager.messageHandler = { msg, client -> enqueueToRelayPipeline(msg, client) }
 
         connectionManager.startNetworkMonitor()
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -410,6 +410,9 @@ class GroupManager(
     private val _restrictedGroups = MutableStateFlow<Map<String, String>>(emptyMap())
     val restrictedGroups: StateFlow<Map<String, String>> = _restrictedGroups.asStateFlow()
 
+    // Lets clientForGroup reconnect a group's own relay on demand. Wired by NostrRepository.
+    var messageHandler: ((String, NostrGroupClient) -> Unit)? = null
+
     // Gate for the approval-recovery path: only fires when the user actually
     // sent kind:9021, never for historical events on already-joined groups.
     private val pendingApprovalSince = mutableMapOf<String, Long>()
@@ -559,23 +562,22 @@ class GroupManager(
 
     /**
      * Returns the WebSocket client for the relay that hosts [groupId].
-     * If the group's relay client exists but is disconnected, returns null — callers must
-     * not send subscriptions to dead sockets (send() silently no-ops on a closed session).
-     * Falls back to the primary only when the group's relay is completely unknown.
+     *
+     * A NIP-29 relay rejects a kind:9 ("blocked: group doesn't exist") if it does not
+     * host the group in the `h` tag, so once the group's relay is known this never falls
+     * back to the primary. A non-primary pool relay that was evicted is reconnected on
+     * demand; a relay that is down (or whose socket is dead) returns null so the send
+     * fails honestly instead of being misrouted.
      */
     private suspend fun clientForGroup(groupId: String): NostrGroupClient? {
         val relayUrl = getRelayForGroup(groupId)
-        return if (relayUrl != null) {
-            val client = connectionManager.getClientForRelay(relayUrl)
-            when {
-                client == null -> connectionManager.getPrimaryClient() // relay not in pool yet
-                client.isConnected() -> client // healthy pool client ✓
-                else -> {
-                    null // dead pool client — reconnect is pending, don't send to it
-                }
-            }
-        } else {
-            connectionManager.getPrimaryClient()
+            ?: return connectionManager.getPrimaryClient()
+        val client = connectionManager.getClientForRelay(relayUrl)
+        return when {
+            client != null && client.isConnected() -> client
+            relayUrl.normalizeRelayUrl() == connectionManager.currentRelayUrl.value.normalizeRelayUrl() -> null
+            client != null -> null
+            else -> messageHandler?.let { connectionManager.getOrConnectRelay(relayUrl, it) }
         }
     }
 


### PR DESCRIPTION
With multiple NIP-29 relays kept active at once, a group often lives on a non-primary pool relay. When that relay's socket was transiently absent from the lazy pool, `clientForGroup` fell back to `getPrimaryClient()`, so a kind:9 carrying `h=<groupId>` went to the relay you happened to be *currently* on, which doesn't host the group, and the relay rejected it with `blocked: group '...' doesn't exist`. Intermittent (only in the reconnect window), persistent once it started (every retry repeated the misroute), and `nak` never hit it because it talks straight to the correct relay.

Once the group's relay is known, `clientForGroup` no longer swaps it for the primary: an evicted pool relay is reconnected on demand (`getOrConnectRelay`, via a newly wired `messageHandler`), and a relay that is down or whose socket is dead returns null so the send fails honestly ("Connection lost. Reconnecting...") instead of being delivered to the wrong relay.

| Scenario | Before | After |
|---|---|---|
| Group's relay socket evicted from pool | sent to primary -> "group doesn't exist" | reconnect group's relay, send there |
| Group's relay down / dead socket | misrouted to primary | null -> "Connection lost. Reconnecting..." |
| Genuine relay rejection | (masked by misroute) | real relay reason surfaced |

Closes #136

Commits:
- fix: route group sends to the group's own relay, never the primary