### PR TITLE
fix(web): keep chat reading position above the mobile keyboard, reopen it after attach

### DIFF
--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatMessageList.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatMessageList.kt
@@ -149,6 +149,44 @@ val ChatMessageList =
             }
         }
 
+        // Keep the reading position anchored above the on-screen keyboard (mobile). The page
+        // shell is sized to visualViewport.height (index.html --app-height), so opening the
+        // keyboard shrinks the message list from the bottom. By default the browser holds the
+        // TOP of the view, so the rows being read slide down behind the keyboard. Native
+        // (adjustResize) keeps the BOTTOM anchored: the same rows stay just above the keyboard.
+        // Mirror that by pushing scrollTop down by the height the viewport lost (and back up by
+        // the height it regains on close). When following the feed, pin straight to the bottom.
+        val prevViewportHeight = useRef(0.0)
+        useEffect(Unit) {
+            val vv = window.asDynamic().visualViewport ?: return@useEffect
+            prevViewportHeight.current = vv.height.unsafeCast<Double>()
+            val onResize: (dynamic) -> Unit = {
+                val newHeight = vv.height.unsafeCast<Double>()
+                val delta = (prevViewportHeight.current ?: 0.0) - newHeight
+                prevViewportHeight.current = newHeight
+                if (delta != 0.0) {
+                    // Defer to the next frame so the list has reflowed to its new height before
+                    // we touch scrollTop (otherwise the shift fights the in-flight relayout).
+                    window.requestAnimationFrame {
+                        val node = el.current ?: return@requestAnimationFrame
+                        if (atBottom.current == true && loadingOlder.current != true) {
+                            node.scrollTop = node.scrollHeight.toDouble()
+                        } else {
+                            // delta > 0 when the keyboard opened (viewport shrank): scroll down
+                            // so the bottom-most visible row stays put; < 0 on close reverses it.
+                            node.scrollTop = node.scrollTop + delta
+                        }
+                    }
+                }
+            }
+            vv.addEventListener("resize", onResize)
+            try {
+                awaitCancellation()
+            } finally {
+                vv.removeEventListener("resize", onResize)
+            }
+        }
+
         // Deep-link / reply jump: scroll the row with the given DOM id into view.
         useEffect(props.scrollToKey, items.size) {
             val key = props.scrollToKey ?: return@useEffect

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.web.components
 
+import kotlinx.coroutines.awaitCancellation
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Int8Array
 import org.khronos.webgl.get
@@ -17,8 +18,11 @@ import react.Props
 import react.dom.html.ReactHTML.input
 import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.span
+import react.useEffect
+import react.useRef
 import react.useState
 import web.cssom.ClassName
+import web.html.HTMLInputElement
 import web.html.InputType
 import web.html.file
 import kotlin.coroutines.resume
@@ -52,6 +56,14 @@ external interface UploadButtonProps : Props {
     var onBusyChange: ((Boolean) -> Unit)?
 
     /**
+     * Fired whenever the OS file dialog closes, whether a file was chosen OR the user
+     * cancelled. The native picker steals focus and collapses the mobile soft keyboard, so
+     * the caller uses this to refocus its input and re-open the keyboard, so tapping attach
+     * never strands the user without a keyboard.
+     */
+    var onPickerClosed: (() -> Unit)?
+
+    /**
      * Restrict to still images only (avatars / banners / group pictures), matching native's
      * MediaAccept.Images. Defaults to the full image/video/audio set used by the composer.
      */
@@ -72,6 +84,21 @@ val UploadButton =
         // caller signals via props.busy shows the spinner on this attach icon.
         val busy = picking || (props.busy == true)
 
+        val inputRef = useRef<HTMLInputElement>(null)
+        // `change` only fires when a file is chosen; `cancel` fires when the OS dialog is
+        // dismissed with no selection. Both mean the picker closed, so both refocus the
+        // composer. Without the cancel path, cancelling left the keyboard shut.
+        useEffect(Unit) {
+            val node = inputRef.current ?: return@useEffect
+            val onCancel: (dynamic) -> Unit = { props.onPickerClosed?.invoke() }
+            node.asDynamic().addEventListener("cancel", onCancel)
+            try {
+                awaitCancellation()
+            } finally {
+                node.asDynamic().removeEventListener("cancel", onCancel)
+            }
+        }
+
         label {
             className = ClassName(props.cls)
             if (busy) {
@@ -80,6 +107,7 @@ val UploadButton =
                 icon(props.icon)
             }
             input {
+                ref = inputRef
                 className = ClassName("upload-file-input")
                 type = InputType.file
                 accept = if (props.imagesOnly == true) "image/*" else "image/*,video/*,audio/*"
@@ -88,6 +116,9 @@ val UploadButton =
                     val target = event.currentTarget
                     val fileList = target.asDynamic().files
                     val f = if (fileList != null && (fileList.length as Int) > 0) fileList[0] else null
+                    // Picker closed with a selection: refocus the composer (cancel is handled
+                    // by the listener above) so the soft keyboard re-opens.
+                    props.onPickerClosed?.invoke()
                     if (f != null) {
                         setPicking(true)
                         props.onBusyChange?.invoke(true)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -484,6 +484,13 @@ private val ChatComposer =
                     // Count a file-pick upload in uploadCount too, so the send button is
                     // disabled until the picked URL lands in the draft (it isn't sent empty).
                     onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
+                    // The native file picker collapses the soft keyboard (no web API keeps it
+                    // open while the OS dialog is up). Refocus the composer the instant the
+                    // dialog closes, whether a file was chosen or cancelled, so the keyboard
+                    // re-opens and the user keeps typing. Fired from the file input's change /
+                    // cancel handlers, the closest point to the gesture, so Android re-pops the
+                    // keyboard; iOS Safari needs a live gesture and may not.
+                    onPickerClosed = { composerInputRef.current?.focus() }
                     onUploaded = { upload ->
                         val url = upload.url
                         setDraft { prev -> if (prev.isBlank()) url else "$prev $url" }


### PR DESCRIPTION
On web mobile the on-screen keyboard shrinks the layout viewport (the shell is sized to `visualViewport.height`), but the browser holds the top of the message list, so the rows being read slid down behind the keyboard instead of staying above it. This anchors the bottom instead, mirroring Android's `adjustResize`: on a `visualViewport` resize, `scrollTop` shifts by the height the viewport lost (and back on close), or pins to the bottom when following the feed.

The native file picker also collapses the keyboard with no web API to keep it open while the OS dialog is up. The composer is now refocused the instant the dialog closes, whether a file was chosen (`change`) or cancelled (`cancel` event), so tapping attach never strands the user without a keyboard. Android Chrome re-pops the keyboard; iOS Safari needs a live gesture and may not. Native (Compose) is unchanged.

| Area | Before | After |
|---|---|---|
| Keyboard opens mid-feed | reading rows slide behind the keyboard | same rows stay just above the keyboard |
| Keyboard opens at bottom | newest messages hidden behind composer | pinned to the bottom, newest visible |
| Attach picker closes | keyboard stayed shut (esp. on cancel) | composer refocused, keyboard re-opens |

Commits:
- fix(web): keep chat reading position above the mobile keyboard, reopen it after attach
