### PR TITLE
feat: mute user (NIP-51 kind:10000) across all platforms

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -301,6 +301,9 @@ object AppModule {
             findMessageAuthor = { messageId ->
                 groupManager.findMessageByIdAcrossGroups(messageId)?.second?.pubkey
             },
+            // Deferred to call time: by the first message flush the repository exists,
+            // so this lazy access never cycles with unreadManager's own construction.
+            isMutedAuthor = { pubkey -> pubkey in nostrRepository.mutedPubkeys.value },
             shouldNotify = { groupId, isDirect ->
                 notificationSettings.shouldNotify(
                     notificationSettings.effectiveLevelFor(groupId),

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -923,6 +923,16 @@ class NostrGroupClient(
                     put("limit", 1)
                 },
             )
+            // The NIP-51 mute list (kind:10000) rides the same REQ as its own filter
+            // (a shared filter with limit 1 would return only the newer of the two
+            // events), so the contact-list retry machinery covers it too.
+            add(
+                buildJsonObject {
+                    putJsonArray("kinds") { add(10000) }
+                    putJsonArray("authors") { add(pubkey) }
+                    put("limit", 1)
+                },
+            )
         }
         sendJson(req)
         return subId

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -66,12 +66,16 @@ import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
 import org.nostr.nostrord.storage.loadDmSyncCursor
+import org.nostr.nostrord.storage.loadKind10000TimestampFor
+import org.nostr.nostrord.storage.loadMuteListFor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
 import org.nostr.nostrord.storage.saveDmLastRead
 import org.nostr.nostrord.storage.saveDmProcessedWrapIds
 import org.nostr.nostrord.storage.saveDmSyncCursor
 import org.nostr.nostrord.storage.saveGroupFetchLazy
+import org.nostr.nostrord.storage.saveKind10000TimestampFor
+import org.nostr.nostrord.storage.saveMuteListFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
 import org.nostr.nostrord.utils.AppError
@@ -572,6 +576,52 @@ class NostrRepository(
         }
     }
 
+    // ===== NIP-51 mute list (kind:10000) =====
+    // Mirrors the kind:3 handling above: optimistic local set + debounced publish that
+    // preserves foreign tags/content, per-account persistence, staleness-guarded ingest.
+
+    private val _mutedPubkeys = MutableStateFlow<Set<String>>(emptySet())
+    override val mutedPubkeys: StateFlow<Set<String>> = _mutedPubkeys.asStateFlow()
+    private var muteListCreatedAt = 0L
+    private var muteListContent = ""
+    private var muteListTags: List<List<String>> = emptyList()
+    private var muteListRequested = false
+    private var pendingMuteListPublish: Job? = null
+    private var hasUnpublishedMuteChanges = false
+    private val muteListMutex = Mutex()
+
+    private fun handleKind10000Event(event: JsonObject) {
+        // Only the active account's own list drives [mutedPubkeys].
+        val pubKey = sessionManager.getPublicKey() ?: return
+        val eventPubkey = event["pubkey"]?.jsonPrimitive?.contentOrNull ?: return
+        if (eventPubkey != pubKey) return
+        val createdAt = event["created_at"]?.jsonPrimitive?.longOrNull ?: 0L
+        // muteListCreatedAt is floored by the persisted timestamp (hydrateMuteListFromCache),
+        // so a lagging relay can't resurrect mutes removed in a previous session.
+        if (createdAt < muteListCreatedAt) return
+        val tags =
+            event["tags"]?.jsonArray.orEmpty().map { tag ->
+                tag.jsonArray.mapNotNull { it.jsonPrimitive.contentOrNull }
+            }
+        muteListCreatedAt = createdAt
+        muteListContent = event["content"]?.jsonPrimitive?.contentOrNull ?: ""
+        muteListTags = tags
+        muteListRequested = true
+        // Keep the optimistic set while local taps are unpublished, so a relay echo
+        // arriving mid-mute doesn't clobber a just-tapped mute.
+        if (!hasUnpublishedMuteChanges) {
+            _mutedPubkeys.value = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(tags)
+            SecureStorage.saveMuteListFor(pubKey, _mutedPubkeys.value.toList())
+            SecureStorage.saveKind10000TimestampFor(pubKey, createdAt)
+        }
+    }
+
+    /** Seed [mutedPubkeys] from the per-account cache so filtering works before the network answers. */
+    private fun hydrateMuteListFromCache(pubkey: String) {
+        _mutedPubkeys.value = SecureStorage.loadMuteListFor(pubkey).toSet()
+        muteListCreatedAt = SecureStorage.loadKind10000TimestampFor(pubkey)
+    }
+
     override fun forceInitialized() {
         _isInitialized.value = true
     }
@@ -798,6 +848,7 @@ class NostrRepository(
                     unreadManager.initialize(pubkey)
                     notificationSettings?.initialize(pubkey)
                     notificationHistoryStore?.initialize(pubkey)
+                    hydrateMuteListFromCache(pubkey)
                     initializeOutboxModel()
                     scope.launch {
                         outboxManager.loadJoinedGroupsFromNostr(pubkey) { msg, c ->
@@ -862,6 +913,7 @@ class NostrRepository(
                 unreadManager.initialize(pubkey)
                 notificationSettings?.initialize(pubkey)
                 notificationHistoryStore?.initialize(pubkey)
+                hydrateMuteListFromCache(pubkey)
                 // Arm catch-up so the first mux refresh after connect replays
                 // messages that arrived while the app was closed (notifications
                 // + unread). Must run after notificationHistoryStore.initialize
@@ -1197,6 +1249,7 @@ class NostrRepository(
             unreadManager.initialize(newPubkey)
             notificationSettings?.initialize(newPubkey)
             notificationHistoryStore?.initialize(newPubkey)
+            hydrateMuteListFromCache(newPubkey)
             // Arm catch-up so the first mux refresh after connect() replays the
             // backlog accumulated while this identity was logged out. A fresh
             // identity has no backlog, so skip it there. Must run after
@@ -1300,7 +1353,7 @@ class NostrRepository(
 
     // ===== Direct messages (NIP-17 over NIP-59 gift wraps) =====
 
-    private val dmManager = DmManager(scope)
+    private val dmManager = DmManager(scope, mutedPubkeys)
 
     /** Conversations (most-recent first), derived from decrypted NIP-17 messages. */
     override val dmConversations: StateFlow<List<DmConversation>> get() = dmManager.conversations
@@ -1714,6 +1767,15 @@ class NostrRepository(
         hasUnpublishedContactChanges = false
         _contactListLoaded.value = false
         _following.value = emptySet()
+        // The mute list is per-account too; same lifecycle as the contact list.
+        pendingMuteListPublish?.cancel()
+        pendingMuteListPublish = null
+        hasUnpublishedMuteChanges = false
+        muteListCreatedAt = 0L
+        muteListContent = ""
+        muteListTags = emptyList()
+        muteListRequested = false
+        _mutedPubkeys.value = emptySet()
         dmPersistenceJobs.forEach { it.cancel() }
         dmPersistenceJobs.clear()
         dmManager.clear()
@@ -1766,6 +1828,9 @@ class NostrRepository(
         val pubkey = sessionManager.getPublicKey() ?: return
         // The contact list is per-account; drop the prior account's before the swap.
         resetContactListState()
+        // Re-seed the incoming account's mutes so filtering holds through the swap;
+        // the network refresh rides the requestContactList() below.
+        hydrateMuteListFromCache(pubkey)
         // Same session-cache teardown the full-logout path runs, so a warm swap does not
         // leak account A's restricted-relay / dedup state into account B (which otherwise
         // left B's groups dark until an app restart). Runs BEFORE B's re-derive below.
@@ -3203,7 +3268,12 @@ class NostrRepository(
                 }
             }
         }
-        if (sent > 0) contactListRequested = true
+        if (sent > 0) {
+            contactListRequested = true
+            // The same REQ carries the kind:10000 filter (see NostrGroupClient.requestContactList),
+            // so the mute list is fetched, and retried, together with the contact list.
+            muteListRequested = true
+        }
     }
 
     /**
@@ -3333,6 +3403,101 @@ class NostrRepository(
                 Result.Success(Unit)
             } catch (e: Exception) {
                 Result.Error(AppError.Unknown(e.message ?: "Failed to update contact list", e))
+            }
+        }
+    }
+
+    override suspend fun muteUser(pubkey: String): Result<Unit> {
+        // Muting yourself would hide your own messages everywhere; ignore it.
+        if (pubkey.isBlank() || pubkey == sessionManager.getPublicKey()) return Result.Success(Unit)
+        applyMuteChange { it + pubkey }
+        return Result.Success(Unit)
+    }
+
+    override suspend fun unmuteUser(pubkey: String): Result<Unit> {
+        applyMuteChange { it - pubkey }
+        return Result.Success(Unit)
+    }
+
+    /**
+     * Flips [mutedPubkeys] immediately (filtering reacts without a relay round-trip),
+     * persists the set, and schedules a single debounced kind:10000 publish so rapid
+     * taps (bulk unmute in Settings) coalesce into one event.
+     */
+    private fun applyMuteChange(transform: (Set<String>) -> Set<String>) {
+        val next = transform(_mutedPubkeys.value)
+        if (next == _mutedPubkeys.value) return
+        _mutedPubkeys.value = next
+        sessionManager.getPublicKey()?.let { SecureStorage.saveMuteListFor(it, next.toList()) }
+        hasUnpublishedMuteChanges = true
+        pendingMuteListPublish?.cancel()
+        pendingMuteListPublish =
+            scope.launch {
+                delay(contactListPublishDebounceMs)
+                publishMuteList()
+            }
+    }
+
+    /**
+     * Builds, signs and publishes a fresh kind:10000 from [mutedPubkeys], preserving
+     * non-"p" tags and the (possibly NIP-44 encrypted) content of the last known list so
+     * entries added by other clients aren't clobbered. On the first run it best-effort
+     * fetches the existing list (it rides the kind:3 REQ) before overwriting.
+     */
+    private suspend fun publishMuteList(): Result<Unit> {
+        val pubKey = sessionManager.getPublicKey()
+            ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        return muteListMutex.withLock {
+            if (!muteListRequested) {
+                contactListMutex.withLock { requestContactListLocked() }
+                withTimeoutOrNull(3_000L) { mutedPubkeys.first { muteListCreatedAt > 0L } }
+            }
+
+            val newTags = org.nostr.nostrord.nostr.Nip51.rebuildMuteTags(muteListTags, _mutedPubkeys.value)
+            try {
+                val event = org.nostr.nostrord.nostr.Event(
+                    pubkey = pubKey,
+                    createdAt = org.nostr.nostrord.utils.epochSeconds(),
+                    kind = org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST,
+                    tags = newTags,
+                    content = muteListContent,
+                )
+                val signedEvent = sessionManager.signEvent(event)
+                val eventId = signedEvent.id
+                    ?: return@withLock Result.Error(AppError.Unknown("Event has no id after signing", null))
+                val message = buildJsonArray {
+                    add("EVENT")
+                    add(signedEvent.toJsonObject())
+                }.toString()
+
+                // Same routing as kind:3: general-purpose relays only, never NIP-29 relays
+                // (they don't serve replaceable lists back).
+                val nip29Relays = outboxManager.kind10009Relays.value + connectionManager.currentRelayUrl.value
+                val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays)
+                    .distinct()
+                    .filter { it !in nip29Relays }
+                val clients = targets.mapNotNull { relayUrl ->
+                    connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }
+                        ?: connectionManager.getOrConnectRelay(relayUrl, metadataMessageHandler)?.takeIf { it.isConnected() }
+                }
+                if (clients.isEmpty()) {
+                    return@withLock Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
+                }
+                val results = clients.map { client ->
+                    scope.async { client.sendAndAwaitOkOrError(message, eventId) }
+                }.awaitAll()
+                if (results.none { it is PublishResult.Success }) {
+                    return@withLock Result.Error(AppError.Network.PublishRejected(results.summarizeFailures()))
+                }
+
+                muteListCreatedAt = signedEvent.createdAt
+                muteListTags = newTags
+                muteListRequested = true
+                hasUnpublishedMuteChanges = false
+                SecureStorage.saveKind10000TimestampFor(pubKey, signedEvent.createdAt)
+                Result.Success(Unit)
+            } catch (e: Exception) {
+                Result.Error(AppError.Unknown(e.message ?: "Failed to update mute list", e))
             }
         }
     }
@@ -3771,6 +3936,10 @@ class NostrRepository(
             }
             if (kind == 3) {
                 handleKind3Event(event)
+                return
+            }
+            if (kind == org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST) {
+                handleKind10000Event(event)
                 return
             }
             // NIP-17 DM gift wrap addressed to us: decrypt with the active signer.
@@ -4380,6 +4549,12 @@ class NostrRepository(
                 // Handle kind:3 (NIP-02 contact list) for the active account
                 if (kind == 3) {
                     handleKind3Event(event)
+                    return
+                }
+
+                // Handle kind:10000 (NIP-51 mute list) for the active account
+                if (kind == org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST) {
+                    handleKind10000Event(event)
                     return
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -198,6 +198,13 @@ interface NostrRepositoryApi {
      */
     val contactListLoaded: StateFlow<Boolean>
 
+    /**
+     * The active account's publicly muted pubkeys from its NIP-51 kind:10000 mute list.
+     * Hydrated from the per-account cache at login and kept in sync with the relays.
+     * Messages, DM conversations, and notifications from these authors are hidden.
+     */
+    val mutedPubkeys: StateFlow<Set<String>>
+
     // --- Initialization ---
     fun forceInitialized()
 
@@ -641,6 +648,12 @@ interface NostrRepositoryApi {
      * contact list and publish it once (a single event, not one per pubkey).
      */
     suspend fun followUsers(pubkeys: Set<String>): Result<Unit>
+
+    /** Add [pubkey] to the active account's kind:10000 mute list and publish it. */
+    suspend fun muteUser(pubkey: String): Result<Unit>
+
+    /** Remove [pubkey] from the active account's kind:10000 mute list and publish it. */
+    suspend fun unmuteUser(pubkey: String): Result<Unit>
 
     suspend fun updateProfileMetadata(
         displayName: String? = null,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -43,6 +43,10 @@ data class DmConversation(
  */
 class DmManager(
     private val scope: CoroutineScope,
+    // NIP-51 muted authors: their conversations and unread counts are hidden at the
+    // source so no badge points at a conversation the lists don't show. Messages stay
+    // cached, so an unmute restores the conversation instantly.
+    private val mutedPubkeys: StateFlow<Set<String>> = MutableStateFlow(emptySet()),
 ) {
     private val _messagesByPeer = MutableStateFlow<Map<String, List<DmMessage>>>(emptyMap())
     val messagesByPeer: StateFlow<Map<String, List<DmMessage>>> = _messagesByPeer.asStateFlow()
@@ -52,8 +56,9 @@ class DmManager(
     val lastReadByPeer: StateFlow<Map<String, Long>> = _lastReadByPeer.asStateFlow()
 
     val conversations: StateFlow<List<DmConversation>> =
-        combine(_messagesByPeer, _lastReadByPeer) { byPeer, reads ->
+        combine(_messagesByPeer, _lastReadByPeer, mutedPubkeys) { byPeer, reads, muted ->
             byPeer.entries
+                .filter { (peer, _) -> peer !in muted }
                 .mapNotNull { (peer, msgs) ->
                     val last = msgs.maxByOrNull { it.createdAt } ?: return@mapNotNull null
                     val lastRead = reads[peer] ?: 0L
@@ -66,8 +71,9 @@ class DmManager(
 
     /** Unread count per peer (incoming messages newer than the read high-water), zero entries dropped. */
     val unreadByPeer: StateFlow<Map<String, Int>> =
-        combine(_messagesByPeer, _lastReadByPeer) { byPeer, reads ->
+        combine(_messagesByPeer, _lastReadByPeer, mutedPubkeys) { byPeer, reads, muted ->
             byPeer
+                .filterKeys { it !in muted }
                 .mapValues { (peer, msgs) ->
                     val lastRead = reads[peer] ?: 0L
                     msgs.count { !it.mine && it.createdAt > lastRead }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -18,6 +18,9 @@ class UnreadManager(
     private val isRestricted: (String) -> Boolean = { false },
     private val isAppFocused: () -> Boolean = { true },
     private val findMessageAuthor: (messageId: String) -> String? = { null },
+    // NIP-51 muted authors: their messages/reactions never bump badges or notify.
+    // Checked per event (not per group) so unread counts match the filtered chat view.
+    private val isMutedAuthor: (pubkey: String) -> Boolean = { false },
     // Per-group notification gate (issue #70). `isDirect` is true for replies,
     // mentions and reactions to the user's own message. Returning false suppresses
     // the notification callbacks below WITHOUT touching the unread badge — a muted
@@ -175,7 +178,7 @@ class UnreadManager(
             previousHighWater,
         )
         val qualifying = newMessages.filter {
-            it.kind == 9 && it.pubkey != pubkey && it.createdAt > anchor
+            it.kind == 9 && it.pubkey != pubkey && it.createdAt > anchor && !isMutedAuthor(it.pubkey)
         }
         if (qualifying.isEmpty()) {
             if (highWaterAdvanced) persistEntries()
@@ -231,6 +234,7 @@ class UnreadManager(
     fun onReactionReceived(groupId: String, reaction: NostrGroupClient.NostrReaction) {
         val pubkey = currentPubkey ?: return
         if (reaction.pubkey == pubkey) return
+        if (isMutedAuthor(reaction.pubkey)) return
         if (!isJoined(groupId) || isRestricted(groupId)) return
         val lastRead = SecureStorage.getLastReadTimestamp(pubkey, groupId)
         val previousHighWater = _latestMessageTimestamps.value[groupId] ?: 0L

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip51.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip51.kt
@@ -1,0 +1,26 @@
+package org.nostr.nostrord.nostr
+
+/**
+ * NIP-51 lists. Only the mute list (kind:10000) is supported: public mutes are `p` tags.
+ * The encrypted private section lives in `content` and is passed through untouched on
+ * publish, so private items and non-pubkey entries (words, hashtags, threads) added by
+ * other clients survive a publish from this one.
+ */
+object Nip51 {
+    const val KIND_MUTE_LIST = 10000
+
+    /** Public muted pubkeys (`p` tags) of a kind:10000 tag list. */
+    fun mutedPubkeysFrom(tags: List<List<String>>): Set<String> = tags
+        .filter { it.firstOrNull() == "p" }
+        .mapNotNull { it.getOrNull(1)?.takeIf { pk -> pk.isNotBlank() } }
+        .toSet()
+
+    /**
+     * Tag list for a new kind:10000: [muted] as `p` tags plus every non-`p` tag of
+     * [previousTags] (words, hashtags, thread ids) so other clients' entries are kept.
+     */
+    fun rebuildMuteTags(
+        previousTags: List<List<String>>,
+        muted: Set<String>,
+    ): List<List<String>> = previousTags.filterNot { it.firstOrNull() == "p" } + muted.map { listOf("p", it) }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -486,6 +486,52 @@ fun SecureStorage.loadFollowingCacheFor(pubkey: String): List<String> {
     }
 }
 
+// ── Per-account mute list (NIP-51 kind:10000) ───────────────────────────────
+// Public muted pubkeys, hydrated at login so message filtering works before the
+// network answers. The timestamp floors the kind:10000 staleness check so a lagging
+// relay can't resurrect mutes removed in a previous session (same guard as kind:10009).
+private fun muteListKey(pubkey: String) = "mute_list_${pubkeyDigest(pubkey)}"
+
+private fun kind10000TimestampKey(pubkey: String) = "kind10000_latest_ts_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.saveMuteListFor(
+    pubkey: String,
+    muted: List<String>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(
+            muteListKey(pubkey),
+            Json.encodeToString(ListSerializer(String.serializer()), muted),
+        )
+    } catch (_: Exception) {
+    }
+}
+
+fun SecureStorage.loadMuteListFor(pubkey: String): List<String> {
+    if (pubkey.isBlank()) return emptyList()
+    val raw = getStringPref(muteListKey(pubkey), "")
+    if (raw.isBlank()) return emptyList()
+    return try {
+        Json.decodeFromString(ListSerializer(String.serializer()), raw)
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
+fun SecureStorage.saveKind10000TimestampFor(
+    pubkey: String,
+    timestamp: Long,
+) {
+    if (pubkey.isBlank()) return
+    saveStringPref(kind10000TimestampKey(pubkey), timestamp.toString())
+}
+
+fun SecureStorage.loadKind10000TimestampFor(pubkey: String): Long {
+    if (pubkey.isBlank()) return 0L
+    return getStringPref(kind10000TimestampKey(pubkey), "0").toLongOrNull() ?: 0L
+}
+
 // ── Per-account group membership cache ──────────────────────────────────────
 // One JSON blob per account holding every known group's members/admins/roles
 // (NIP-29 kind:39002/39001/39003) plus each list's source-event timestamp, so a

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -91,7 +91,21 @@ class GroupViewModel(
     private val repo: NostrRepositoryApi,
     val groupId: String,
 ) : ViewModel() {
-    val messages = repo.messages
+    /**
+     * Chat messages with NIP-51 muted authors filtered out. The raw repo cache stays
+     * untouched (membership derivation below reads it directly), so an unmute restores
+     * the author's messages instantly without a re-fetch.
+     */
+    val messages: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> =
+        combine(repo.messages, repo.mutedPubkeys) { byGroup, muted ->
+            if (muted.isEmpty()) {
+                byGroup
+            } else {
+                byGroup.mapValues { (_, list) -> list.filter { it.pubkey !in muted } }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.messages.value)
+
+    val mutedPubkeys = repo.mutedPubkeys
     val messageStatus = repo.messageStatus
     val connectionState = repo.connectionState
     val joinedGroups = repo.joinedGroups

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersViewModel.kt
@@ -1,0 +1,40 @@
+package org.nostr.nostrord.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.network.NostrRepositoryApi
+
+/**
+ * Shared logic for the Settings "Muted users" panel (NIP-51 kind:10000). Both the web and
+ * Compose panels consume this VM so listing and unmuting live in one place.
+ */
+class MutedUsersViewModel(
+    private val repo: NostrRepositoryApi,
+) : ViewModel() {
+    /** Muted pubkeys, stable-sorted so the list doesn't jump as relay echoes arrive. */
+    val muted: StateFlow<List<String>> =
+        repo.mutedPubkeys
+            .map { it.sorted() }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, repo.mutedPubkeys.value.sorted())
+
+    val userMetadata = repo.userMetadata
+
+    init {
+        // Resolve names/avatars for the listed pubkeys; the metadata layer dedups
+        // cached entries, so re-collecting on every change is cheap.
+        viewModelScope.launch {
+            repo.mutedPubkeys.collect { pubkeys ->
+                if (pubkeys.isNotEmpty()) repo.requestUserMetadata(pubkeys)
+            }
+        }
+    }
+
+    fun unmute(pubkey: String) {
+        viewModelScope.launch { repo.unmuteUser(pubkey) }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -457,6 +457,23 @@ class FakeNostrRepository : NostrRepositoryApi {
         return Result.Success(Unit)
     }
 
+    val _mutedPubkeys = MutableStateFlow<Set<String>>(emptySet())
+    override val mutedPubkeys: StateFlow<Set<String>> = _mutedPubkeys
+
+    override suspend fun muteUser(pubkey: String): Result<Unit> {
+        calls += "muteUser:$pubkey"
+        if (pubkey.isNotBlank() && pubkey != fakePublicKey) {
+            _mutedPubkeys.value = _mutedPubkeys.value + pubkey
+        }
+        return Result.Success(Unit)
+    }
+
+    override suspend fun unmuteUser(pubkey: String): Result<Unit> {
+        calls += "unmuteUser:$pubkey"
+        _mutedPubkeys.value = _mutedPubkeys.value - pubkey
+        return Result.Success(Unit)
+    }
+
     override suspend fun updateProfileMetadata(
         displayName: String?,
         name: String?,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip51Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip51Test.kt
@@ -1,0 +1,49 @@
+package org.nostr.nostrord.nostr
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Nip51Test {
+    @Test
+    fun `mutedPubkeysFrom picks p tags and ignores everything else`() {
+        val tags = listOf(
+            listOf("p", "aaa"),
+            listOf("p", "bbb", "wss://relay.example.com"),
+            listOf("word", "spam"),
+            listOf("t", "hashtag"),
+            listOf("e", "thread-id"),
+            listOf("p", ""),
+            listOf("p"),
+        )
+        assertEquals(setOf("aaa", "bbb"), Nip51.mutedPubkeysFrom(tags))
+    }
+
+    @Test
+    fun `rebuildMuteTags replaces p tags and preserves foreign entries`() {
+        val previous = listOf(
+            listOf("p", "old-mute"),
+            listOf("word", "spam"),
+            listOf("t", "hashtag"),
+            listOf("e", "thread-id"),
+        )
+        val rebuilt = Nip51.rebuildMuteTags(previous, setOf("new-mute"))
+        assertEquals(
+            listOf(
+                listOf("word", "spam"),
+                listOf("t", "hashtag"),
+                listOf("e", "thread-id"),
+                listOf("p", "new-mute"),
+            ),
+            rebuilt,
+        )
+    }
+
+    @Test
+    fun `rebuildMuteTags with an empty set keeps only foreign entries`() {
+        val previous = listOf(
+            listOf("p", "old-mute"),
+            listOf("word", "spam"),
+        )
+        assertEquals(listOf(listOf("word", "spam")), Nip51.rebuildMuteTags(previous, emptySet()))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/MutedUsersViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/MutedUsersViewModelTest.kt
@@ -1,0 +1,54 @@
+package org.nostr.nostrord.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.ui.screens.settings.MutedUsersViewModel
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MutedUsersViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `muted list mirrors the repo set sorted`() = runTest {
+        val repo = FakeNostrRepository()
+        repo._mutedPubkeys.value = setOf("ccc", "aaa", "bbb")
+        val vm = MutedUsersViewModel(repo)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("aaa", "bbb", "ccc"), vm.muted.value)
+    }
+
+    @Test
+    fun `unmute delegates to the repo and drops the entry`() = runTest {
+        val repo = FakeNostrRepository()
+        repo._mutedPubkeys.value = setOf("aaa", "bbb")
+        val vm = MutedUsersViewModel(repo)
+
+        vm.unmute("aaa")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue("unmuteUser:aaa" in repo.calls)
+        assertEquals(listOf("bbb"), vm.muted.value)
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
@@ -136,6 +136,8 @@ fun UserProfileModal(
     // Follow state from the active account's kind:3 contact list (fetched once on open).
     val scope = rememberCoroutineScope()
     val following by AppModule.nostrRepository.following.collectAsState()
+    val mutedPubkeys by AppModule.nostrRepository.mutedPubkeys.collectAsState()
+    val isMuted = pubkey in mutedPubkeys
     val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     val isFollowing = pubkey in following
     var followBusy by remember(pubkey) { mutableStateOf(false) }
@@ -346,8 +348,8 @@ fun UserProfileModal(
                                 }
                                 // Mention only exists inside a group chat (where a composer
                                 // can receive it); elsewhere (home sidebar, etc.) the row is
-                                // absent rather than shown disabled. Mute / report join when
-                                // their backends land (mute list, NIP-56 reports).
+                                // absent rather than shown disabled. Report joins when its
+                                // backend lands (NIP-56 reports).
                                 if (onMention != null) {
                                     ProfileActionRow(
                                         label = "Mention",
@@ -356,7 +358,18 @@ fun UserProfileModal(
                                         onMention.invoke(pubkey)
                                     }
                                 }
-                                ProfileActionRow(label = "Mute user", emoji = "🔕", enabled = false) {}
+                                ProfileActionRow(
+                                    label = if (isMuted) "Unmute user" else "Mute user",
+                                    emoji = "🔕",
+                                ) {
+                                    scope.launch {
+                                        if (isMuted) {
+                                            AppModule.nostrRepository.unmuteUser(pubkey)
+                                        } else {
+                                            AppModule.nostrRepository.muteUser(pubkey)
+                                        }
+                                    }
+                                }
                                 ProfileActionRow(label = "Report user", icon = Icons.Default.Shield, enabled = false) {}
 
                                 if (iAmAdmin && onRemoveFromGroup != null) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersPanelContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersPanelContent.kt
@@ -1,0 +1,99 @@
+package org.nostr.nostrord.ui.screens.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * Settings "Muted users" panel: the account's NIP-51 kind:10000 mute list with an
+ * Unmute action per user. Web parity: MutedUsersPanel in web/screens/SettingsScreen.kt.
+ */
+@Composable
+fun MutedUsersPanelContent(vm: MutedUsersViewModel) {
+    val muted by vm.muted.collectAsState()
+    val userMetadata by vm.userMetadata.collectAsState()
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Muted users don't appear in chats, direct messages, or notifications. " +
+                "Mutes sync to your other Nostr clients.",
+            color = NostrordColors.TextSecondary,
+            fontSize = 13.sp,
+        )
+        Spacer(Modifier.height(Spacing.lg))
+
+        if (muted.isEmpty()) {
+            Text(
+                text = "You haven't muted anyone. Mute someone from their profile to hide their messages.",
+                color = NostrordColors.TextMuted,
+                fontSize = 13.sp,
+            )
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                muted.forEach { pubkey ->
+                    val meta = userMetadata[pubkey]
+                    val npub = remember(pubkey) { Nip19.encodeNpub(pubkey) }
+                    val displayName =
+                        meta?.displayName?.takeIf { it.isNotBlank() }
+                            ?: meta?.name?.takeIf { it.isNotBlank() }
+                            ?: (npub.take(12) + "…")
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                    ) {
+                        ProfileAvatar(
+                            imageUrl = meta?.picture,
+                            displayName = displayName,
+                            pubkey = pubkey,
+                            size = 36.dp,
+                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = displayName,
+                                color = NostrordColors.TextPrimary,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = npub.take(20) + "…",
+                                color = NostrordColors.TextMuted,
+                                fontSize = 12.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        AppButton(
+                            text = "Unmute",
+                            onClick = { vm.unmute(pubkey) },
+                            variant = AppButtonVariant.Secondary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -86,6 +86,7 @@ enum class SettingsSection(val label: String) {
     Appearance("Appearance"),
     Media("Media"),
     Notifications("Notifications"),
+    MutedUsers("Muted users"),
     Security("Security"),
 }
 
@@ -252,6 +253,11 @@ fun SettingsScreen(
         )
     }
 
+    val mutedUsersVm = viewModel { MutedUsersViewModel(AppModule.nostrRepository) }
+    val mutedUsersContent: @Composable () -> Unit = {
+        MutedUsersPanelContent(mutedUsersVm)
+    }
+
     val securityContent: @Composable () -> Unit = {
         SecurityPanelContent()
     }
@@ -305,6 +311,7 @@ fun SettingsScreen(
                 appearanceContent = appearanceContent,
                 mediaContent = mediaContent,
                 notificationsContent = notificationsContent,
+                mutedUsersContent = mutedUsersContent,
                 securityContent = securityContent,
             )
         } else {
@@ -321,6 +328,7 @@ fun SettingsScreen(
                 appearanceContent = appearanceContent,
                 mediaContent = mediaContent,
                 notificationsContent = notificationsContent,
+                mutedUsersContent = mutedUsersContent,
                 securityContent = securityContent,
             )
         }
@@ -343,6 +351,7 @@ private fun DesktopSettings(
     appearanceContent: @Composable () -> Unit,
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    mutedUsersContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
@@ -390,7 +399,7 @@ private fun DesktopSettings(
                         .padding(top = 24.dp, start = 40.dp, end = 20.dp, bottom = 80.dp),
                 ) {
                     Box(modifier = Modifier.widthIn(max = 660.dp)) {
-                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, securityContent)
+                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, securityContent)
                     }
                 }
 
@@ -420,6 +429,7 @@ private fun MobileSettings(
     appearanceContent: @Composable () -> Unit,
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    mutedUsersContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     if (!showPanel) {
@@ -461,7 +471,7 @@ private fun MobileSettings(
                     .verticalScroll(rememberScrollState())
                     .padding(horizontal = 20.dp, vertical = 24.dp),
             ) {
-                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, securityContent)
+                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, securityContent)
             }
         }
     }
@@ -518,6 +528,9 @@ private fun SettingsSidebar(
     }
     SettingsNavItem("Notifications", activeSection == SettingsSection.Notifications, compact = compact) {
         onSelectSection(SettingsSection.Notifications)
+    }
+    SettingsNavItem("Muted users", activeSection == SettingsSection.MutedUsers, compact = compact) {
+        onSelectSection(SettingsSection.MutedUsers)
     }
     if (PassphraseSettings.isApplicable) {
         SettingsNavItem("Security", activeSection == SettingsSection.Security, compact = compact) {
@@ -633,6 +646,7 @@ private fun SettingsPanel(
     appearanceContent: @Composable () -> Unit,
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    mutedUsersContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -654,6 +668,7 @@ private fun SettingsPanel(
             SettingsSection.Appearance -> appearanceContent()
             SettingsSection.Media -> mediaContent()
             SettingsSection.Notifications -> notificationsContent()
+            SettingsSection.MutedUsers -> mutedUsersContent()
             SettingsSection.Security -> securityContent()
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
@@ -72,6 +72,8 @@ val UserProfileModal =
         val (removeError, setRemoveError) = useState<String?> { null }
         val following = useStateFlow(AppModule.nostrRepository.following)
         val isFollowing = pubkey in following
+        val mutedPubkeys = useStateFlow(AppModule.nostrRepository.mutedPubkeys)
+        val isMuted = pubkey in mutedPubkeys
         val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         val (followBusy, setFollowBusy) = useState { false }
 
@@ -206,14 +208,21 @@ val UserProfileModal =
                             }
                             // Mention only exists inside a group chat (where a composer can
                             // receive it); elsewhere the row is absent rather than shown
-                            // disabled. Mute / report join when their backends land (mute
-                            // list, NIP-56 reports).
+                            // disabled. Report joins when its backend lands (NIP-56 reports).
                             props.onMention?.let { onMention ->
                                 actionRow(Ic.Reply, "Mention") {
                                     onMention(pubkey)
                                 }
                             }
-                            actionRow(null, "Mute user", disabled = true, emoji = "🔕") {}
+                            actionRow(null, if (isMuted) "Unmute user" else "Mute user", emoji = "🔕") {
+                                launchApp {
+                                    if (isMuted) {
+                                        AppModule.nostrRepository.unmuteUser(pubkey)
+                                    } else {
+                                        AppModule.nostrRepository.muteUser(pubkey)
+                                    }
+                                }
+                            }
                             actionRow(Ic.Shield, "Report user", disabled = true) {}
 
                             val groupId = props.groupId

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -14,7 +14,9 @@ import org.nostr.nostrord.ui.screens.backup.BackupViewModel
 import org.nostr.nostrord.ui.screens.backup.MIN_BACKUP_PASSWORD
 import org.nostr.nostrord.ui.screens.backup.backupSecurityTips
 import org.nostr.nostrord.ui.screens.profile.EditProfileViewModel
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.screens.settings.DmRelaySettingsViewModel
+import org.nostr.nostrord.ui.screens.settings.MutedUsersViewModel
 import org.nostr.nostrord.ui.screens.settings.SecurityViewModel
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.isValidRelayUrl
@@ -55,7 +57,7 @@ external interface SettingsScreenProps : Props {
 }
 
 private val sections =
-    listOf("Profile", "Backup Keys", "Relays (NIP-65)", "Direct Messages", "Appearance", "Media", "Notifications", "Security")
+    listOf("Profile", "Backup Keys", "Relays (NIP-65)", "Direct Messages", "Appearance", "Media", "Notifications", "Muted users", "Security")
 
 /**
  * Settings — real port of the Compose SettingsScreen: a full-screen overlay with a section
@@ -152,6 +154,7 @@ val SettingsScreen =
                     "Appearance" -> AppearancePanel()
                     "Media" -> MediaPanel()
                     "Notifications" -> NotificationsPanel()
+                    "Muted users" -> MutedUsersPanel()
                     "Security" -> SecurityPanel()
                 }
             }
@@ -747,6 +750,71 @@ private fun react.ChildrenBuilder.relayChip(label: String, active: Boolean, onTo
         +label
     }
 }
+
+// ── Muted users ──────────────────────────────────────────────────────────────
+
+/**
+ * The account's NIP-51 kind:10000 mute list with an Unmute action per user.
+ * Compose parity: MutedUsersPanelContent.kt.
+ */
+private val MutedUsersPanel =
+    FC<Props> {
+        val vm = useViewModel { MutedUsersViewModel(AppModule.nostrRepository) }
+        val muted = useStateFlow(vm.muted)
+        val userMetadata = useStateFlow(vm.userMetadata)
+
+        div {
+            className = ClassName("settings-card")
+            div {
+                className = ClassName("settings-info-text")
+                +(
+                    "Muted users don't appear in chats, direct messages, or notifications. " +
+                        "Mutes sync to your other Nostr clients."
+                    )
+            }
+        }
+
+        div {
+            className = ClassName("settings-card")
+            div {
+                className = ClassName("settings-section-head")
+                +"MUTED USERS"
+            }
+            if (muted.isEmpty()) {
+                div {
+                    className = ClassName("settings-info-text")
+                    +"You haven't muted anyone. Mute someone from their profile to hide their messages."
+                }
+            }
+            muted.forEach { pubkey ->
+                val meta = userMetadata[pubkey]
+                val npub = Nip19.encodeNpub(pubkey)
+                val name =
+                    meta?.displayName?.takeIf { it.isNotBlank() }
+                        ?: meta?.name?.takeIf { it.isNotBlank() }
+                        ?: (npub.take(12) + "…")
+                div {
+                    key = pubkey
+                    className = ClassName("member-row")
+                    WebAvatar {
+                        url = meta?.picture
+                        seed = pubkey
+                        this.name = name
+                        cls = "member-avatar"
+                    }
+                    span {
+                        className = ClassName("member-name")
+                        +name
+                    }
+                    button {
+                        className = ClassName("btn-ghost")
+                        onClick = { vm.unmute(pubkey) }
+                        +"Unmute"
+                    }
+                }
+            }
+        }
+    }
 
 // ── Notifications ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Adds a NIP-51 mute list (kind:10000, public p tags). Muting a user from their profile hides their messages in group chats, drops their DM conversations and unread badges, and suppresses their notifications, on Android, desktop, iOS, and web. A new Settings > Muted users section lists the mutes with per-user Unmute. Mutes publish to general relays and sync with other Nostr clients.

| Piece | Where |
|---|---|
| Tag parsing/rebuild helpers | `nostr/Nip51.kt` (+ tests) |
| Fetch / ingest / publish / per-account cache | `NostrRepository` (mirrors the kind:3 contact-list handling; rides the kind:3 REQ as a second filter) |
| Staleness guard | persisted kind:10000 timestamp floors ingest, so a lagging relay can't resurrect removed mutes |
| Foreign data safety | non-p tags (words, hashtags, threads) and the encrypted content section are preserved verbatim on publish |
| Chat filter | `GroupViewModel.messages` (raw cache intact, unmute restores instantly) |
| DM filter | `DmManager` conversations/unread at the source (no ghost badges) |
| Badges/notifications | `UnreadManager` skips muted authors' messages and reactions |
| UI | profile modal Mute/Unmute toggle + Settings panel, Compose and web, shared `MutedUsersViewModel` (+ test) |

Commits:
- feat: NIP-51 mute list (kind:10000) with muted-author filtering
- feat(ui): mute/unmute action + Muted users settings panel (Compose + web)

Validated with `compileKotlinJvm`, `compileKotlinJs`, and `:composeApp:jvmTest`.