### PR TITLE
feat: add master toggle to disable all direct-message features

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -40,6 +40,7 @@ import org.nostr.nostrord.notifications.NotificationService
 import org.nostr.nostrord.notifications.NotificationType
 import org.nostr.nostrord.notifications.playNotificationSound
 import org.nostr.nostrord.settings.AppearanceSettings
+import org.nostr.nostrord.settings.DmSettings
 import org.nostr.nostrord.settings.MediaSettings
 import org.nostr.nostrord.settings.NotificationSettings
 import org.nostr.nostrord.storage.SecureStorage
@@ -503,6 +504,8 @@ object AppModule {
     val mediaSettings: MediaSettings by lazy { MediaSettings() }
 
     val appearanceSettings: AppearanceSettings by lazy { AppearanceSettings() }
+
+    val dmSettings: DmSettings by lazy { DmSettings() }
 
     val nostrRepository: NostrRepository by lazy {
         NostrRepository(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -673,11 +674,16 @@ class NostrRepository(
             }
         }
 
-        // Open the NIP-17 DM inbox once we're logged in (cold-boot restore or a fresh login).
-        // startDmInbox() dedups; resetContactListState re-arms it on account switch.
+        // Open the NIP-17 DM inbox while logged in AND the DM feature is enabled (cold-boot
+        // restore or a fresh login). Flipping the master toggle off tears the inbox down live —
+        // stopDmInbox() closes the kind:1059 subscription so no more wraps are fetched or decrypted;
+        // flipping it back on re-subscribes. startDmInbox()/stopDmInbox() both dedup on
+        // dmInboxStarted, so redundant emissions are no-ops.
         scope.launch {
-            sessionManager.isLoggedIn.collect { loggedIn ->
-                if (loggedIn) startDmInbox()
+            combine(sessionManager.isLoggedIn, AppModule.dmSettings.dmEnabled) { loggedIn, enabled ->
+                loggedIn && enabled
+            }.distinctUntilChanged().collect { active ->
+                if (active) startDmInbox() else stopDmInbox()
             }
         }
 
@@ -1424,6 +1430,33 @@ class NostrRepository(
                     }
                 }
             }
+    }
+
+    /**
+     * Tear the DM inbox down: close the kind:1059 subscription on every relay it was streaming from,
+     * cancel the retry/persistence jobs, and drop all decrypted state. Called when the master DM
+     * toggle is switched off (Settings → Direct Messages) so the app stops fetching and decrypting
+     * DMs entirely. Idempotent — a no-op when the inbox was never started.
+     */
+    private fun stopDmInbox() {
+        if (!dmInboxStarted) return
+        dmInboxStarted = false
+        dmPersistenceWired = false
+        dmPersistenceJobs.forEach { it.cancel() }
+        dmPersistenceJobs.clear()
+        val relays = dmInboxSubscribedRelays
+        dmInboxSubscribedRelays = emptySet()
+        relays.forEach { url ->
+            scope.launch {
+                try {
+                    connectionManager.getClientForRelay(url)?.send("""["CLOSE","dm_inbox"]""")
+                } catch (_: Throwable) {
+                }
+            }
+        }
+        dmManager.clear()
+        _myDmRelays.value = emptyList()
+        dmInboxEosedRelays = emptySet()
     }
 
     // Ids already written to the CacheStore, so the persistence collector upserts only new DMs
@@ -3738,6 +3771,8 @@ class NostrRepository(
             }
             // NIP-17 DM gift wrap addressed to us: decrypt with the active signer.
             if (kind == Nip17.KIND_GIFT_WRAP) {
+                // Master DM toggle off: never unwrap/decrypt, even for a wrap that raced the CLOSE.
+                if (!AppModule.dmSettings.dmEnabled.value) return
                 val giftWrap = runCatching { parseSignedEventJson(event.toString()) }.getOrNull() ?: return
                 val myPub = sessionManager.getPublicKey() ?: return
                 val signer = ActiveAccountManager.session.value?.signer ?: return
@@ -3812,6 +3847,7 @@ class NostrRepository(
             }
             // A user's NIP-17 DM relay list (kind:10050).
             if (kind == Nip17.KIND_DM_RELAYS) {
+                if (!AppModule.dmSettings.dmEnabled.value) return
                 runCatching { parseSignedEventJson(event.toString()) }.getOrNull()?.let {
                     dmManager.ingestDmRelays(it)
                     if (it.pubkey == sessionManager.getPublicKey()) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1378,6 +1378,7 @@ class NostrRepository(
 
     /** Connect to our DM relays and subscribe to the kind:1059 inbox so DMs arrive in real time. */
     suspend fun startDmInbox() {
+        if (!AppModule.dmSettings.dmEnabled.value) return
         if (dmInboxStarted) return
         val myPub = sessionManager.getPublicKey() ?: return
         dmInboxStarted = true
@@ -3807,6 +3808,8 @@ class NostrRepository(
                         // longer matches.
                         val decrypt: suspend () -> Boolean = {
                             if (sessionManager.getPublicKey() != myPub) {
+                                false
+                            } else if (!AppModule.dmSettings.dmEnabled.value) {
                                 false
                             } else {
                                 kotlinx.coroutines.withTimeoutOrNull(DM_DECRYPT_TIMEOUT_MS) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1406,15 +1406,18 @@ class NostrRepository(
         // Make ourselves reachable: publish a default kind:10050 only if the account truly has none.
         // Gate on the fetch landing an event (our pubkey appearing in dmRelaysByPubkey), not a fixed
         // delay - the old 4s fired before the fetch finished and overwrote existing lists with the
-        // defaults.
-        scope.launch {
-            val found = withTimeoutOrNull(12_000) { dmManager.dmRelaysByPubkey.first { myPub in it } } != null
-            if (found) {
-                _myDmRelays.value = dmRelaysFor(myPub)
-            } else {
-                publishDmRelayList(defaultDmRelays)
+        // defaults. Registered as a dmPersistenceJob: stopDmInbox clears dmRelaysByPubkey and the
+        // ingest guard drops the real 10050 while disabled, so an orphaned job would deterministically
+        // time out and overwrite the user's published list with the defaults mid-disable.
+        dmPersistenceJobs +=
+            scope.launch {
+                val found = withTimeoutOrNull(12_000) { dmManager.dmRelaysByPubkey.first { myPub in it } } != null
+                if (found) {
+                    _myDmRelays.value = dmRelaysFor(myPub)
+                } else if (AppModule.dmSettings.dmEnabled.value && dmInboxStarted) {
+                    publishDmRelayList(defaultDmRelays)
+                }
             }
-        }
 
         // Retry undecrypted wraps as the (flaky) bunker signer recovers: a timed-out nip44_decrypt
         // leaves its wrap un-acked, so periodically re-stream the inbox window. The persisted dedup

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/DmSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/DmSettings.kt
@@ -1,0 +1,34 @@
+package org.nostr.nostrord.settings
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.nostr.nostrord.storage.SecureStorage
+
+/**
+ * Master on/off switch for the entire direct-messages feature — toggled from
+ * Settings → Direct Messages.
+ *
+ * When off, the app stops subscribing to the NIP-17 gift-wrap inbox (kind:1059)
+ * and never unwraps or decrypts DMs, and all DM UI (rail entry, sidebar, unread
+ * badges, "Message" buttons, DM relay editor) is hidden. Default on, so existing
+ * behavior is unchanged unless the user opts out. Your published kind:10050 DM
+ * relay list is left untouched — this switch is local only.
+ */
+class DmSettings {
+    private val _dmEnabled =
+        MutableStateFlow(
+            SecureStorage.getBooleanPref(KEY_DM_ENABLED, default = true),
+        )
+
+    val dmEnabled: StateFlow<Boolean> = _dmEnabled.asStateFlow()
+
+    fun setDmEnabled(enabled: Boolean) {
+        _dmEnabled.value = enabled
+        SecureStorage.saveBooleanPref(KEY_DM_ENABLED, enabled)
+    }
+
+    private companion object {
+        const val KEY_DM_ENABLED = "dm_enabled"
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/DmSettingsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/DmSettingsTest.kt
@@ -1,0 +1,37 @@
+package org.nostr.nostrord.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DmSettingsTest {
+    @Test
+    fun defaultsToEnabled() {
+        val settings = DmSettings()
+        val original = settings.dmEnabled.value
+        try {
+            // A fresh account with nothing stored must have DMs on, so existing users are unaffected.
+            settings.setDmEnabled(true)
+            assertTrue(DmSettings().dmEnabled.value)
+        } finally {
+            settings.setDmEnabled(original)
+        }
+    }
+
+    @Test
+    fun setDmEnabledPersistsAcrossInstances() {
+        val settings = DmSettings()
+        val original = settings.dmEnabled.value
+        try {
+            settings.setDmEnabled(false)
+            assertEquals(false, settings.dmEnabled.value)
+            assertEquals(false, DmSettings().dmEnabled.value)
+
+            settings.setDmEnabled(true)
+            assertEquals(true, settings.dmEnabled.value)
+            assertEquals(true, DmSettings().dmEnabled.value)
+        } finally {
+            settings.setDmEnabled(original)
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -177,6 +177,7 @@ fun AppFrame() {
     val unreadCounts by vm.unreadCounts.collectAsState()
     val notificationUnread by vm.notificationUnread.collectAsState()
     val dmUnread by AppModule.nostrRepository.totalDmUnread.collectAsState()
+    val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     var addGroupStep by remember { mutableStateOf<AddGroupStep?>(null) }
     // Friend tapped in the home sidebar: open the quick profile modal first (no
     // chat composer around, so no Mention action), with "View profile" inside it
@@ -197,6 +198,12 @@ fun AppFrame() {
     val groupRoute = route as? GroupRoute
     // Notifications is a real route now; the rail and sidebar gate their layout on it.
     val showNotifications = route is NotificationsRoute
+
+    // DMs disabled while a DM route is on screen (toggled off, or a restored/deep-linked DM
+    // route): bounce home so the hidden feature can't stay visible.
+    LaunchedEffect(dmEnabled, route) {
+        if (!dmEnabled && route is DmRoute) history.navigate(null)
+    }
 
     // A genuine account switch drops the previous account's history (its open group or
     // profile must never leak into the new session) and re-seeds into the new account's own
@@ -348,16 +355,18 @@ fun AppFrame() {
                 }
             }
             HorizontalDivider(modifier = Modifier.width(32.dp), color = NostrordColors.Divider)
-            Box {
-                RailButton(icon = Icons.Default.Mail, label = "Direct messages", active = route is DmRoute && !showNotifications) {
-                    history.navigate(DmRoute())
-                    closeDrawer()
-                }
-                if (dmUnread > 0) {
-                    RailBadge(
-                        count = dmUnread,
-                        modifier = Modifier.align(Alignment.TopEnd),
-                    )
+            if (dmEnabled) {
+                Box {
+                    RailButton(icon = Icons.Default.Mail, label = "Direct messages", active = route is DmRoute && !showNotifications) {
+                        history.navigate(DmRoute())
+                        closeDrawer()
+                    }
+                    if (dmUnread > 0) {
+                        RailBadge(
+                            count = dmUnread,
+                            modifier = Modifier.align(Alignment.TopEnd),
+                        )
+                    }
                 }
             }
             Box {
@@ -412,7 +421,7 @@ fun AppFrame() {
                         },
                     )
                 }
-            } else if (route is DmRoute) {
+            } else if (route is DmRoute && dmEnabled) {
                 Box(modifier = Modifier.weight(1f)) {
                     DmSidebar(
                         onOpenConversation = {
@@ -683,13 +692,19 @@ private fun FrameContent(
                     onEditProfile = onEditProfile,
                     onOpenDrawer = onOpenDrawer,
                 )
-            is DmRoute ->
-                DmPageScreen(
-                    pubkey = route.pubkey,
-                    onOpenProfile = onNavigate,
-                    onOpenConversation = onNavigate,
-                    onOpenDrawer = onOpenDrawer,
-                )
+            is DmRoute -> {
+                // Guarded: a LaunchedEffect bounces DmRoute home when DMs are off, so this renders
+                // only while enabled (the guard covers the frame before the redirect lands).
+                val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
+                if (dmEnabled) {
+                    DmPageScreen(
+                        pubkey = route.pubkey,
+                        onOpenProfile = onNavigate,
+                        onOpenConversation = onNavigate,
+                        onOpenDrawer = onOpenDrawer,
+                    )
+                }
+            }
             // Notifications is a real route rendered here so back/forward traverse it like
             // any page. Settings is a full-screen overlay in AppFrame (over the rail and
             // sidebar), so its arm is empty.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
@@ -136,6 +136,7 @@ fun UserProfileModal(
     // Follow state from the active account's kind:3 contact list (fetched once on open).
     val scope = rememberCoroutineScope()
     val following by AppModule.nostrRepository.following.collectAsState()
+    val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     val isFollowing = pubkey in following
     var followBusy by remember(pubkey) { mutableStateOf(false) }
     LaunchedEffect(Unit) { AppModule.nostrRepository.requestContactList() }
@@ -305,17 +306,19 @@ fun UserProfileModal(
                                     },
                                     modifier = Modifier.weight(1f),
                                 )
-                                AppButton(
-                                    text = "Message",
-                                    onClick = {
-                                        onDismiss()
-                                        frameNavigator?.invoke(DmRoute(pubkey))
-                                    },
-                                    enabled = frameNavigator != null,
-                                    variant = AppButtonVariant.Secondary,
-                                    icon = Icons.Default.Mail,
-                                    modifier = Modifier.weight(1f),
-                                )
+                                if (dmEnabled) {
+                                    AppButton(
+                                        text = "Message",
+                                        onClick = {
+                                            onDismiss()
+                                            frameNavigator?.invoke(DmRoute(pubkey))
+                                        },
+                                        enabled = frameNavigator != null,
+                                        variant = AppButtonVariant.Secondary,
+                                        icon = Icons.Default.Mail,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
                             }
                         }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
@@ -106,6 +106,7 @@ fun HomePageScreen(
     val friendsGroupsLoading by vm.friendsGroupsLoading.collectAsState()
     val recommendedGroupsLoading by vm.recommendedGroupsLoading.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()
+    val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     // Group ids you're a member of, to flag the "Joined" badge on cards in mixed lists.
     val joinedGroupsByRelay by AppModule.nostrRepository.joinedGroupsByRelay.collectAsState()
     val joinedIds = joinedGroupsByRelay.values.flatten().toSet()
@@ -130,13 +131,15 @@ fun HomePageScreen(
             onOpenDrawer = onOpenDrawer,
         ) {
             Spacer(modifier = Modifier.weight(1f))
-            IconButton(onClick = onOpenDms) {
-                Icon(
-                    imageVector = Icons.Default.Mail,
-                    contentDescription = "Direct messages",
-                    tint = NostrordColors.TextSecondary,
-                    modifier = Modifier.size(18.dp),
-                )
+            if (dmEnabled) {
+                IconButton(onClick = onOpenDms) {
+                    Icon(
+                        imageVector = Icons.Default.Mail,
+                        contentDescription = "Direct messages",
+                        tint = NostrordColors.TextSecondary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
             }
             IconButton(onClick = onOpenNotifications) {
                 Icon(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageScreen.kt
@@ -157,14 +157,17 @@ fun ProfilePageScreen(
                                     )
                                 } else {
                                     val frameNavigator = LocalFrameNavigator.current
+                                    val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
                                     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                                        AppButton(
-                                            text = "Message",
-                                            onClick = { frameNavigator?.invoke(DmRoute(pubkey)) },
-                                            enabled = frameNavigator != null,
-                                            variant = AppButtonVariant.Secondary,
-                                            icon = Icons.Default.Mail,
-                                        )
+                                        if (dmEnabled) {
+                                            AppButton(
+                                                text = "Message",
+                                                onClick = { frameNavigator?.invoke(DmRoute(pubkey)) },
+                                                enabled = frameNavigator != null,
+                                                variant = AppButtonVariant.Secondary,
+                                                icon = Icons.Default.Mail,
+                                            )
+                                        }
                                         FollowButton(
                                             isFollowing = isFollowing,
                                             isBusy = isFollowBusy,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -224,8 +224,12 @@ fun SettingsScreen(
         )
     }
 
+    val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     val dmRelaysContent: @Composable () -> Unit = {
-        DmRelayPanelContent()
+        DmSettingsPanelContent(
+            dmEnabled = dmEnabled,
+            onToggleDm = { AppModule.dmSettings.setDmEnabled(it) },
+        )
     }
 
     val notificationsContent: @Composable () -> Unit = {
@@ -1249,6 +1253,35 @@ private fun MediaPanelContent(
                 checked = autoLoadMedia,
                 onCheckedChange = onToggleAutoLoad,
             )
+        }
+    }
+}
+
+@Composable
+private fun DmSettingsPanelContent(
+    dmEnabled: Boolean,
+    onToggleDm: (Boolean) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.lg),
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = NostrordShapes.cardShape,
+            colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
+        ) {
+            SettingsToggleRow(
+                label = "Direct messages",
+                description = "Send and receive private messages. When off, the app stops " +
+                    "fetching and decrypting your DMs and hides all direct-message features.",
+                checked = dmEnabled,
+                onCheckedChange = onToggleDm,
+            )
+        }
+        // Relay editor only matters while DMs are on; hidden with the rest of the feature when off.
+        if (dmEnabled) {
+            DmRelayPanelContent()
         }
     }
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -86,6 +86,7 @@ val AppFrame =
         val unreadCounts = useStateFlow(vm.unreadCounts)
         val notificationUnread = useStateFlow(vm.notificationUnread)
         val dmUnread = useStateFlow(repo.totalDmUnread)
+        val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         // Browser-tab badge = unread notifications + unread DMs, so the favicon alerts for both,
         // using the notification count (not the old per-group message-unread total, which
         // over-counted vs the Notifications bell). Web only; native uses OS notifications;
@@ -135,6 +136,11 @@ val AppFrame =
         // Close the mobile nav drawer whenever the destination changes (a rail/sidebar tap
         // navigates or opens notifications), so it doesn't stay over the new screen.
         useEffect(route) { setDrawerOpen(false) }
+        // DMs disabled while a DM route is showing (toggled off, or a restored/deep-linked #/dm):
+        // bounce home so the hidden feature can't stay open.
+        useEffect(dmEnabled, route) {
+            if (!dmEnabled && route is DmRoute) pushHome()
+        }
         // Switching accounts resets navigation to Home and strips the URL, so the previous
         // account's open group doesn't linger or get reopened on refresh. useStateFlow seeds
         // activeId synchronously, so the first run is the current account (no reset); only a
@@ -320,18 +326,20 @@ val AppFrame =
                     }
                     div { className = ClassName("rail-spacer") }
                     div { className = ClassName("rail-divider") }
-                    div {
-                        className = ClassName("rail-group")
-                        button {
-                            className = ClassName(if (route is DmRoute && !notificationsOpen) "rail-btn active" else "rail-btn")
-                            title = "Direct messages"
-                            onClick = { pushRoute(DmRoute()) }
-                            icon(Ic.Mail)
-                        }
-                        if (dmUnread > 0) {
-                            span {
-                                className = ClassName("rail-badge top")
-                                +(if (dmUnread > 99) "99+" else "$dmUnread")
+                    if (dmEnabled) {
+                        div {
+                            className = ClassName("rail-group")
+                            button {
+                                className = ClassName(if (route is DmRoute && !notificationsOpen) "rail-btn active" else "rail-btn")
+                                title = "Direct messages"
+                                onClick = { pushRoute(DmRoute()) }
+                                icon(Ic.Mail)
+                            }
+                            if (dmUnread > 0) {
+                                span {
+                                    className = ClassName("rail-badge top")
+                                    +(if (dmUnread > 99) "99+" else "$dmUnread")
+                                }
                             }
                         }
                     }
@@ -363,7 +371,7 @@ val AppFrame =
                             this.route = groupRoute
                             onNavigateGroup = { pushRoute(it) }
                         }
-                    } else if (dmRoute != null) {
+                    } else if (dmRoute != null && dmEnabled) {
                         DmSidebar {
                             activePubkey = dmRoute.pubkey
                             onOpenConversation = { pushRoute(it) }
@@ -635,7 +643,7 @@ val AppFrame =
                             onEditProfile = { pushRoute(SettingsRoute) }
                             onOpenDrawer = { setDrawerOpen(true) }
                         }
-                    r is DmRoute ->
+                    r is DmRoute && dmEnabled ->
                         DmPage {
                             pubkey = r.pubkey
                             onOpenProfile = { pushRoute(it) }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
@@ -72,6 +72,7 @@ val UserProfileModal =
         val (removeError, setRemoveError) = useState<String?> { null }
         val following = useStateFlow(AppModule.nostrRepository.following)
         val isFollowing = pubkey in following
+        val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         val (followBusy, setFollowBusy) = useState { false }
 
         useEffect(pubkey) {
@@ -175,14 +176,16 @@ val UserProfileModal =
                                     setFollowBusy(false)
                                 }
                             }
-                            button {
-                                className = ClassName("btn-secondary profile-btn")
-                                onClick = {
-                                    props.onClose()
-                                    pushRoute(DmRoute(pubkey))
+                            if (dmEnabled) {
+                                button {
+                                    className = ClassName("btn-secondary profile-btn")
+                                    onClick = {
+                                        props.onClose()
+                                        pushRoute(DmRoute(pubkey))
+                                    }
+                                    icon(Ic.Mail)
+                                    +"Message"
                                 }
-                                icon(Ic.Mail)
-                                +"Message"
                             }
                         }
                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
@@ -61,6 +61,7 @@ external interface HomePageProps : Props {
 val HomePage =
     FC<HomePageProps> { props ->
         val vm = useViewModel { HomePageViewModel(AppModule.nostrRepository) }
+        val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         // The page list is filtered by the search box; the rail (AppFrame) keeps the full myGroups.
         val myGroups = useStateFlow(vm.filteredMyGroups)
         val query = useStateFlow(vm.query)
@@ -112,11 +113,13 @@ val HomePage =
                 }
                 div {
                     className = ClassName("page-header-actions")
-                    button {
-                        className = ClassName("icon-btn")
-                        title = "Direct messages"
-                        onClick = { props.onOpenDms() }
-                        icon(Ic.Mail)
+                    if (dmEnabled) {
+                        button {
+                            className = ClassName("icon-btn")
+                            title = "Direct messages"
+                            onClick = { props.onOpenDms() }
+                            icon(Ic.Mail)
+                        }
                     }
                     button {
                         className = ClassName("icon-btn")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
@@ -57,6 +57,7 @@ val ProfilePage =
         val metadata = useStateFlow(vm.metadata)
         val groups = useStateFlow(vm.userGroups)
         val isFollowing = useStateFlow(vm.isFollowing)
+        val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         val isFollowBusy = useStateFlow(vm.isFollowBusy)
         val allMeta = useStateFlow(AppModule.nostrRepository.userMetadata)
         val relayMetadata = useStateFlow(AppModule.nostrRepository.relayMetadata)
@@ -133,11 +134,13 @@ val ProfilePage =
                                 } else {
                                     div {
                                         className = ClassName("profile-page-actions")
-                                        button {
-                                            className = ClassName("btn-secondary profile-btn")
-                                            onClick = { pushRoute(DmRoute(props.pubkey)) }
-                                            icon(Ic.Mail)
-                                            +"Message"
+                                        if (dmEnabled) {
+                                            button {
+                                                className = ClassName("btn-secondary profile-btn")
+                                                onClick = { pushRoute(DmRoute(props.pubkey)) }
+                                                icon(Ic.Mail)
+                                                +"Message"
+                                            }
                                         }
                                         followToggleButton(isFollowing, isFollowBusy) { vm.toggleFollow() }
                                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -621,6 +621,8 @@ private val RelaysPanel =
 
 private val DmRelaysPanel =
     FC<Props> {
+        val dm = AppModule.dmSettings
+        val dmEnabled = useStateFlow(dm.dmEnabled)
         val dmVm = useViewModel { DmRelaySettingsViewModel(AppModule.nostrRepository) }
         val published = useStateFlow(dmVm.relays)
         val saving = useStateFlow(dmVm.saving)
@@ -642,85 +644,98 @@ private val DmRelaysPanel =
 
         div {
             className = ClassName("settings-card")
-            div {
-                className = ClassName("settings-info-text")
-                +(
-                    "NIP-17 DM relays (kind 10050) tell other clients where to deliver your private " +
-                        "direct messages. Pick a few reliable relays. They can be the same as your NIP-65 " +
-                        "relays or dedicated ones. Until you publish a list, sensible defaults are used."
-                    )
-            }
+            settingsToggle(
+                "Direct messages",
+                "Send and receive private messages. When off, the app stops fetching and " +
+                    "decrypting your DMs and hides all direct-message features.",
+                dmEnabled,
+            ) { dm.setDmEnabled(!dmEnabled) }
         }
 
-        div {
-            className = ClassName("settings-card")
+        // Relay editor only matters while DMs are on; hidden with the rest of the feature when off.
+        if (dmEnabled) {
             div {
-                className = ClassName("settings-section-head")
-                +"YOUR DM RELAYS"
-            }
-            if (relays.isEmpty()) {
+                className = ClassName("settings-card")
                 div {
-                    className = ClassName("relay-warn")
-                    +"No DM relays. Others won't be able to reach you. Add at least one."
+                    className = ClassName("settings-info-text")
+                    +(
+                        "NIP-17 DM relays (kind 10050) tell other clients where to deliver your private " +
+                            "direct messages. Pick a few reliable relays. They can be the same as your NIP-65 " +
+                            "relays or dedicated ones. Until you publish a list, sensible defaults are used."
+                        )
                 }
             }
-            relays.forEachIndexed { i, url ->
+
+            div {
+                className = ClassName("settings-card")
                 div {
-                    key = url
-                    className = ClassName("relay-row")
-                    span {
-                        className = ClassName("relay-row-url")
-                        +url.removePrefix("wss://").removePrefix("ws://")
+                    className = ClassName("settings-section-head")
+                    +"YOUR DM RELAYS"
+                }
+                if (relays.isEmpty()) {
+                    div {
+                        className = ClassName("relay-warn")
+                        +"No DM relays. Others won't be able to reach you. Add at least one."
                     }
+                }
+                relays.forEachIndexed { i, url ->
+                    div {
+                        key = url
+                        className = ClassName("relay-row")
+                        span {
+                            className = ClassName("relay-row-url")
+                            +url.removePrefix("wss://").removePrefix("ws://")
+                        }
+                        button {
+                            className = ClassName("relay-row-remove")
+                            onClick = { setRelays(relays.filterIndexed { j, _ -> j != i }) }
+                            icon(Ic.Close)
+                        }
+                    }
+                }
+
+                div {
+                    className = ClassName("settings-section-head relay-add-head")
+                    +"ADD RELAY"
+                }
+                input {
+                    className = ClassName("modal-input")
+                    placeholder = "relay.example.com"
+                    value = newUrl
+                    onChange = { event -> setNewUrl(event.currentTarget.value) }
+                    onKeyDown = { event ->
+                        if (event.key == "Enter") {
+                            event.preventDefault()
+                            addRelay()
+                        }
+                    }
+                }
+                div {
+                    className = ClassName("relay-add-row")
                     button {
-                        className = ClassName("relay-row-remove")
-                        onClick = { setRelays(relays.filterIndexed { j, _ -> j != i }) }
-                        icon(Ic.Close)
+                        className = ClassName("relay-add-btn")
+                        disabled = !canAdd
+                        onClick = { addRelay() }
+                        icon(Ic.Add)
+                        +"Add"
                     }
                 }
             }
 
             div {
-                className = ClassName("settings-section-head relay-add-head")
-                +"ADD RELAY"
-            }
-            input {
-                className = ClassName("modal-input")
-                placeholder = "relay.example.com"
-                value = newUrl
-                onChange = { event -> setNewUrl(event.currentTarget.value) }
-                onKeyDown = { event ->
-                    if (event.key == "Enter") {
-                        event.preventDefault()
-                        addRelay()
+                className = ClassName("relay-save-row")
+                error?.let {
+                    span {
+                        className = ClassName("relay-save-status")
+                        +it
                     }
                 }
-            }
-            div {
-                className = ClassName("relay-add-row")
                 button {
-                    className = ClassName("relay-add-btn")
-                    disabled = !canAdd
-                    onClick = { addRelay() }
-                    icon(Ic.Add)
-                    +"Add"
+                    className = ClassName("settings-save")
+                    disabled = saving
+                    onClick = { dmVm.publish(relays) }
+                    +(if (saving) "Publishing…" else "Save & Publish")
                 }
-            }
-        }
-
-        div {
-            className = ClassName("relay-save-row")
-            error?.let {
-                span {
-                    className = ClassName("relay-save-status")
-                    +it
-                }
-            }
-            button {
-                className = ClassName("settings-save")
-                disabled = saving
-                onClick = { dmVm.publish(relays) }
-                +(if (saving) "Publishing…" else "Save & Publish")
             }
         }
     }


### PR DESCRIPTION
Settings → Direct Messages gains an on/off switch (global, default on, persisted). When off, NostrRepository stops subscribing to the NIP-17 kind:1059 inbox and never unwraps/decrypts DMs: a combine(isLoggedIn, dmEnabled) collector starts the inbox only while enabled and tears it down live via stopDmInbox() (CLOSE dm_inbox, cancel retry jobs, clear state). Ingest handlers guard against wraps that race the CLOSE.

All DM UI is hidden while off on both platforms (Compose + web React): rail entry + unread badge, Home header DM button, DM sidebar, the "Message" buttons on the profile page and user-profile modal, and the DM relays editor. A route guard bounces DmRoute/#/dm back home. The published kind:10050 relay list is left untouched.