### PR TITLE
Admins delete member messages via NIP-29 kind 9005

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -2421,9 +2421,16 @@ class GroupManager(
     }
 
     /**
-     * Delete a message from a group (NIP-09: kind 5 deletion event).
-     * Sends the deletion event to the relay; the relay will broadcast it and
-     * handleDeletion() will remove it from local state when received back.
+     * Delete a message from a group.
+     *
+     * The deletion kind is chosen by who is deleting whose message:
+     * - Authors deleting their own message use kind 5 (NIP-09 standard deletion).
+     * - Admins deleting another member's message use kind 9005 (NIP-29
+     *   delete-event moderation action). NIP-29 relays only honor a kind 5 from
+     *   the author; removing someone else's message requires the admin kind 9005.
+     *
+     * Sends the deletion event to the relay; the relay broadcasts it and
+     * handleDeletion() removes it from local state when received back.
      */
     suspend fun deleteMessage(
         groupId: String,
@@ -2433,14 +2440,19 @@ class GroupManager(
     ): Result<Unit> {
         val currentClient = clientForGroup(groupId)
             ?: return Result.Error(AppError.Network.Disconnected(""))
+        val messageAuthor = _messages.value[groupId]?.firstOrNull { it.id == messageId }?.pubkey
+        val deletionKind = deletionKindFor(
+            isOwnMessage = messageAuthor == pubKey,
+            isAdmin = isGroupAdmin(groupId, pubKey),
+        )
         return try {
             val event = Event(
                 pubkey = pubKey,
                 createdAt = epochMillis() / 1000,
-                kind = 5,
+                kind = deletionKind,
                 tags = listOf(
-                    listOf("e", messageId),
                     listOf("h", groupId),
+                    listOf("e", messageId),
                 ),
                 content = "",
             )
@@ -3430,3 +3442,14 @@ class GroupManager(
         SecureStorage.clearMessagesForGroup(pubkey, groupId)
     }
 }
+
+/**
+ * Pick the deletion event kind for a group message.
+ *
+ * - Kind 5 (NIP-09) is the standard deletion an author issues for their own message.
+ * - Kind 9005 is the NIP-29 delete-event moderation action; NIP-29 relays only let an
+ *   admin remove another member's message through it, never through kind 5.
+ *
+ * An admin deleting their own message stays on kind 5 (they are the author).
+ */
+internal fun deletionKindFor(isOwnMessage: Boolean, isAdmin: Boolean): Int = if (!isOwnMessage && isAdmin) 9005 else 5

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DeletionKindTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DeletionKindTest.kt
@@ -1,0 +1,28 @@
+package org.nostr.nostrord.network.managers
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DeletionKindTest {
+    @Test
+    fun `author deleting own message uses kind 5`() {
+        assertEquals(5, deletionKindFor(isOwnMessage = true, isAdmin = false))
+    }
+
+    @Test
+    fun `admin deleting own message uses kind 5`() {
+        // An admin is still the author of their own message, so it is a standard deletion.
+        assertEquals(5, deletionKindFor(isOwnMessage = true, isAdmin = true))
+    }
+
+    @Test
+    fun `admin deleting another member's message uses kind 9005`() {
+        assertEquals(9005, deletionKindFor(isOwnMessage = false, isAdmin = true))
+    }
+
+    @Test
+    fun `non-admin targeting another member's message stays on kind 5`() {
+        // The relay rejects it, but the client must not forge an admin kind 9005.
+        assertEquals(5, deletionKindFor(isOwnMessage = false, isAdmin = false))
+    }
+}


### PR DESCRIPTION
`deleteMessage` always emitted `kind:5`, the NIP-09 user deletion that NIP-29 relays only honor when it comes from the message author. So when a group admin tried to remove another member's message, the relay rejected it. Admin moderation requires `kind:9005` (NIP-29 delete-event), and that path was never taken.

The fix picks the deletion kind by who is deleting whose message, all inside `GroupManager.deleteMessage` (commonMain, shared by every platform):

| Case | Kind |
|---|---|
| Author deletes own message | 5 (NIP-09) |
| Admin deletes own message | 5 (still the author) |
| Admin deletes another member's message | 9005 (NIP-29 moderation) |
| Non-admin targets another member's message | 5 (relay rejects; client must not forge 9005) |

The rule is extracted to a pure `deletionKindFor(isOwnMessage, isAdmin)` helper with a unit test. The tag set switches to `["h", groupId]` + `["e", messageId]`, matching the other moderation events (e.g. `rejectJoinRequest`, also kind 9005).

No UI or per-platform change: both Compose and web already gate the delete action on `author || admin` and call the same `repo.deleteMessage`, and `handleDeletion()` already treats kinds 5 and 9005 identically. Works across Android, JVM, iOS, and web.

- `feat(moderation): admins delete member messages via NIP-29 kind 9005`

Verified: `compileKotlinJvm`, `compileKotlinJs`, and the new `DeletionKindTest` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)