### PR TITLE
Join and share groups by NIP-29 address (wss://relay'groupId) and naddr

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupLink.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupLink.kt
@@ -1,5 +1,7 @@
 package org.nostr.nostrord.utils
 
+import org.nostr.nostrord.nostr.Nip19
+
 /** A parsed join target: which relay hosts the group, the group id, and an optional invite code. */
 data class GroupJoinTarget(
     val relayUrl: String,
@@ -18,15 +20,27 @@ fun buildGroupAddress(relayUrl: String, groupId: String): String {
 }
 
 /**
- * Parse a join input into a [GroupJoinTarget]. Accepts both:
+ * Parse a join input into a [GroupJoinTarget]. Accepts:
  * - NIP-29 group address: `wss://relay.com'groupId` (or a bare `relay.com'groupId`)
+ * - NIP-19 group naddr (as shared by ShareGroupModal): `nostr:naddr1...` / bare `naddr1...`
  * - nostrord invite link: `https://nostrord.com/open/?relay=X&group=Y&code=Z` / `nostrord://...`
  *
- * Returns null when neither form yields a relay and group id.
+ * Returns null when no form yields a relay and group id.
  */
 fun parseGroupJoinInput(input: String): GroupJoinTarget? {
     val trimmed = input.trim()
     if (trimmed.isEmpty()) return null
+
+    // NIP-19 group naddr: decode to its relay hint + group identifier. Requires a relay hint
+    // (without it we don't know which relay hosts the group) and the group metadata kind.
+    val bech = trimmed.removePrefix("nostr:")
+    if (bech.startsWith("naddr1")) {
+        val naddr = Nip19.decode(bech) as? Nip19.Entity.Naddr ?: return null
+        if (naddr.kind != 39000) return null
+        val relay = naddr.relays.firstOrNull()?.takeIf { it.isNotBlank() } ?: return null
+        val groupId = naddr.identifier.takeIf { it.isNotBlank() } ?: return null
+        return GroupJoinTarget(relay.toRelayUrl(), groupId)
+    }
 
     // NIP-29 group address takes priority: an apostrophe separates relay from group id, and the
     // form carries no query string (so we don't mistake an invite link's `?code=a'b` for one).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupLink.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupLink.kt
@@ -1,0 +1,54 @@
+package org.nostr.nostrord.utils
+
+/** A parsed join target: which relay hosts the group, the group id, and an optional invite code. */
+data class GroupJoinTarget(
+    val relayUrl: String,
+    val groupId: String,
+    val inviteCode: String? = null,
+)
+
+/**
+ * Build the NIP-29 group address `wss://host'groupId` from a relay url + group id. This is the
+ * compact reference clients paste into chat; [parseGroupJoinInput] reads it back, and the chat
+ * message renderer turns it into a tappable group card.
+ */
+fun buildGroupAddress(relayUrl: String, groupId: String): String {
+    val normalized = relayUrl.toRelayUrl().trimEnd('/')
+    return "$normalized'$groupId"
+}
+
+/**
+ * Parse a join input into a [GroupJoinTarget]. Accepts both:
+ * - NIP-29 group address: `wss://relay.com'groupId` (or a bare `relay.com'groupId`)
+ * - nostrord invite link: `https://nostrord.com/open/?relay=X&group=Y&code=Z` / `nostrord://...`
+ *
+ * Returns null when neither form yields a relay and group id.
+ */
+fun parseGroupJoinInput(input: String): GroupJoinTarget? {
+    val trimmed = input.trim()
+    if (trimmed.isEmpty()) return null
+
+    // NIP-29 group address takes priority: an apostrophe separates relay from group id, and the
+    // form carries no query string (so we don't mistake an invite link's `?code=a'b` for one).
+    val apostrophe = trimmed.indexOf('\'')
+    if (apostrophe > 0 && trimmed.indexOf('?') < 0) {
+        val relayPart = trimmed.substring(0, apostrophe).trim()
+        val groupId = trimmed.substring(apostrophe + 1).trim()
+        if (groupId.isEmpty()) return null
+        val relayUrl = relayPart.toRelayUrl()
+        if (relayUrl.isEmpty()) return null
+        return GroupJoinTarget(relayUrl, groupId)
+    }
+
+    // Invite-link form: pull the relay/group/code query params.
+    val queryStart = trimmed.indexOf('?')
+    if (queryStart < 0) return null
+    val params =
+        trimmed.substring(queryStart + 1).split("&").associate { param ->
+            val idx = param.indexOf("=")
+            if (idx >= 0) param.substring(0, idx) to param.substring(idx + 1) else param to ""
+        }
+    val relay = params["relay"]?.takeIf { it.isNotBlank() } ?: return null
+    val group = params["group"]?.takeIf { it.isNotBlank() } ?: return null
+    return GroupJoinTarget(relay.toRelayUrl(), group, params["code"]?.takeIf { it.isNotBlank() })
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupLink.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupLink.kt
@@ -39,7 +39,9 @@ fun parseGroupJoinInput(input: String): GroupJoinTarget? {
         if (naddr.kind != 39000) return null
         val relay = naddr.relays.firstOrNull()?.takeIf { it.isNotBlank() } ?: return null
         val groupId = naddr.identifier.takeIf { it.isNotBlank() } ?: return null
-        return GroupJoinTarget(relay.toRelayUrl(), groupId)
+        val relayUrl = relay.toRelayUrl()
+        if (relayUrl.isEmpty()) return null
+        return GroupJoinTarget(relayUrl, groupId)
     }
 
     // NIP-29 group address takes priority: an apostrophe separates relay from group id, and the
@@ -64,5 +66,7 @@ fun parseGroupJoinInput(input: String): GroupJoinTarget? {
         }
     val relay = params["relay"]?.takeIf { it.isNotBlank() } ?: return null
     val group = params["group"]?.takeIf { it.isNotBlank() } ?: return null
-    return GroupJoinTarget(relay.toRelayUrl(), group, params["code"]?.takeIf { it.isNotBlank() })
+    val relayUrl = relay.toRelayUrl()
+    if (relayUrl.isEmpty()) return null
+    return GroupJoinTarget(relayUrl, group, params["code"]?.takeIf { it.isNotBlank() })
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupLinkTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupLinkTest.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.utils
 
+import org.nostr.nostrord.nostr.Nip19
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -60,5 +61,29 @@ class GroupLinkTest {
     @Test
     fun `buildGroupAddress adds scheme to bare host`() {
         assertEquals("wss://relay.com'abc123", buildGroupAddress("relay.com", "abc123"))
+    }
+
+    @Test
+    fun `parses group naddr with relay hint`() {
+        val naddr = Nip19.encodeNaddr(identifier = "abc123", relay = "wss://relay.com", kind = 39000)
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123"), parseGroupJoinInput(naddr))
+    }
+
+    @Test
+    fun `parses group naddr with nostr prefix`() {
+        val naddr = "nostr:" + Nip19.encodeNaddr(identifier = "abc123", relay = "wss://relay.com", kind = 39000)
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123"), parseGroupJoinInput(naddr))
+    }
+
+    @Test
+    fun `naddr without a relay hint is rejected`() {
+        val naddr = Nip19.encodeNaddr(identifier = "abc123", relay = "", kind = 39000)
+        assertNull(parseGroupJoinInput(naddr))
+    }
+
+    @Test
+    fun `non-group naddr kind is rejected`() {
+        val naddr = Nip19.encodeNaddr(identifier = "abc123", relay = "wss://relay.com", kind = 30023)
+        assertNull(parseGroupJoinInput(naddr))
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupLinkTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupLinkTest.kt
@@ -86,4 +86,27 @@ class GroupLinkTest {
         val naddr = Nip19.encodeNaddr(identifier = "abc123", relay = "wss://relay.com", kind = 30023)
         assertNull(parseGroupJoinInput(naddr))
     }
+
+    @Test
+    fun `garbage naddr is rejected`() {
+        assertNull(parseGroupJoinInput("naddr1notvalidbech32"))
+    }
+
+    @Test
+    fun `address with userinfo relay is rejected`() {
+        // toRelayUrl rejects `@` userinfo (it could bypass loopback checks); none of the forms
+        // should let a blank relay slip through.
+        assertNull(parseGroupJoinInput("ws://localhost:7777@evil.com'abc123"))
+    }
+
+    @Test
+    fun `invite link with userinfo relay is rejected`() {
+        assertNull(parseGroupJoinInput("nostrord://open?relay=ws://localhost:7777@evil.com&group=abc123"))
+    }
+
+    @Test
+    fun `naddr with userinfo relay hint is rejected`() {
+        val naddr = Nip19.encodeNaddr(identifier = "abc123", relay = "ws://localhost:7777@evil.com", kind = 39000)
+        assertNull(parseGroupJoinInput(naddr))
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupLinkTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupLinkTest.kt
@@ -1,0 +1,64 @@
+package org.nostr.nostrord.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GroupLinkTest {
+    @Test
+    fun `parses NIP-29 group address with scheme`() {
+        val target = parseGroupJoinInput("wss://relay.com'abc123")
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123"), target)
+    }
+
+    @Test
+    fun `parses bare host group address by adding wss`() {
+        val target = parseGroupJoinInput("relay.com'abc123")
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123"), target)
+    }
+
+    @Test
+    fun `trims surrounding whitespace on group address`() {
+        val target = parseGroupJoinInput("  wss://relay.com'abc123  ")
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123"), target)
+    }
+
+    @Test
+    fun `parses invite link with relay group and code`() {
+        val target = parseGroupJoinInput("https://nostrord.com/open/?relay=relay.com&group=abc123&code=secret")
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123", "secret"), target)
+    }
+
+    @Test
+    fun `invite link without code yields null code`() {
+        val target = parseGroupJoinInput("nostrord://open?relay=relay.com&group=abc123")
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123", null), target)
+    }
+
+    @Test
+    fun `group address without id is rejected`() {
+        assertNull(parseGroupJoinInput("wss://relay.com'"))
+    }
+
+    @Test
+    fun `blank input is rejected`() {
+        assertNull(parseGroupJoinInput("   "))
+    }
+
+    @Test
+    fun `plain relay url without id or query is rejected`() {
+        assertNull(parseGroupJoinInput("wss://relay.com"))
+    }
+
+    @Test
+    fun `buildGroupAddress round-trips through the parser`() {
+        val address = buildGroupAddress("wss://relay.com", "abc123")
+        assertEquals("wss://relay.com'abc123", address)
+        assertEquals(GroupJoinTarget("wss://relay.com", "abc123"), parseGroupJoinInput(address))
+    }
+
+    @Test
+    fun `buildGroupAddress adds scheme to bare host`() {
+        assertEquals("wss://relay.com'abc123", buildGroupAddress("relay.com", "abc123"))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/JoinGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/JoinGroupModal.kt
@@ -8,11 +8,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.nostr.nostrord.ui.theme.NostrordColors
-import org.nostr.nostrord.utils.toRelayUrl
+import org.nostr.nostrord.utils.parseGroupJoinInput
 
 /**
- * Modal for joining a group by pasting an invite link.
+ * Modal for joining a group by pasting an invite link or a NIP-29 group address.
  * Accepts formats:
+ * - Group address: wss://relay.com'groupId
  * - Full URL: https://nostrord.com/open/?relay=X&group=Y&code=Z
  * - nostrord://open?relay=X&group=Y&code=Z
  */
@@ -23,32 +24,6 @@ fun JoinGroupModal(
 ) {
     var linkInput by remember { mutableStateOf("") }
     var parseError by remember { mutableStateOf<String?>(null) }
-
-    fun tryParseLink(input: String): Triple<String, String, String?>? {
-        if (input.isBlank()) return null
-        val trimmed = input.trim()
-
-        val queryStart = trimmed.indexOf('?')
-        if (queryStart < 0) return null
-
-        val query = trimmed.substring(queryStart + 1)
-        val params =
-            query.split("&").associate { param ->
-                val idx = param.indexOf("=")
-                if (idx >= 0) {
-                    param.substring(0, idx) to param.substring(idx + 1)
-                } else {
-                    param to ""
-                }
-            }
-
-        val relay = params["relay"]?.takeIf { it.isNotBlank() } ?: return null
-        val group = params["group"]?.takeIf { it.isNotBlank() } ?: return null
-        val relayUrl = relay.toRelayUrl()
-        val code = params["code"]?.takeIf { it.isNotBlank() }
-
-        return Triple(relayUrl, group, code)
-    }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -63,31 +38,39 @@ fun JoinGroupModal(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
-                    "Paste an invite link to join a group.",
+                    "Paste an invite link or a group address to join a group.",
                     color = NostrordColors.TextSecondary,
                     style = MaterialTheme.typography.bodySmall,
                 )
 
-                OutlinedTextField(
-                    value = linkInput,
-                    onValueChange = {
-                        linkInput = it
-                        parseError = null
-                    },
-                    placeholder = {
-                        Text(
-                            "https://nostrord.com/open/?relay=...&group=...",
-                            color = NostrordColors.TextMuted,
-                            style = MaterialTheme.typography.bodySmall,
-                        )
-                    },
-                    label = { Text("Invite Link", color = NostrordColors.TextSecondary) },
-                    singleLine = true,
-                    modifier = Modifier.fillMaxWidth(),
-                    colors = outlinedFieldColors(),
-                    textStyle = MaterialTheme.typography.bodyMedium,
-                    shape = RoundedCornerShape(8.dp),
-                )
+                // Standalone label above the field, mirroring the web `field-label` +
+                // placeholder structure (not Material's in-field floating label).
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        "Invite Link or Group Address",
+                        color = NostrordColors.TextSecondary,
+                        style = MaterialTheme.typography.labelSmall,
+                    )
+                    OutlinedTextField(
+                        value = linkInput,
+                        onValueChange = {
+                            linkInput = it
+                            parseError = null
+                        },
+                        placeholder = {
+                            Text(
+                                "wss://relay.com'groupId",
+                                color = NostrordColors.TextMuted,
+                                style = MaterialTheme.typography.bodySmall,
+                            )
+                        },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = outlinedFieldColors(),
+                        textStyle = MaterialTheme.typography.bodyMedium,
+                        shape = RoundedCornerShape(8.dp),
+                    )
+                }
 
                 if (parseError != null) {
                     Text(
@@ -101,12 +84,12 @@ fun JoinGroupModal(
         confirmButton = {
             Button(
                 onClick = {
-                    val parsed = tryParseLink(linkInput)
+                    val parsed = parseGroupJoinInput(linkInput)
                     if (parsed == null) {
-                        parseError = "Invalid link. Use a nostrord.com/open/ or nostrord:// invite link."
+                        parseError = "Invalid input. Use a wss://relay'groupId address or a nostrord invite link."
                         return@Button
                     }
-                    onJoin(parsed.first, parsed.second, parsed.third)
+                    onJoin(parsed.relayUrl, parsed.groupId, parsed.inviteCode)
                 },
                 enabled = linkInput.isNotBlank(),
                 colors =
@@ -118,7 +101,7 @@ fun JoinGroupModal(
                 ),
                 shape = RoundedCornerShape(8.dp),
             ) {
-                Text("Join")
+                Text("Open")
             }
         },
         dismissButton = {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/JoinGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/JoinGroupModal.kt
@@ -38,7 +38,7 @@ fun JoinGroupModal(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text(
-                    "Paste an invite link or a group address to join a group.",
+                    "Paste a wss://relay'id, a naddr, or a nostrord invite link.",
                     color = NostrordColors.TextSecondary,
                     style = MaterialTheme.typography.bodySmall,
                 )
@@ -47,7 +47,7 @@ fun JoinGroupModal(
                 // placeholder structure (not Material's in-field floating label).
                 Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     Text(
-                        "Invite Link or Group Address",
+                        "Group address, naddr, or invite link",
                         color = NostrordColors.TextSecondary,
                         style = MaterialTheme.typography.labelSmall,
                     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
@@ -20,6 +20,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.util.buildGroupNaddr
 import org.nostr.nostrord.ui.util.buildShareGroupLink
+import org.nostr.nostrord.utils.buildGroupAddress
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.utils.rememberTextSharer
 import org.nostr.nostrord.utils.supportsNativeShare
@@ -35,6 +36,7 @@ fun ShareGroupModal(
 
     val link = buildShareGroupLink(relayUrl, groupId)
     val naddr = buildGroupNaddr(relayUrl, groupId, relayPubkey)
+    val address = buildGroupAddress(relayUrl, groupId)
     val copyToClipboard = rememberClipboardWriter()
     val shareText = rememberTextSharer()
 
@@ -57,6 +59,13 @@ fun ShareGroupModal(
                     actionIcon = if (supportsNativeShare) Icons.Default.Share else Icons.Default.ContentCopy,
                     actionLabel = if (supportsNativeShare) "Share" else "Copy",
                     onAction = { if (supportsNativeShare) shareText(link) else copyToClipboard(link) },
+                )
+                ShareRow(
+                    label = "Group Address",
+                    value = address,
+                    actionIcon = if (supportsNativeShare) Icons.Default.Share else Icons.Default.ContentCopy,
+                    actionLabel = if (supportsNativeShare) "Share" else "Copy",
+                    onAction = { if (supportsNativeShare) shareText(address) else copyToClipboard(address) },
                 )
                 ShareRow(
                     label = "Nostr Address (naddr)",

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppShell.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppShell.kt
@@ -1194,7 +1194,26 @@ val AppShell =
 
             when (modal) {
                 "create" -> CreateGroupModal { onClose = { setModal(null) } }
-                "join" -> JoinGroupModal { onClose = { setModal(null) } }
+                "join" ->
+                    JoinGroupModal {
+                        onClose = { setModal(null) }
+                        // Mirror Compose (App.kt): open the group and let the user decide there;
+                        // only an explicit invite code auto-joins. Cross-relay order matches the
+                        // deep-link path (switchRelay first, then setSelectedGroupId).
+                        onJoin = { relayUrl, groupId, inviteCode ->
+                            setNotificationsOpen(false)
+                            if (relayUrl != repo.currentRelayUrl.value) {
+                                launchApp {
+                                    repo.switchRelay(relayUrl)
+                                    setSelectedGroupId(groupId)
+                                    if (inviteCode != null) repo.joinGroup(groupId, inviteCode)
+                                }
+                            } else {
+                                setSelectedGroupId(groupId)
+                                if (inviteCode != null) launchApp { repo.joinGroup(groupId, inviteCode) }
+                            }
+                        }
+                    }
                 "relay" ->
                     AddRelayModal {
                         initialTab = relayTab

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/JoinGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/JoinGroupModal.kt
@@ -51,12 +51,12 @@ val JoinGroupModal =
                 }
                 div {
                     className = ClassName("modal-subtitle tight")
-                    +"Paste an invite link or a group address to join a group."
+                    +"Paste a wss://relay'id, a naddr, or a nostrord invite link."
                 }
 
                 div {
                     className = ClassName("field-label")
-                    +"Invite Link or Group Address"
+                    +"Group address, naddr, or invite link"
                 }
                 input {
                     className = ClassName("modal-input")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/JoinGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/JoinGroupModal.kt
@@ -1,9 +1,6 @@
 package org.nostr.nostrord.web.modals
 
-import org.nostr.nostrord.di.AppModule
-import org.nostr.nostrord.utils.Result
-import org.nostr.nostrord.utils.toRelayUrl
-import org.nostr.nostrord.web.bridge.launchApp
+import org.nostr.nostrord.utils.parseGroupJoinInput
 import org.nostr.nostrord.web.components.useEscClose
 import react.FC
 import react.Props
@@ -15,51 +12,28 @@ import web.cssom.ClassName
 
 external interface JoinGroupModalProps : Props {
     var onClose: () -> Unit
-}
-
-/** Parse a nostrord.com/open or nostrord:// invite link into (relayUrl, groupId, code?). */
-private fun parseInviteLink(input: String): Triple<String, String, String?>? {
-    val trimmed = input.trim()
-    val queryStart = trimmed.indexOf('?')
-    if (queryStart < 0) return null
-    val params =
-        trimmed.substring(queryStart + 1).split("&").associate { param ->
-            val idx = param.indexOf("=")
-            if (idx >= 0) param.substring(0, idx) to param.substring(idx + 1) else param to ""
-        }
-    val relay = params["relay"]?.takeIf { it.isNotBlank() } ?: return null
-    val group = params["group"]?.takeIf { it.isNotBlank() } ?: return null
-    return Triple(relay.toRelayUrl(), group, params["code"]?.takeIf { it.isNotBlank() })
+    var onJoin: (relayUrl: String, groupId: String, inviteCode: String?) -> Unit
 }
 
 /**
- * Join-group modal — real port of the Compose [JoinGroupModal]: paste an invite link, parse
- * it, switch to its relay and join. Closes on success, shows the parse/join error otherwise.
+ * Join-group modal — mirrors the Compose flow (App.kt onJoin): paste an invite link or a NIP-29
+ * group address, parse it, then open the group. Joining is the user's decision inside the group
+ * screen (its Join button), not the modal's; only an explicit invite code auto-joins. The
+ * navigate + switch-relay + optional-join wiring lives in [onJoin] (AppShell).
  */
 val JoinGroupModal =
     FC<JoinGroupModalProps> { props ->
         val (link, setLink) = useState { "" }
-        val (busy, setBusy) = useState { false }
         val (error, setError) = useState<String?> { null }
 
         fun submit() {
-            val parsed = parseInviteLink(link)
+            val parsed = parseGroupJoinInput(link)
             if (parsed == null) {
-                setError("Invalid link. Use a nostrord.com/open/ or nostrord:// invite link.")
+                setError("Invalid input. Use a wss://relay'groupId address or a nostrord invite link.")
                 return
             }
-            val (relayUrl, groupId, code) = parsed
-            setError(null)
-            setBusy(true)
-            launchApp {
-                AppModule.nostrRepository.switchRelay(relayUrl)
-                val result = AppModule.nostrRepository.joinGroup(groupId, code)
-                setBusy(false)
-                when (result) {
-                    is Result.Success -> props.onClose()
-                    is Result.Error -> setError(result.error.message.ifBlank { "Failed to join group." })
-                }
-            }
+            props.onJoin(parsed.relayUrl, parsed.groupId, parsed.inviteCode)
+            props.onClose()
         }
 
         useEscClose { props.onClose() }
@@ -77,16 +51,16 @@ val JoinGroupModal =
                 }
                 div {
                     className = ClassName("modal-subtitle tight")
-                    +"Paste an invite link to join a group."
+                    +"Paste an invite link or a group address to join a group."
                 }
 
                 div {
                     className = ClassName("field-label")
-                    +"Invite Link"
+                    +"Invite Link or Group Address"
                 }
                 input {
                     className = ClassName("modal-input")
-                    placeholder = "https://nostrord.com/open/?relay=...&group=..."
+                    placeholder = "wss://relay.com'groupId"
                     value = link
                     onChange = { event ->
                         setLink(event.currentTarget.value)
@@ -110,9 +84,9 @@ val JoinGroupModal =
                     }
                     button {
                         className = ClassName("btn-primary")
-                        disabled = link.isBlank() || busy
+                        disabled = link.isBlank()
                         onClick = { submit() }
-                        +(if (busy) "Joining…" else "Join")
+                        +"Open"
                     }
                 }
             }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.web.modals
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.utils.buildGroupAddress
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.copyToClipboard
@@ -35,6 +36,7 @@ val ShareGroupModal =
         // Author = the relay's own pubkey (NIP-11), like native; falls back to zero bytes inside encodeNaddr.
         val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
         val naddr = "nostr:" + Nip19.encodeNaddr(identifier = group.id, relay = relayUrl, kind = 39000, pubkeyHex = relayPubkey)
+        val address = buildGroupAddress(relayUrl, group.id)
 
         useEscClose { props.onClose() }
 
@@ -62,6 +64,7 @@ val ShareGroupModal =
                 }
 
                 shareField("Link", link)
+                shareField("Group Address", address)
                 shareField("Nostr Address (naddr)", naddr)
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2787,6 +2787,9 @@ private val URL_REGEX =
     Regex(
         "(data:image/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+)" +
             "|(https?://[^\\s]+)" +
+            // ws(s):// relay urls, incl. the NIP-29 group address `wss://relay'groupId`
+            // (mirrors native MessageContentParser so the apostrophe form renders a group card).
+            "|(wss?://[^\\s<>\"]+)" +
             "|(nostr:(?:npub1|nprofile1|nevent1|note1|naddr1)[0-9a-z]+)" +
             "|\\b((?:npub1|nprofile1|nevent1|note1|naddr1)[0-9a-z]{20,})",
     )
@@ -2969,6 +2972,19 @@ private fun ChildrenBuilder.renderEntities(
                 }
             }
             if (url.length < token.length) +token.substring(url.length)
+        } else if (token.startsWith("wss://") || token.startsWith("ws://")) {
+            // NIP-29 group address `wss://relay'groupId` renders as a tappable group card,
+            // mirroring native MessageContent (RelayPart). A bare relay url stays plain text.
+            val apostrophe = token.indexOf('\'')
+            if (apostrophe > 0) {
+                GroupLinkCard {
+                    groupId = token.substring(apostrophe + 1)
+                    relayUrl = token.substring(0, apostrophe)
+                    onNavigate = onGroupRef
+                }
+            } else {
+                +token
+            }
         } else {
             when (val entity = Nip19.decode(token.removePrefix("nostr:"))) {
                 is Nip19.Entity.Npub -> mentionSpan(entity.pubkey, userMetadata, onUser)


### PR DESCRIPTION
Join and share NIP-29 groups by their compact address `wss://relay'groupId`, plus accept a group `naddr` as join input. A shared, tested parser replaces the link-parsing that was duplicated in each modal, and the join flow is brought to parity across web and native.

`parseGroupJoinInput` (commonMain `utils/GroupLink.kt`) accepts three forms and rejects anything that doesn't resolve to a relay + group id, including a relay that `toRelayUrl` blanks out (e.g. a `@` userinfo host):

| Input | Example |
|---|---|
| NIP-29 group address | `wss://relay.com'groupId` / bare `relay.com'groupId` |
| Group naddr (kind 39000) | `nostr:naddr1...` / `naddr1...` (requires a relay hint) |
| nostrord invite link | `https://nostrord.com/open/?relay=&group=&code=` / `nostrord://...` |

Behavior changes:
- **Join is consistent on both UIs**: the modal now opens the group and lets the user decide to join there (only an explicit invite code auto-joins), matching native `App.kt`. The web modal previously fired the join request straight from the modal.
- **Share** gains a "Group Address" row (`wss://relay'groupId`) next to the existing link and naddr.
- **Web chat** renders a `wss://relay'groupId` posted in a message as a tappable group card, like native and like the existing naddr handling (the web tokenizer only matched `https?://` before).
- Join modal copy on both platforms lists the three accepted formats; native field label moved above the input to mirror the web structure.

Covered by `GroupLinkTest` (19 cases). `compileKotlinJvm` + `compileKotlinJs` + `:composeApp:jvmTest` green.

Commits:
- feat(groups): join and share groups by NIP-29 address (wss://relay'groupId)
- feat(groups): accept a group naddr as join input
- fix(groups): reject a blank relay in every join-input form
- docs(groups): JoinGroupModal copy lists all three join formats
- fix(web): render wss://relay'groupId in chat as a tappable group card
