### PR TITLE
fix(web): stop retry banner and avatars flickering on reconnect

### DIFF
--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppShell.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppShell.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.web
 
 import kotlinx.browser.window
+import kotlinx.coroutines.delay
 import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.auth.AuthMethod
 import org.nostr.nostrord.auth.removeAccountBusyLabel
@@ -101,6 +102,24 @@ val AppShell =
         val activeAccountId = useStateFlow(AppModule.accountStore.activeId)
         val notifUnread = useStateFlow(AppModule.notificationHistoryStore.entries).count { !it.read }
         val connState = useStateFlow(repo.connectionState)
+
+        // The reconnect loop cycles Reconnecting -> Connecting -> Error in quick succession, so
+        // gating the banner straight on connState made it blink (it hid on every transient
+        // Connecting between attempts). Drive it from sticky state instead: hide only once truly
+        // Connected, hold it visible across the Connecting blips of a retry, and require the
+        // trouble to persist past a short grace window so a normal cold-start connect never
+        // flashes a banner.
+        val (showConnBanner, setShowConnBanner) = useState(false)
+        useEffect(connState) {
+            when (connState) {
+                ConnectionManager.ConnectionState.Connected -> setShowConnBanner(false)
+                ConnectionManager.ConnectionState.Connecting -> Unit // keep current across retry blips
+                else -> {
+                    delay(1500)
+                    setShowConnBanner(true)
+                }
+            }
+        }
 
         val relayNames = relayMetadata.mapValues { it.value.name ?: "" }
         val relayList =
@@ -791,18 +810,21 @@ val AppShell =
             div {
                 className = ClassName("content")
 
-                // Connection status banner (disconnected / reconnecting / error)
-                if (hasRelays &&
-                    !notificationsOpen &&
-                    connState != ConnectionManager.ConnectionState.Connected &&
-                    connState != ConnectionManager.ConnectionState.Connecting
-                ) {
+                // Connection status banner (disconnected / reconnecting / error).
+                // Both children of `.content` carry a stable `key`: without one React matches
+                // siblings by position, so toggling this banner shifted `.content-screen` by an
+                // index and React remounted the whole screen from scratch. That reset every
+                // WebAvatar's `loaded` flag, flashing the identicon fallback and re-fetching the
+                // photo each time the banner appeared or hid — the avatars "blinking" with the bar.
+                if (hasRelays && !notificationsOpen && showConnBanner) {
                     div {
+                        key = "connection-banner"
                         className = ClassName("connection-banner")
                         span {
                             +when (val s = connState) {
                                 is ConnectionManager.ConnectionState.Reconnecting ->
                                     "Reconnecting (${s.attempt}/${s.maxAttempts})…"
+                                ConnectionManager.ConnectionState.Connecting -> "Reconnecting…"
                                 is ConnectionManager.ConnectionState.Error -> "Unable to connect to the relay."
                                 else -> "Disconnected from the relay."
                             }
@@ -816,6 +838,7 @@ val AppShell =
                 }
 
                 div {
+                    key = "content-screen"
                     className = ClassName("content-screen")
                     when {
                         notificationsOpen ->


### PR DESCRIPTION
On the web, when the relay drops and the reconnect loop runs, the connection banner blinked and the user/group avatars blinked along with it (visible in a screen recording on iOS Safari).

Two causes, one render path:

| Symptom | Cause | Fix |
|---|---|---|
| Banner blinks | Visibility was gated straight on `connectionState`, which the reconnect loop cycles `Reconnecting -> Connecting -> Error` in quick succession; the banner hid on each transient `Connecting`. | Drive it from sticky state: hide only once `Connected`, hold visible across the `Connecting` blips of a retry, and require the trouble to persist past a short grace window so a cold-start connect never flashes it. |
| Avatars blink with the banner | The banner is a sibling rendered before `.content-screen` with no `key`, so each toggle shifted the screen's child index and React remounted the whole screen, resetting every `WebAvatar` `loaded` flag (fallback identicon flashes, photo re-fetches). | Give both children of `.content` stable `key`s so the screen is never remounted when the banner toggles. |

Web-only change (`AppShell.kt`); `compileKotlinJs` passes.

Commits:
- fix(web): stop the retry banner and avatars from flickering on reconnect