### PR TITLE
fix: heal zombie WebSockets and stop caching unconfirmed own messages

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -230,6 +230,14 @@ class NostrGroupClient(
     // Track if this was a graceful disconnect
     private var isDisconnecting = false
 
+    // Epoch ms of the last frame received from the relay. A socket that stays
+    // silent while an OK is awaited (or across a whole mux stale window) is a
+    // zombie: mobile networks kill TCP without a close frame, writes buffer
+    // locally without throwing, and the engine ping can be deferred under Doze.
+    // Zombies must be torn down via markDead() — nothing else ever detects them.
+    @kotlin.concurrent.Volatile
+    private var lastInboundAtMs: Long = 0L
+
     // Open subscription IDs tracked for diagnostic logging.
     // Updated in send() on every REQ/CLOSE. Not synchronised — count may be off by ±1
     // under concurrent sends, which is acceptable for logging purposes.
@@ -263,6 +271,58 @@ class NostrGroupClient(
      */
     fun isConnected(): Boolean = session != null && connectionJob?.isActive == true
 
+    /** How long the relay has been completely silent (no frames of any kind), or null if not connected. */
+    fun inboundSilenceMs(nowMs: Long = epochMillis()): Long? = if (isConnected()) nowMs - lastInboundAtMs else null
+
+    /**
+     * Tear down a socket believed to be a zombie (writes buffer, nothing inbound).
+     * Cancelling the frame loop makes its finally run the normal lost-connection
+     * path: session is cleared, onConnectionLost fires, and the reconnect
+     * scheduler rebuilds the socket + resubscribes + flushes pending events.
+     */
+    fun markDead() {
+        if (isDisconnecting) return
+        connectionJob?.cancel()
+    }
+
+    @kotlin.concurrent.Volatile
+    private var probeInFlight = false
+
+    /**
+     * Actively verify the socket is alive. Sends a REQ any relay must answer
+     * (EOSE, or CLOSED on auth-gated relays — any inbound frame counts) and
+     * waits for inbound traffic; total silence means zombie → [markDead].
+     * Cheap on a live relay (one REQ+CLOSE round trip). Needed because engine
+     * pongs never reach the frame loop, so inbound silence alone cannot
+     * distinguish a quiet-but-alive relay from a dead socket.
+     */
+    suspend fun probeLiveness(timeoutMs: Long = 5_000) {
+        if (!isConnected() || probeInFlight) return
+        probeInFlight = true
+        try {
+            val sentAtMs = epochMillis()
+            try {
+                session?.send(Frame.Text("""["REQ","_probe",{"ids":["${"0".repeat(64)}"],"limit":1}]"""))
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                markDead()
+                return
+            }
+            while (epochMillis() - sentAtMs < timeoutMs) {
+                delay(250)
+                if (lastInboundAtMs >= sentAtMs) {
+                    try {
+                        session?.send(Frame.Text("""["CLOSE","_probe"]"""))
+                    } catch (_: Exception) {}
+                    return
+                }
+            }
+            markDead()
+        } finally {
+            probeInFlight = false
+        }
+    }
+
     /**
      * Parse NIP-42 AUTH challenge from relay
      * Returns the challenge string if this is an AUTH message, null otherwise
@@ -286,6 +346,7 @@ class NostrGroupClient(
             try {
                 client.webSocket(relayUrl) {
                     session = this
+                    lastInboundAtMs = epochMillis()
 
                     // Signal that connection is ready
                     connectionResult.complete(true)
@@ -320,6 +381,7 @@ class NostrGroupClient(
 
                     // Listen to incoming messages
                     for (frame in incoming) {
+                        lastInboundAtMs = epochMillis()
                         when (frame) {
                             is Frame.Text -> onMessage(frame.readText())
                             is Frame.Close -> {} // CLOSED event below captures code + reason
@@ -455,6 +517,7 @@ class NostrGroupClient(
         timeoutMs: Long = 10_000,
     ): PublishResult {
         val deferred = CompletableDeferred<PublishResult>()
+        val sentAtMs = epochMillis()
 
         // Register pending response
         pendingOkMutex.withLock {
@@ -475,6 +538,13 @@ class NostrGroupClient(
             }
         } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
             pendingOkMutex.withLock { pendingOkResponses.remove(eventId) }
+            // No OK and not a single frame of any kind while we waited: the socket
+            // is a zombie, not a slow relay. Tear it down so the reconnect path
+            // (resubscribe + pending-event flush) takes over; otherwise the write
+            // keeps buffering into a dead pipe and the message stays Sending forever.
+            if (lastInboundAtMs < sentAtMs) {
+                markDead()
+            }
             PublishResult.Timeout(eventId)
         } catch (e: Exception) {
             pendingOkMutex.withLock { pendingOkResponses.remove(eventId) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -91,6 +91,10 @@ private const val DISCOVERY_CURATOR_PUBKEY = "b2cdcb37d32533145c00c4f43d5e1e1deb
 // must reach back this far from the sync cursor or recent wraps would be missed on resync.
 private const val GIFT_WRAP_BACKDATE_SECONDS = 2L * 24 * 60 * 60
 
+// Min frame silence before a foreground return probes a socket. A frame in the
+// last minute proves the socket is alive; below this, probing is pure overhead.
+private const val FOREGROUND_PROBE_MIN_SILENCE_MS = 60_000L
+
 /**
  * Repository for Nostr operations.
  * Coordinates between specialized managers for different concerns.
@@ -1922,12 +1926,33 @@ class NostrRepository(
                     reconnectDroppedNip29PoolRelays()
                 }
 
-                // Already connected — refresh subscriptions and pool relays.
+                // Already connected — verify the sockets actually survived the
+                // background period (Doze/radio sleep kills TCP without a close
+                // frame; "Connected" can be a zombie), then refresh subs.
                 is ConnectionManager.ConnectionState.Connected -> {
+                    probeIdleSockets()
                     groupManager.refreshLiveSubscriptions()
                     reconnectDroppedNip29PoolRelays()
                 }
             }
+        }
+    }
+
+    /**
+     * Probe every connected relay socket that has been frame-silent for a while.
+     * Zombies are marked dead inside probeLiveness, and the resulting
+     * onConnectionLost drives reconnect + resubscribe + pending-event flush.
+     * Probes run concurrently so one dead socket doesn't delay the others.
+     */
+    private suspend fun probeIdleSockets() {
+        val clients = (
+            connectionManager.getAllConnectedClients() +
+                listOfNotNull(connectionManager.getFocusedClient())
+            ).distinct()
+        for (client in clients) {
+            val silence = client.inboundSilenceMs() ?: continue
+            if (silence < FOREGROUND_PROBE_MIN_SILENCE_MS) continue
+            scope.launch { client.probeLiveness() }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -1068,6 +1068,15 @@ class GroupManager(
                 // window, an eaten REQ keeps being nudged).
                 if (muxTracker.isStale(relayUrl, now, MUX_STALE_REARM_MS)) {
                     muxTracker.clearRelay(relayUrl)
+                    // A zombie socket eats the re-sent REQ silently and update()
+                    // re-arms the staleness clock, deferring detection forever. When
+                    // the socket itself has been frame-silent for the whole window,
+                    // verify it: probeLiveness marks it dead if nothing answers, and
+                    // onConnectionLost drives reconnect + resubscribe + pending flush.
+                    val client = connectionManager.getClientForRelay(relayUrl)
+                    if (client != null && (client.inboundSilenceMs(now) ?: 0L) > MUX_STALE_REARM_MS) {
+                        scope.launch { client.probeLiveness() }
+                    }
                 }
                 refreshMuxSubscriptionsForRelay(relayUrl)
             } catch (_: Exception) {}
@@ -2868,6 +2877,7 @@ class GroupManager(
     /**
      * Insert one of the local user's own messages into [_messages] immediately,
      * reusing [messageIdIndex] so the relay's later echo of the same id is deduped.
+     *
      */
     private fun insertOwnMessage(groupId: String, message: NostrGroupClient.NostrMessage) {
         _messages.update { currentMap ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -2878,6 +2878,10 @@ class GroupManager(
      * Insert one of the local user's own messages into [_messages] immediately,
      * reusing [messageIdIndex] so the relay's later echo of the same id is deduped.
      *
+     * NOT cached here: the message status lives only in memory, so a cached
+     * optimistic message the relay never accepted would come back after restart
+     * with no pending icon — a ghost only this device can see. [markDelivered]
+     * caches it once the relay confirms.
      */
     private fun insertOwnMessage(groupId: String, message: NostrGroupClient.NostrMessage) {
         _messages.update { currentMap ->
@@ -2887,7 +2891,6 @@ class GroupManager(
             currentMap + (groupId to (current + message).sortedBy { it.createdAt })
         }
         touchGroupRecency(groupId)
-        cacheMessages(groupId, listOf(message))
     }
 
     /**
@@ -2944,6 +2947,14 @@ class GroupManager(
         // previous session) stays absent so history never grows a stray check.
         _messageStatus.update { statuses ->
             if (eventId in statuses) statuses + (eventId to MessageStatus.Delivered) else statuses
+        }
+        // First relay confirmation is what makes the message durable. The relay's
+        // echo is deduped by messageIdIndex and never reaches the batch cache path,
+        // so this is the only place an own message enters the cache.
+        for ((groupId, msgs) in _messages.value) {
+            val msg = msgs.lastOrNull { it.id == eventId } ?: continue
+            cacheMessages(groupId, listOf(msg))
+            break
         }
     }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/App.kt
@@ -23,6 +23,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.startup.AppStartState
@@ -70,6 +73,32 @@ fun App() {
     var hasEnteredApp by remember { mutableStateOf(false) }
     LaunchedEffect(isLoggedIn) { if (isLoggedIn) hasEnteredApp = true }
     LaunchedEffect(activeId) { if (activeId == null) hasEnteredApp = false }
+
+    // Background/foreground wiring (the web wires this via visibilitychange in
+    // WebApp.kt). onForeground probes for zombie sockets and refreshes subs;
+    // FocusTracker drives the "active group + unfocused → still notify" branch.
+    // The first ON_RESUME of a cold start is skipped: initialize()/login own the
+    // connection sequence and a concurrent reconnect would race them.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        var wasBackgrounded = false
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> {
+                    AppModule.focusTracker.setFocused(true)
+                    if (wasBackgrounded) AppModule.nostrRepository.onForeground()
+                }
+                Lifecycle.Event.ON_STOP -> {
+                    wasBackgrounded = true
+                    AppModule.focusTracker.setFocused(false)
+                    AppModule.nostrRepository.onBackground()
+                }
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // Compute startup state synchronously from current values.
     val startupState: AppStartState =


### PR DESCRIPTION
On Android, sent group messages stayed on the pending clock forever and live events stopped arriving while the connection indicator stayed green; only an app restart recovered (the PWA on the same device/account worked). Cause: mobile networks and Doze kill TCP without a close frame. Writes into the dead socket buffer locally without throwing, so `isConnected()` stayed true and nothing ever reconnected. The mux stale self-heal made it worse by re-sending the REQ into the dead pipe and re-arming its own staleness clock. A second bug fell out of the first: optimistic messages were written to the persistent cache at insert time while their status lives only in memory, so a never-delivered message came back after restart looking delivered, visible only on that device.

`NostrGroupClient` now stamps `lastInboundAtMs` on every frame and gains `markDead()` (cancels the frame loop so the normal `onConnectionLost` -> reconnect -> resubscribe -> pending-flush path runs) and `probeLiveness()` (a REQ any relay must answer; total silence within 5s = zombie). The probe is required because engine pongs never reach the frame loop, so inbound silence alone cannot distinguish a quiet-but-alive relay from a dead socket.

| Detection point | Trigger | Action |
|---|---|---|
| `sendAndAwaitOk` | OK timeout with zero inbound frames during the wait | `markDead()` (covers NIP-46 bunker sockets, same call) |
| `refreshLiveSubscriptions` | mux stale + socket frame-silent for the whole window | `probeLiveness()` alongside the re-REQ |
| `onForeground` | any socket idle > 60s on return to foreground | `probeLiveness()` per socket, concurrently |

`onForeground()`/`onBackground()` turned out to be web-only (`visibilitychange` in WebApp.kt); the Compose targets never called them. They are now wired in `App.kt` via `LifecycleEventObserver` (first ON_RESUME of a cold start is skipped so it does not race login/initialize), which also gives Android cursor persistence on background and a real `FocusTracker` state for notifications.

The cache fix: `insertOwnMessage` no longer writes to the history cache; `markDelivered` persists the message on the first relay confirmation (OK or the relay's echo, which is deduped by `messageIdIndex` and never reaches the batch cache path). An undelivered message now disappears on restart; the persisted retry queue still re-publishes it and success brings it back through the normal incoming path.

Commits:
- d141234c fix(network): detect and heal zombie WebSockets (sends stuck pending, deaf feed)
- 24274aa0 fix(groups): cache own messages only after relay confirmation