### PR TITLE
fix(web): chat composer keyboard and long-name placeholder on mobile

### DIFF
--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -409,6 +409,8 @@ private val ChatComposer =
                     setMentions(emptyMap())
                     setGroupMentions(emptyMap())
                     setPendingUploads(emptyList())
+                    // Keep the mobile keyboard up and the cursor in the field for the next message.
+                    composerInputRef.current?.focus()
                     props.onSent()
                 },
                 onFailure = { setSending(false) },
@@ -517,7 +519,9 @@ private val ChatComposer =
                         className = ClassName("composer-input")
                         placeholder = "Message $groupName"
                         value = draft
-                        readOnly = sending
+                        // Intentionally NOT readOnly while sending: toggling readOnly on the
+                        // focused field dismisses the mobile virtual keyboard. The double-send
+                        // guard lives in send() (sending check) and the Send button's disabled.
                         rows = 1
                         onChange = { event ->
                             val v = event.currentTarget.value
@@ -639,6 +643,9 @@ private val ChatComposer =
                         if (draft.isNotBlank() || sending) "composer-send active" else "composer-send",
                     )
                     disabled = (draft.isBlank() && !uploading) || sending || uploading
+                    // preventDefault on mousedown keeps focus on the textarea so tapping Send
+                    // does not blur it and dismiss the mobile keyboard (same trick as mention rows).
+                    onMouseDown = { e -> e.preventDefault() }
                     onClick = { send() }
                     if (sending) {
                         span { className = ClassName("btn-spinner") }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3874,6 +3874,12 @@ body {
 
 .composer-input::placeholder {
     color: var(--color-text-muted);
+    /* Keep a long "Message <group name>" on one line with an ellipsis instead of
+       wrapping (which also grew the auto-resizing textarea to several rows). Only
+       the placeholder is clamped; typed multi-line messages still wrap normally. */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .composer-send {


### PR DESCRIPTION
Two web composer fixes for mobile, both in the chat input bar.

The mobile virtual keyboard dismissed itself on every send. There were two DOM-focus causes at send time: `readOnly = sending` toggled the focused textarea to readonly during the publish (mobile browsers drop the keyboard for a readonly field), and tapping the Send button blurred the textarea. The readonly is gone (the double-send guard already lives in `send()` and the button's `disabled`), the Send button now does `preventDefault` on mousedown so focus stays on the textarea (same trick the mention rows use), and `onSuccess` re-focuses the field for the next message.

Separately, a long `Message <group name>` placeholder wrapped to several lines and grew the auto-resizing textarea with it. The placeholder is now clamped to one line with an ellipsis; typed multi-line messages still wrap normally.

| Area | Change |
|---|---|
| `ChatScreen.kt` | remove `readOnly=sending`, `preventDefault` on Send mousedown, re-focus on success |
| `styles.css` | `white-space:nowrap` + `text-overflow:ellipsis` on `.composer-input::placeholder` |

- `7ef74f23` fix(web): keep mobile keyboard open when sending a chat message
- `11673d20` fix(web): ellipsize long group name in composer placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)