### PR TITLE
chore(release): bump version to 2.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.1.1
-app.versionCode=15
+app.version=2.2.0
+app.versionCode=16
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Minor release: richer direct messages (#183) — media/markdown bodies, context + header menus, reliable send with delivery status, persisted retry queue, cross-device sync, and the desktop audio fix. Bumps app.version 2.1.1 -> 2.2.0 and versionCode 15 -> 16.