### PR TITLE
fix(zap): correct NIP-57 zap request and gate the zap action

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -230,7 +230,6 @@ object AppModule {
         ZapManager(
             metadataManager = metadataManager,
             connectionManager = connectionManager,
-            outboxManager = outboxManager,
             scope = appScope,
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ZapManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ZapManager.kt
@@ -123,14 +123,18 @@ class ZapManager(
                 }
 
                 // 2. Build + sign the zap request (kind 9734). Not published to a relay.
-                val cappedComment = if (params.commentAllowed > 0) comment.take(params.commentAllowed) else ""
+                // The zap comment belongs in the 9734 `content` per NIP-57, independent of the
+                // LNURL `commentAllowed` field (that governs the separate LNURL-pay `comment`
+                // query param, which zaps do not use). Gating on it drops the comment for wallets
+                // that report commentAllowed: 0.
+                val zapComment = comment.trim()
                 val request = Nip57.buildZapRequest(
                     senderPubkey = senderPubkey,
                     recipientPubkey = recipientPubkey,
                     amountMsats = amountMsats,
                     relays = receiptRelays(),
                     lnurlBech32 = lnurlBech32,
-                    comment = cappedComment,
+                    comment = zapComment,
                     eventId = eventId,
                     createdAt = epochMillis() / 1000,
                 )
@@ -157,7 +161,7 @@ class ZapManager(
                         amountMsats = amountMsats,
                         recipientPubkey = recipientPubkey,
                         eventId = eventId,
-                        comment = cappedComment,
+                        comment = zapComment,
                     ),
                 )
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ZapManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ZapManager.kt
@@ -38,16 +38,14 @@ import org.nostr.nostrord.utils.epochMillis
 class ZapManager(
     private val metadataManager: MetadataManager,
     private val connectionManager: ConnectionManager,
-    private val outboxManager: OutboxManager,
     @Suppress("unused") private val scope: CoroutineScope,
 ) {
     private val http = createHttpClient()
 
     companion object {
         private const val HTTP_TIMEOUT_MS = 15_000L
-        private const val MAX_RECEIPT_RELAYS = 6
         private val DEFAULT_RELAYS =
-            listOf("wss://relay.damus.io", "wss://nos.lol", "wss://relay.nostr.band")
+            listOf("wss://relay.damus.io", "wss://nos.lol")
     }
 
     /** Aggregated zaps for a target event id: total amount + distinct zappers. */
@@ -205,18 +203,17 @@ class ZapManager(
     }
 
     /**
-     * Relays to request the zap receipt be published to (the 9734 `relays` tag): the active
-     * group relay first (where the zapped message lives and where we read it back), then the
-     * account's NIP-65/NIP-29 relays, then well-known general relays for redundancy.
-     *
-     * Also the canonical set to read receipts back from — they are published here, not to the
-     * NIP-29 group relay (which rejects events without an `h` tag).
+     * Relays to request the zap receipt be published to (the 9734 `relays` tag), and the same
+     * set we read the receipt back from: the relay of the group where the zapped message lives,
+     * plus a few well-known general relays. A zap targets one group on one relay, so the single
+     * group relay is what is relevant, not every group relay the account belongs to. The general
+     * relays guarantee the receipt (kind 9735, no `h` tag) lands somewhere readable even if the
+     * NIP-29 group relay rejects events without an `h` tag.
      */
     fun receiptRelays(): List<String> {
         val relays = LinkedHashSet<String>()
         connectionManager.currentRelayUrl.value.takeIf { it.isNotBlank() }?.let { relays.add(it) }
-        relays.addAll(outboxManager.kind10009Relays.value)
         relays.addAll(DEFAULT_RELAYS)
-        return relays.take(MAX_RECEIPT_RELAYS).toList()
+        return relays.toList()
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -47,10 +47,12 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.nostr.nostrord.auth.ActiveAccountManager
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.zap.ZapBadge
 import org.nostr.nostrord.ui.components.zap.ZapController
@@ -136,8 +138,12 @@ fun MessageItem(
     // the current user), and surface the running total for this message.
     val zapTotals by AppModule.nostrRepository.zaps.collectAsState()
     val zapInfo = zapTotals[message.id]
-    val canZap = message.pubkey != currentUserPubkey &&
-        (!metadata?.lud16.isNullOrBlank() || !metadata?.lud06.isNullOrBlank())
+    // Zaps require signing a kind:9734 request, so only offer them when an account
+    // with a usable signer is active.
+    val activeSession by ActiveAccountManager.session.collectAsState()
+    val canZap = activeSession != null &&
+        message.pubkey != currentUserPubkey &&
+        Nip57.resolvePayEndpoint(metadata?.lud16, metadata?.lud06) != null
 
     // Look up parent via caller-provided resolver, then in cachedEvents
     val parentMessage =

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/zap/Zap.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/zap/Zap.kt
@@ -276,7 +276,7 @@ private fun ZapAmountStep(
                         modifier = Modifier.weight(1f),
                         colors = ButtonDefaults.outlinedButtonColors(
                             containerColor = if (selected) NostrordColors.Primary.copy(alpha = 0.18f) else Color.Transparent,
-                            contentColor = if (selected) NostrordColors.Primary else NostrordColors.TextPrimary,
+                            contentColor = if (selected) Color.White else NostrordColors.TextPrimary,
                         ),
                     ) {
                         Text("$preset", fontSize = 13.sp)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
@@ -35,8 +35,10 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import org.nostr.nostrord.auth.ActiveAccountManager
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.ui.components.RichAboutText
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.zap.ZapController
@@ -68,7 +70,11 @@ fun UserProfileModal(
     val npub = remember(pubkey) { Nip19.encodeNpub(pubkey) }
     val displayName = metadata?.displayName ?: metadata?.name ?: pubkey.take(8) + "..."
 
-    val canZap = !metadata?.lud16.isNullOrBlank() || !metadata?.lud06.isNullOrBlank()
+    // Zaps require signing a kind:9734 request, so only offer them when an account
+    // with a usable signer is active.
+    val activeSession by ActiveAccountManager.session.collectAsState()
+    val canZap = activeSession != null &&
+        Nip57.resolvePayEndpoint(metadata?.lud16, metadata?.lud06) != null
     val username = metadata?.name
 
     Dialog(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
@@ -1,7 +1,9 @@
 package org.nostr.nostrord.web.modals
 
+import org.nostr.nostrord.auth.ActiveAccountManager
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.components.Ic
@@ -46,7 +48,10 @@ val UserProfileModal =
                 ?: meta?.name?.takeIf { it.isNotBlank() }
                 ?: (npub.take(12) + "…")
         val handle = meta?.name?.takeIf { it.isNotBlank() }
-        val canZap = !meta?.lud16.isNullOrBlank() || !meta?.lud06.isNullOrBlank()
+        // Zaps require signing a kind:9734 request, so only offer them when an account
+        // with a usable signer is active.
+        val canSign = useStateFlow(ActiveAccountManager.session) != null
+        val canZap = canSign && Nip57.resolvePayEndpoint(meta?.lud16, meta?.lud06) != null
 
         useEffect(pubkey) {
             launchApp { AppModule.nostrRepository.requestUserMetadata(setOf(pubkey)) }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.json.addJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
+import org.nostr.nostrord.auth.ActiveAccountManager
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.NostrGroupClient
@@ -16,6 +17,7 @@ import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.utils.ChatSearch
 import org.nostr.nostrord.utils.Result
@@ -690,6 +692,9 @@ val ChatScreen =
         val connState = useStateFlow(repo.connectionState)
         val membersLoading = group.id in useStateFlow(repo.loadingMembers)
         val myPubkey = repo.getPublicKey()
+        // Zaps require signing a kind:9734 request, so only offer them when an account
+        // with a usable signer is active.
+        val canSign = useStateFlow(ActiveAccountManager.session) != null
         // Re-key effects that fire per-session work (requestGroupMessages,
         // metadata, polling) on activeAccountId too. Without this, switching
         // accounts while the same group is open leaves group.id unchanged, the
@@ -1664,8 +1669,9 @@ val ChatScreen =
                                                 onEventRef = { id -> scrollToMessage(id) }
                                                 onGroupRef = { gid, relay -> props.onNavigateGroup(gid, relay) }
                                                 canZap =
+                                                    canSign &&
                                                     message.pubkey != myPubkey &&
-                                                    (!authorMeta?.lud16.isNullOrBlank() || !authorMeta?.lud06.isNullOrBlank())
+                                                    Nip57.resolvePayEndpoint(authorMeta?.lud16, authorMeta?.lud06) != null
                                                 zapTotalMsats = zapInfo?.totalMsats ?: 0L
                                                 zapCount = zapInfo?.count ?: 0
                                                 zappedByMe = myPubkey != null && zapInfo != null && myPubkey in zapInfo.zappers

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3392,26 +3392,28 @@ body {
 .profile-name-col {
     min-width: 0;
 }
+/* Mirror the native profile zap pill: solid neutral surface, white label, yellow bolt. */
 .profile-zap {
     display: inline-flex;
     align-items: center;
     gap: 4px;
     flex-shrink: 0;
-    padding: 5px 12px;
+    padding: 8px 12px;
     font-size: 13px;
     font-weight: 600;
-    color: var(--color-warning-orange);
-    background: rgba(255, 165, 0, 0.15);
-    border: 1px solid rgba(255, 165, 0, 0.4);
-    border-radius: 16px;
+    color: var(--color-text-primary);
+    background: var(--color-surface-variant);
+    border: none;
+    border-radius: 10px;
     cursor: pointer;
 }
 .profile-zap:hover {
-    background: rgba(255, 165, 0, 0.25);
+    background: #4a4f57;
 }
 .profile-zap .ico {
     width: 16px;
     height: 16px;
+    color: #fee75c;
 }
 
 /* Fenced code block + inline code (mirrors native CodeBlockContent / Monospace) */
@@ -6346,7 +6348,7 @@ body {
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 2px 8px;
+    padding: 4px 8px;
     font-size: 12px;
     font-weight: 600;
     color: var(--color-text-secondary);
@@ -6356,9 +6358,9 @@ body {
     cursor: pointer;
 }
 .zap-badge.mine {
-    color: var(--color-warning-orange);
-    background: rgba(255, 165, 0, 0.18);
-    border-color: rgba(255, 165, 0, 0.4);
+    color: #fee75c;
+    background: rgba(254, 231, 92, 0.18);
+    border-color: transparent;
 }
 .zap-badge-bolt {
     font-size: 12px;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -6242,6 +6242,10 @@ body {
     flex-direction: column;
     gap: 12px;
 }
+/* Match the native zap glyph color (NostrordColors.Warning) on the modal title. */
+.zap-card .modal-title .ico {
+    color: #fee75c;
+}
 .zap-presets {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -6262,7 +6266,7 @@ body {
     border-color: var(--color-primary);
 }
 .zap-preset.selected {
-    color: var(--color-primary);
+    color: #ffffff;
     background: rgba(88, 101, 242, 0.18);
     border-color: var(--color-primary);
 }


### PR DESCRIPTION
Several fixes to the NIP-57 zap flow, found while inspecting real kind:9734 events. The zap request was advertising every group relay the account belonged to, dropping the comment for some wallets, and showing the action for accounts that cannot sign or for authors without a usable lightning address.

| Area | Before | After |
|---|---|---|
| Receipt `relays` tag | active relay + every kind:10009 group relay + fallbacks, capped at 6 (general fallbacks squeezed out) | the group relay where the zapped message lives + general fallbacks |
| `DEFAULT_RELAYS` | damus, nos.lol, relay.nostr.band | damus, nos.lol (relay.nostr.band dropped, not functional) |
| Zap comment | gated on LNURL `commentAllowed`, wiped to "" when a wallet reports 0 | always carried in the 9734 `content` per NIP-57 |
| Zap action visibility | shown whenever the author has a non-blank lud16/lud06 | shown only when an active signer exists and the address resolves via `Nip57.resolvePayEndpoint` |
| Selected amount preset | primary-colored text | white text (native + web) |
| Web modal title bolt | inherited title text color | native zap glyph color (`#fee75c`) |

Verified against the NIP-57 spec: the request carries exactly one `p`, a `relays` tag, `amount` in millisats, `lnurl`, and 0-or-1 `e`, with the comment in `content`. Compiles on JVM, Android, and JS; `jvmTest` and `spotlessCheck` pass. iOS target has a pre-existing build break on main unrelated to these changes.

Commits:
- fix(zap): scope receipt relays to the group relay plus fallbacks
- fix(zap): carry the zap comment in the 9734 content
- feat(zap): only show zap when signing is possible and the address is valid
- style(zap): white selected preset text and native warning color on web modal icon