### PR TITLE
chore(release): bump version to 2.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.1.0
-app.versionCode=14
+app.version=2.1.1
+app.versionCode=15
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Patch release: the send-reliability fixes already on main (zombie WebSocket healing, confirmed-only own-message cache, #179). Bumps app.version to 2.1.1 and versionCode to 15 ahead of tagging.