### PR TITLE
Desktop packaging crash + send/UX fixes

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -330,6 +330,11 @@ compose.desktop {
             packageName = "Nostrord"
             packageVersion = appVersion
 
+            // jpackage's jlink image ships only Compose's default modules; java-keyring's
+            // DBus backend touches java.sql.DriverManager at startup and kills the app
+            // with NoClassDefFoundError when the module is absent (#165).
+            modules("java.sql")
+
             linux {
                 iconFile.set(project.file("src/jvmMain/resources/icon-512.png"))
                 debPackageVersion = packageVersion

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -91,6 +91,27 @@ class GroupManager(
         pendingEventManager?.onEventPermanentlyFailed = { eventId, groupId, eventJson, reason ->
             markFailed(eventId, groupId, eventJson, reason)
         }
+        // Queued retries must hit the relay that hosts their group: a NIP-29 relay
+        // rejects a kind:9 for a group it doesn't host ("group doesn't exist").
+        pendingEventManager?.resolveClient = { groupId -> clientForGroup(groupId) }
+        // Any event sitting in the retry queue is an undelivered own message. Marking it
+        // Sending here covers events restored from the persisted queue after a restart,
+        // whose cached bubble would otherwise look delivered.
+        pendingEventManager?.let { pending ->
+            scope.launch {
+                pending.pendingEvents.collect { events ->
+                    if (events.isEmpty()) return@collect
+                    _messageStatus.update { statuses ->
+                        val missing = events.filter { it.eventId !in statuses }
+                        if (missing.isEmpty()) {
+                            statuses
+                        } else {
+                            statuses + missing.associate { it.eventId to MessageStatus.Sending }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**
@@ -3832,9 +3853,19 @@ class GroupManager(
         // here to prevent cross-account message contamination.
         if (currentPubkey == null) return
 
-        val chatMessages = messages.filter { it.kind == 9 }
-        if (chatMessages.isNotEmpty()) {
+        // A relay echoing back one of our own optimistic messages proves it was accepted
+        // even when the OK was lost: resolve the on-screen status and drop the queued
+        // retry before it double-sends.
+        val ownStatuses = _messageStatus.value
+        if (ownStatuses.isNotEmpty()) {
+            for (msg in messages) {
+                if (msg.id in ownStatuses) {
+                    markDelivered(msg.id)
+                    pendingEventManager?.let { pending -> scope.launch { pending.removeByEventId(msg.id) } }
+                }
+            }
         }
+
         // Record burst for adaptive tuning
         adaptiveConfig?.recordEventBurst(messages.size)
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/PendingEventManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/PendingEventManager.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.network.managers
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -9,6 +10,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
+import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.utils.epochMillis
@@ -25,6 +27,7 @@ data class PendingEvent(
     val retryCount: Int = 0,
     val maxRetries: Int = 3,
     val lastError: String? = null,
+    val lastAttemptAt: Long = 0,
 ) {
     val canRetry: Boolean get() = retryCount < maxRetries
 }
@@ -65,6 +68,7 @@ class PendingEventManager(
         const val MAX_QUEUE_SIZE = 100
         const val BASE_RETRY_DELAY_MS = 1000L
         const val MAX_RETRY_DELAY_MS = 30_000L
+        const val RETRY_SWEEP_MS = 5_000L
     }
 
     private val json = Json { ignoreUnknownKeys = true }
@@ -104,6 +108,28 @@ class PendingEventManager(
     var onEventPermanentlyFailed: ((eventId: String, groupId: String, eventJson: String, reason: String) -> Unit)? = null
 
     /**
+     * Resolves the client for the relay that hosts a group. A NIP-29 relay rejects a
+     * kind:9 for a group it doesn't host ("group doesn't exist"), so retries must be
+     * routed per group, never blanket-sent to the focused relay. Wired by GroupManager.
+     * When it returns null the relay is down: the event stays queued for the next sweep.
+     */
+    var resolveClient: (suspend (groupId: String) -> NostrGroupClient?)? = null
+
+    // Periodic retry sweep: runs while the queue is non-empty so a send that timed out
+    // on a live socket still retries without waiting for a reconnect event.
+    private var retrySweepJob: Job? = null
+
+    private fun ensureRetrySweep() {
+        if (retrySweepJob?.isActive == true) return
+        retrySweepJob = scope.launch {
+            while (_pendingEvents.value.isNotEmpty()) {
+                delay(RETRY_SWEEP_MS)
+                retryPendingEvents()
+            }
+        }
+    }
+
+    /**
      * Queue an event for later sending.
      * Called when send fails due to offline or network error.
      *
@@ -114,7 +140,7 @@ class PendingEventManager(
         eventId: String,
         groupId: String,
     ): Boolean {
-        return mutex.withLock {
+        val queued = mutex.withLock {
             val current = _pendingEvents.value
 
             // Prevent duplicate events
@@ -144,6 +170,11 @@ class PendingEventManager(
             _eventStatuses.value = _eventStatuses.value + (pendingEvent.id to PendingEventStatus.Queued)
             true
         }
+        if (queued) {
+            saveToStorage()
+            ensureRetrySweep()
+        }
+        return queued
     }
 
     /**
@@ -154,6 +185,23 @@ class PendingEventManager(
             _pendingEvents.value = _pendingEvents.value.filter { it.id != pendingId }
             _eventStatuses.value = _eventStatuses.value - pendingId
         }
+        saveToStorage()
+    }
+
+    /**
+     * Remove a pending event by its nostr event id. Used when the relay's live feed
+     * echoes back an event whose OK was lost: the echo proves acceptance, so the
+     * queued retry must be dropped before it double-sends.
+     */
+    suspend fun removeByEventId(eventId: String) {
+        val removed = mutex.withLock {
+            val matches = _pendingEvents.value.filter { it.eventId == eventId }
+            if (matches.isEmpty()) return@withLock false
+            _pendingEvents.value = _pendingEvents.value.filterNot { it.eventId == eventId }
+            _eventStatuses.value = _eventStatuses.value - matches.map { it.id }.toSet()
+            true
+        }
+        if (removed) saveToStorage()
     }
 
     /**
@@ -168,8 +216,6 @@ class PendingEventManager(
             val events = _pendingEvents.value.toList()
             if (events.isEmpty()) return
 
-            val client = connectionManager.getFocusedClient() ?: return
-
             for (event in events) {
                 if (!event.canRetry) {
                     // Mark as permanently failed
@@ -183,14 +229,19 @@ class PendingEventManager(
                     continue
                 }
 
+                // Honor per-event exponential backoff without blocking the rest of the queue.
+                if (event.retryCount > 0 && epochMillis() < event.lastAttemptAt + calculateRetryDelay(event.retryCount)) {
+                    continue
+                }
+
+                // Route to the group's own relay; null means it is down, so the event
+                // stays queued for the next sweep (no attempt is counted).
+                val resolve = resolveClient
+                val client = if (resolve != null) resolve(event.groupId) else connectionManager.getFocusedClient()
+                if (client == null) continue
+
                 // Update status to sending
                 updateStatus(event.id, PendingEventStatus.Sending)
-
-                // Calculate retry delay with exponential backoff
-                val delayMs = calculateRetryDelay(event.retryCount)
-                if (event.retryCount > 0) {
-                    delay(delayMs)
-                }
 
                 // Attempt to send
                 val result = client.sendAndAwaitOk(event.eventJson, event.eventId)
@@ -237,7 +288,8 @@ class PendingEventManager(
         val event = _pendingEvents.value.find { it.id == pendingId } ?: return null
         if (!event.canRetry) return null
 
-        val client = connectionManager.getFocusedClient() ?: return null
+        val resolve = resolveClient
+        val client = (if (resolve != null) resolve(event.groupId) else connectionManager.getFocusedClient()) ?: return null
 
         updateStatus(event.id, PendingEventStatus.Sending)
 
@@ -288,6 +340,10 @@ class PendingEventManager(
      * Clear all pending events (e.g., on logout).
      */
     suspend fun clear() {
+        // In-memory only: the persisted per-account queue survives an account switch
+        // so undelivered messages still send when that account becomes active again.
+        retrySweepJob?.cancel()
+        retrySweepJob = null
         mutex.withLock {
             _pendingEvents.value = emptyList()
             _eventStatuses.value = emptyMap()
@@ -301,6 +357,7 @@ class PendingEventManager(
     fun onConnectionRestored() {
         scope.launch {
             retryPendingEvents()
+            ensureRetrySweep()
         }
     }
 
@@ -325,6 +382,7 @@ class PendingEventManager(
                 event.copy(
                     retryCount = event.retryCount + 1,
                     lastError = errorMsg,
+                    lastAttemptAt = epochMillis(),
                 )
 
             _pendingEvents.value = current.map { if (it.id == pendingId) updated else it }
@@ -344,6 +402,7 @@ class PendingEventManager(
                 _eventStatuses.value = _eventStatuses.value - pendingId
             }
         }
+        saveToStorage()
     }
 
     private fun calculateRetryDelay(retryCount: Int): Long {
@@ -378,6 +437,7 @@ class PendingEventManager(
                             retryCount = obj["retryCount"]?.jsonPrimitive?.int ?: 0,
                             maxRetries = obj["maxRetries"]?.jsonPrimitive?.int ?: 3,
                             lastError = obj["lastError"]?.jsonPrimitive?.contentOrNull,
+                            lastAttemptAt = obj["lastAttemptAt"]?.jsonPrimitive?.long ?: 0,
                         )
                     } catch (e: Exception) {
                         null
@@ -389,6 +449,7 @@ class PendingEventManager(
                 events.forEach { event ->
                     _eventStatuses.value = _eventStatuses.value + (event.id to PendingEventStatus.Queued)
                 }
+                ensureRetrySweep()
             }
         } catch (e: Exception) {
             // Ignore parsing errors
@@ -420,6 +481,7 @@ class PendingEventManager(
                                 put("createdAt", event.createdAt)
                                 put("retryCount", event.retryCount)
                                 put("maxRetries", event.maxRetries)
+                                put("lastAttemptAt", event.lastAttemptAt)
                                 event.lastError?.let { put("lastError", it) }
                             },
                         )

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/PendingEventQueueTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/PendingEventQueueTest.kt
@@ -1,0 +1,96 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.cache.InMemoryCacheStore
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val PQ_PUBKEY = "00000000000000000000000000000000000000000000000000000000feedface"
+private const val PQ_GROUP = "pending-queue-group"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PendingEventQueueTest {
+    @AfterTest
+    fun cleanup() {
+        SecureStorage.clearPendingEvents(PQ_PUBKEY)
+        SecureStorage.clearAllMessagesForAccount(PQ_PUBKEY)
+    }
+
+    @Test
+    fun `queued events persist and reload across restarts`() = runTest {
+        val scope = TestScope(testScheduler)
+        val first = PendingEventManager(ConnectionManager(scope), scope)
+        first.setCurrentPubkey(PQ_PUBKEY)
+        first.queueEvent("""["EVENT",{}]""", "event-1", PQ_GROUP)
+
+        // Fresh manager (app restart): the queue reloads from storage.
+        val second = PendingEventManager(ConnectionManager(scope), scope)
+        second.setCurrentPubkey(PQ_PUBKEY)
+        assertEquals(listOf("event-1"), second.pendingEvents.value.map { it.eventId })
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a restored queue surfaces its events as Sending`() = runTest {
+        val scope = TestScope(testScheduler)
+        // Persist an undelivered event, as a previous app run would have.
+        PendingEventManager(ConnectionManager(scope), scope).apply {
+            setCurrentPubkey(PQ_PUBKEY)
+            queueEvent("""["EVENT",{}]""", "event-2", PQ_GROUP)
+        }
+
+        val pending = PendingEventManager(ConnectionManager(scope), scope)
+        val manager = GroupManager(
+            connectionManager = ConnectionManager(scope),
+            scope = scope,
+            pendingEventManager = pending,
+            cacheStore = InMemoryCacheStore(),
+        ).apply { setCurrentPubkey(PQ_PUBKEY) }
+        pending.setCurrentPubkey(PQ_PUBKEY)
+        runCurrent()
+
+        assertEquals(GroupManager.MessageStatus.Sending, manager.messageStatus.value["event-2"])
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `the relay echo of an own message resolves Sending and clears the queue`() = runTest {
+        val scope = TestScope(testScheduler)
+        val pending = PendingEventManager(ConnectionManager(scope), scope).apply { setCurrentPubkey(PQ_PUBKEY) }
+        val manager = GroupManager(
+            connectionManager = ConnectionManager(scope),
+            scope = scope,
+            pendingEventManager = pending,
+            cacheStore = InMemoryCacheStore(),
+        ).apply { setCurrentPubkey(PQ_PUBKEY) }
+
+        manager.sendMessage(PQ_GROUP, "hello", PQ_PUBKEY) { it.copy(id = it.calculateId(), sig = "ff".repeat(64)) }
+        runCurrent()
+
+        val message = manager.getMessagesForGroup(PQ_GROUP).single()
+        assertEquals(GroupManager.MessageStatus.Sending, manager.messageStatus.value[message.id])
+        assertEquals(1, pending.pendingEvents.value.size)
+
+        // The relay's live feed echoes the same event id back (its OK was lost).
+        val rawMsg = """["EVENT","sub",{"id":"${message.id}","kind":9,"tags":[["h","$PQ_GROUP"]]}]"""
+        manager.handleMessage(message, rawMsg, subscriptionId = null, relayUrl = "wss://relay.test")
+        advanceTimeBy(1_000) // ordering-buffer debounce
+        runCurrent()
+
+        assertNull(manager.messageStatus.value[message.id], "echo must resolve the Sending status")
+        assertTrue(pending.pendingEvents.value.isEmpty(), "echo must drop the queued retry")
+
+        scope.cancel()
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -77,6 +77,8 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
@@ -264,6 +266,17 @@ fun AppFrame() {
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val drawerScope = rememberCoroutineScope()
     val closeDrawer: () -> Unit = { drawerScope.launch { drawerState.close() } }
+
+    // Dismiss the soft keyboard as soon as the drawer starts opening (hamburger tap or
+    // swipe-in gesture), so it never overlaps the slide-over sidebar.
+    val focusManager = LocalFocusManager.current
+    val keyboardController = LocalSoftwareKeyboardController.current
+    LaunchedEffect(drawerState.targetValue) {
+        if (drawerState.targetValue == DrawerValue.Open) {
+            focusManager.clearFocus()
+            keyboardController?.hide()
+        }
+    }
 
     // Android system back / swipe-back: close an open drawer or modal first, otherwise step
     // back through the shared history. At Home with nothing left to pop the handler is

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2238,6 +2238,9 @@ val ChatScreen =
                         setReplyingToId(null)
                         // Sending acknowledges the "New messages" boundary: drop the divider.
                         consumeDivider()
+                        // Own send always lands the view at the bottom, even when reading
+                        // history (native parity: AutoScrollEffect's ownAppend).
+                        setJumpNonce { it + 1 }
                     }
                     this.onJoin = { join() }
                     this.pendingRequestedAtSeconds = pendingRequestedAt


### PR DESCRIPTION
Four fixes on top of v2.0.0. The desktop one is release-blocking: the packaged 2.0.0 (deb/rpm/msi/dmg) crashes at startup with NoClassDefFoundError: java/sql/DriverManager because the jpackage jlink image lacks the java.sql module the SQLDelight sqlite driver needs. Fixes #165, verified on an installed package (does not reproduce under gradle run, which uses the full JDK).

| Commit | Fix |
|---|---|
| 90fabab8 | desktop: include java.sql in the jpackage runtime (#165) |
| 6d80e9bc | web: scroll to bottom on own send even when reading history |
| 901798f3 | network: optimistic send actually delivers instead of caching silently |
| 20fd41e3 | ui: hide the soft keyboard when the mobile drawer opens |