### PR TITLE
Richer direct messages (#183)

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayer.android.kt
@@ -128,8 +128,9 @@ actual fun AudioPlayerContent(
 
     AudioPlayerChrome(
         isPlaying = isPlaying,
-        currentMs = currentMs,
-        durationMs = durationMs,
+        progress = if (durationMs > 0) currentMs.toFloat() / durationMs.toFloat() else 0f,
+        positionText = formatDuration(currentMs),
+        durationText = if (durationMs > 0) formatDuration(durationMs) else null,
         fileName = audioFileName(url),
         onToggle = { if (isPlaying) player.pause() else player.play(url) },
         modifier = modifier,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -45,6 +45,7 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.managers.LiveCursorStore
 import org.nostr.nostrord.network.managers.MetadataManager
 import org.nostr.nostrord.network.managers.OutboxManager
+import org.nostr.nostrord.network.managers.PendingDmWrap
 import org.nostr.nostrord.network.managers.RelayMetadataManager
 import org.nostr.nostrord.network.managers.RelayReconnectScheduler
 import org.nostr.nostrord.network.managers.SessionManager
@@ -66,15 +67,19 @@ import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
 import org.nostr.nostrord.storage.loadDmSeenRelays
+import org.nostr.nostrord.storage.loadDmSendQueue
 import org.nostr.nostrord.storage.loadDmSyncCursor
 import org.nostr.nostrord.storage.loadDmWrapRumor
+import org.nostr.nostrord.storage.loadFollowingCacheFor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
 import org.nostr.nostrord.storage.saveDmLastRead
 import org.nostr.nostrord.storage.saveDmProcessedWrapIds
 import org.nostr.nostrord.storage.saveDmSeenRelays
+import org.nostr.nostrord.storage.saveDmSendQueue
 import org.nostr.nostrord.storage.saveDmSyncCursor
 import org.nostr.nostrord.storage.saveDmWrapRumor
+import org.nostr.nostrord.storage.saveFollowingCacheFor
 import org.nostr.nostrord.storage.saveGroupFetchLazy
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
@@ -199,6 +204,16 @@ class NostrRepository(
     // quiet gaps), wasting the work and stalling progress. 90s rides out a quiet gap while still
     // freeing the permit for the periodic retry when the signer is genuinely gone.
     private val DM_DECRYPT_TIMEOUT_MS = 90_000L
+
+    // Per-relay budget for a background event publish (connect + send). Bounds a dead socket so it
+    // can't leak the publish job; delivery is best-effort and swallows failures anyway.
+    private val PUBLISH_RELAY_TIMEOUT_MS = 8_000L
+
+    // DM wrap publish retry: rides out a transiently offline DM relay so a message isn't stranded
+    // local-only. Linear backoff, capped; ~a couple minutes of attempts before giving up this session.
+    private val DM_SEND_MAX_ATTEMPTS = 6
+    private val DM_SEND_RETRY_BASE_MS = 4_000L
+    private val DM_SEND_RETRY_MAX_MS = 30_000L
 
     // Give up on a wrap after this many failed decrypt attempts (this session). Stops the retry
     // loop from hammering wraps the signer never answers, or genuinely malformed ones.
@@ -574,6 +589,9 @@ class NostrRepository(
         // so a relay echo arriving mid-follow doesn't clobber a just-tapped follow.
         if (!hasUnpublishedContactChanges) {
             _following.value = followsFrom(tags)
+            // Persist so the next cold boot can seed the follow set (and the DM Follows/Others
+            // split) instantly, regardless of which screen wrote it last.
+            SecureStorage.saveFollowingCacheFor(pubKey, _following.value.toList())
         }
     }
 
@@ -1326,6 +1344,8 @@ class NostrRepository(
 
     override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmManager.dmRelaysByPubkey
 
+    override val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = dmManager.messageStatus
+
     override fun requestPeerDmRelays(pubkey: String) {
         scope.launch { fetchDmRelays(pubkey) }
     }
@@ -1345,6 +1365,12 @@ class NostrRepository(
 
     private fun dmRelaysFor(pubkey: String): List<String> = dmManager.dmRelaysFor(pubkey).map { it.normalizeRelayUrl() }.ifEmpty { defaultDmRelays }
 
+    // Union of a user's resolved DM relays with the defaults. The inbox subscribes and the wrap
+    // publish targets this, so devices always overlap regardless of when each resolves the kind:10050
+    // (a fresh login subscribes to defaults first; a peer may publish to defaults before their list
+    // loads). Keeping the defaults in the set closes those cross-device gaps.
+    private fun dmRelaysWithDefaults(pubkey: String): List<String> = (dmRelaysFor(pubkey) + defaultDmRelays).distinct()
+
     /**
      * Send a NIP-17 direct message: build the rumor, seal + gift-wrap it for the recipient and a
      * self-copy for us, and publish each to its side's DM relays. The seal's NIP-44 encrypt and
@@ -1360,8 +1386,19 @@ class NostrRepository(
             val recipientWrap = Nip17.wrap(rumor, recipientPubkey, signer)
             val selfWrap = Nip17.wrap(rumor, myPub, signer)
             dmManager.addOptimistic(rumor, recipientPubkey, myPub)
-            publishEventToRelays(dmRelaysFor(recipientPubkey), recipientWrap)
-            publishEventToRelays(dmRelaysFor(myPub), selfWrap)
+            val rumorId = rumor.id ?: return Result.Error(AppError.Unknown("Failed to build the message"))
+            // Enqueue both wraps (recipient + self-copy) in the persisted send queue, then publish.
+            // The message shows as Sending and flips to Delivered on the first relay OK (or when the
+            // self-copy echoes back). The queue survives an app restart, so a wrap that never reached
+            // a relay is retried on next launch instead of being stranded local-only.
+            val now = rumor.createdAt
+            enqueueDmWraps(
+                myPub,
+                listOf(
+                    PendingDmWrap(rumorId, recipientWrap.id ?: "", recipientWrap.toJsonObject().toString(), dmRelaysWithDefaults(recipientPubkey), now),
+                    PendingDmWrap(rumorId, selfWrap.id ?: "", selfWrap.toJsonObject().toString(), dmRelaysWithDefaults(myPub), now),
+                ),
+            )
             Result.Success(Unit)
         } catch (e: NostrSigner.SigningException) {
             Result.Error(AppError.Unknown("Your signer could not encrypt this message (NIP-44). It may not support direct messages."))
@@ -1377,13 +1414,95 @@ class NostrRepository(
                 add(event.toJsonObject())
             }.toString()
         relays.distinct().forEach { url ->
-            val client =
-                connectionManager.getClientForRelay(url)
-                    ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+            // Bound the connect + send per relay so a dead/half-open socket can't hang the caller
+            // (or leak the background publish job) indefinitely.
             try {
-                client?.send(json)
+                withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
+                    val client =
+                        connectionManager.getClientForRelay(url)
+                            ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+                    client?.send(json)
+                }
             } catch (_: Throwable) {
             }
+        }
+    }
+
+    // Publish a pre-serialized gift wrap event and wait for a relay OK, so a DM has a real delivered
+    // signal (not fire-and-forget). Returns true once any relay accepts the event.
+    private suspend fun publishWrapJsonAwaitOk(relays: List<String>, wrapJson: String, wrapId: String): Boolean {
+        if (wrapId.isBlank()) return false
+        val frame = """["EVENT",$wrapJson]"""
+        var accepted = false
+        relays.distinct().forEach { url ->
+            try {
+                val result =
+                    withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
+                        val client =
+                            connectionManager.getClientForRelay(url)
+                                ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+                        client?.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
+                    }
+                if (result is PublishResult.Success) accepted = true
+            } catch (_: Throwable) {
+            }
+        }
+        return accepted
+    }
+
+    // Persisted DM send queue: undelivered wraps by account, mirrored to SecureStorage.
+    private val pendingDmWraps = mutableListOf<PendingDmWrap>()
+    private val pendingDmMutex = kotlinx.coroutines.sync.Mutex()
+
+    private suspend fun persistDmQueue(myPub: String) {
+        val snapshot = pendingDmMutex.withLock { pendingDmWraps.toList() }
+        SecureStorage.saveDmSendQueue(myPub, snapshot)
+    }
+
+    private fun enqueueDmWraps(myPub: String, entries: List<PendingDmWrap>) {
+        scope.launch {
+            pendingDmMutex.withLock { pendingDmWraps.addAll(entries) }
+            persistDmQueue(myPub)
+            entries.forEach { entry -> scope.launch { deliverPendingDmWrap(myPub, entry) } }
+        }
+    }
+
+    private suspend fun removeDmWrap(myPub: String, wrapId: String) {
+        pendingDmMutex.withLock { pendingDmWraps.removeAll { it.wrapId == wrapId } }
+        persistDmQueue(myPub)
+    }
+
+    // Retry a queued wrap with linear backoff until a relay accepts it (or the message is already
+    // Delivered, e.g. the self-copy echoed back), then drop it from the queue. Un-delivered wraps
+    // stay persisted and resume on the next startDmInbox.
+    private suspend fun deliverPendingDmWrap(myPub: String, entry: PendingDmWrap) {
+        var attempt = 0
+        while (attempt < DM_SEND_MAX_ATTEMPTS) {
+            if (dmManager.messageStatus.value[entry.rumorId] is GroupManager.MessageStatus.Delivered) {
+                removeDmWrap(myPub, entry.wrapId)
+                return
+            }
+            if (publishWrapJsonAwaitOk(entry.relays, entry.wrapJson, entry.wrapId)) {
+                dmManager.markDelivered(entry.rumorId)
+                removeDmWrap(myPub, entry.wrapId)
+                return
+            }
+            attempt++
+            delay(minOf(DM_SEND_RETRY_MAX_MS, DM_SEND_RETRY_BASE_MS * attempt))
+        }
+    }
+
+    // Resume undelivered wraps from disk on login so a send interrupted by an app close still lands.
+    private suspend fun resumeDmSendQueue(myPub: String) {
+        val queued = SecureStorage.loadDmSendQueue(myPub)
+        if (queued.isEmpty()) return
+        pendingDmMutex.withLock {
+            pendingDmWraps.clear()
+            pendingDmWraps.addAll(queued)
+        }
+        queued.forEach { entry ->
+            dmManager.setSending(entry.rumorId)
+            scope.launch { deliverPendingDmWrap(myPub, entry) }
         }
     }
 
@@ -1394,10 +1513,21 @@ class NostrRepository(
         val myPub = sessionManager.getPublicKey() ?: return
         dmInboxStarted = true
 
+        // Seed the follow set from its persisted cache before the DM list partitions, so
+        // conversations land in Follows/Others immediately instead of all falling in Others until
+        // the kind:3 arrives from a relay (the visible "reorganizing" delay). The live kind:3
+        // corrects it when it lands. Only seed when empty so it never clobbers a fresher list.
+        if (_following.value.isEmpty()) {
+            val cached = SecureStorage.loadFollowingCacheFor(myPub)
+            if (cached.isNotEmpty()) _following.value = cached.toSet()
+        }
+
         // Hydrate from the CacheStore before the inbox streams so old conversations render instantly
         // and already-seen gift wraps are never re-decrypted.
         hydrateDmCache(myPub)
         wireDmPersistence(myPub)
+        // Resume any wraps that never reached a relay before the app last closed.
+        resumeDmSendQueue(myPub)
 
         // Resume per-wrap decrypt progress, and reset the this-session sync bookkeeping.
         dmProcessedWrapIds = SecureStorage.loadDmProcessedWrapIds(myPub)
@@ -1472,6 +1602,9 @@ class NostrRepository(
         dmManager.clear()
         _myDmRelays.value = emptyList()
         dmInboxEosedRelays = emptySet()
+        // Drop the in-memory send queue; the persisted per-account copy stays on disk and is
+        // reloaded by resumeDmSendQueue when this (or another) account's inbox next starts.
+        scope.launch { pendingDmMutex.withLock { pendingDmWraps.clear() } }
     }
 
     // Ids already written to the CacheStore, so the persistence collector upserts only new DMs
@@ -1653,7 +1786,7 @@ class NostrRepository(
                 add("dm_inbox")
                 add(filter)
             }.toString()
-        val urls = dmRelaysFor(myPub).distinct()
+        val urls = dmRelaysWithDefaults(myPub).distinct()
         dmInboxSubscribedRelays = urls.toSet()
         // Keep DM relays alive: register them with the reconnect scheduler so a dropped DM
         // socket is revived (and re-subscribed via resubscribePoolRelay) rather than going
@@ -3906,7 +4039,7 @@ class NostrRepository(
                         // to them are never requested. Only when the set actually CHANGED, so the
                         // same kind:10050 arriving from several relays doesn't re-stream the whole
                         // gift-wrap backlog and flood the bunker signer.
-                        val newRelays = dmRelaysFor(it.pubkey).distinct().toSet()
+                        val newRelays = dmRelaysWithDefaults(it.pubkey).distinct().toSet()
                         if (newRelays != dmInboxSubscribedRelays) {
                             scope.launch { resendDmInboxReq(it.pubkey) }
                         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -65,12 +65,16 @@ import org.nostr.nostrord.storage.isGroupFetchLazy
 import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
+import org.nostr.nostrord.storage.loadDmSeenRelays
 import org.nostr.nostrord.storage.loadDmSyncCursor
+import org.nostr.nostrord.storage.loadDmWrapRumor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
 import org.nostr.nostrord.storage.saveDmLastRead
 import org.nostr.nostrord.storage.saveDmProcessedWrapIds
+import org.nostr.nostrord.storage.saveDmSeenRelays
 import org.nostr.nostrord.storage.saveDmSyncCursor
+import org.nostr.nostrord.storage.saveDmWrapRumor
 import org.nostr.nostrord.storage.saveGroupFetchLazy
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
@@ -236,6 +240,7 @@ class NostrRepository(
     @kotlin.concurrent.Volatile
     private var dmInboxEosedRelays: Set<String> = emptySet()
     private var dmProcessedSaveJob: kotlinx.coroutines.Job? = null
+    private var dmSeenRelaysSaveJob: kotlinx.coroutines.Job? = null
 
     // Upper bound on how long a bunker account holds its DM gift-wrap backlog
     // while the active relay signs its NIP-42 AUTH. awaitAuthOrTimeout returns
@@ -1474,7 +1479,11 @@ class NostrRepository(
         createdAt = createdAt,
         kind = DM_CACHE_KIND,
         content = content,
-        tagsJson = "[]",
+        // The rumor's real tags: with them the row IS the kind:14 rumor (DM_CACHE_KIND = 14),
+        // so toDmMessage can rebuild the exact event JSON across restarts.
+        tagsJson = rumorJson?.let { rj ->
+            runCatching { Json.parseToJsonElement(rj).jsonObject["tags"]?.toString() }.getOrNull()
+        } ?: "[]",
     )
 
     private fun org.nostr.nostrord.storage.cache.CachedMsg.toDmMessage(myPubkey: String): DmMessage = DmMessage(
@@ -1484,6 +1493,15 @@ class NostrRepository(
         content = content,
         createdAt = createdAt,
         mine = pubkey == myPubkey,
+        rumorJson =
+        buildJsonObject {
+            put("id", id)
+            put("pubkey", pubkey)
+            put("created_at", createdAt)
+            put("kind", kind)
+            put("tags", runCatching { Json.parseToJsonElement(tagsJson) }.getOrElse { JsonArray(emptyList()) })
+            put("content", content)
+        }.toString(),
     )
 
     /**
@@ -1521,7 +1539,12 @@ class NostrRepository(
                 emptyList()
             }
         dmPersistedIds = cached.mapTo(HashSet()) { it.id }
-        dmManager.hydrate(cached.map { it.toDmMessage(myPub) }, SecureStorage.loadDmLastRead(myPub))
+        dmManager.hydrate(
+            cached.map { it.toDmMessage(myPub) },
+            SecureStorage.loadDmLastRead(myPub),
+            SecureStorage.loadDmSeenRelays(myPub),
+            SecureStorage.loadDmWrapRumor(myPub),
+        )
     }
 
     /** Persist decrypted messages + read state whenever they change (one collector per session). */
@@ -1556,6 +1579,17 @@ class NostrRepository(
                     SecureStorage.saveDmLastRead(myPub, reads)
                 }
             }
+        // Persist the "seen on" relay map (debounced) so View source keeps it across restarts.
+        dmManager.onSeenRelaysChanged = { scheduleSaveSeenRelays(myPub) }
+    }
+
+    private fun scheduleSaveSeenRelays(myPub: String) {
+        dmSeenRelaysSaveJob?.cancel()
+        dmSeenRelaysSaveJob = scope.launch {
+            delay(2_000)
+            SecureStorage.saveDmSeenRelays(myPub, dmManager.seenRelaysSnapshot())
+            SecureStorage.saveDmWrapRumor(myPub, dmManager.wrapToRumorSnapshot())
+        }
     }
 
     /** (Re)subscribe to the kind:1059 inbox on all DM relays. Idempotent; also run on reconnect. */
@@ -3783,6 +3817,9 @@ class NostrRepository(
                 val wrapId = giftWrap.id
                 if (wrapId != null) {
                     if (wrapId !in dmReceivedWrapIds) dmReceivedWrapIds = dmReceivedWrapIds + wrapId
+                    // Before any dedup skip: the same wrap sits on several DM relays, and every
+                    // delivery counts for the message's "seen on" relay list.
+                    dmManager.recordWrapRelay(wrapId, client.getRelayUrl().normalizeRelayUrl())
                     // Already decrypted, or given up this session: skip the (expensive) round-trip.
                     if (wrapId in dmProcessedWrapIds || wrapId in dmGivenUpWrapIds) {
                         maybeLatchDmFullSync(myPub)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1324,6 +1324,12 @@ class NostrRepository(
     private val _myDmRelays = MutableStateFlow<List<String>>(emptyList())
     override val myDmRelays: StateFlow<List<String>> = _myDmRelays.asStateFlow()
 
+    override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmManager.dmRelaysByPubkey
+
+    override fun requestPeerDmRelays(pubkey: String) {
+        scope.launch { fetchDmRelays(pubkey) }
+    }
+
     // Fallback DM relays for users (and us) without a published kind:10050.
     private val defaultDmRelays =
         listOf("wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net", "wss://auth.nostr1.com")

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -144,6 +144,12 @@ interface NostrRepositoryApi {
     /** Our own effective NIP-17 DM relays (kind:10050, or the defaults until one is published). */
     val myDmRelays: StateFlow<List<String>>
 
+    /** Published kind:10050 DM relay lists by author pubkey, as they are fetched. */
+    val dmRelaysByPubkey: StateFlow<Map<String, List<String>>>
+
+    /** Fetch a peer's kind:10050 so [dmRelaysByPubkey] gains its entry (fire-and-forget). */
+    fun requestPeerDmRelays(pubkey: String)
+
     /** Send a NIP-17 direct message to [recipientPubkey]. */
     suspend fun sendDm(recipientPubkey: String, content: String): Result<Unit>
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -147,6 +147,9 @@ interface NostrRepositoryApi {
     /** Published kind:10050 DM relay lists by author pubkey, as they are fetched. */
     val dmRelaysByPubkey: StateFlow<Map<String, List<String>>>
 
+    /** Send status of our own DM messages, keyed by rumor id (Sending until a relay OKs). */
+    val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>>
+
     /** Fetch a peer's kind:10050 so [dmRelaysByPubkey] gains its entry (fire-and-forget). */
     fun requestPeerDmRelays(pubkey: String)
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -23,6 +23,12 @@ data class DmMessage(
     val content: String,
     val createdAt: Long,
     val mine: Boolean,
+    /** Full decrypted kind:14 rumor as NIP-01 JSON (unsigned). Null on messages cached
+     *  before this field existed; DmMessage.eventJson() reconstructs a fallback. */
+    val rumorJson: String? = null,
+    /** Normalized relay urls this message's gift wrap was seen on. In-memory only
+     *  (session-accumulated); empty for messages hydrated from cache. */
+    val relays: List<String> = emptyList(),
 )
 
 /** A conversation summary derived from its messages. */
@@ -116,7 +122,12 @@ class DmManager(
                 sender
             } ?: return true
 
-        if (!seenRumorIds.add(rumorId)) return true
+        if (!seenRumorIds.add(rumorId)) {
+            // Same rumor from another relay or the self-wrap echo of an optimistic send:
+            // nothing new to show, but its relay still counts for "seen on".
+            linkWrapToRumor(giftWrap.id, rumorId, peer)
+            return true
+        }
         val message =
             DmMessage(
                 id = rumorId,
@@ -125,8 +136,10 @@ class DmManager(
                 content = rumor.content,
                 createdAt = rumor.createdAt,
                 mine = sender == myPubkey,
+                rumorJson = rumor.toJsonString(),
             )
         addMessage(peer, message)
+        linkWrapToRumor(giftWrap.id, rumorId, peer)
         return true
     }
 
@@ -143,16 +156,77 @@ class DmManager(
                 content = rumor.content,
                 createdAt = rumor.createdAt,
                 mine = true,
+                rumorJson = rumor.toJsonString(),
             ),
         )
     }
 
     private fun addMessage(peer: String, message: DmMessage) {
+        peerByRumor[message.id] = peer
         _messagesByPeer.update { current ->
             val merged = (current[peer].orEmpty() + message).sortedBy { it.createdAt }
             current + (peer to merged)
         }
     }
+
+    // Relays each DM was seen on. Recorded on EVERY wrap arrival — including the duplicates
+    // the decrypt pipeline skips (the same wrap sits on several DM relays) — so "seen on"
+    // keeps growing after the first decrypt. Keyed by rumor id (stable across restarts) so
+    // NostrRepository can persist it; wrapRelays buffers arrivals seen before decrypt.
+    private val wrapRelays = mutableMapOf<String, MutableSet<String>>()
+    private val rumorByWrap = mutableMapOf<String, String>()
+    private val peerByRumor = mutableMapOf<String, String>()
+    private val relaysByRumor = mutableMapOf<String, MutableSet<String>>()
+
+    /** Set by NostrRepository to persist the seen-on + wrap-to-rumor maps when they grow. */
+    var onSeenRelaysChanged: (() -> Unit)? = null
+
+    /** Record that [wrapId] was delivered by [relayUrl] (normalized). Safe pre-decrypt. */
+    fun recordWrapRelay(wrapId: String, relayUrl: String) {
+        if (relayUrl.isBlank()) return
+        wrapRelays.getOrPut(wrapId) { mutableSetOf() }.add(relayUrl)
+        // Known rumor (decrypted this session, or the wrap->rumor link restored from disk):
+        // attach immediately. This is what lets a re-streamed but already-decrypted wrap add
+        // its relay without paying the decrypt again.
+        rumorByWrap[wrapId]?.let { mergeRelays(it, listOf(relayUrl)) }
+    }
+
+    private fun linkWrapToRumor(wrapId: String?, rumorId: String, peer: String) {
+        peerByRumor[rumorId] = peer
+        if (wrapId == null) return
+        val isNew = rumorByWrap.put(wrapId, rumorId) != rumorId
+        // Optimistic sends have no wrap of their own; adopt the echo's buffered relays.
+        wrapRelays[wrapId]?.let { mergeRelays(rumorId, it) }
+        // Persist the new link so a later session attaches relays on the decrypt-skip path.
+        if (isNew) onSeenRelaysChanged?.invoke()
+    }
+
+    /** Snapshot of the wrap-id to rumor-id links, for persistence. */
+    fun wrapToRumorSnapshot(): Map<String, String> = rumorByWrap.toMap()
+
+    /** Merge [relays] into the rumor's seen-on set; sync the visible message + persist on change. */
+    private fun mergeRelays(rumorId: String, relays: Collection<String>) {
+        if (relays.isEmpty()) return
+        val set = relaysByRumor.getOrPut(rumorId) { mutableSetOf() }
+        if (!set.addAll(relays)) return
+        syncMessageRelays(rumorId)
+        onSeenRelaysChanged?.invoke()
+    }
+
+    private fun syncMessageRelays(rumorId: String) {
+        val peer = peerByRumor[rumorId] ?: return
+        val relays = relaysByRumor[rumorId]?.sorted() ?: return
+        _messagesByPeer.update { current ->
+            val msgs = current[peer] ?: return@update current
+            current + (
+                peer to
+                    msgs.map { m -> if (m.id == rumorId && m.relays != relays) m.copy(relays = relays) else m }
+                )
+        }
+    }
+
+    /** Snapshot of seen-on relays keyed by rumor id, for persistence. */
+    fun seenRelaysSnapshot(): Map<String, List<String>> = relaysByRumor.mapValues { it.value.sorted() }
 
     /** Mark a conversation read up to its newest message; clears its unread count. */
     fun markRead(peer: String) {
@@ -160,14 +234,31 @@ class DmManager(
         _lastReadByPeer.update { it + (peer to maxOf(it[peer] ?: 0L, latest)) }
     }
 
-    /** Restore decrypted messages + read state from disk on login (before the inbox streams). */
-    fun hydrate(messages: List<DmMessage>, lastRead: Map<String, Long>) {
+    /** Restore decrypted messages + read state + seen-on relays from disk on login. */
+    fun hydrate(
+        messages: List<DmMessage>,
+        lastRead: Map<String, Long>,
+        seenRelays: Map<String, List<String>> = emptyMap(),
+        wrapToRumor: Map<String, String> = emptyMap(),
+    ) {
+        seenRelays.forEach { (rumorId, relays) -> relaysByRumor[rumorId] = relays.toMutableSet() }
+        // Restore the wrap->rumor links so a re-streamed, already-processed wrap can attach its
+        // relay on the decrypt-skip path (recordWrapRelay) instead of being dropped.
+        rumorByWrap.putAll(wrapToRumor)
         if (messages.isNotEmpty()) {
-            messages.forEach { seenRumorIds.add(it.id) }
+            messages.forEach {
+                seenRumorIds.add(it.id)
+                // Late wrap arrivals must find hydrated messages too for "seen on".
+                peerByRumor[it.id] = it.peerPubkey
+            }
             _messagesByPeer.value =
                 messages
                     .groupBy { it.peerPubkey }
-                    .mapValues { (_, msgs) -> msgs.sortedBy { it.createdAt } }
+                    .mapValues { (_, msgs) ->
+                        msgs.sortedBy { it.createdAt }.map { m ->
+                            relaysByRumor[m.id]?.sorted()?.let { m.copy(relays = it) } ?: m
+                        }
+                    }
         }
         if (lastRead.isNotEmpty()) _lastReadByPeer.value = lastRead
     }
@@ -190,6 +281,10 @@ class DmManager(
     /** Drop all state on account switch. */
     fun clear() {
         seenRumorIds.clear()
+        wrapRelays.clear()
+        rumorByWrap.clear()
+        peerByRumor.clear()
+        relaysByRumor.clear()
         _messagesByPeer.value = emptyMap()
         _dmRelaysByPubkey.value = emptyMap()
         _lastReadByPeer.value = emptyMap()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -31,6 +31,20 @@ data class DmMessage(
     val relays: List<String> = emptyList(),
 )
 
+/**
+ * A signed gift wrap awaiting relay acceptance, persisted per account so a send survives an app
+ * restart (delivery is retried on next launch until a relay OKs it). One send enqueues two: the
+ * recipient wrap and the self-copy, each with its own target relay set.
+ */
+@Serializable
+data class PendingDmWrap(
+    val rumorId: String,
+    val wrapId: String,
+    val wrapJson: String,
+    val relays: List<String>,
+    val createdAt: Long,
+)
+
 /** A conversation summary derived from its messages. */
 data class DmConversation(
     val peerPubkey: String,
@@ -92,6 +106,21 @@ class DmManager(
     private val _dmRelaysByPubkey = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = _dmRelaysByPubkey.asStateFlow()
 
+    // Send status of our own optimistic messages, keyed by rumor id (in-memory, like GroupManager).
+    // Sending until a relay OKs the wrap or the self-copy echoes back; then Delivered. Reuses the
+    // group MessageStatus so the same send-state icon renders on DM bubbles.
+    private val _messageStatus = MutableStateFlow<Map<String, GroupManager.MessageStatus>>(emptyMap())
+    val messageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = _messageStatus.asStateFlow()
+
+    fun setSending(rumorId: String) {
+        _messageStatus.update { it + (rumorId to GroupManager.MessageStatus.Sending) }
+    }
+
+    /** Flip to Delivered only if the id is tracked (an own optimistic message we are awaiting). */
+    fun markDelivered(rumorId: String) {
+        _messageStatus.update { if (rumorId in it) it + (rumorId to GroupManager.MessageStatus.Delivered) else it }
+    }
+
     // Dedup: a gift wrap can arrive from several relays; the same rumor can arrive via the
     // recipient wrap and the self wrap.
     private val seenRumorIds = HashSet<String>()
@@ -123,8 +152,10 @@ class DmManager(
             } ?: return true
 
         if (!seenRumorIds.add(rumorId)) {
-            // Same rumor from another relay or the self-wrap echo of an optimistic send:
-            // nothing new to show, but its relay still counts for "seen on".
+            // Same rumor from another relay or the self-wrap echo of an optimistic send: nothing
+            // new to show, but the wrap round-tripped a relay, so an own message is now Delivered,
+            // and its relay still counts for "seen on".
+            markDelivered(rumorId)
             linkWrapToRumor(giftWrap.id, rumorId, peer)
             return true
         }
@@ -146,6 +177,7 @@ class DmManager(
     /** Optimistically add a just-sent message so the UI shows it before the self-wrap echoes back. */
     fun addOptimistic(rumor: Event, recipientPubkey: String, myPubkey: String) {
         val rumorId = rumor.id ?: return
+        setSending(rumorId)
         if (!seenRumorIds.add(rumorId)) return
         addMessage(
             recipientPubkey,
@@ -285,6 +317,7 @@ class DmManager(
         rumorByWrap.clear()
         peerByRumor.clear()
         relaysByRumor.clear()
+        _messageStatus.value = emptyMap()
         _messagesByPeer.value = emptyMap()
         _dmRelaysByPubkey.value = emptyMap()
         _lastReadByPeer.value = emptyMap()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -942,6 +942,33 @@ fun SecureStorage.saveDmSeenRelays(
     }
 }
 
+// Undelivered outgoing DM gift wraps, persisted per account so a send survives an app restart and
+// is retried on next launch until a relay OKs it (the "cached but never published" gap).
+private fun dmSendQueueKey(pubkey: String): String = "dm_send_queue_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.loadDmSendQueue(pubkey: String): List<org.nostr.nostrord.network.managers.PendingDmWrap> {
+    if (pubkey.isBlank()) return emptyList()
+    val raw = getStringPref(dmSendQueueKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return emptyList()
+    return runCatching {
+        Json.decodeFromString(ListSerializer(org.nostr.nostrord.network.managers.PendingDmWrap.serializer()), raw)
+    }.getOrDefault(emptyList())
+}
+
+fun SecureStorage.saveDmSendQueue(
+    pubkey: String,
+    queue: List<org.nostr.nostrord.network.managers.PendingDmWrap>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(
+            dmSendQueueKey(pubkey),
+            Json.encodeToString(ListSerializer(org.nostr.nostrord.network.managers.PendingDmWrap.serializer()), queue),
+        )
+    } catch (_: Exception) {
+    }
+}
+
 // Gift-wrap id -> rumor id links, so a re-streamed but already-decrypted wrap can attach its
 // delivering relay to the right message without paying the decrypt again (View source "Seen on").
 private fun dmWrapRumorKey(pubkey: String): String = "dm_wrap_rumor_${pubkeyDigest(pubkey)}"

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -920,6 +920,50 @@ fun SecureStorage.saveDmProcessedWrapIds(
     }
 }
 
+// Relays each DM rumor's gift wrap was seen on, keyed by rumor id, so the "View source"
+// modal's "Seen on" list survives restarts instead of only covering the current session.
+private fun dmSeenRelaysKey(pubkey: String): String = "dm_seen_relays_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.loadDmSeenRelays(pubkey: String): Map<String, List<String>> {
+    if (pubkey.isBlank()) return emptyMap()
+    val raw = getStringPref(dmSeenRelaysKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return emptyMap()
+    return runCatching { Json.decodeFromString<Map<String, List<String>>>(raw) }.getOrDefault(emptyMap())
+}
+
+fun SecureStorage.saveDmSeenRelays(
+    pubkey: String,
+    seen: Map<String, List<String>>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(dmSeenRelaysKey(pubkey), Json.encodeToString(seen))
+    } catch (_: Exception) {
+    }
+}
+
+// Gift-wrap id -> rumor id links, so a re-streamed but already-decrypted wrap can attach its
+// delivering relay to the right message without paying the decrypt again (View source "Seen on").
+private fun dmWrapRumorKey(pubkey: String): String = "dm_wrap_rumor_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.loadDmWrapRumor(pubkey: String): Map<String, String> {
+    if (pubkey.isBlank()) return emptyMap()
+    val raw = getStringPref(dmWrapRumorKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return emptyMap()
+    return runCatching { Json.decodeFromString<Map<String, String>>(raw) }.getOrDefault(emptyMap())
+}
+
+fun SecureStorage.saveDmWrapRumor(
+    pubkey: String,
+    links: Map<String, String>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(dmWrapRumorKey(pubkey), Json.encodeToString(links))
+    } catch (_: Exception) {
+    }
+}
+
 // Notification history — persisted feed of cross-relay notifications shown in
 // the notification center. Scoped by pubkey so multi-account devices stay isolated.
 private fun notificationHistoryKey(pubkey: String): String = "notification_history_${pubkeyDigest(pubkey)}"

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
@@ -1,7 +1,43 @@
 package org.nostr.nostrord.ui.screens.dm
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
 import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.utils.getDateLabel
+
+/**
+ * NIP-01 JSON of the decrypted kind:14 rumor for the context menu's "Copy event JSON".
+ * Messages cached before rumorJson existed fall back to a reconstruction from the
+ * reduced model (tags survive only as the recipient `p` on own messages).
+ */
+/** [eventJson] pretty-printed for the "View source" modal. */
+fun DmMessage.prettyEventJson(): String = runCatching {
+    dmPrettyJson.encodeToString(JsonElement.serializer(), Json.parseToJsonElement(eventJson()))
+}.getOrElse { eventJson() }
+
+private val dmPrettyJson = Json { prettyPrint = true }
+
+fun DmMessage.eventJson(): String = rumorJson ?: buildJsonObject {
+    put("id", id)
+    put("pubkey", senderPubkey)
+    put("created_at", createdAt)
+    put("kind", Nip17.KIND_CHAT)
+    putJsonArray("tags") {
+        if (mine) {
+            addJsonArray {
+                add("p")
+                add(peerPubkey)
+            }
+        }
+    }
+    put("content", content)
+}.toString()
 
 /** Consecutive same-side bubbles within this window render as one visual group. */
 const val DM_GROUP_WINDOW_SECONDS = 5 * 60L

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
@@ -1,0 +1,48 @@
+package org.nostr.nostrord.ui.screens.dm
+
+import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.utils.getDateLabel
+
+/** Consecutive same-side bubbles within this window render as one visual group. */
+const val DM_GROUP_WINDOW_SECONDS = 5 * 60L
+
+/**
+ * Render list for a DM thread, shared by the Compose and web UIs: a day separator
+ * whenever the calendar day changes, and bubbles with their group edges resolved
+ * (tight spacing inside a group; every bubble carries its own clock).
+ */
+sealed class DmChatItem {
+    data class DateSeparator(val label: String) : DmChatItem()
+
+    data class Message(
+        val message: DmMessage,
+        /** Opens a visual group: gets the full inter-group spacing above it. */
+        val firstInGroup: Boolean,
+        /** Closes a visual group. */
+        val lastInGroup: Boolean,
+    ) : DmChatItem()
+}
+
+fun buildDmChatItems(messages: List<DmMessage>): List<DmChatItem> {
+    val sorted = messages.sortedBy { it.createdAt }
+    val items = mutableListOf<DmChatItem>()
+    sorted.forEachIndexed { i, m ->
+        val prev = sorted.getOrNull(i - 1)
+        val next = sorted.getOrNull(i + 1)
+        val label = getDateLabel(m.createdAt)
+        val newDay = prev == null || getDateLabel(prev.createdAt) != label
+        if (newDay) items += DmChatItem.DateSeparator(label)
+        val firstInGroup =
+            newDay ||
+                prev == null ||
+                prev.mine != m.mine ||
+                m.createdAt - prev.createdAt > DM_GROUP_WINDOW_SECONDS
+        val lastInGroup =
+            next == null ||
+                next.mine != m.mine ||
+                next.createdAt - m.createdAt > DM_GROUP_WINDOW_SECONDS ||
+                getDateLabel(next.createdAt) != label
+        items += DmChatItem.Message(m, firstInGroup, lastInGroup)
+    }
+    return items
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -32,6 +32,9 @@ class DmViewModel(
     val totalUnread = repo.totalDmUnread
     val userMetadata = repo.userMetadata
 
+    /** Published kind:10050 DM relays by author, for the header "DM relays" view. */
+    val dmRelaysByPubkey = repo.dmRelaysByPubkey
+
     val followsConversations: StateFlow<List<DmConversation>> =
         partition(keepFollowed = true)
 
@@ -47,6 +50,14 @@ class DmViewModel(
     private fun partition(keepFollowed: Boolean): StateFlow<List<DmConversation>> = combine(repo.dmConversations, repo.following) { convos, follows ->
         convos.filter { (it.peerPubkey in follows) == keepFollowed }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), emptyList())
+
+    /** A peer's published kind:10050 DM relays (empty until fetched, or if none published). */
+    fun peerDmRelays(peerPubkey: String): StateFlow<List<String>> = repo.dmRelaysByPubkey
+        .map { it[peerPubkey].orEmpty() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(STOP_TIMEOUT_MS), emptyList())
+
+    /** Fetch the peer's kind:10050 so [peerDmRelays] fills in (for the header "DM relays" view). */
+    fun loadPeerDmRelays(peerPubkey: String) = repo.requestPeerDmRelays(peerPubkey)
 
     fun getPublicKey(): String? = repo.getPublicKey()
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -35,6 +35,9 @@ class DmViewModel(
     /** Published kind:10050 DM relays by author, for the header "DM relays" view. */
     val dmRelaysByPubkey = repo.dmRelaysByPubkey
 
+    /** Send status of our own messages (Sending → Delivered), keyed by rumor id. */
+    val messageStatus = repo.dmMessageStatus
+
     val followsConversations: StateFlow<List<DmConversation>> =
         partition(keepFollowed = true)
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -125,6 +125,7 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val myDmRelays: StateFlow<List<String>> = myDmRelaysFlow
     val dmRelaysByPubkeyFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmRelaysByPubkeyFlow
+    override val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = MutableStateFlow(emptyMap())
     override fun requestPeerDmRelays(pubkey: String) {}
     override val latestMessageTimestamps: StateFlow<Map<String, Long>> = MutableStateFlow(emptyMap())
     override val totalUnread: StateFlow<Int> = MutableStateFlow(0)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -123,6 +123,9 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val totalDmUnread: StateFlow<Int> = MutableStateFlow(0)
     val myDmRelaysFlow = MutableStateFlow<List<String>>(emptyList())
     override val myDmRelays: StateFlow<List<String>> = myDmRelaysFlow
+    val dmRelaysByPubkeyFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())
+    override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmRelaysByPubkeyFlow
+    override fun requestPeerDmRelays(pubkey: String) {}
     override val latestMessageTimestamps: StateFlow<Map<String, Long>> = MutableStateFlow(emptyMap())
     override val totalUnread: StateFlow<Int> = MutableStateFlow(0)
     override val unreadByRelay: StateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
@@ -118,4 +118,69 @@ class DmManagerTest {
         val convo = dm.conversations.first { it.isNotEmpty() }
         assertEquals(0, convo.first().unread)
     }
+
+    @Test
+    fun `seen-on relays accumulate across every wrap arrival and dedupe`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val rumor = Nip17.buildRumor(alice.pubkey, bob.pubkey, "hi")
+        val wrap = Nip17.wrap(rumor, bob.pubkey, alice)
+        val wrapId = wrap.id!!
+
+        // Relay recorded before decrypt, then the wrap decrypts, then the same wrap arrives
+        // again from a second relay (deduped as a message, but its relay still counts).
+        dm.recordWrapRelay(wrapId, "wss://a.example")
+        dm.ingestGiftWrap(wrap, bob.pubkey, bob)
+        dm.recordWrapRelay(wrapId, "wss://b.example")
+        dm.recordWrapRelay(wrapId, "wss://a.example")
+
+        val msg = dm.messagesByPeer.value[alice.pubkey]!!.first()
+        assertEquals(listOf("wss://a.example", "wss://b.example"), msg.relays)
+        assertEquals(listOf("wss://a.example", "wss://b.example"), dm.seenRelaysSnapshot()[rumor.id])
+    }
+
+    @Test
+    fun `hydrate restores persisted seen-on relays onto messages`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val peer = "cd".repeat(32)
+        val msg = DmMessage(id = "rumor1", peerPubkey = peer, senderPubkey = peer, content = "hi", createdAt = 10L, mine = false)
+
+        dm.hydrate(listOf(msg), emptyMap(), mapOf("rumor1" to listOf("wss://seen.example")))
+
+        assertEquals(listOf("wss://seen.example"), dm.messagesByPeer.value[peer]?.first()?.relays)
+    }
+
+    @Test
+    fun `restored wrap-to-rumor link attaches a relay on the decrypt-skip path`() = runTest {
+        // A wrap decrypted in a previous session: its message is hydrated from cache and the
+        // wrap->rumor link is restored, but the wrap is never decrypted again this session.
+        val dm = DmManager(backgroundScope)
+        val peer = "cd".repeat(32)
+        val msg = DmMessage(id = "rumor1", peerPubkey = peer, senderPubkey = peer, content = "hi", createdAt = 10L, mine = false)
+        dm.hydrate(listOf(msg), emptyMap(), emptyMap(), mapOf("wrap1" to "rumor1"))
+
+        // Re-streamed wrap: only recordWrapRelay runs (no ingestGiftWrap), yet the relay attaches.
+        dm.recordWrapRelay("wrap1", "wss://seen.example")
+
+        assertEquals(listOf("wss://seen.example"), dm.messagesByPeer.value[peer]?.first()?.relays)
+        assertEquals(mapOf("wrap1" to "rumor1"), dm.wrapToRumorSnapshot())
+    }
+
+    @Test
+    fun `onSeenRelaysChanged fires when a new relay is recorded`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val rumor = Nip17.buildRumor(alice.pubkey, bob.pubkey, "hi")
+        val wrap = Nip17.wrap(rumor, bob.pubkey, alice)
+        dm.ingestGiftWrap(wrap, bob.pubkey, bob)
+
+        var fired = 0
+        dm.onSeenRelaysChanged = { fired++ }
+        val wrapId = wrap.id!!
+        dm.recordWrapRelay(wrapId, "wss://new.example")
+        dm.recordWrapRelay(wrapId, "wss://new.example") // duplicate: no extra fire
+        assertEquals(1, fired)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
@@ -168,6 +168,27 @@ class DmManagerTest {
     }
 
     @Test
+    fun `own message is Sending then Delivered on the self-echo`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val rumor = Nip17.buildRumor(alice.pubkey, "bb".repeat(32), "hi")
+        dm.addOptimistic(rumor, "bb".repeat(32), alice.pubkey)
+        assertEquals(GroupManager.MessageStatus.Sending, dm.messageStatus.value[rumor.id])
+
+        // The self-copy echoes back through the inbox (deduped) -> Delivered.
+        val selfWrap = Nip17.wrap(rumor, alice.pubkey, alice)
+        dm.ingestGiftWrap(selfWrap, alice.pubkey, alice)
+        assertEquals(GroupManager.MessageStatus.Delivered, dm.messageStatus.value[rumor.id])
+    }
+
+    @Test
+    fun `markDelivered is a no-op for an untracked id`() = runTest {
+        val dm = DmManager(backgroundScope)
+        dm.markDelivered("never-sent")
+        assertTrue(dm.messageStatus.value["never-sent"] == null)
+    }
+
+    @Test
     fun `onSeenRelaysChanged fires when a new relay is recorded`() = runTest {
         val dm = DmManager(backgroundScope)
         val alice = signer()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParserTest.kt
@@ -574,6 +574,14 @@ class MessageContentParserTest {
     }
 
     @Test
+    fun `markdown double-asterisk bold is parsed`() {
+        val parts = MessageContentParser.parse("Hello **world** there")
+        assertEquals(3, parts.size)
+        assertIs<MessageContentParser.ParsedPart.Bold>(parts[1])
+        assertEquals("world", (parts[1] as MessageContentParser.ParsedPart.Bold).content)
+    }
+
+    @Test
     fun `italic text is parsed`() {
         val input = "Hello _world_ there"
         val parts = MessageContentParser.parse(input)
@@ -583,6 +591,22 @@ class MessageContentParserTest {
         assertIs<MessageContentParser.ParsedPart.Italic>(parts[1])
         assertEquals("world", (parts[1] as MessageContentParser.ParsedPart.Italic).content)
         assertIs<MessageContentParser.ParsedPart.Text>(parts[2])
+    }
+
+    @Test
+    fun `blockquote line is parsed with markers stripped`() {
+        val parts = MessageContentParser.parse("> quoted line")
+        val bq = parts.filterIsInstance<MessageContentParser.ParsedPart.Blockquote>()
+        assertEquals(1, bq.size)
+        assertEquals("quoted line", bq[0].content)
+    }
+
+    @Test
+    fun `multiline blockquote joins its lines`() {
+        val parts = MessageContentParser.parse("> line one\n> line two")
+        val bq = parts.filterIsInstance<MessageContentParser.ParsedPart.Blockquote>()
+        assertEquals(1, bq.size)
+        assertEquals("line one\nline two", bq[0].content)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItemsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItemsTest.kt
@@ -1,0 +1,98 @@
+package org.nostr.nostrord.ui.screens.dm
+
+import org.nostr.nostrord.network.managers.DmMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DmChatItemsTest {
+    // 2023-11-14 ~19:13 America/Sao_Paulo; mid-day in most CI timezones too, so
+    // small offsets never cross midnight.
+    private val base = 1_700_000_000L
+
+    private fun msg(id: String, at: Long, mine: Boolean) = DmMessage(
+        id = id,
+        peerPubkey = "peer",
+        senderPubkey = if (mine) "me" else "peer",
+        content = "m$id",
+        createdAt = at,
+        mine = mine,
+    )
+
+    private fun messagesOf(items: List<DmChatItem>) = items.filterIsInstance<DmChatItem.Message>()
+
+    private fun separatorsOf(items: List<DmChatItem>) = items.filterIsInstance<DmChatItem.DateSeparator>()
+
+    @Test
+    fun one_separator_per_day() {
+        val items = buildDmChatItems(
+            listOf(
+                msg("a", base, mine = false),
+                msg("b", base + 60, mine = false),
+                msg("c", base + 2 * 86_400, mine = true),
+            ),
+        )
+        val seps = separatorsOf(items)
+        assertEquals(2, seps.size)
+        assertTrue(seps[0].label != seps[1].label)
+        assertTrue(items[0] is DmChatItem.DateSeparator)
+    }
+
+    @Test
+    fun same_side_within_window_groups() {
+        val items = messagesOf(
+            buildDmChatItems(
+                listOf(
+                    msg("a", base, mine = true),
+                    msg("b", base + 60, mine = true),
+                    msg("c", base + 120, mine = true),
+                ),
+            ),
+        )
+        assertEquals(listOf(true, false, false), items.map { it.firstInGroup })
+        assertEquals(listOf(false, false, true), items.map { it.lastInGroup })
+    }
+
+    @Test
+    fun side_switch_breaks_group() {
+        val items = messagesOf(
+            buildDmChatItems(
+                listOf(
+                    msg("a", base, mine = false),
+                    msg("b", base + 30, mine = true),
+                ),
+            ),
+        )
+        assertTrue(items[0].firstInGroup)
+        assertTrue(items[0].lastInGroup)
+        assertTrue(items[1].firstInGroup)
+        assertTrue(items[1].lastInGroup)
+    }
+
+    @Test
+    fun gap_over_window_breaks_group() {
+        val items = messagesOf(
+            buildDmChatItems(
+                listOf(
+                    msg("a", base, mine = true),
+                    msg("b", base + DM_GROUP_WINDOW_SECONDS + 1, mine = true),
+                ),
+            ),
+        )
+        assertTrue(items[0].lastInGroup)
+        assertTrue(items[1].firstInGroup)
+    }
+
+    @Test
+    fun unsorted_input_is_sorted() {
+        val items = messagesOf(
+            buildDmChatItems(
+                listOf(
+                    msg("b", base + 60, mine = true),
+                    msg("a", base, mine = false),
+                ),
+            ),
+        )
+        assertEquals(listOf("a", "b"), items.map { it.message.id })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/dm/DmEventJsonTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/dm/DmEventJsonTest.kt
@@ -1,0 +1,54 @@
+package org.nostr.nostrord.ui.screens.dm
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.nostr.nostrord.network.managers.DmMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DmEventJsonTest {
+    private fun msg(rumorJson: String? = null, mine: Boolean = false) = DmMessage(
+        id = "rumor-id",
+        peerPubkey = "peer-pub",
+        senderPubkey = if (mine) "my-pub" else "peer-pub",
+        content = "hello",
+        createdAt = 1_700_000_000L,
+        mine = mine,
+        rumorJson = rumorJson,
+    )
+
+    @Test
+    fun uses_stored_rumor_json_verbatim() {
+        val stored = """{"id":"rumor-id","kind":14,"content":"hello","tags":[["p","peer-pub"]]}"""
+        assertEquals(stored, msg(rumorJson = stored).eventJson())
+    }
+
+    @Test
+    fun reconstructs_when_rumor_json_absent() {
+        val obj = Json.parseToJsonElement(msg(mine = true).eventJson()).jsonObject
+        assertEquals("rumor-id", obj["id"]?.jsonPrimitive?.content)
+        assertEquals("14", obj["kind"]?.jsonPrimitive?.content)
+        assertEquals("hello", obj["content"]?.jsonPrimitive?.content)
+        // Own message carries the recipient p tag; sig is absent (rumors are unsigned).
+        assertTrue(obj["tags"].toString().contains("peer-pub"))
+        assertTrue(!obj.containsKey("sig"))
+    }
+
+    @Test
+    fun incoming_reconstruction_has_no_tags() {
+        val obj = Json.parseToJsonElement(msg(mine = false).eventJson()).jsonObject
+        assertEquals("[]", obj["tags"].toString())
+    }
+
+    @Test
+    fun pretty_json_is_multiline_and_parses_back() {
+        val pretty = msg(mine = true).prettyEventJson()
+        assertTrue(pretty.contains("\n"))
+        assertEquals(
+            "rumor-id",
+            Json.parseToJsonElement(pretty).jsonObject["id"]?.jsonPrimitive?.content,
+        )
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayerContent.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayerContent.ios.kt
@@ -14,8 +14,9 @@ actual fun AudioPlayerContent(
 ) {
     AudioPlayerChrome(
         isPlaying = false,
-        currentMs = 0L,
-        durationMs = 0L,
+        progress = 0f,
+        positionText = "0:00",
+        durationText = null,
         fileName = audioFileName(url),
         onToggle = {},
         modifier = modifier,

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayerContent.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayerContent.jvm.kt
@@ -29,26 +29,32 @@ actual fun AudioPlayerContent(
         onDispose { state.pause() }
     }
 
-    val durationMs = state.metadata.duration ?: 0L
-    val currentMs = (state.currentTime * 1000).toLong()
+    // Use the library's own normalized position + formatted text (like the video player), not the
+    // raw metadata.duration: a streamed file (e.g. a CDN .wav) can report a bogus duration on the
+    // GStreamer/Linux backend (millions of minutes), which the raw value would then display. Hide
+    // the duration when it is missing or absurd (> 12h) so the chrome shows just the elapsed time.
+    val rawDurationMs = state.metadata.duration ?: 0L
+    val durationValid = rawDurationMs in 1..(12L * 60 * 60 * 1000)
+    val progress = state.sliderPos / SLIDER_MAX
 
     AudioPlayerChrome(
         isPlaying = state.isPlaying,
-        currentMs = currentMs,
-        durationMs = durationMs,
+        progress = progress,
+        positionText = state.positionText.ifBlank { "0:00" },
+        durationText = if (durationValid) state.durationText.ifBlank { null } else null,
         fileName = audioFileName(url),
         onToggle = {
             if (state.isPlaying) {
                 state.pause()
             } else {
-                // At end-of-media currentTime sits at the end; rewind so play replays instead
-                // of doing nothing (slider runs 0..1000).
-                val d = state.metadata.duration ?: 0L
-                val c = (state.currentTime * 1000).toLong()
-                if (d > 0 && c >= d - 250) state.seekTo(0f)
+                // At end-of-media the slider sits at the end; rewind so play replays instead of
+                // doing nothing (slider runs 0..SLIDER_MAX).
+                if (state.sliderPos >= SLIDER_MAX - 1f) state.seekTo(0f)
                 state.play()
             }
         },
         modifier = modifier,
     )
 }
+
+private const val SLIDER_MAX = 1000f

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/RichAboutText.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/RichAboutText.kt
@@ -185,6 +185,7 @@ private fun partToPlainText(part: MessageContentParser.ParsedPart): String = whe
     is MessageContentParser.ParsedPart.Strikethrough -> part.content
     is MessageContentParser.ParsedPart.Spoiler -> part.content
     is MessageContentParser.ParsedPart.CodeBlock -> part.code
+    is MessageContentParser.ParsedPart.Blockquote -> part.content
     is MessageContentParser.ParsedPart.Hashtag -> "#${part.tag}"
     is MessageContentParser.ParsedPart.Cashu -> part.token
     is MessageContentParser.ParsedPart.CashuRequest -> part.request

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmEventSourceDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmEventSourceDialog.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.ui.components.chat
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,11 +12,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -49,13 +53,17 @@ fun DmEventSourceDialog(
                         .clip(NostrordShapes.shapeSmall)
                         .background(NostrordColors.BackgroundFloating)
                         .verticalScroll(rememberScrollState())
+                        .horizontalScroll(rememberScrollState())
                         .padding(Spacing.sm),
                 ) {
+                    // softWrap = false so long lines scroll horizontally instead of wrapping
+                    // (web parity: the .dm-source-json box scrolls).
                     Text(
                         json,
                         color = NostrordColors.TextContent,
                         fontSize = 12.sp,
                         fontFamily = FontFamily.Monospace,
+                        softWrap = false,
                     )
                 }
                 if (relays.isNotEmpty()) {
@@ -78,15 +86,23 @@ fun DmEventSourceDialog(
             }
         },
         confirmButton = {
-            TextButton(
+            // Primary filled action, matching the web modal's purple "Copy JSON" button.
+            Button(
                 onClick = {
                     onCopyJson()
                     onDismiss()
                 },
+                colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = NostrordColors.Primary,
+                    contentColor = Color.White,
+                ),
             ) { Text("Copy JSON") }
         },
         dismissButton = {
-            TextButton(onClick = onDismiss) { Text("Close") }
+            TextButton(onClick = onDismiss) {
+                Text("Close", color = NostrordColors.TextSecondary)
+            }
         },
     )
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmEventSourceDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmEventSourceDialog.kt
@@ -1,0 +1,92 @@
+package org.nostr.nostrord.ui.components.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * "View source" for a DM: the decrypted kind:14 rumor as pretty JSON plus the relays
+ * its gift wrap was seen on this session. Mirrors the web DmPage source modal.
+ */
+@Composable
+fun DmEventSourceDialog(
+    json: String,
+    relays: List<String>,
+    onCopyJson: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = NostrordColors.Surface,
+        title = { Text("Message source", color = NostrordColors.TextPrimary) },
+        text = {
+            Column {
+                Box(
+                    modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 320.dp)
+                        .clip(NostrordShapes.shapeSmall)
+                        .background(NostrordColors.BackgroundFloating)
+                        .verticalScroll(rememberScrollState())
+                        .padding(Spacing.sm),
+                ) {
+                    Text(
+                        json,
+                        color = NostrordColors.TextContent,
+                        fontSize = 12.sp,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                }
+                if (relays.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(Spacing.sm))
+                    Text(
+                        "Seen on",
+                        color = NostrordColors.TextPrimary,
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    relays.forEach { relay ->
+                        Text(
+                            relay,
+                            color = NostrordColors.TextMuted,
+                            fontSize = 12.sp,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onCopyJson()
+                    onDismiss()
+                },
+            ) { Text("Copy JSON") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
@@ -1,0 +1,134 @@
+package org.nostr.nostrord.ui.components.chat
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.selection.DisableSelection
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Code
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.Visibility
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+import org.nostr.nostrord.ui.theme.NostrordAnimation
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * Context menu for a DM bubble: the group chat's [MessageContextMenu] shell (same popup,
+ * positioning and card styling) trimmed to the actions that exist for NIP-17 messages.
+ * Rumors are unsigned and never addressable on public relays, so there is no
+ * nevent/link/pin/reaction here — just the local copy actions.
+ */
+@Composable
+fun DmMessageContextMenu(
+    visible: Boolean,
+    anchorOffsetPx: Offset?,
+    onDismiss: () -> Unit,
+    onViewSource: () -> Unit,
+    onCopyText: () -> Unit,
+    onCopyJson: () -> Unit,
+) {
+    if (!visible) return
+    val marginPx = with(LocalDensity.current) { 8.dp.roundToPx() }
+    val positionProvider =
+        remember(anchorOffsetPx, marginPx) {
+            MessageMenuPositionProvider(anchorOffsetPx, anchorWidthPx = 0, marginPx = marginPx)
+        }
+    Popup(
+        popupPositionProvider = positionProvider,
+        onDismissRequest = onDismiss,
+        properties =
+        PopupProperties(
+            focusable = true,
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
+    ) {
+        DisableSelection {
+            AnimatedVisibility(
+                visible = true,
+                enter =
+                fadeIn(animationSpec = tween(NostrordAnimation.popupEnter)) +
+                    scaleIn(
+                        animationSpec = tween(NostrordAnimation.popupEnter),
+                        initialScale = 0.9f,
+                        transformOrigin = TransformOrigin(0f, 0f),
+                    ),
+                exit =
+                fadeOut(animationSpec = tween(NostrordAnimation.popupExit)) +
+                    scaleOut(
+                        animationSpec = tween(NostrordAnimation.popupExit),
+                        transformOrigin = TransformOrigin(0f, 0f),
+                    ),
+            ) {
+                Column(
+                    modifier =
+                    Modifier
+                        .width(214.dp)
+                        .shadow(
+                            elevation = 12.dp,
+                            shape = NostrordShapes.shapeMedium,
+                            ambientColor = Color.Black.copy(alpha = 0.4f),
+                            spotColor = Color.Black.copy(alpha = 0.4f),
+                        ).clip(NostrordShapes.shapeMedium)
+                        .background(NostrordColors.Surface)
+                        .border(
+                            width = Spacing.dividerThickness,
+                            color = NostrordColors.Divider,
+                            shape = NostrordShapes.shapeMedium,
+                        ).padding(6.dp)
+                        .pointerInput(Unit) {
+                            detectTapGestures { /* consume */ }
+                        },
+                ) {
+                    ContextMenuItem(
+                        icon = Icons.Outlined.Visibility,
+                        label = "View source",
+                        onClick = {
+                            onViewSource()
+                            onDismiss()
+                        },
+                    )
+                    ContextMenuItem(
+                        icon = Icons.Outlined.ContentCopy,
+                        label = "Copy text",
+                        onClick = {
+                            onCopyText()
+                            onDismiss()
+                        },
+                    )
+                    ContextMenuItem(
+                        icon = Icons.Outlined.Code,
+                        label = "Copy event JSON",
+                        onClick = {
+                            onCopyJson()
+                            onDismiss()
+                        },
+                    )
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Code
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.runtime.Composable
@@ -48,7 +47,6 @@ fun DmMessageContextMenu(
     onDismiss: () -> Unit,
     onViewSource: () -> Unit,
     onCopyText: () -> Unit,
-    onCopyJson: () -> Unit,
 ) {
     if (!visible) return
     val marginPx = with(LocalDensity.current) { 8.dp.roundToPx() }
@@ -116,14 +114,6 @@ fun DmMessageContextMenu(
                         label = "Copy text",
                         onClick = {
                             onCopyText()
-                            onDismiss()
-                        },
-                    )
-                    ContextMenuItem(
-                        icon = Icons.Outlined.Code,
-                        label = "Copy event JSON",
-                        onClick = {
-                            onCopyJson()
                             onDismiss()
                         },
                     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmRelaysDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmRelaysDialog.kt
@@ -1,0 +1,53 @@
+package org.nostr.nostrord.ui.components.chat
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * Where a peer's DMs route: their published kind:10050 relay list. Empty until the fetch lands,
+ * or when the peer has published none (senders then fall back to defaults). Mirrors the web modal.
+ */
+@Composable
+fun DmRelaysDialog(
+    relays: List<String>,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        containerColor = NostrordColors.Surface,
+        title = { Text("DM relays", color = NostrordColors.TextPrimary) },
+        text = {
+            if (relays.isEmpty()) {
+                Text(
+                    "No published DM relay list yet. Messages route to default relays.",
+                    color = NostrordColors.TextMuted,
+                    fontSize = 13.sp,
+                )
+            } else {
+                Column {
+                    relays.forEach { relay ->
+                        Text(
+                            relay,
+                            color = NostrordColors.TextContent,
+                            fontSize = 13.sp,
+                            fontFamily = FontFamily.Monospace,
+                            modifier = Modifier.padding(vertical = Spacing.xxs),
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        },
+    )
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -98,6 +98,7 @@ private typealias MonospacePart = MessageContentParser.ParsedPart.Monospace
 private typealias StrikethroughPart = MessageContentParser.ParsedPart.Strikethrough
 private typealias SpoilerPart = MessageContentParser.ParsedPart.Spoiler
 private typealias CodeBlockPart = MessageContentParser.ParsedPart.CodeBlock
+private typealias BlockquotePart = MessageContentParser.ParsedPart.Blockquote
 private typealias HashtagPart = MessageContentParser.ParsedPart.Hashtag
 private typealias VideoPart = MessageContentParser.ParsedPart.Video
 private typealias AudioPart = MessageContentParser.ParsedPart.Audio
@@ -171,6 +172,7 @@ private fun AnnotatedString.Builder.appendWithEmojiFont(
 private fun isBlockPart(part: ContentPart): Boolean = when (part) {
     is ImagePart -> true
     is CodeBlockPart -> true
+    is BlockquotePart -> true
     is VideoPart -> true
     is AudioPart -> true
     is RelayPart -> true
@@ -224,6 +226,9 @@ fun MessageContent(
     currentGroupId: String? = null,
     currentRelayUrl: String? = null,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit = { _, _, _, _ -> },
+    // Base text color. Defaults to the neutral message color; DM bubbles override it (white on
+    // the primary "mine" bubble). Inline accents (links, mentions) keep their own colors.
+    textColor: Color = NostrordColors.TextContent,
 ) {
     // Extract custom emoji map from NIP-30 tags
     val emojiMap = remember(tags) { MessageContentParser.extractEmojiMap(tags) }
@@ -319,6 +324,33 @@ fun MessageContent(
                                 code = firstPart.code,
                                 language = firstPart.language,
                             )
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
+                        is BlockquotePart -> {
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Row(modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Min)) {
+                                Box(
+                                    modifier =
+                                    Modifier
+                                        .width(3.dp)
+                                        .fillMaxHeight()
+                                        .clip(RoundedCornerShape(2.dp))
+                                        .background(NostrordColors.TextMuted),
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                // Recurse so inline formatting / links / mentions inside the quote
+                                // still render; the stripped inner text has no `>` so it can't loop.
+                                MessageContent(
+                                    content = firstPart.content,
+                                    tags = tags,
+                                    onMentionClick = onMentionClick,
+                                    onHashtagClick = onHashtagClick,
+                                    currentGroupId = currentGroupId,
+                                    currentRelayUrl = currentRelayUrl,
+                                    onNavigateToGroup = onNavigateToGroup,
+                                    textColor = textColor,
+                                )
+                            }
                             Spacer(modifier = Modifier.height(4.dp))
                         }
                         is VideoPart -> {
@@ -445,6 +477,7 @@ fun MessageContent(
                         userMetadata = userMetadata,
                         onMentionClick = onMentionClick,
                         onHashtagClick = onHashtagClick,
+                        textColor = textColor,
                     )
                 }
             }
@@ -480,6 +513,7 @@ private fun InlineContentGroup(
     modifier: Modifier = Modifier,
     onMentionClick: (String) -> Unit = {},
     onHashtagClick: (String) -> Unit = {},
+    textColor: Color = NostrordColors.TextContent,
 ) {
     // Check if this group contains any custom emojis
     val hasCustomEmojis =
@@ -496,6 +530,7 @@ private fun InlineContentGroup(
                 modifier = modifier,
                 onMentionClick = onMentionClick,
                 onHashtagClick = onHashtagClick,
+                textColor = textColor,
             )
         }
     } else {
@@ -506,6 +541,7 @@ private fun InlineContentGroup(
             modifier = modifier,
             onMentionClick = onMentionClick,
             onHashtagClick = onHashtagClick,
+            textColor = textColor,
         )
     }
 }
@@ -521,6 +557,7 @@ private fun InlineContentWithEmojis(
     modifier: Modifier = Modifier,
     onMentionClick: (String) -> Unit = {},
     onHashtagClick: (String) -> Unit = {},
+    textColor: Color = NostrordColors.TextContent,
 ) {
     val context = LocalPlatformContext.current
     val emojiUrls =
@@ -710,7 +747,7 @@ private fun InlineContentWithEmojis(
 
     Text(
         text = annotatedString,
-        color = NostrordColors.TextContent,
+        color = textColor,
         style = NostrordTypography.MessageBody,
         inlineContent = inlineContentMap,
         modifier = modifier,
@@ -759,6 +796,7 @@ private fun InlineContentTextOnly(
     modifier: Modifier = Modifier,
     onMentionClick: (String) -> Unit = {},
     onHashtagClick: (String) -> Unit = {},
+    textColor: Color = NostrordColors.TextContent,
 ) {
     val emojiFontFamily = rememberEmojiFontFamily()
     var revealedSpoilers by remember(parts) { mutableStateOf(emptySet<Int>()) }
@@ -893,7 +931,7 @@ private fun InlineContentTextOnly(
 
     Text(
         text = annotatedString,
-        color = NostrordColors.TextContent,
+        color = textColor,
         style = NostrordTypography.MessageBody,
         modifier = modifier,
     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
@@ -128,6 +128,11 @@ object MessageContentParser {
             val language: String?,
         ) : ParsedPart()
 
+        /** Blockquote (one or more `> ` lines). [content] is the inner text, markers stripped. */
+        data class Blockquote(
+            val content: String,
+        ) : ParsedPart()
+
         // Hashtags (inline)
 
         /** Hashtag (#tag) */
@@ -187,8 +192,10 @@ object MessageContentParser {
         val cacheKey = if (emojiMap.isEmpty()) content else "$content\u0000${emojiMap.hashCode()}"
         parseCache.get(cacheKey)?.let { return it }
 
-        // Pass 1: Extract code blocks and replace with placeholders
-        val (contentWithPlaceholders, codeBlockMatches) = extractCodeBlocks(content)
+        // Pass 1: Extract code blocks, then blockquotes, replacing each with placeholders so
+        // downstream passes never parse inside them (markers/positions preserved for buildParts).
+        val (contentAfterCode, codeBlockMatches) = extractCodeBlocks(content)
+        val (contentWithPlaceholders, blockquoteMatches) = extractBlockquotes(contentAfterCode)
 
         // Pass 2: Parse remaining content with priority system
 
@@ -231,11 +238,11 @@ object MessageContentParser {
             }
         val emojiMatches = findCustomEmojis(contentWithPlaceholders, emojiMap, allCoveredRanges)
 
-        // Step 8: Combine all matches (including code blocks) and sort by position
+        // Step 8: Combine all matches (including code blocks + blockquotes) and sort by position
         val allMatches =
             (
-                codeBlockMatches + urlMatches + relayMatches + cashuMatches + nostrMatches + formattingMatches + hashtagMatches +
-                    emojiMatches
+                codeBlockMatches + blockquoteMatches + urlMatches + relayMatches + cashuMatches + nostrMatches +
+                    formattingMatches + hashtagMatches + emojiMatches
                 ).sortedBy { it.range.first }
 
         // Step 9: Build parts list with text between matches, cache, and return
@@ -693,13 +700,46 @@ object MessageContentParser {
         return resultBuilder.toString() to codeBlockMatches
     }
 
+    private const val BLOCKQUOTE_PLACEHOLDER = '\uE001'
+
+    // One or more consecutive lines beginning with `>` (optional leading space + one space
+    // after the marker), captured as a single block. Runs on the code-block-masked content.
+    private val blockquoteRegex = Regex("(?m)^[ \\t]*>[ \\t]?.*(?:\\r?\\n[ \\t]*>[ \\t]?.*)*")
+    private val blockquoteLinePrefix = Regex("^[ \\t]*>[ \\t]?")
+
+    /**
+     * Extract blockquote blocks and replace with same-length placeholders (mirrors
+     * [extractCodeBlocks]). The stored [ParsedPart.Blockquote] holds the inner text with the
+     * `>` markers stripped; the renderer parses that inner text again for inline formatting.
+     */
+    private fun extractBlockquotes(content: String): Pair<String, List<ParsedMatch>> {
+        val matches = blockquoteRegex.findAll(content).toList()
+        if (matches.isEmpty()) return content to emptyList()
+
+        val out = mutableListOf<ParsedMatch>()
+        val builder = StringBuilder()
+        var lastIndex = 0
+        for (match in matches) {
+            builder.append(content.substring(lastIndex, match.range.first))
+            repeat(match.value.length) { builder.append(BLOCKQUOTE_PLACEHOLDER) }
+            val inner = match.value.lines().joinToString("\n") { it.replaceFirst(blockquoteLinePrefix, "") }
+            out.add(ParsedMatch(match.range, ParsedPart.Blockquote(inner)))
+            lastIndex = match.range.last + 1
+        }
+        if (lastIndex < content.length) builder.append(content.substring(lastIndex))
+        return builder.toString() to out
+    }
+
     // ============================================================================
     // TEXT FORMATTING PARSING
     // ============================================================================
 
     /**
-     * Bold text: *text* (non-greedy, allows any content including newlines)
+     * Bold text: **text** (markdown) and *text* (Nostr style). Both render bold — additive, so
+     * existing *bold* keeps working while markdown **bold** is also recognized. The double form is
+     * matched first (see [findFormatting]) so it isn't split into two empty single-asterisk marks.
      */
+    private val boldDoubleRegex = Regex("\\*\\*([\\s\\S]+?)\\*\\*")
     private val boldRegex = Regex("\\*([\\s\\S]*?)\\*")
 
     /**
@@ -743,6 +783,14 @@ object MessageContentParser {
         strikethroughRegex.findAll(content).forEach { match ->
             if (!match.range.any { it in coveredPositions } && !overlapsExisting(match.range)) {
                 matches.add(ParsedMatch(match.range, ParsedPart.Strikethrough(match.groupValues[1])))
+            }
+        }
+
+        // Find markdown bold **text** before single-asterisk *text*, so the double markers
+        // aren't read as two empty bolds; both map to Bold (additive).
+        boldDoubleRegex.findAll(content).forEach { match ->
+            if (!match.range.any { it in coveredPositions } && !overlapsExisting(match.range)) {
+                matches.add(ParsedMatch(match.range, ParsedPart.Bold(match.groupValues[1])))
             }
         }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -193,7 +193,7 @@ fun MessageContextMenu(
  * a cursor anchor opens rightward/downward from the click; a null anchor (the
  * hover More button) hangs the menu off the row's right edge (opens leftward).
  */
-private class MessageMenuPositionProvider(
+internal class MessageMenuPositionProvider(
     private val anchorOffsetPx: Offset?,
     private val anchorWidthPx: Int,
     private val marginPx: Int,
@@ -472,7 +472,7 @@ private fun QuickReactionButton(
  * Individual context menu item.
  */
 @Composable
-private fun ContextMenuItem(
+internal fun ContextMenuItem(
     icon: ImageVector,
     label: String,
     onClick: () -> Unit,
@@ -538,7 +538,7 @@ private fun ContextMenuItem(
  * Divider between menu sections.
  */
 @Composable
-private fun ContextMenuDivider() {
+internal fun ContextMenuDivider() {
     HorizontalDivider(
         // Web `.ctx-divider` has margin 6px 4px.
         modifier = Modifier.padding(horizontal = Spacing.xs, vertical = 6.dp),

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageStatusIndicator.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageStatusIndicator.kt
@@ -30,6 +30,7 @@ import org.nostr.nostrord.ui.theme.Spacing
 fun SendStateIcon(
     status: GroupManager.MessageStatus,
     modifier: Modifier = Modifier,
+    tint: androidx.compose.ui.graphics.Color = NostrordColors.TextMuted,
 ) {
     val (image, description) = when (status) {
         is GroupManager.MessageStatus.Sending -> Icons.Default.Schedule to "Sending"
@@ -39,7 +40,7 @@ fun SendStateIcon(
     Icon(
         imageVector = image,
         contentDescription = description,
-        tint = NostrordColors.TextMuted,
+        tint = tint,
         // The caller bottom-aligns this in the content row; the 2dp lift keeps the
         // glyph on the text baseline instead of down in the font's descent.
         modifier = modifier.padding(start = Spacing.xxs, bottom = 2.dp).size(13.dp),

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayerContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayerContent.kt
@@ -30,17 +30,23 @@ expect fun AudioPlayerContent(
     modifier: Modifier = Modifier,
 )
 
-/** Shared visual: play/pause button, filename, progress bar and the position/duration row. */
+/**
+ * Shared visual: play/pause button, filename, progress bar and the position/duration row.
+ * Takes a normalized [progress] (0..1) and pre-formatted [positionText]/[durationText] so each
+ * platform can source them from its own engine (the desktop player's own text avoids the raw,
+ * sometimes-bogus, duration a streamed file reports). [durationText] null hides the duration.
+ */
 @Composable
 internal fun AudioPlayerChrome(
     isPlaying: Boolean,
-    currentMs: Long,
-    durationMs: Long,
+    progress: Float,
+    positionText: String,
+    durationText: String?,
     fileName: String,
     onToggle: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val progress = if (durationMs > 0) currentMs.toFloat() / durationMs.toFloat() else 0f
+    val clampedProgress = progress.coerceIn(0f, 1f)
 
     Row(
         modifier =
@@ -82,7 +88,7 @@ internal fun AudioPlayerChrome(
             Spacer(Modifier.height(4.dp))
 
             LinearProgressIndicator(
-                progress = { progress },
+                progress = { clampedProgress },
                 modifier =
                 Modifier
                     .fillMaxWidth()
@@ -99,13 +105,13 @@ internal fun AudioPlayerChrome(
                 horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Text(
-                    text = formatDuration(currentMs),
+                    text = positionText,
                     style = NostrordTypography.Caption,
                     color = NostrordColors.TextMuted,
                 )
-                if (durationMs > 0) {
+                if (durationText != null) {
                     Text(
-                        text = formatDuration(durationMs),
+                        text = durationText,
                         style = NostrordTypography.Caption,
                         color = NostrordColors.TextMuted,
                     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
+import org.nostr.nostrord.ui.components.chat.DateSeparator
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.layout.DmConversationList
 import org.nostr.nostrord.ui.components.layout.FrameMenuButton
@@ -50,6 +51,7 @@ import org.nostr.nostrord.ui.screens.profile.ProfilePageViewModel
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.utils.formatTime
 
 /**
  * Direct-message conversation page (NIP-17). Renders the decrypted thread and a composer that
@@ -240,22 +242,53 @@ fun DmPageScreen(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.widthIn(max = 320.dp),
             )
-            messages.forEach { m ->
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(top = Spacing.sm),
-                    horizontalArrangement = if (m.mine) Arrangement.End else Arrangement.Start,
-                ) {
-                    Surface(
-                        shape = NostrordShapes.shapeMedium,
-                        color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
-                        modifier = Modifier.widthIn(max = 320.dp),
-                    ) {
-                        Text(
-                            m.content,
-                            color = if (m.mine) Color.White else NostrordColors.TextPrimary,
-                            fontSize = 14.sp,
-                            modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
-                        )
+            val chatItems = remember(messages) { buildDmChatItems(messages) }
+            chatItems.forEach { item ->
+                when (item) {
+                    is DmChatItem.DateSeparator -> DateSeparator(item.label)
+                    is DmChatItem.Message -> {
+                        val m = item.message
+                        // WhatsApp/Telegram-style: a small clock inside every bubble,
+                        // bottom-right under the text.
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs),
+                            verticalAlignment = Alignment.Bottom,
+                        ) {
+                            // Web parity (.dm-bubble max-width 75%): the spacer eats the other
+                            // 25% on the bubble's growth side; the Box owns the 75% slot and
+                            // pins the bubble to the correct edge inside it.
+                            if (m.mine) Spacer(modifier = Modifier.weight(0.25f))
+                            Box(
+                                modifier = Modifier.weight(0.75f),
+                                contentAlignment = if (m.mine) Alignment.BottomEnd else Alignment.BottomStart,
+                            ) {
+                                Surface(
+                                    shape = NostrordShapes.shapeMedium,
+                                    color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
+                                ) {
+                                    // Clock rides beside the text's last line, bottom-aligned
+                                    // (web parity: the float-right .dm-bubble-time).
+                                    Row(
+                                        modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                                        verticalAlignment = Alignment.Bottom,
+                                    ) {
+                                        Text(
+                                            m.content,
+                                            color = if (m.mine) Color.White else NostrordColors.TextPrimary,
+                                            fontSize = 14.sp,
+                                            modifier = Modifier.weight(1f, fill = false),
+                                        )
+                                        Text(
+                                            formatTime(m.createdAt),
+                                            color = if (m.mine) Color.White.copy(alpha = 0.7f) else NostrordColors.TextMuted,
+                                            fontSize = 10.sp,
+                                            modifier = Modifier.padding(start = Spacing.xs),
+                                        )
+                                    }
+                                }
+                            }
+                            if (!m.mine) Spacer(modifier = Modifier.weight(0.25f))
+                        }
                     }
                 }
             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -17,7 +17,17 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mail
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.Person
+import androidx.compose.material.icons.outlined.PersonAdd
+import androidx.compose.material.icons.outlined.PersonRemove
+import androidx.compose.material.icons.outlined.Public
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,6 +54,7 @@ import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.chat.DateSeparator
 import org.nostr.nostrord.ui.components.chat.DmEventSourceDialog
 import org.nostr.nostrord.ui.components.chat.DmMessageContextMenu
+import org.nostr.nostrord.ui.components.chat.DmRelaysDialog
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
 import org.nostr.nostrord.ui.components.layout.DmConversationList
@@ -170,6 +181,15 @@ fun DmPageScreen(
                 ?: metadata?.name?.takeIf { it.isNotBlank() }
                 ?: vm.npub.take(12) + "..."
 
+        val copyToClipboard = rememberClipboardWriter()
+        val isFollowing by vm.isFollowing.collectAsState()
+        var headerMenuOpen by remember { mutableStateOf(false) }
+        var relaysDialogOpen by remember { mutableStateOf(false) }
+        val peerRelays by remember(pubkey) { dmVm.peerDmRelays(pubkey) }.collectAsState()
+        if (relaysDialogOpen) {
+            DmRelaysDialog(relays = peerRelays, onDismiss = { relaysDialogOpen = false })
+        }
+
         Row(
             modifier = Modifier.fillMaxWidth().height(48.dp).padding(horizontal = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
@@ -203,14 +223,59 @@ fun DmPageScreen(
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            Surface(shape = NostrordShapes.shapeSmall, color = NostrordColors.BackgroundFloating) {
-                Text(
-                    "DM · encrypted",
-                    color = NostrordColors.TextMuted,
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Medium,
-                    modifier = Modifier.padding(horizontal = 6.dp, vertical = 2.dp),
-                )
+            Spacer(modifier = Modifier.weight(1f))
+            Box {
+                IconButton(onClick = { headerMenuOpen = true }) {
+                    Icon(
+                        imageVector = Icons.Outlined.MoreVert,
+                        contentDescription = "More",
+                        tint = NostrordColors.TextSecondary,
+                    )
+                }
+                DropdownMenu(
+                    expanded = headerMenuOpen,
+                    onDismissRequest = { headerMenuOpen = false },
+                    containerColor = NostrordColors.Surface,
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("View profile") },
+                        leadingIcon = { Icon(Icons.Outlined.Person, contentDescription = null) },
+                        onClick = {
+                            headerMenuOpen = false
+                            onOpenProfile(UserRoute(pubkey))
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(if (isFollowing) "Unfollow" else "Follow") },
+                        leadingIcon = {
+                            Icon(
+                                if (isFollowing) Icons.Outlined.PersonRemove else Icons.Outlined.PersonAdd,
+                                contentDescription = null,
+                            )
+                        },
+                        onClick = {
+                            headerMenuOpen = false
+                            vm.toggleFollow()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Copy npub") },
+                        leadingIcon = { Icon(Icons.Outlined.ContentCopy, contentDescription = null) },
+                        onClick = {
+                            headerMenuOpen = false
+                            copyToClipboard(vm.npub)
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text("View DM relays") },
+                        leadingIcon = { Icon(Icons.Outlined.Public, contentDescription = null) },
+                        onClick = {
+                            headerMenuOpen = false
+                            dmVm.loadPeerDmRelays(pubkey)
+                            relaysDialogOpen = true
+                        },
+                    )
+                }
             }
         }
         HorizontalDivider(color = NostrordColors.Divider)
@@ -248,7 +313,6 @@ fun DmPageScreen(
                 modifier = Modifier.widthIn(max = 320.dp),
             )
             val chatItems = remember(messages) { buildDmChatItems(messages) }
-            val copyToClipboard = rememberClipboardWriter()
             var menuForId by remember { mutableStateOf<String?>(null) }
             var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
             var sourceForId by remember { mutableStateOf<String?>(null) }
@@ -288,7 +352,6 @@ fun DmPageScreen(
                                 onDismiss = { menuForId = null },
                                 onViewSource = { sourceForId = m.id },
                                 onCopyText = { copyToClipboard(m.content) },
-                                onCopyJson = { copyToClipboard(m.eventJson()) },
                             )
                             // Web parity (.dm-bubble max-width 75%): the spacer eats the other
                             // 25% on the bubble's growth side; the Box owns the 75% slot and

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -56,6 +56,8 @@ import org.nostr.nostrord.ui.components.chat.DmEventSourceDialog
 import org.nostr.nostrord.ui.components.chat.DmMessageContextMenu
 import org.nostr.nostrord.ui.components.chat.DmRelaysDialog
 import org.nostr.nostrord.ui.components.chat.MessageComposer
+import org.nostr.nostrord.ui.components.chat.MessageContent
+import org.nostr.nostrord.ui.components.chat.SendStateIcon
 import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
 import org.nostr.nostrord.ui.components.layout.DmConversationList
 import org.nostr.nostrord.ui.components.layout.FrameMenuButton
@@ -146,6 +148,7 @@ fun DmPageScreen(
         val dmVm = viewModel { DmViewModel(AppModule.nostrRepository) }
         val messagesByPeer by dmVm.messagesByPeer.collectAsState()
         val messages = messagesByPeer[pubkey].orEmpty()
+        val dmStatus by dmVm.messageStatus.collectAsState()
         // Mark the conversation read while it is open (and as new messages stream in).
         LaunchedEffect(pubkey, messages.size) {
             if (messages.isNotEmpty()) dmVm.markRead(pubkey)
@@ -156,8 +159,23 @@ fun DmPageScreen(
 
         // Open a conversation pinned to the latest message (scroll to the bottom), like a chat.
         val messagesScroll = rememberScrollState()
+        // True while the user rests at the bottom; drives whether async media growth keeps the view
+        // pinned. Recomputed only when a scroll gesture settles, so programmatic follow-scrolls (and
+        // the moment media grows maxValue) don't flip it off.
+        val pinnedToBottom = remember { mutableStateOf(true) }
         LaunchedEffect(pubkey, messages.size) {
             messagesScroll.scrollTo(messagesScroll.maxValue)
+            pinnedToBottom.value = true
+        }
+        LaunchedEffect(messagesScroll.isScrollInProgress) {
+            if (!messagesScroll.isScrollInProgress) {
+                pinnedToBottom.value = messagesScroll.value >= messagesScroll.maxValue - 40
+            }
+        }
+        // Inline media (images/video) loads after render and raises maxValue; follow it to the
+        // bottom when the user was pinned, so the newest message stays in view.
+        LaunchedEffect(messagesScroll.maxValue) {
+            if (pinnedToBottom.value) messagesScroll.scrollTo(messagesScroll.maxValue)
         }
 
         val send = {
@@ -365,24 +383,31 @@ fun DmPageScreen(
                                     shape = NostrordShapes.shapeMedium,
                                     color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
                                 ) {
-                                    // Clock rides beside the text's last line, bottom-aligned
-                                    // (web parity: the float-right .dm-bubble-time).
-                                    Row(
-                                        modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm),
-                                        verticalAlignment = Alignment.Bottom,
-                                    ) {
-                                        Text(
-                                            m.content,
-                                            color = if (m.mine) Color.White else NostrordColors.TextPrimary,
-                                            fontSize = 14.sp,
-                                            modifier = Modifier.weight(1f, fill = false),
+                                    Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
+                                        // Rich body: inline images/video/audio/links/mentions/markdown,
+                                        // reusing the group chat renderer. White text on the "mine" bubble.
+                                        MessageContent(
+                                            content = m.content,
+                                            onMentionClick = { onOpenProfile(UserRoute(it)) },
+                                            textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
                                         )
-                                        Text(
-                                            formatTime(m.createdAt),
-                                            color = if (m.mine) Color.White.copy(alpha = 0.7f) else NostrordColors.TextMuted,
-                                            fontSize = 10.sp,
-                                            modifier = Modifier.padding(start = Spacing.xs),
-                                        )
+                                        // Time + send-state (clock while Sending, check once Delivered),
+                                        // reusing the group chat's SendStateIcon on own messages.
+                                        Row(
+                                            modifier = Modifier.align(Alignment.End).padding(top = Spacing.xxs),
+                                            verticalAlignment = Alignment.CenterVertically,
+                                        ) {
+                                            Text(
+                                                formatTime(m.createdAt),
+                                                color = if (m.mine) Color.White.copy(alpha = 0.7f) else NostrordColors.TextMuted,
+                                                fontSize = 10.sp,
+                                            )
+                                            if (m.mine) {
+                                                dmStatus[m.id]?.let { st ->
+                                                    SendStateIcon(status = st, tint = Color.White.copy(alpha = 0.7f))
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
@@ -41,7 +42,10 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.chat.DateSeparator
+import org.nostr.nostrord.ui.components.chat.DmEventSourceDialog
+import org.nostr.nostrord.ui.components.chat.DmMessageContextMenu
 import org.nostr.nostrord.ui.components.chat.MessageComposer
+import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
 import org.nostr.nostrord.ui.components.layout.DmConversationList
 import org.nostr.nostrord.ui.components.layout.FrameMenuButton
 import org.nostr.nostrord.ui.components.layout.PageHeader
@@ -52,6 +56,7 @@ import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.utils.formatTime
+import org.nostr.nostrord.utils.rememberClipboardWriter
 
 /**
  * Direct-message conversation page (NIP-17). Renders the decrypted thread and a composer that
@@ -243,6 +248,18 @@ fun DmPageScreen(
                 modifier = Modifier.widthIn(max = 320.dp),
             )
             val chatItems = remember(messages) { buildDmChatItems(messages) }
+            val copyToClipboard = rememberClipboardWriter()
+            var menuForId by remember { mutableStateOf<String?>(null) }
+            var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
+            var sourceForId by remember { mutableStateOf<String?>(null) }
+            messages.firstOrNull { it.id == sourceForId }?.let { src ->
+                DmEventSourceDialog(
+                    json = src.prettyEventJson(),
+                    relays = src.relays,
+                    onCopyJson = { copyToClipboard(src.eventJson()) },
+                    onDismiss = { sourceForId = null },
+                )
+            }
             chatItems.forEach { item ->
                 when (item) {
                     is DmChatItem.DateSeparator -> DateSeparator(item.label)
@@ -251,9 +268,28 @@ fun DmPageScreen(
                         // WhatsApp/Telegram-style: a small clock inside every bubble,
                         // bottom-right under the text.
                         Row(
-                            modifier = Modifier.fillMaxWidth().padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs),
+                            modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs)
+                                // Tap (mobile) / right-click (desktop) opens the context menu
+                                // at the pointer, same interaction as group chat rows.
+                                .then(
+                                    rightClickContextMenuModifier { clickOffset ->
+                                        menuAnchorPx = clickOffset
+                                        menuForId = m.id
+                                    },
+                                ),
                             verticalAlignment = Alignment.Bottom,
                         ) {
+                            DmMessageContextMenu(
+                                visible = menuForId == m.id,
+                                anchorOffsetPx = menuAnchorPx,
+                                onDismiss = { menuForId = null },
+                                onViewSource = { sourceForId = m.id },
+                                onCopyText = { copyToClipboard(m.content) },
+                                onCopyJson = { copyToClipboard(m.eventJson()) },
+                            )
                             // Web parity (.dm-bubble max-width 75%): the spacer eats the other
                             // 25% on the bubble's growth side; the Box owns the 75% slot and
                             // pins the bubble to the correct edge inside it.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
@@ -65,12 +65,18 @@ val WebAvatar =
 
         val seed = props.seed?.takeIf { it.isNotBlank() } ?: props.name
         val kind = props.kind ?: AvatarKind.USER
-        // Drop the retained URL when this component is reused for a DIFFERENT identity (list
-        // slot reuse): without this, a member row recycled for another user would briefly show
-        // the previous user's avatar (leaked picture).
+        // Drop the retained URL AND load state when this component is reused for a DIFFERENT
+        // identity (list slot reuse, or the DM header switching peers): without this, the
+        // previous identity's photo stays at opacity 1 (loaded == true) and paints for a frame
+        // before the url effect recomputes, leaking the old avatar. Resetting during render (a
+        // React-sanctioned prop-change adjustment, guarded by the ref so it runs once) discards
+        // this render before it commits, so the stale picture never shows.
         if (lastSeedRef.current != seed) {
             lastSeedRef.current = seed
             lastUrlRef.current = null
+            setLoaded(false)
+            setErrored(false)
+            setAttempts(0)
         }
         // Keep the last good picture if the URL transiently drops to null/blank for the SAME
         // identity (metadata churn, an LRU eviction that briefly removes the entry, or a parent

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/DmEventSourceModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/DmEventSourceModal.kt
@@ -1,0 +1,71 @@
+package org.nostr.nostrord.web.modals
+
+import org.nostr.nostrord.web.components.useEscClose
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.pre
+import web.cssom.ClassName
+
+external interface DmEventSourceModalProps : Props {
+    var json: String
+    var relays: Array<String>
+    var onCopy: () -> Unit
+    var onClose: () -> Unit
+}
+
+/**
+ * "View source" for a DM: the decrypted kind:14 rumor as pretty JSON plus the relays its
+ * gift wrap was seen on this session. Mirrors the Compose DmEventSourceDialog.
+ */
+val DmEventSourceModal =
+    FC<DmEventSourceModalProps> { props ->
+        useEscClose { props.onClose() }
+
+        div {
+            className = ClassName("modal-overlay")
+            onClick = { props.onClose() }
+            div {
+                className = ClassName("modal-card sm")
+                onClick = { it.stopPropagation() }
+
+                div {
+                    className = ClassName("modal-title")
+                    +"Message source"
+                }
+                pre {
+                    className = ClassName("dm-source-json")
+                    +props.json
+                }
+                if (props.relays.isNotEmpty()) {
+                    div {
+                        className = ClassName("dm-source-relays-label")
+                        +"Seen on"
+                    }
+                    props.relays.forEach { relay ->
+                        div {
+                            className = ClassName("dm-source-relay")
+                            +relay
+                        }
+                    }
+                }
+                div {
+                    className = ClassName("modal-footer")
+                    button {
+                        className = ClassName("btn-text")
+                        onClick = { props.onClose() }
+                        +"Close"
+                    }
+                    button {
+                        className = ClassName("btn-primary")
+                        onClick = {
+                            props.onCopy()
+                            props.onClose()
+                        }
+                        +"Copy JSON"
+                    }
+                }
+            }
+        }
+    }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/DmRelaysModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/DmRelaysModal.kt
@@ -1,0 +1,57 @@
+package org.nostr.nostrord.web.modals
+
+import org.nostr.nostrord.web.components.useEscClose
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import web.cssom.ClassName
+
+external interface DmRelaysModalProps : Props {
+    var relays: Array<String>
+    var onClose: () -> Unit
+}
+
+/**
+ * Where a peer's DMs route: their published kind:10050 relay list. Empty until the fetch lands,
+ * or when the peer has published none (senders fall back to defaults). Mirrors the Compose dialog.
+ */
+val DmRelaysModal =
+    FC<DmRelaysModalProps> { props ->
+        useEscClose { props.onClose() }
+
+        div {
+            className = ClassName("modal-overlay")
+            onClick = { props.onClose() }
+            div {
+                className = ClassName("modal-card sm")
+                onClick = { it.stopPropagation() }
+
+                div {
+                    className = ClassName("modal-title")
+                    +"DM relays"
+                }
+                if (props.relays.isEmpty()) {
+                    div {
+                        className = ClassName("modal-subtitle tight")
+                        +"No published DM relay list yet. Messages route to default relays."
+                    }
+                } else {
+                    props.relays.forEach { relay ->
+                        div {
+                            className = ClassName("dm-source-relay")
+                            +relay
+                        }
+                    }
+                }
+                div {
+                    className = ClassName("modal-footer")
+                    button {
+                        className = ClassName("btn-primary")
+                        onClick = { props.onClose() }
+                        +"Close"
+                    }
+                }
+            }
+        }
+    }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -81,12 +81,14 @@ import react.dom.html.ReactHTML.br
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.code
 import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.em
 import react.dom.html.ReactHTML.img
 import react.dom.html.ReactHTML.input
 import react.dom.html.ReactHTML.kbd
 import react.dom.html.ReactHTML.pre
 import react.dom.html.ReactHTML.s
 import react.dom.html.ReactHTML.span
+import react.dom.html.ReactHTML.strong
 import react.dom.html.ReactHTML.textarea
 import react.useEffect
 import react.useMemo
@@ -3410,7 +3412,11 @@ private fun ChildrenBuilder.renderTextWithEmojis(text: String, emojiMap: Map<Str
  * Render message text: fenced code blocks (```), then inline `code`, then links / images /
  * videos / NIP-27 mentions / event & group refs in the remaining text — mirroring native.
  */
-private fun ChildrenBuilder.renderMessageContent(
+// JS RegExp rejects inline (?m); use the MULTILINE option so `^` matches each line start.
+private val BLOCKQUOTE_REGEX = Regex("^[ \\t]*>[ \\t]?.*(?:\\r?\\n[ \\t]*>[ \\t]?.*)*", RegexOption.MULTILINE)
+private val BLOCKQUOTE_LINE_PREFIX = Regex("^[ \\t]*>[ \\t]?", RegexOption.MULTILINE)
+
+internal fun ChildrenBuilder.renderMessageContent(
     content: String,
     tags: List<List<String>>,
     userMetadata: Map<String, UserMetadata>,
@@ -3422,6 +3428,36 @@ private fun ChildrenBuilder.renderMessageContent(
     val emojiMap = extractEmojiMap(tags)
     val posters = extractVideoPosters(tags)
     val dims = Nip68.extractImetaDimensions(tags)
+    // Split blockquote blocks (`> ` line runs) out first; each renders in a quote box with its
+    // inner text (markers stripped) run back through the normal body. Mirrors native Blockquote.
+    var qLast = 0
+    for (q in BLOCKQUOTE_REGEX.findAll(content)) {
+        if (q.range.first > qLast) {
+            renderBody(content.substring(qLast, q.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+        }
+        div {
+            className = ClassName("msg-quote")
+            renderBody(q.value.replace(BLOCKQUOTE_LINE_PREFIX, ""), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+        }
+        qLast = q.range.last + 1
+    }
+    if (qLast < content.length) {
+        renderBody(content.substring(qLast), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+    }
+}
+
+/** The message body pipeline (code fences → inline code → entities → formatting), quote-free. */
+private fun ChildrenBuilder.renderBody(
+    content: String,
+    emojiMap: Map<String, String>,
+    posters: Map<String, String>,
+    dims: Map<String, Pair<Int, Int>>,
+    userMetadata: Map<String, UserMetadata>,
+    messagesById: Map<String, NostrGroupClient.NostrMessage>,
+    onUser: (String) -> Unit,
+    onEventRef: (String) -> Unit,
+    onGroupRef: (String, String?) -> Unit,
+) {
     var last = 0
     for (block in CODE_BLOCK_REGEX.findAll(content)) {
         if (block.range.first > last) {
@@ -3622,26 +3658,31 @@ private fun ChildrenBuilder.renderEntities(
     if (last < content.length) renderFormattedText(content.substring(last), emojiMap)
 }
 
-private val STRIKE_OR_SPOILER_REGEX = Regex("~~[\\s\\S]+?~~|\\|\\|[\\s\\S]+?\\|\\|")
+// Inline formatting tokens, longest markers first so **bold** wins over *bold* and ~~/|| aren't
+// split. Mirrors native MessageContentParser: * and ** are bold (additive), _ italic, ~~ strike,
+// || spoiler.
+private val INLINE_FORMAT_REGEX =
+    Regex("~~[\\s\\S]+?~~|\\|\\|[\\s\\S]+?\\|\\||\\*\\*[\\s\\S]+?\\*\\*|\\*[^*\\n]+?\\*|_[^_\\n]+?_")
 
 /**
- * Render inline ~~strikethrough~~ and ||spoiler|| in a non-URL text run, delegating the
- * remaining text to [renderTextWithEmojis]. Mirrors native MessageContent's Strikethrough
- * / Spoiler parts.
+ * Render inline *bold* / **bold**, _italic_, ~~strikethrough~~ and ||spoiler|| in a non-URL text
+ * run, delegating the remaining text to [renderTextWithEmojis]. Mirrors native MessageContent.
  */
 private fun ChildrenBuilder.renderFormattedText(text: String, emojiMap: Map<String, String>) {
     var last = 0
-    for (m in STRIKE_OR_SPOILER_REGEX.findAll(text)) {
+    for (m in INLINE_FORMAT_REGEX.findAll(text)) {
         if (m.range.first > last) renderTextWithEmojis(text.substring(last, m.range.first), emojiMap)
         val token = m.value
-        val inner = token.substring(2, token.length - 2)
-        if (token.startsWith("~~")) {
-            s {
-                className = ClassName("msg-strike")
-                renderTextWithEmojis(inner, emojiMap)
-            }
-        } else {
-            Spoiler { content = inner }
+        when {
+            token.startsWith("~~") ->
+                s {
+                    className = ClassName("msg-strike")
+                    renderTextWithEmojis(token.substring(2, token.length - 2), emojiMap)
+                }
+            token.startsWith("||") -> Spoiler { content = token.substring(2, token.length - 2) }
+            token.startsWith("**") -> strong { renderTextWithEmojis(token.substring(2, token.length - 2), emojiMap) }
+            token.startsWith("*") -> strong { renderTextWithEmojis(token.substring(1, token.length - 1), emojiMap) }
+            else -> em { renderTextWithEmojis(token.substring(1, token.length - 1), emojiMap) }
         }
         last = m.range.last + 1
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -3201,7 +3201,7 @@ private val MessageRow =
         }
     }
 
-private fun ChildrenBuilder.ctxItem(
+internal fun ChildrenBuilder.ctxItem(
     ic: Ic,
     label: String,
     danger: Boolean = false,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -168,6 +168,13 @@ val DmPage =
         val (uploadCount, setUploadCount) = useState { 0 }
         val (uploadError, setUploadError) = useState<String?> { null }
         val composerInputRef = useRef<HTMLTextAreaElement>(null)
+        // Auto-grow the composer as newlines are added (Shift+Enter), matching the group chat
+        // composer; reset to "auto" first so it also shrinks when text is deleted or sent.
+        useEffect(text) {
+            val el = composerInputRef.current ?: return@useEffect
+            el.style.height = "auto"
+            el.style.height = "${el.scrollHeight}px"
+        }
 
         // Header kebab menu + its DM-relays modal.
         val isFollowing = useStateFlow(vm.isFollowing)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -4,9 +4,13 @@ import kotlinx.browser.document
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
+import org.nostr.nostrord.ui.screens.dm.DmChatItem
 import org.nostr.nostrord.ui.screens.dm.DmViewModel
+import org.nostr.nostrord.ui.screens.dm.buildDmChatItems
 import org.nostr.nostrord.ui.screens.profile.ProfilePageViewModel
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.formatDateTime
+import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.web.DmConversationList
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
@@ -211,13 +215,42 @@ val DmPage =
                         +"Beginning of your direct conversation with $name. Direct messages are encrypted (NIP-17)."
                     }
                 }
-                messages.forEach { m ->
-                    div {
-                        key = m.id
-                        className = ClassName(if (m.mine) "dm-msg mine" else "dm-msg")
-                        div {
-                            className = ClassName("dm-bubble")
-                            +m.content
+                buildDmChatItems(messages).forEach { item ->
+                    when (item) {
+                        is DmChatItem.DateSeparator ->
+                            div {
+                                key = "sep-${item.label}"
+                                className = ClassName("date-sep")
+                                span {
+                                    className = ClassName("date-sep-label")
+                                    +item.label
+                                }
+                            }
+                        is DmChatItem.Message -> {
+                            val m = item.message
+                            div {
+                                key = m.id
+                                className =
+                                    ClassName(
+                                        buildString {
+                                            append("dm-msg")
+                                            if (m.mine) append(" mine")
+                                            if (!item.firstInGroup) append(" grouped")
+                                        },
+                                    )
+                                // WhatsApp/Telegram-style: the clock floats bottom-right inside
+                                // every bubble (rides the last text line when it fits, wraps below
+                                // otherwise); hover shows the full date.
+                                div {
+                                    className = ClassName("dm-bubble")
+                                    title = formatDateTime(m.createdAt)
+                                    +m.content
+                                    span {
+                                        className = ClassName("dm-bubble-time")
+                                        +formatTime(m.createdAt)
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.web.screens
 
 import kotlinx.browser.document
 import kotlinx.browser.window
+import kotlinx.coroutines.awaitCancellation
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
@@ -24,6 +25,7 @@ import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.copyToClipboard
 import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.sendStateIcon
 import org.nostr.nostrord.web.components.uploadBlob
 import org.nostr.nostrord.web.components.useEscClose
 import org.nostr.nostrord.web.modals.DmEventSourceModal
@@ -107,14 +109,38 @@ val DmPage =
         val metadata = useStateFlow(vm.metadata)
         val dmVm = useViewModel { DmViewModel(AppModule.nostrRepository) }
         val messages = useStateFlow(dmVm.messagesByPeer)[pubkey].orEmpty()
+        // Metadata map for resolving @-mention names inside rich message bodies.
+        val userMetadata = useStateFlow(dmVm.userMetadata)
+        val dmStatus = useStateFlow(dmVm.messageStatus)
         // Mark the conversation read while it is open (and as new messages stream in).
         useEffect(pubkey, messages.size) {
             if (messages.isNotEmpty()) dmVm.markRead(pubkey)
         }
         // Open a conversation pinned to the latest message (scroll to the bottom), like a chat.
         val messagesRef = useRef<HTMLDivElement>(null)
+        // True while the user is at (or near) the bottom; drives whether async media growth keeps
+        // the view pinned. Updated on scroll; seeded true so a fresh conversation stays pinned.
+        val pinnedToBottom = useRef(true)
         useEffect(pubkey, messages.size) {
             messagesRef.current?.let { el -> el.scrollTop = el.scrollHeight.toDouble() }
+            pinnedToBottom.current = true
+        }
+        // Inline media (images/video/audio) loads after render and grows the list; if the user was
+        // at the bottom, follow the growth so the newest message stays in view. A capturing listener
+        // catches child load/loadedmetadata (they don't bubble). Setting scrollTop is jank-free.
+        useEffect(pubkey) {
+            val el = messagesRef.current ?: return@useEffect
+            val onMediaLoad: (dynamic) -> Unit = {
+                if (pinnedToBottom.current == true) el.scrollTop = el.scrollHeight.toDouble()
+            }
+            el.asDynamic().addEventListener("load", onMediaLoad, true)
+            el.asDynamic().addEventListener("loadedmetadata", onMediaLoad, true)
+            try {
+                awaitCancellation()
+            } finally {
+                el.asDynamic().removeEventListener("load", onMediaLoad, true)
+                el.asDynamic().removeEventListener("loadedmetadata", onMediaLoad, true)
+            }
         }
         val (text, setText) = useState { "" }
         val (sending, setSending) = useState { false }
@@ -268,6 +294,12 @@ val DmPage =
             div {
                 className = ClassName("dm-messages")
                 ref = messagesRef
+                onScroll = {
+                    val el = messagesRef.current
+                    if (el != null) {
+                        pinnedToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80.0
+                    }
+                }
                 div {
                     className = ClassName("dm-intro")
                     WebAvatar {
@@ -359,16 +391,28 @@ val DmPage =
                                         setMenuFor(m.id)
                                     }
                                 }
-                                // WhatsApp/Telegram-style: the clock floats bottom-right inside
-                                // every bubble (rides the last text line when it fits, wraps below
-                                // otherwise); hover shows the full date.
+                                // Clock on its own line below the message, right-aligned (matches
+                                // native); hover shows the full date.
                                 div {
                                     className = ClassName("dm-bubble")
                                     title = formatDateTime(m.createdAt)
-                                    +m.content
+                                    // Rich body: inline images/video/audio/links/mentions/markdown,
+                                    // reusing the group chat renderer (same package).
+                                    renderMessageContent(
+                                        m.content,
+                                        emptyList(),
+                                        userMetadata,
+                                        emptyMap(),
+                                        { props.onOpenProfile(UserRoute(it)) },
+                                        {},
+                                        { _, _ -> },
+                                    )
                                     span {
                                         className = ClassName("dm-bubble-time")
                                         +formatTime(m.createdAt)
+                                        // Send state on own messages: clock while Sending, check
+                                        // once a relay OKs the wrap (reuses the group chat icon).
+                                        if (m.mine) sendStateIcon(dmStatus[m.id])
                                     }
                                 }
                             }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -1,12 +1,15 @@
 package org.nostr.nostrord.web.screens
 
 import kotlinx.browser.document
+import kotlinx.browser.window
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.screens.dm.DmChatItem
 import org.nostr.nostrord.ui.screens.dm.DmViewModel
 import org.nostr.nostrord.ui.screens.dm.buildDmChatItems
+import org.nostr.nostrord.ui.screens.dm.eventJson
+import org.nostr.nostrord.ui.screens.dm.prettyEventJson
 import org.nostr.nostrord.ui.screens.profile.ProfilePageViewModel
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.formatDateTime
@@ -19,9 +22,11 @@ import org.nostr.nostrord.web.components.EmojiPicker
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.components.copyToClipboard
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.uploadBlob
 import org.nostr.nostrord.web.components.useEscClose
+import org.nostr.nostrord.web.modals.DmEventSourceModal
 import react.ChildrenBuilder
 import react.FC
 import react.Props
@@ -37,6 +42,7 @@ import react.useState
 import web.cssom.ClassName
 import web.html.HTMLDivElement
 import web.html.HTMLTextAreaElement
+import kotlin.math.abs
 
 external interface DmPageProps : Props {
     /** Peer of the open conversation; null shows the section's empty hero. */
@@ -135,6 +141,35 @@ val DmPage =
         val (uploadCount, setUploadCount) = useState { 0 }
         val (uploadError, setUploadError) = useState<String?> { null }
         val composerInputRef = useRef<HTMLTextAreaElement>(null)
+
+        // Context menu (right-click / long-press on a bubble), mirroring ChatScreen's
+        // two-stage pattern trimmed to the DM action set.
+        val (menuFor, setMenuFor) = useState<String?> { null }
+        // Message whose source (rumor JSON + relays) is shown in the modal.
+        val (sourceFor, setSourceFor) = useState<String?> { null }
+        val (menuAt, setMenuAt) = useState { 0 to 0 }
+        val menuRef = useRef<HTMLDivElement>(null)
+        val longPressTimer = useRef(0)
+        val longPressReady = useRef(false)
+        val touchStartX = useRef(0.0)
+        val touchStartY = useRef(0.0)
+        // Timestamp (ms) of a touch-opened menu, to swallow the trailing ghost click.
+        val menuOpenedAt = useRef(0.0)
+
+        // Place the fixed menu at its anchor, flipping up/left when it would overflow.
+        useEffect(menuFor) {
+            if (menuFor == null) return@useEffect
+            val el = menuRef.current?.asDynamic() ?: return@useEffect
+            val w = el.offsetWidth as Int
+            val h = el.offsetHeight as Int
+            var left = menuAt.first
+            if (left + w > window.innerWidth - 8) left = (window.innerWidth - 8 - w).coerceAtLeast(8)
+            var top = menuAt.second
+            if (top + h > window.innerHeight - 8) top = (menuAt.second - h).coerceAtLeast(8)
+            el.style.left = "${left}px"
+            el.style.top = "${top}px"
+            el.style.visibility = "visible"
+        }
         useEscClose { if (emojiOpen) setEmojiOpen(false) }
 
         fun isMediaMime(type: String?): Boolean = type != null && (type.startsWith("image/") || type.startsWith("video/") || type.startsWith("audio/"))
@@ -238,6 +273,55 @@ val DmPage =
                                             if (!item.firstInGroup) append(" grouped")
                                         },
                                     )
+                                // First right-click opens our menu at the cursor; with it open the
+                                // second lands on the overlay, which closes ours without
+                                // preventDefault so the native menu shows (Telegram-style).
+                                onContextMenu = { event ->
+                                    if (menuFor == null) {
+                                        event.preventDefault()
+                                        menuOpenedAt.current = 0.0
+                                        setMenuAt(event.clientX.toInt() to event.clientY.toInt())
+                                        setMenuFor(m.id)
+                                    } else {
+                                        setMenuFor(null)
+                                    }
+                                }
+                                // Stationary 380ms hold arms the long-press; the menu opens on
+                                // touchend so the page can't jump while the finger is down.
+                                onTouchStart = { event ->
+                                    val t = event.asDynamic().touches[0]
+                                    touchStartX.current = t.clientX as Double
+                                    touchStartY.current = t.clientY as Double
+                                    longPressReady.current = false
+                                    window.clearTimeout(longPressTimer.current ?: 0)
+                                    longPressTimer.current = window.setTimeout({
+                                        longPressReady.current = true
+                                        val nav = window.navigator.asDynamic()
+                                        if (nav.vibrate != null) nav.vibrate(15)
+                                    }, 380)
+                                }
+                                onTouchMove = { event ->
+                                    val t = event.asDynamic().touches[0]
+                                    val dx = (t.clientX as Double) - (touchStartX.current ?: 0.0)
+                                    val dy = (t.clientY as Double) - (touchStartY.current ?: 0.0)
+                                    if (abs(dx) > 10.0 || abs(dy) > 10.0) {
+                                        window.clearTimeout(longPressTimer.current ?: 0)
+                                        longPressReady.current = false
+                                    }
+                                }
+                                onTouchEnd = { event ->
+                                    window.clearTimeout(longPressTimer.current ?: 0)
+                                    if (longPressReady.current == true && menuFor == null) {
+                                        // Suppress the synthesized click so it can't hit the
+                                        // overlay and instantly close the menu we're opening.
+                                        event.preventDefault()
+                                        menuOpenedAt.current = kotlin.js.Date.now()
+                                        setMenuAt(
+                                            (touchStartX.current ?: 0.0).toInt() to (touchStartY.current ?: 0.0).toInt(),
+                                        )
+                                        setMenuFor(m.id)
+                                    }
+                                }
                                 // WhatsApp/Telegram-style: the clock floats bottom-right inside
                                 // every bubble (rides the last text line when it fits, wraps below
                                 // otherwise); hover shows the full date.
@@ -253,6 +337,51 @@ val DmPage =
                             }
                         }
                     }
+                }
+            }
+
+            val menuMsg = messages.firstOrNull { it.id == menuFor }
+            if (menuMsg != null) {
+                div {
+                    className = ClassName("ctx-overlay")
+                    onTouchStart = { it.stopPropagation() }
+                    onTouchMove = { it.stopPropagation() }
+                    onTouchEnd = { it.stopPropagation() }
+                    onClick = {
+                        // Ignore the synthesized click that trails a touch-open.
+                        if (kotlin.js.Date.now() - (menuOpenedAt.current ?: 0.0) > 400.0) setMenuFor(null)
+                    }
+                    // Close without preventDefault so the browser shows its native menu.
+                    onContextMenu = { setMenuFor(null) }
+                }
+                div {
+                    ref = menuRef
+                    className = ClassName("ctx-menu")
+                    onTouchStart = { it.stopPropagation() }
+                    onTouchMove = { it.stopPropagation() }
+                    onTouchEnd = { it.stopPropagation() }
+                    ctxItem(Ic.Visibility, "View source") {
+                        setSourceFor(menuMsg.id)
+                        setMenuFor(null)
+                    }
+                    ctxItem(Ic.ContentCopy, "Copy text") {
+                        copyToClipboard(menuMsg.content)
+                        setMenuFor(null)
+                    }
+                    ctxItem(Ic.Code, "Copy event JSON") {
+                        copyToClipboard(menuMsg.eventJson())
+                        setMenuFor(null)
+                    }
+                }
+            }
+
+            val sourceMsg = messages.firstOrNull { it.id == sourceFor }
+            if (sourceMsg != null) {
+                DmEventSourceModal {
+                    json = sourceMsg.prettyEventJson()
+                    relays = sourceMsg.relays.toTypedArray()
+                    onCopy = { copyToClipboard(sourceMsg.eventJson()) }
+                    onClose = { setSourceFor(null) }
                 }
             }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -27,6 +27,7 @@ import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.uploadBlob
 import org.nostr.nostrord.web.components.useEscClose
 import org.nostr.nostrord.web.modals.DmEventSourceModal
+import org.nostr.nostrord.web.modals.DmRelaysModal
 import react.ChildrenBuilder
 import react.FC
 import react.Props
@@ -142,6 +143,12 @@ val DmPage =
         val (uploadError, setUploadError) = useState<String?> { null }
         val composerInputRef = useRef<HTMLTextAreaElement>(null)
 
+        // Header kebab menu + its DM-relays modal.
+        val isFollowing = useStateFlow(vm.isFollowing)
+        val peerRelays = useStateFlow(dmVm.dmRelaysByPubkey)[pubkey].orEmpty()
+        val (headerMenuOpen, setHeaderMenuOpen) = useState { false }
+        val (relaysOpen, setRelaysOpen) = useState { false }
+
         // Context menu (right-click / long-press on a bubble), mirroring ChatScreen's
         // two-stage pattern trimmed to the DM action set.
         val (menuFor, setMenuFor) = useState<String?> { null }
@@ -222,9 +229,39 @@ val DmPage =
                         +name
                     }
                 }
-                span {
-                    className = ClassName("dm-chip")
-                    +"DM · encrypted"
+                div {
+                    className = ClassName("dm-header-menu-wrap")
+                    button {
+                        className = ClassName("icon-btn")
+                        onClick = { setHeaderMenuOpen(true) }
+                        icon(Ic.MoreVert)
+                    }
+                    if (headerMenuOpen) {
+                        div {
+                            className = ClassName("dm-header-menu-backdrop")
+                            onClick = { setHeaderMenuOpen(false) }
+                        }
+                        div {
+                            className = ClassName("dm-header-menu")
+                            ctxItem(Ic.Person, "View profile") {
+                                setHeaderMenuOpen(false)
+                                props.onOpenProfile(UserRoute(pubkey))
+                            }
+                            ctxItem(if (isFollowing) Ic.PersonRemove else Ic.PersonAdd, if (isFollowing) "Unfollow" else "Follow") {
+                                setHeaderMenuOpen(false)
+                                vm.toggleFollow()
+                            }
+                            ctxItem(Ic.ContentCopy, "Copy npub") {
+                                setHeaderMenuOpen(false)
+                                copyToClipboard(vm.npub)
+                            }
+                            ctxItem(Ic.Public, "View DM relays") {
+                                setHeaderMenuOpen(false)
+                                dmVm.loadPeerDmRelays(pubkey)
+                                setRelaysOpen(true)
+                            }
+                        }
+                    }
                 }
             }
 
@@ -368,10 +405,6 @@ val DmPage =
                         copyToClipboard(menuMsg.content)
                         setMenuFor(null)
                     }
-                    ctxItem(Ic.Code, "Copy event JSON") {
-                        copyToClipboard(menuMsg.eventJson())
-                        setMenuFor(null)
-                    }
                 }
             }
 
@@ -382,6 +415,14 @@ val DmPage =
                     relays = sourceMsg.relays.toTypedArray()
                     onCopy = { copyToClipboard(sourceMsg.eventJson()) }
                     onClose = { setSourceFor(null) }
+                }
+            }
+            // Rendered after the message list so toggling it never shifts the list's
+            // sibling position (which would remount it and reset the scroll to the top).
+            if (relaysOpen) {
+                DmRelaysModal {
+                    relays = peerRelays.toTypedArray()
+                    onClose = { setRelaysOpen(false) }
                 }
             }
 

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2844,6 +2844,7 @@ body {
     border: 0;
     background: transparent;
     resize: none;
+    overflow-y: auto;
     font-family: inherit;
     font-size: 15px;
     line-height: 1.4;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2703,6 +2703,35 @@ body {
     color: rgb(255 255 255 / 0.7);
 }
 
+/* DM "View source" modal: monospace rumor JSON + relay list. */
+.dm-source-json {
+    max-height: 320px;
+    margin: var(--space-sm) 0;
+    padding: var(--space-sm);
+    overflow: auto;
+    border-radius: var(--radius-sm);
+    background: var(--color-surface-variant);
+    color: var(--color-text-primary);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px;
+    line-height: 1.5;
+    white-space: pre;
+}
+
+.dm-source-relays-label {
+    margin-top: var(--space-sm);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+}
+
+.dm-source-relay {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px;
+    color: var(--color-text-muted);
+    overflow-wrap: anywhere;
+}
+
 .dm-bubble {
     max-width: 75%;
     padding: 8px 12px;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2605,14 +2605,31 @@ body {
     border-radius: var(--radius-full);
 }
 
-.dm-chip {
-    flex-shrink: 0;
-    padding: 2px 6px;
-    font-size: 10px;
-    font-weight: 500;
-    color: var(--color-text-muted);
-    background: var(--color-floating);
-    border-radius: var(--radius-sm);
+/* Header kebab menu: anchored below-right of the 3-dot button, with a click-catching backdrop. */
+.dm-header-menu-wrap {
+    position: relative;
+    margin-left: auto;
+}
+
+.dm-header-menu-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 40;
+}
+
+.dm-header-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 41;
+    width: 200px;
+    padding: 6px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-md);
+    box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.55);
+    -webkit-user-select: none;
+    user-select: none;
 }
 
 .dm-hero {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2679,8 +2679,28 @@ body {
     margin-top: 8px;
 }
 
+/* Consecutive same-side bubbles within the group window sit tight together. */
+.dm-msg.grouped {
+    margin-top: 2px;
+}
+
 .dm-msg.mine {
     justify-content: flex-end;
+}
+
+/* WhatsApp-style clock inside the bubble: floats after the text so it rides the
+   last line when it fits and drops below it when it doesn't. */
+.dm-bubble-time {
+    float: right;
+    margin: 8px -4px -2px 10px;
+    font-size: 10px;
+    line-height: 1;
+    color: var(--color-text-muted);
+    user-select: none;
+}
+
+.dm-msg.mine .dm-bubble-time {
+    color: rgb(255 255 255 / 0.7);
 }
 
 .dm-bubble {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2705,11 +2705,11 @@ body {
     justify-content: flex-end;
 }
 
-/* WhatsApp-style clock inside the bubble: floats after the text so it rides the
-   last line when it fits and drops below it when it doesn't. */
+/* Clock on its own line below the message, right-aligned (matches native). */
 .dm-bubble-time {
-    float: right;
-    margin: 8px -4px -2px 10px;
+    display: block;
+    text-align: right;
+    margin-top: 4px;
     font-size: 10px;
     line-height: 1;
     color: var(--color-text-muted);
@@ -2717,6 +2717,11 @@ body {
 }
 
 .dm-msg.mine .dm-bubble-time {
+    color: rgb(255 255 255 / 0.7);
+}
+
+/* Send-state icon (clock/check) rides the time inside the mine bubble; match its tint. */
+.dm-msg.mine .msg-state-icon {
     color: rgb(255 255 255 / 0.7);
 }
 
@@ -6102,6 +6107,14 @@ body {
 .msg-strike {
     color: var(--color-text-muted);
     text-decoration: line-through;
+}
+
+/* > blockquote: muted text behind a left accent bar (matches native Blockquote). */
+.msg-quote {
+    margin: 4px 0;
+    padding: 2px 0 2px 10px;
+    border-left: 3px solid var(--color-text-muted);
+    color: var(--color-text-muted);
 }
 
 /* ||spoiler||: blurred until clicked (matches the prototype Spoiler). */


### PR DESCRIPTION
Closes #183. Turns DMs from plain-text bubbles into a full chat surface, and hardens NIP-17 send/sync so messages actually propagate across devices. All screen logic is shared in commonMain; both the Compose (native) and React (web) UIs consume it.

The issue asked for dates, a context menu to see the event JSON, and "relays in which it was found". That is all here, plus the media/markdown/reliability work it pulled in along the way.

| Area | What changed |
| --- | --- |
| Dates | Day separators (Today / Yesterday / 23 May) and a per-bubble clock, both platforms |
| Rich bodies | Inline images, video, audio, links, mentions and markdown, reusing the group chat renderer (`MessageContent` / `renderMessageContent`) |
| Markdown | `**bold**` / `*bold*` (additive), `_italic_`, and `> blockquote` in the shared parser, rendered in group chat and DMs |
| Context menu | Right-click / long-press: View source (pretty rumor JSON + "Seen on" relays) and Copy text |
| Header menu | 3-dot menu: View profile, Follow/Unfollow, Copy npub, View DM relays |
| Reliable send | Each wrap waits for a relay OK and retries with backoff; a persisted per-account queue resumes undelivered wraps after an app restart |
| Delivery status | Sending -> Delivered (clock -> check) per rumor, reusing the group `MessageStatus` + icon |
| Cross-device sync | Inbox + publish target the union of the user's DM relays and the defaults, so devices always overlap regardless of when each resolves kind:10050 |
| Follows/Others | Seed the follow set from its cache at inbox start so the split is correct immediately instead of everything falling in Others |
| Desktop audio | Fixed a bogus duration ("18333:20") for streamed files whose duration the GStreamer backend can't determine |
| Polish | Media-load scroll pinning, unified time position, native View source dialog matched to web, web composer auto-grow on Shift+Enter, WebAvatar leak on peer switch |

Commits:
- fix(dm): auto-grow the web composer on Shift+Enter
- fix(dm): match the native View source dialog to the web modal
- feat(dm): rich message bodies, reliable send with status, and cross-device sync
- feat(chat): parse markdown bold, italic and blockquote
- fix(desktop): audio player showed a bogus duration for streamed files
- feat(dm): conversation header menu; trim the bubble menu and header
- fix(web): stop the previous avatar leaking when a slot is reused
- feat(dm): context menu on DM bubbles, with view source
- feat(dm): day separators and in-bubble time in the DM thread

Verified with `compileKotlinJvm` + `compileKotlinJs` + `:composeApp:jvmTest`; DM parser/status/seen-relays covered by commonTest. iOS deferred to a macOS session as usual. Validated end to end on Android, desktop and web (send, sync, delivery check, media, markdown).