### PR TITLE
chore(release): bump version to 2.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.0.0
-app.versionCode=12
+app.version=2.0.1
+app.versionCode=13
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Patch release carrying the #165 desktop packaging fix (java.sql module in the jpackage runtime). Bumps app.version to 2.0.1 and versionCode to 13 (Zapstore dedups by APK manifest version).