### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.0.1
-app.versionCode=13
+app.version=2.1.0
+app.versionCode=14
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Version bump for the v2.1.0 release: the relay pool fold, self-healing live subscriptions, and the send-state/scroll UX fixes from #176.