### PR TITLE
feat: mute user (NIP-51 kind:10000) across all platforms

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -301,6 +301,9 @@ object AppModule {
             findMessageAuthor = { messageId ->
                 groupManager.findMessageByIdAcrossGroups(messageId)?.second?.pubkey
             },
+            // Deferred to call time: by the first message flush the repository exists,
+            // so this lazy access never cycles with unreadManager's own construction.
+            isMutedAuthor = { pubkey -> pubkey in nostrRepository.mutedPubkeys.value },
             shouldNotify = { groupId, isDirect ->
                 notificationSettings.shouldNotify(
                     notificationSettings.effectiveLevelFor(groupId),

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -923,6 +923,16 @@ class NostrGroupClient(
                     put("limit", 1)
                 },
             )
+            // The NIP-51 mute list (kind:10000) rides the same REQ as its own filter
+            // (a shared filter with limit 1 would return only the newer of the two
+            // events), so the contact-list retry machinery covers it too.
+            add(
+                buildJsonObject {
+                    putJsonArray("kinds") { add(10000) }
+                    putJsonArray("authors") { add(pubkey) }
+                    put("limit", 1)
+                },
+            )
         }
         sendJson(req)
         return subId

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -27,9 +27,11 @@ import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.auth.ActiveAccountManager
@@ -72,7 +74,7 @@ import org.nostr.nostrord.storage.loadDmSyncCursor
 import org.nostr.nostrord.storage.loadDmWrapRumor
 import org.nostr.nostrord.storage.loadFollowingCacheFor
 import org.nostr.nostrord.storage.loadKind10000TimestampFor
-import org.nostr.nostrord.storage.loadMuteListFor
+import org.nostr.nostrord.storage.loadMuteListSnapshotFor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
 import org.nostr.nostrord.storage.saveDmLastRead
@@ -84,7 +86,7 @@ import org.nostr.nostrord.storage.saveDmWrapRumor
 import org.nostr.nostrord.storage.saveFollowingCacheFor
 import org.nostr.nostrord.storage.saveGroupFetchLazy
 import org.nostr.nostrord.storage.saveKind10000TimestampFor
-import org.nostr.nostrord.storage.saveMuteListFor
+import org.nostr.nostrord.storage.saveMuteListSnapshotFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
 import org.nostr.nostrord.utils.AppError
@@ -600,18 +602,62 @@ class NostrRepository(
     }
 
     // ===== NIP-51 mute list (kind:10000) =====
-    // Mirrors the kind:3 handling above: optimistic local set + debounced publish that
-    // preserves foreign tags/content, per-account persistence, staleness-guarded ingest.
+    // Mirrors the kind:3 handling above: optimistic local sets + debounced publish,
+    // per-account persistence, staleness-guarded ingest. New mutes go to the PRIVATE
+    // section (NIP-44 self-encrypted `content`); public `p` tags written by other clients
+    // are honored for filtering and kept public. Invariant: a `content` we could not
+    // decrypt is republished verbatim, never rebuilt, so another client's private data
+    // cannot be destroyed from here.
 
     private val _mutedPubkeys = MutableStateFlow<Set<String>>(emptySet())
     override val mutedPubkeys: StateFlow<Set<String>> = _mutedPubkeys.asStateFlow()
+    private var publicMuted: Set<String> = emptySet()
+    private var privateMuted: Set<String> = emptySet()
     private var muteListCreatedAt = 0L
     private var muteListContent = ""
-    private var muteListTags: List<List<String>> = emptyList()
+    private var muteListPublicTags: List<List<String>> = emptyList()
+
+    // Decrypted private-section tags, valid only for the ciphertext they came from:
+    // when muteListContent no longer matches, the section is treated as unreadable.
+    private var muteListPrivateTags: List<List<String>> = emptyList()
+    private var muteListPrivateDecryptedFrom = ""
     private var muteListRequested = false
     private var pendingMuteListPublish: Job? = null
     private var hasUnpublishedMuteChanges = false
     private val muteListMutex = Mutex()
+
+    /** Full last-known list, persisted so a publish after restart never rebuilds from a partial base. */
+    @Serializable
+    private data class MuteListSnapshot(
+        val createdAt: Long,
+        val publicTags: List<List<String>>,
+        val content: String,
+        val privateTags: List<List<String>>,
+        val privateDecryptedFrom: String,
+    )
+
+    /** True when the private section is safe to rebuild (absent, or we decrypted this exact ciphertext). */
+    private fun muteListPrivateWritable() = muteListContent.isBlank() || muteListContent == muteListPrivateDecryptedFrom
+
+    private fun applyMutedSetsAndPersist(pubkey: String) {
+        _mutedPubkeys.value = publicMuted + privateMuted
+        try {
+            SecureStorage.saveMuteListSnapshotFor(
+                pubkey,
+                Json.encodeToString(
+                    MuteListSnapshot(
+                        createdAt = muteListCreatedAt,
+                        publicTags = muteListPublicTags,
+                        content = muteListContent,
+                        privateTags = muteListPrivateTags,
+                        privateDecryptedFrom = muteListPrivateDecryptedFrom,
+                    ),
+                ),
+            )
+        } catch (_: Exception) {
+        }
+        SecureStorage.saveKind10000TimestampFor(pubkey, muteListCreatedAt)
+    }
 
     private fun handleKind10000Event(event: JsonObject) {
         // Only the active account's own list drives [mutedPubkeys].
@@ -626,23 +672,75 @@ class NostrRepository(
             event["tags"]?.jsonArray.orEmpty().map { tag ->
                 tag.jsonArray.mapNotNull { it.jsonPrimitive.contentOrNull }
             }
+        val content = event["content"]?.jsonPrimitive?.contentOrNull ?: ""
         muteListCreatedAt = createdAt
-        muteListContent = event["content"]?.jsonPrimitive?.contentOrNull ?: ""
-        muteListTags = tags
+        muteListPublicTags = tags
+        val contentChanged = content != muteListContent
+        muteListContent = content
+        if (content.isBlank()) {
+            muteListPrivateTags = emptyList()
+            muteListPrivateDecryptedFrom = ""
+        }
         muteListRequested = true
-        // Keep the optimistic set while local taps are unpublished, so a relay echo
+        // Keep the optimistic sets while local taps are unpublished, so a relay echo
         // arriving mid-mute doesn't clobber a just-tapped mute.
-        if (!hasUnpublishedMuteChanges) {
-            _mutedPubkeys.value = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(tags)
-            SecureStorage.saveMuteListFor(pubKey, _mutedPubkeys.value.toList())
-            SecureStorage.saveKind10000TimestampFor(pubKey, createdAt)
+        if (hasUnpublishedMuteChanges) return
+        publicMuted = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(tags)
+        if (content.isBlank()) {
+            privateMuted = emptySet()
+            applyMutedSetsAndPersist(pubKey)
+            return
+        }
+        applyMutedSetsAndPersist(pubKey)
+        if (!contentChanged && content == muteListPrivateDecryptedFrom) return
+        // Decrypt the private section off the ingest path (a bunker signer is a remote
+        // round-trip). One decrypt per new list, not per event.
+        scope.launch {
+            val signer = ActiveAccountManager.session.value?.signer ?: return@launch
+            val plaintext =
+                try {
+                    signer.nip44Decrypt(pubKey, content)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (_: Throwable) {
+                    // NIP-04-era or foreign encryption: leave the section opaque; the
+                    // writable() guard keeps it verbatim on publish.
+                    return@launch
+                }
+            val privateTags = org.nostr.nostrord.nostr.Nip51.decodeTags(plaintext) ?: return@launch
+            // Superseded while decrypting (newer event, local tap, account switch): drop it.
+            if (muteListContent != content || hasUnpublishedMuteChanges) return@launch
+            if (sessionManager.getPublicKey() != pubKey) return@launch
+            muteListPrivateTags = privateTags
+            muteListPrivateDecryptedFrom = content
+            privateMuted = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(privateTags)
+            applyMutedSetsAndPersist(pubKey)
         }
     }
 
-    /** Seed [mutedPubkeys] from the per-account cache so filtering works before the network answers. */
+    /** Seed the mute state from the per-account snapshot so filtering works before the network answers. */
     private fun hydrateMuteListFromCache(pubkey: String) {
-        _mutedPubkeys.value = SecureStorage.loadMuteListFor(pubkey).toSet()
         muteListCreatedAt = SecureStorage.loadKind10000TimestampFor(pubkey)
+        val snapshot =
+            SecureStorage.loadMuteListSnapshotFor(pubkey)?.let {
+                try {
+                    Json.decodeFromString<MuteListSnapshot>(it)
+                } catch (_: Exception) {
+                    null
+                }
+            }
+        if (snapshot == null) {
+            _mutedPubkeys.value = emptySet()
+            return
+        }
+        muteListCreatedAt = maxOf(muteListCreatedAt, snapshot.createdAt)
+        muteListPublicTags = snapshot.publicTags
+        muteListContent = snapshot.content
+        muteListPrivateTags = snapshot.privateTags
+        muteListPrivateDecryptedFrom = snapshot.privateDecryptedFrom
+        publicMuted = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(snapshot.publicTags)
+        privateMuted = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(snapshot.privateTags)
+        _mutedPubkeys.value = publicMuted + privateMuted
     }
 
     override fun forceInitialized() {
@@ -1946,8 +2044,12 @@ class NostrRepository(
         hasUnpublishedMuteChanges = false
         muteListCreatedAt = 0L
         muteListContent = ""
-        muteListTags = emptyList()
+        muteListPublicTags = emptyList()
+        muteListPrivateTags = emptyList()
+        muteListPrivateDecryptedFrom = ""
         muteListRequested = false
+        publicMuted = emptySet()
+        privateMuted = emptySet()
         _mutedPubkeys.value = emptySet()
         dmPersistenceJobs.forEach { it.cancel() }
         dmPersistenceJobs.clear()
@@ -3583,25 +3685,37 @@ class NostrRepository(
     override suspend fun muteUser(pubkey: String): Result<Unit> {
         // Muting yourself would hide your own messages everywhere; ignore it.
         if (pubkey.isBlank() || pubkey == sessionManager.getPublicKey()) return Result.Success(Unit)
-        applyMuteChange { it + pubkey }
+        if (pubkey in _mutedPubkeys.value) return Result.Success(Unit)
+        // Private by default (who you mute is nobody's business). Falls back to a public
+        // `p` tag while the existing private section is unreadable: merging into a
+        // ciphertext we can't decrypt would destroy another client's entries.
+        if (muteListPrivateWritable()) {
+            applyMuteChange(newPrivate = privateMuted + pubkey)
+        } else {
+            applyMuteChange(newPublic = publicMuted + pubkey)
+        }
         return Result.Success(Unit)
     }
 
     override suspend fun unmuteUser(pubkey: String): Result<Unit> {
-        applyMuteChange { it - pubkey }
+        if (pubkey !in _mutedPubkeys.value) return Result.Success(Unit)
+        applyMuteChange(newPublic = publicMuted - pubkey, newPrivate = privateMuted - pubkey)
         return Result.Success(Unit)
     }
 
     /**
      * Flips [mutedPubkeys] immediately (filtering reacts without a relay round-trip),
-     * persists the set, and schedules a single debounced kind:10000 publish so rapid
+     * persists the snapshot, and schedules a single debounced kind:10000 publish so rapid
      * taps (bulk unmute in Settings) coalesce into one event.
      */
-    private fun applyMuteChange(transform: (Set<String>) -> Set<String>) {
-        val next = transform(_mutedPubkeys.value)
-        if (next == _mutedPubkeys.value) return
-        _mutedPubkeys.value = next
-        sessionManager.getPublicKey()?.let { SecureStorage.saveMuteListFor(it, next.toList()) }
+    private fun applyMuteChange(
+        newPublic: Set<String> = publicMuted,
+        newPrivate: Set<String> = privateMuted,
+    ) {
+        if (newPublic == publicMuted && newPrivate == privateMuted) return
+        publicMuted = newPublic
+        privateMuted = newPrivate
+        sessionManager.getPublicKey()?.let { applyMutedSetsAndPersist(it) }
         hasUnpublishedMuteChanges = true
         pendingMuteListPublish?.cancel()
         pendingMuteListPublish =
@@ -3612,10 +3726,12 @@ class NostrRepository(
     }
 
     /**
-     * Builds, signs and publishes a fresh kind:10000 from [mutedPubkeys], preserving
-     * non-"p" tags and the (possibly NIP-44 encrypted) content of the last known list so
-     * entries added by other clients aren't clobbered. On the first run it best-effort
-     * fetches the existing list (it rides the kind:3 REQ) before overwriting.
+     * Builds, signs and publishes a fresh kind:10000: public `p` tags from [publicMuted],
+     * plus the private section (non-`p` private tags + [privateMuted]) re-encrypted with
+     * NIP-44 to self. Non-`p` public tags are carried over and an unreadable `content` is
+     * republished verbatim, so entries added by other clients aren't clobbered. On the
+     * first run it best-effort fetches the existing list (it rides the kind:3 REQ) before
+     * overwriting.
      */
     private suspend fun publishMuteList(): Result<Unit> {
         val pubKey = sessionManager.getPublicKey()
@@ -3626,14 +3742,32 @@ class NostrRepository(
                 withTimeoutOrNull(3_000L) { mutedPubkeys.first { muteListCreatedAt > 0L } }
             }
 
-            val newTags = org.nostr.nostrord.nostr.Nip51.rebuildMuteTags(muteListTags, _mutedPubkeys.value)
+            val newPublicTags = org.nostr.nostrord.nostr.Nip51.rebuildMuteTags(muteListPublicTags, publicMuted)
+            val privateWritable = muteListPrivateWritable()
+            val newPrivateTags =
+                if (privateWritable) {
+                    org.nostr.nostrord.nostr.Nip51.rebuildMuteTags(muteListPrivateTags, privateMuted)
+                } else {
+                    muteListPrivateTags
+                }
             try {
+                val newContent =
+                    when {
+                        // Opaque private section: pass it through untouched.
+                        !privateWritable -> muteListContent
+                        newPrivateTags.isEmpty() -> ""
+                        else -> {
+                            val signer = ActiveAccountManager.session.value?.signer
+                                ?: return@withLock Result.Error(AppError.Auth.NotAuthenticated)
+                            signer.nip44Encrypt(pubKey, org.nostr.nostrord.nostr.Nip51.encodeTags(newPrivateTags))
+                        }
+                    }
                 val event = org.nostr.nostrord.nostr.Event(
                     pubkey = pubKey,
                     createdAt = org.nostr.nostrord.utils.epochSeconds(),
                     kind = org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST,
-                    tags = newTags,
-                    content = muteListContent,
+                    tags = newPublicTags,
+                    content = newContent,
                 )
                 val signedEvent = sessionManager.signEvent(event)
                 val eventId = signedEvent.id
@@ -3664,10 +3798,15 @@ class NostrRepository(
                 }
 
                 muteListCreatedAt = signedEvent.createdAt
-                muteListTags = newTags
+                muteListPublicTags = newPublicTags
+                muteListContent = signedEvent.content
+                if (privateWritable) {
+                    muteListPrivateTags = newPrivateTags
+                    muteListPrivateDecryptedFrom = if (newPrivateTags.isEmpty()) "" else signedEvent.content
+                }
                 muteListRequested = true
                 hasUnpublishedMuteChanges = false
-                SecureStorage.saveKind10000TimestampFor(pubKey, signedEvent.createdAt)
+                applyMutedSetsAndPersist(pubKey)
                 Result.Success(Unit)
             } catch (e: Exception) {
                 Result.Error(AppError.Unknown(e.message ?: "Failed to update mute list", e))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -71,6 +71,8 @@ import org.nostr.nostrord.storage.loadDmSendQueue
 import org.nostr.nostrord.storage.loadDmSyncCursor
 import org.nostr.nostrord.storage.loadDmWrapRumor
 import org.nostr.nostrord.storage.loadFollowingCacheFor
+import org.nostr.nostrord.storage.loadKind10000TimestampFor
+import org.nostr.nostrord.storage.loadMuteListFor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
 import org.nostr.nostrord.storage.saveDmLastRead
@@ -81,6 +83,8 @@ import org.nostr.nostrord.storage.saveDmSyncCursor
 import org.nostr.nostrord.storage.saveDmWrapRumor
 import org.nostr.nostrord.storage.saveFollowingCacheFor
 import org.nostr.nostrord.storage.saveGroupFetchLazy
+import org.nostr.nostrord.storage.saveKind10000TimestampFor
+import org.nostr.nostrord.storage.saveMuteListFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
 import org.nostr.nostrord.utils.AppError
@@ -595,6 +599,52 @@ class NostrRepository(
         }
     }
 
+    // ===== NIP-51 mute list (kind:10000) =====
+    // Mirrors the kind:3 handling above: optimistic local set + debounced publish that
+    // preserves foreign tags/content, per-account persistence, staleness-guarded ingest.
+
+    private val _mutedPubkeys = MutableStateFlow<Set<String>>(emptySet())
+    override val mutedPubkeys: StateFlow<Set<String>> = _mutedPubkeys.asStateFlow()
+    private var muteListCreatedAt = 0L
+    private var muteListContent = ""
+    private var muteListTags: List<List<String>> = emptyList()
+    private var muteListRequested = false
+    private var pendingMuteListPublish: Job? = null
+    private var hasUnpublishedMuteChanges = false
+    private val muteListMutex = Mutex()
+
+    private fun handleKind10000Event(event: JsonObject) {
+        // Only the active account's own list drives [mutedPubkeys].
+        val pubKey = sessionManager.getPublicKey() ?: return
+        val eventPubkey = event["pubkey"]?.jsonPrimitive?.contentOrNull ?: return
+        if (eventPubkey != pubKey) return
+        val createdAt = event["created_at"]?.jsonPrimitive?.longOrNull ?: 0L
+        // muteListCreatedAt is floored by the persisted timestamp (hydrateMuteListFromCache),
+        // so a lagging relay can't resurrect mutes removed in a previous session.
+        if (createdAt < muteListCreatedAt) return
+        val tags =
+            event["tags"]?.jsonArray.orEmpty().map { tag ->
+                tag.jsonArray.mapNotNull { it.jsonPrimitive.contentOrNull }
+            }
+        muteListCreatedAt = createdAt
+        muteListContent = event["content"]?.jsonPrimitive?.contentOrNull ?: ""
+        muteListTags = tags
+        muteListRequested = true
+        // Keep the optimistic set while local taps are unpublished, so a relay echo
+        // arriving mid-mute doesn't clobber a just-tapped mute.
+        if (!hasUnpublishedMuteChanges) {
+            _mutedPubkeys.value = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(tags)
+            SecureStorage.saveMuteListFor(pubKey, _mutedPubkeys.value.toList())
+            SecureStorage.saveKind10000TimestampFor(pubKey, createdAt)
+        }
+    }
+
+    /** Seed [mutedPubkeys] from the per-account cache so filtering works before the network answers. */
+    private fun hydrateMuteListFromCache(pubkey: String) {
+        _mutedPubkeys.value = SecureStorage.loadMuteListFor(pubkey).toSet()
+        muteListCreatedAt = SecureStorage.loadKind10000TimestampFor(pubkey)
+    }
+
     override fun forceInitialized() {
         _isInitialized.value = true
     }
@@ -821,6 +871,7 @@ class NostrRepository(
                     unreadManager.initialize(pubkey)
                     notificationSettings?.initialize(pubkey)
                     notificationHistoryStore?.initialize(pubkey)
+                    hydrateMuteListFromCache(pubkey)
                     initializeOutboxModel()
                     scope.launch {
                         outboxManager.loadJoinedGroupsFromNostr(pubkey) { msg, c ->
@@ -885,6 +936,7 @@ class NostrRepository(
                 unreadManager.initialize(pubkey)
                 notificationSettings?.initialize(pubkey)
                 notificationHistoryStore?.initialize(pubkey)
+                hydrateMuteListFromCache(pubkey)
                 // Arm catch-up so the first mux refresh after connect replays
                 // messages that arrived while the app was closed (notifications
                 // + unread). Must run after notificationHistoryStore.initialize
@@ -1220,6 +1272,7 @@ class NostrRepository(
             unreadManager.initialize(newPubkey)
             notificationSettings?.initialize(newPubkey)
             notificationHistoryStore?.initialize(newPubkey)
+            hydrateMuteListFromCache(newPubkey)
             // Arm catch-up so the first mux refresh after connect() replays the
             // backlog accumulated while this identity was logged out. A fresh
             // identity has no backlog, so skip it there. Must run after
@@ -1323,7 +1376,7 @@ class NostrRepository(
 
     // ===== Direct messages (NIP-17 over NIP-59 gift wraps) =====
 
-    private val dmManager = DmManager(scope)
+    private val dmManager = DmManager(scope, mutedPubkeys)
 
     /** Conversations (most-recent first), derived from decrypted NIP-17 messages. */
     override val dmConversations: StateFlow<List<DmConversation>> get() = dmManager.conversations
@@ -1887,6 +1940,15 @@ class NostrRepository(
         hasUnpublishedContactChanges = false
         _contactListLoaded.value = false
         _following.value = emptySet()
+        // The mute list is per-account too; same lifecycle as the contact list.
+        pendingMuteListPublish?.cancel()
+        pendingMuteListPublish = null
+        hasUnpublishedMuteChanges = false
+        muteListCreatedAt = 0L
+        muteListContent = ""
+        muteListTags = emptyList()
+        muteListRequested = false
+        _mutedPubkeys.value = emptySet()
         dmPersistenceJobs.forEach { it.cancel() }
         dmPersistenceJobs.clear()
         dmManager.clear()
@@ -1939,6 +2001,9 @@ class NostrRepository(
         val pubkey = sessionManager.getPublicKey() ?: return
         // The contact list is per-account; drop the prior account's before the swap.
         resetContactListState()
+        // Re-seed the incoming account's mutes so filtering holds through the swap;
+        // the network refresh rides the requestContactList() below.
+        hydrateMuteListFromCache(pubkey)
         // Same session-cache teardown the full-logout path runs, so a warm swap does not
         // leak account A's restricted-relay / dedup state into account B (which otherwise
         // left B's groups dark until an app restart). Runs BEFORE B's re-derive below.
@@ -3376,7 +3441,12 @@ class NostrRepository(
                 }
             }
         }
-        if (sent > 0) contactListRequested = true
+        if (sent > 0) {
+            contactListRequested = true
+            // The same REQ carries the kind:10000 filter (see NostrGroupClient.requestContactList),
+            // so the mute list is fetched, and retried, together with the contact list.
+            muteListRequested = true
+        }
     }
 
     /**
@@ -3506,6 +3576,101 @@ class NostrRepository(
                 Result.Success(Unit)
             } catch (e: Exception) {
                 Result.Error(AppError.Unknown(e.message ?: "Failed to update contact list", e))
+            }
+        }
+    }
+
+    override suspend fun muteUser(pubkey: String): Result<Unit> {
+        // Muting yourself would hide your own messages everywhere; ignore it.
+        if (pubkey.isBlank() || pubkey == sessionManager.getPublicKey()) return Result.Success(Unit)
+        applyMuteChange { it + pubkey }
+        return Result.Success(Unit)
+    }
+
+    override suspend fun unmuteUser(pubkey: String): Result<Unit> {
+        applyMuteChange { it - pubkey }
+        return Result.Success(Unit)
+    }
+
+    /**
+     * Flips [mutedPubkeys] immediately (filtering reacts without a relay round-trip),
+     * persists the set, and schedules a single debounced kind:10000 publish so rapid
+     * taps (bulk unmute in Settings) coalesce into one event.
+     */
+    private fun applyMuteChange(transform: (Set<String>) -> Set<String>) {
+        val next = transform(_mutedPubkeys.value)
+        if (next == _mutedPubkeys.value) return
+        _mutedPubkeys.value = next
+        sessionManager.getPublicKey()?.let { SecureStorage.saveMuteListFor(it, next.toList()) }
+        hasUnpublishedMuteChanges = true
+        pendingMuteListPublish?.cancel()
+        pendingMuteListPublish =
+            scope.launch {
+                delay(contactListPublishDebounceMs)
+                publishMuteList()
+            }
+    }
+
+    /**
+     * Builds, signs and publishes a fresh kind:10000 from [mutedPubkeys], preserving
+     * non-"p" tags and the (possibly NIP-44 encrypted) content of the last known list so
+     * entries added by other clients aren't clobbered. On the first run it best-effort
+     * fetches the existing list (it rides the kind:3 REQ) before overwriting.
+     */
+    private suspend fun publishMuteList(): Result<Unit> {
+        val pubKey = sessionManager.getPublicKey()
+            ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        return muteListMutex.withLock {
+            if (!muteListRequested) {
+                contactListMutex.withLock { requestContactListLocked() }
+                withTimeoutOrNull(3_000L) { mutedPubkeys.first { muteListCreatedAt > 0L } }
+            }
+
+            val newTags = org.nostr.nostrord.nostr.Nip51.rebuildMuteTags(muteListTags, _mutedPubkeys.value)
+            try {
+                val event = org.nostr.nostrord.nostr.Event(
+                    pubkey = pubKey,
+                    createdAt = org.nostr.nostrord.utils.epochSeconds(),
+                    kind = org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST,
+                    tags = newTags,
+                    content = muteListContent,
+                )
+                val signedEvent = sessionManager.signEvent(event)
+                val eventId = signedEvent.id
+                    ?: return@withLock Result.Error(AppError.Unknown("Event has no id after signing", null))
+                val message = buildJsonArray {
+                    add("EVENT")
+                    add(signedEvent.toJsonObject())
+                }.toString()
+
+                // Same routing as kind:3: general-purpose relays only, never NIP-29 relays
+                // (they don't serve replaceable lists back).
+                val nip29Relays = outboxManager.kind10009Relays.value + connectionManager.currentRelayUrl.value
+                val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays)
+                    .distinct()
+                    .filter { it !in nip29Relays }
+                val clients = targets.mapNotNull { relayUrl ->
+                    connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }
+                        ?: connectionManager.getOrConnectRelay(relayUrl, metadataMessageHandler)?.takeIf { it.isConnected() }
+                }
+                if (clients.isEmpty()) {
+                    return@withLock Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
+                }
+                val results = clients.map { client ->
+                    scope.async { client.sendAndAwaitOkOrError(message, eventId) }
+                }.awaitAll()
+                if (results.none { it is PublishResult.Success }) {
+                    return@withLock Result.Error(AppError.Network.PublishRejected(results.summarizeFailures()))
+                }
+
+                muteListCreatedAt = signedEvent.createdAt
+                muteListTags = newTags
+                muteListRequested = true
+                hasUnpublishedMuteChanges = false
+                SecureStorage.saveKind10000TimestampFor(pubKey, signedEvent.createdAt)
+                Result.Success(Unit)
+            } catch (e: Exception) {
+                Result.Error(AppError.Unknown(e.message ?: "Failed to update mute list", e))
             }
         }
     }
@@ -3944,6 +4109,10 @@ class NostrRepository(
             }
             if (kind == 3) {
                 handleKind3Event(event)
+                return
+            }
+            if (kind == org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST) {
+                handleKind10000Event(event)
                 return
             }
             // NIP-17 DM gift wrap addressed to us: decrypt with the active signer.
@@ -4556,6 +4725,12 @@ class NostrRepository(
                 // Handle kind:3 (NIP-02 contact list) for the active account
                 if (kind == 3) {
                     handleKind3Event(event)
+                    return
+                }
+
+                // Handle kind:10000 (NIP-51 mute list) for the active account
+                if (kind == org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST) {
+                    handleKind10000Event(event)
                     return
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2312,6 +2312,30 @@ class NostrRepository(
                     reconnectDroppedNip29PoolRelays()
                 }
             }
+            refreshUserListsOnForeground()
+        }
+    }
+
+    // Throttle for the foreground kind:3/kind:10000 re-fetch (seconds).
+    private var lastUserListsRefreshAt = 0L
+    private val userListsRefreshMinIntervalS = 60L
+
+    /**
+     * Re-fetch the account's kind:3 + kind:10000 when the app returns to the foreground,
+     * so follows/mutes changed on another device while this one was backgrounded apply
+     * without a restart. The live REQ covers changes while the socket is up; this covers
+     * the suspended window. createdAt guards keep an older copy from regressing anything,
+     * and the unpublished-changes guards protect local taps, so re-requesting is safe.
+     */
+    private suspend fun refreshUserListsOnForeground() {
+        if (sessionManager.getPublicKey() == null) return
+        val now = org.nostr.nostrord.utils.epochSeconds()
+        if (now - lastUserListsRefreshAt < userListsRefreshMinIntervalS) return
+        lastUserListsRefreshAt = now
+        contactListMutex.withLock {
+            contactListRequested = false
+            muteListRequested = false
+            requestContactListLocked()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -658,7 +658,11 @@ interface NostrRepositoryApi {
      */
     suspend fun followUsers(pubkeys: Set<String>): Result<Unit>
 
-    /** Add [pubkey] to the active account's kind:10000 mute list and publish it. */
+    /**
+     * Add [pubkey] to the active account's kind:10000 mute list and publish it. New mutes
+     * go to the private (NIP-44 self-encrypted) section; falls back to a public `p` tag
+     * only while an existing private section can't be decrypted.
+     */
     suspend fun muteUser(pubkey: String): Result<Unit>
 
     /** Remove [pubkey] from the active account's kind:10000 mute list and publish it. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -207,6 +207,13 @@ interface NostrRepositoryApi {
      */
     val contactListLoaded: StateFlow<Boolean>
 
+    /**
+     * The active account's publicly muted pubkeys from its NIP-51 kind:10000 mute list.
+     * Hydrated from the per-account cache at login and kept in sync with the relays.
+     * Messages, DM conversations, and notifications from these authors are hidden.
+     */
+    val mutedPubkeys: StateFlow<Set<String>>
+
     // --- Initialization ---
     fun forceInitialized()
 
@@ -650,6 +657,12 @@ interface NostrRepositoryApi {
      * contact list and publish it once (a single event, not one per pubkey).
      */
     suspend fun followUsers(pubkeys: Set<String>): Result<Unit>
+
+    /** Add [pubkey] to the active account's kind:10000 mute list and publish it. */
+    suspend fun muteUser(pubkey: String): Result<Unit>
+
+    /** Remove [pubkey] from the active account's kind:10000 mute list and publish it. */
+    suspend fun unmuteUser(pubkey: String): Result<Unit>
 
     suspend fun updateProfileMetadata(
         displayName: String? = null,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -63,6 +63,10 @@ data class DmConversation(
  */
 class DmManager(
     private val scope: CoroutineScope,
+    // NIP-51 muted authors: their conversations and unread counts are hidden at the
+    // source so no badge points at a conversation the lists don't show. Messages stay
+    // cached, so an unmute restores the conversation instantly.
+    private val mutedPubkeys: StateFlow<Set<String>> = MutableStateFlow(emptySet()),
 ) {
     private val _messagesByPeer = MutableStateFlow<Map<String, List<DmMessage>>>(emptyMap())
     val messagesByPeer: StateFlow<Map<String, List<DmMessage>>> = _messagesByPeer.asStateFlow()
@@ -72,8 +76,9 @@ class DmManager(
     val lastReadByPeer: StateFlow<Map<String, Long>> = _lastReadByPeer.asStateFlow()
 
     val conversations: StateFlow<List<DmConversation>> =
-        combine(_messagesByPeer, _lastReadByPeer) { byPeer, reads ->
+        combine(_messagesByPeer, _lastReadByPeer, mutedPubkeys) { byPeer, reads, muted ->
             byPeer.entries
+                .filter { (peer, _) -> peer !in muted }
                 .mapNotNull { (peer, msgs) ->
                     val last = msgs.maxByOrNull { it.createdAt } ?: return@mapNotNull null
                     val lastRead = reads[peer] ?: 0L
@@ -86,8 +91,9 @@ class DmManager(
 
     /** Unread count per peer (incoming messages newer than the read high-water), zero entries dropped. */
     val unreadByPeer: StateFlow<Map<String, Int>> =
-        combine(_messagesByPeer, _lastReadByPeer) { byPeer, reads ->
+        combine(_messagesByPeer, _lastReadByPeer, mutedPubkeys) { byPeer, reads, muted ->
             byPeer
+                .filterKeys { it !in muted }
                 .mapValues { (peer, msgs) ->
                     val lastRead = reads[peer] ?: 0L
                     msgs.count { !it.mine && it.createdAt > lastRead }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -18,6 +18,9 @@ class UnreadManager(
     private val isRestricted: (String) -> Boolean = { false },
     private val isAppFocused: () -> Boolean = { true },
     private val findMessageAuthor: (messageId: String) -> String? = { null },
+    // NIP-51 muted authors: their messages/reactions never bump badges or notify.
+    // Checked per event (not per group) so unread counts match the filtered chat view.
+    private val isMutedAuthor: (pubkey: String) -> Boolean = { false },
     // Per-group notification gate (issue #70). `isDirect` is true for replies,
     // mentions and reactions to the user's own message. Returning false suppresses
     // the notification callbacks below WITHOUT touching the unread badge — a muted
@@ -175,7 +178,7 @@ class UnreadManager(
             previousHighWater,
         )
         val qualifying = newMessages.filter {
-            it.kind == 9 && it.pubkey != pubkey && it.createdAt > anchor
+            it.kind == 9 && it.pubkey != pubkey && it.createdAt > anchor && !isMutedAuthor(it.pubkey)
         }
         if (qualifying.isEmpty()) {
             if (highWaterAdvanced) persistEntries()
@@ -231,6 +234,7 @@ class UnreadManager(
     fun onReactionReceived(groupId: String, reaction: NostrGroupClient.NostrReaction) {
         val pubkey = currentPubkey ?: return
         if (reaction.pubkey == pubkey) return
+        if (isMutedAuthor(reaction.pubkey)) return
         if (!isJoined(groupId) || isRestricted(groupId)) return
         val lastRead = SecureStorage.getLastReadTimestamp(pubkey, groupId)
         val previousHighWater = _latestMessageTimestamps.value[groupId] ?: 0L

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip51.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip51.kt
@@ -1,13 +1,32 @@
 package org.nostr.nostrord.nostr
 
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
 /**
- * NIP-51 lists. Only the mute list (kind:10000) is supported: public mutes are `p` tags.
- * The encrypted private section lives in `content` and is passed through untouched on
- * publish, so private items and non-pubkey entries (words, hashtags, threads) added by
- * other clients survive a publish from this one.
+ * NIP-51 lists. Only the mute list (kind:10000) is supported. Public mutes are `p` tags;
+ * the private section is a NIP-44 self-encrypted JSON tag array in `content`. New mutes go
+ * to the private section; a `content` that can't be decrypted is passed through untouched
+ * on publish, so private items and non-pubkey entries (words, hashtags, threads) added by
+ * other clients always survive a publish from this one.
  */
 object Nip51 {
     const val KIND_MUTE_LIST = 10000
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val tagsSerializer = ListSerializer(ListSerializer(String.serializer()))
+
+    /** The private-section plaintext: a JSON tag array, same shape as the public tags. */
+    fun encodeTags(tags: List<List<String>>): String = json.encodeToString(tagsSerializer, tags)
+
+    /** Parse a decrypted private section; null when it isn't a tag array. */
+    fun decodeTags(plaintext: String): List<List<String>>? = try {
+        json.decodeFromString(tagsSerializer, plaintext)
+    } catch (_: Exception) {
+        null
+    }
 
     /** Public muted pubkeys (`p` tags) of a kind:10000 tag list. */
     fun mutedPubkeysFrom(tags: List<List<String>>): Set<String> = tags

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip51.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip51.kt
@@ -1,0 +1,26 @@
+package org.nostr.nostrord.nostr
+
+/**
+ * NIP-51 lists. Only the mute list (kind:10000) is supported: public mutes are `p` tags.
+ * The encrypted private section lives in `content` and is passed through untouched on
+ * publish, so private items and non-pubkey entries (words, hashtags, threads) added by
+ * other clients survive a publish from this one.
+ */
+object Nip51 {
+    const val KIND_MUTE_LIST = 10000
+
+    /** Public muted pubkeys (`p` tags) of a kind:10000 tag list. */
+    fun mutedPubkeysFrom(tags: List<List<String>>): Set<String> = tags
+        .filter { it.firstOrNull() == "p" }
+        .mapNotNull { it.getOrNull(1)?.takeIf { pk -> pk.isNotBlank() } }
+        .toSet()
+
+    /**
+     * Tag list for a new kind:10000: [muted] as `p` tags plus every non-`p` tag of
+     * [previousTags] (words, hashtags, thread ids) so other clients' entries are kept.
+     */
+    fun rebuildMuteTags(
+        previousTags: List<List<String>>,
+        muted: Set<String>,
+    ): List<List<String>> = previousTags.filterNot { it.firstOrNull() == "p" } + muted.map { listOf("p", it) }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -486,6 +486,52 @@ fun SecureStorage.loadFollowingCacheFor(pubkey: String): List<String> {
     }
 }
 
+// ── Per-account mute list (NIP-51 kind:10000) ───────────────────────────────
+// Public muted pubkeys, hydrated at login so message filtering works before the
+// network answers. The timestamp floors the kind:10000 staleness check so a lagging
+// relay can't resurrect mutes removed in a previous session (same guard as kind:10009).
+private fun muteListKey(pubkey: String) = "mute_list_${pubkeyDigest(pubkey)}"
+
+private fun kind10000TimestampKey(pubkey: String) = "kind10000_latest_ts_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.saveMuteListFor(
+    pubkey: String,
+    muted: List<String>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(
+            muteListKey(pubkey),
+            Json.encodeToString(ListSerializer(String.serializer()), muted),
+        )
+    } catch (_: Exception) {
+    }
+}
+
+fun SecureStorage.loadMuteListFor(pubkey: String): List<String> {
+    if (pubkey.isBlank()) return emptyList()
+    val raw = getStringPref(muteListKey(pubkey), "")
+    if (raw.isBlank()) return emptyList()
+    return try {
+        Json.decodeFromString(ListSerializer(String.serializer()), raw)
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
+fun SecureStorage.saveKind10000TimestampFor(
+    pubkey: String,
+    timestamp: Long,
+) {
+    if (pubkey.isBlank()) return
+    saveStringPref(kind10000TimestampKey(pubkey), timestamp.toString())
+}
+
+fun SecureStorage.loadKind10000TimestampFor(pubkey: String): Long {
+    if (pubkey.isBlank()) return 0L
+    return getStringPref(kind10000TimestampKey(pubkey), "0").toLongOrNull() ?: 0L
+}
+
 // ── Per-account group membership cache ──────────────────────────────────────
 // One JSON blob per account holding every known group's members/admins/roles
 // (NIP-29 kind:39002/39001/39003) plus each list's source-event timestamp, so a

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -487,36 +487,27 @@ fun SecureStorage.loadFollowingCacheFor(pubkey: String): List<String> {
 }
 
 // ── Per-account mute list (NIP-51 kind:10000) ───────────────────────────────
-// Public muted pubkeys, hydrated at login so message filtering works before the
-// network answers. The timestamp floors the kind:10000 staleness check so a lagging
-// relay can't resurrect mutes removed in a previous session (same guard as kind:10009).
+// One JSON blob per account with the full last-known list (public tags, raw encrypted
+// content, decrypted private section), hydrated at login so filtering works before the
+// network answers AND so a publish never rebuilds from a partial base (which would clobber
+// words/private mutes written by other clients). The blob shape is owned by NostrRepository;
+// this slot only stores the encoded string. The timestamp floors the kind:10000 staleness
+// check so a lagging relay can't resurrect mutes removed in a previous session.
 private fun muteListKey(pubkey: String) = "mute_list_${pubkeyDigest(pubkey)}"
 
 private fun kind10000TimestampKey(pubkey: String) = "kind10000_latest_ts_${pubkeyDigest(pubkey)}"
 
-fun SecureStorage.saveMuteListFor(
+fun SecureStorage.saveMuteListSnapshotFor(
     pubkey: String,
-    muted: List<String>,
+    snapshotJson: String,
 ) {
     if (pubkey.isBlank()) return
-    try {
-        saveStringPref(
-            muteListKey(pubkey),
-            Json.encodeToString(ListSerializer(String.serializer()), muted),
-        )
-    } catch (_: Exception) {
-    }
+    saveStringPref(muteListKey(pubkey), snapshotJson)
 }
 
-fun SecureStorage.loadMuteListFor(pubkey: String): List<String> {
-    if (pubkey.isBlank()) return emptyList()
-    val raw = getStringPref(muteListKey(pubkey), "")
-    if (raw.isBlank()) return emptyList()
-    return try {
-        Json.decodeFromString(ListSerializer(String.serializer()), raw)
-    } catch (_: Exception) {
-        emptyList()
-    }
+fun SecureStorage.loadMuteListSnapshotFor(pubkey: String): String? {
+    if (pubkey.isBlank()) return null
+    return getStringPref(muteListKey(pubkey), "").ifBlank { null }
 }
 
 fun SecureStorage.saveKind10000TimestampFor(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -91,7 +91,21 @@ class GroupViewModel(
     private val repo: NostrRepositoryApi,
     val groupId: String,
 ) : ViewModel() {
-    val messages = repo.messages
+    /**
+     * Chat messages with NIP-51 muted authors filtered out. The raw repo cache stays
+     * untouched (membership derivation below reads it directly), so an unmute restores
+     * the author's messages instantly without a re-fetch.
+     */
+    val messages: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> =
+        combine(repo.messages, repo.mutedPubkeys) { byGroup, muted ->
+            if (muted.isEmpty()) {
+                byGroup
+            } else {
+                byGroup.mapValues { (_, list) -> list.filter { it.pubkey !in muted } }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.messages.value)
+
+    val mutedPubkeys = repo.mutedPubkeys
     val messageStatus = repo.messageStatus
     val connectionState = repo.connectionState
     val joinedGroups = repo.joinedGroups

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -19,6 +19,7 @@ import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.network.UserGroupRef
 import org.nostr.nostrord.network.managers.ConnectionManager
+import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
@@ -113,7 +114,25 @@ class GroupViewModel(
     val groups = repo.groups
     val groupsByRelay = repo.groupsByRelay
     val userMetadata = repo.userMetadata
-    val reactions = repo.reactions
+
+    /**
+     * Reactions with NIP-51 muted reactors removed, same contract as [messages]: the raw
+     * repo cache stays untouched, so an unmute restores their reactions instantly.
+     */
+    val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> =
+        combine(repo.reactions, repo.mutedPubkeys) { byMessage, muted ->
+            if (muted.isEmpty()) {
+                byMessage
+            } else {
+                byMessage.mapNotNull { (messageId, byEmoji) ->
+                    val filtered = byEmoji.mapNotNull { (emoji, info) ->
+                        val reactors = info.reactors.filter { it !in muted }
+                        if (reactors.isEmpty()) null else emoji to info.copy(reactors = reactors)
+                    }.toMap()
+                    if (filtered.isEmpty()) null else messageId to filtered
+                }.toMap()
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.reactions.value)
     val groupMembers = repo.groupMembers
     val groupAdmins = repo.groupAdmins
     val groupRoles = repo.groupRoles

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageViewModel.kt
@@ -133,6 +133,20 @@ class ProfilePageViewModel(
         }
     }
 
+    /** Whether the active account mutes this user (NIP-51 kind:10000). */
+    val isMuted: StateFlow<Boolean> =
+        repo.mutedPubkeys
+            .map { pubkey in it }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    /** Mute or unmute this user, toggling based on the current [isMuted]. */
+    fun toggleMute() {
+        if (isSelf) return
+        viewModelScope.launch {
+            if (isMuted.value) repo.unmuteUser(pubkey) else repo.muteUser(pubkey)
+        }
+    }
+
     init {
         // The kind:0 may not be cached (deep link straight to a profile), and the
         // public group list (kind:10009) is only fetched on demand. The own contact

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersViewModel.kt
@@ -1,0 +1,40 @@
+package org.nostr.nostrord.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.network.NostrRepositoryApi
+
+/**
+ * Shared logic for the Settings "Muted users" panel (NIP-51 kind:10000). Both the web and
+ * Compose panels consume this VM so listing and unmuting live in one place.
+ */
+class MutedUsersViewModel(
+    private val repo: NostrRepositoryApi,
+) : ViewModel() {
+    /** Muted pubkeys, stable-sorted so the list doesn't jump as relay echoes arrive. */
+    val muted: StateFlow<List<String>> =
+        repo.mutedPubkeys
+            .map { it.sorted() }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, repo.mutedPubkeys.value.sorted())
+
+    val userMetadata = repo.userMetadata
+
+    init {
+        // Resolve names/avatars for the listed pubkeys; the metadata layer dedups
+        // cached entries, so re-collecting on every change is cheap.
+        viewModelScope.launch {
+            repo.mutedPubkeys.collect { pubkeys ->
+                if (pubkeys.isNotEmpty()) repo.requestUserMetadata(pubkeys)
+            }
+        }
+    }
+
+    fun unmute(pubkey: String) {
+        viewModelScope.launch { repo.unmuteUser(pubkey) }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -461,6 +461,23 @@ class FakeNostrRepository : NostrRepositoryApi {
         return Result.Success(Unit)
     }
 
+    val _mutedPubkeys = MutableStateFlow<Set<String>>(emptySet())
+    override val mutedPubkeys: StateFlow<Set<String>> = _mutedPubkeys
+
+    override suspend fun muteUser(pubkey: String): Result<Unit> {
+        calls += "muteUser:$pubkey"
+        if (pubkey.isNotBlank() && pubkey != fakePublicKey) {
+            _mutedPubkeys.value = _mutedPubkeys.value + pubkey
+        }
+        return Result.Success(Unit)
+    }
+
+    override suspend fun unmuteUser(pubkey: String): Result<Unit> {
+        calls += "unmuteUser:$pubkey"
+        _mutedPubkeys.value = _mutedPubkeys.value - pubkey
+        return Result.Success(Unit)
+    }
+
     override suspend fun updateProfileMetadata(
         displayName: String?,
         name: String?,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip51Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip51Test.kt
@@ -1,0 +1,49 @@
+package org.nostr.nostrord.nostr
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class Nip51Test {
+    @Test
+    fun `mutedPubkeysFrom picks p tags and ignores everything else`() {
+        val tags = listOf(
+            listOf("p", "aaa"),
+            listOf("p", "bbb", "wss://relay.example.com"),
+            listOf("word", "spam"),
+            listOf("t", "hashtag"),
+            listOf("e", "thread-id"),
+            listOf("p", ""),
+            listOf("p"),
+        )
+        assertEquals(setOf("aaa", "bbb"), Nip51.mutedPubkeysFrom(tags))
+    }
+
+    @Test
+    fun `rebuildMuteTags replaces p tags and preserves foreign entries`() {
+        val previous = listOf(
+            listOf("p", "old-mute"),
+            listOf("word", "spam"),
+            listOf("t", "hashtag"),
+            listOf("e", "thread-id"),
+        )
+        val rebuilt = Nip51.rebuildMuteTags(previous, setOf("new-mute"))
+        assertEquals(
+            listOf(
+                listOf("word", "spam"),
+                listOf("t", "hashtag"),
+                listOf("e", "thread-id"),
+                listOf("p", "new-mute"),
+            ),
+            rebuilt,
+        )
+    }
+
+    @Test
+    fun `rebuildMuteTags with an empty set keeps only foreign entries`() {
+        val previous = listOf(
+            listOf("p", "old-mute"),
+            listOf("word", "spam"),
+        )
+        assertEquals(listOf(listOf("word", "spam")), Nip51.rebuildMuteTags(previous, emptySet()))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip51Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip51Test.kt
@@ -46,4 +46,19 @@ class Nip51Test {
         )
         assertEquals(listOf(listOf("word", "spam")), Nip51.rebuildMuteTags(previous, emptySet()))
     }
+
+    @Test
+    fun `private section tags round-trip through encode and decode`() {
+        val tags = listOf(
+            listOf("p", "aaa"),
+            listOf("word", "spam"),
+        )
+        assertEquals(tags, Nip51.decodeTags(Nip51.encodeTags(tags)))
+    }
+
+    @Test
+    fun `decodeTags rejects non tag-array plaintext`() {
+        assertEquals(null, Nip51.decodeTags("not json"))
+        assertEquals(null, Nip51.decodeTags("""{"p":"aaa"}"""))
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -56,6 +56,32 @@ class GroupViewModelTest {
         assertFalse(vm.isLoadingMore.value["test-group"] ?: false)
     }
 
+    @Test
+    fun `reactions from muted users are hidden and empty entries dropped`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._reactions.value = mapOf(
+            "m1" to mapOf(
+                "👍" to org.nostr.nostrord.network.managers.GroupManager.ReactionInfo(null, listOf("friend", "spammer")),
+                "🔥" to org.nostr.nostrord.network.managers.GroupManager.ReactionInfo(null, listOf("spammer")),
+            ),
+            "m2" to mapOf(
+                "👍" to org.nostr.nostrord.network.managers.GroupManager.ReactionInfo(null, listOf("spammer")),
+            ),
+        )
+        fake._mutedPubkeys.value = setOf("spammer")
+        val vm = vm(fake)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            mapOf(
+                "m1" to mapOf(
+                    "👍" to org.nostr.nostrord.network.managers.GroupManager.ReactionInfo(null, listOf("friend")),
+                ),
+            ),
+            vm.reactions.value,
+        )
+    }
+
     // -------------------------------------------------------------------------
     // leaveGroup — onSuccess callback
     // -------------------------------------------------------------------------

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/MutedUsersViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/MutedUsersViewModelTest.kt
@@ -1,0 +1,54 @@
+package org.nostr.nostrord.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.ui.screens.settings.MutedUsersViewModel
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MutedUsersViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `muted list mirrors the repo set sorted`() = runTest {
+        val repo = FakeNostrRepository()
+        repo._mutedPubkeys.value = setOf("ccc", "aaa", "bbb")
+        val vm = MutedUsersViewModel(repo)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("aaa", "bbb", "ccc"), vm.muted.value)
+    }
+
+    @Test
+    fun `unmute delegates to the repo and drops the entry`() = runTest {
+        val repo = FakeNostrRepository()
+        repo._mutedPubkeys.value = setOf("aaa", "bbb")
+        val vm = MutedUsersViewModel(repo)
+
+        vm.unmute("aaa")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue("unmuteUser:aaa" in repo.calls)
+        assertEquals(listOf("bbb"), vm.muted.value)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ProfilePageViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ProfilePageViewModelTest.kt
@@ -91,4 +91,23 @@ class ProfilePageViewModelTest {
         assertEquals(false, vm.isFollowing.value)
         assertEquals(false, "pk1" in fake.following.value)
     }
+
+    @Test
+    fun `toggleMute mutes then unmutes the user`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.fakePublicKey = "me"
+        val vm = ProfilePageViewModel(fake, "pk1")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(false, vm.isMuted.value)
+
+        vm.toggleMute()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(vm.isMuted.value)
+        assertTrue("pk1" in fake.mutedPubkeys.value)
+
+        vm.toggleMute()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(false, vm.isMuted.value)
+        assertEquals(false, "pk1" in fake.mutedPubkeys.value)
+    }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -652,24 +652,35 @@ fun AppFrame() {
             // Settings opens full-screen over the rail and sidebar (its own layout carries
             // the close button); the toolbar above stays visible so back/forward still leave it.
             if (route is SettingsRoute) {
-                // Full-screen overlay: background bleeds to the edges, content inset off the bars.
-                Box(
-                    modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .background(NostrordColors.Background)
-                        .windowInsetsPadding(WindowInsets.safeDrawing),
+                // Settings content can navigate (Muted users rows open the profile page);
+                // the route change away from SettingsRoute closes the overlay. Also close
+                // the mobile drawer: settings is usually opened from it, and the drawer
+                // would otherwise still be sitting open over the destination page.
+                CompositionLocalProvider(
+                    LocalFrameNavigator provides {
+                        closeDrawer()
+                        history.navigate(it)
+                    },
                 ) {
-                    SettingsScreen(
-                        onClose = { history.back() },
-                        // Legacy in-page navigation targets the old Screen graph the new frame
-                        // doesn't route; just close, like the old overlay did.
-                        onNavigate = { history.back() },
-                        onLogout = {
-                            history.back()
-                            AppModule.accountStore.activeId.value?.let { AppModule.accountManager.removeAccountAsync(it) }
-                        },
-                    )
+                    // Full-screen overlay: background bleeds to the edges, content inset off the bars.
+                    Box(
+                        modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .background(NostrordColors.Background)
+                            .windowInsetsPadding(WindowInsets.safeDrawing),
+                    ) {
+                        SettingsScreen(
+                            onClose = { history.back() },
+                            // Legacy in-page navigation targets the old Screen graph the new frame
+                            // doesn't route; just close, like the old overlay did.
+                            onNavigate = { history.back() },
+                            onLogout = {
+                                history.back()
+                                AppModule.accountStore.activeId.value?.let { AppModule.accountManager.removeAccountAsync(it) }
+                            },
+                        )
+                    }
                 }
             }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Mail
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.MoreVert
+import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.PersonAdd
 import androidx.compose.material.icons.outlined.PersonRemove
@@ -201,6 +202,7 @@ fun DmPageScreen(
 
         val copyToClipboard = rememberClipboardWriter()
         val isFollowing by vm.isFollowing.collectAsState()
+        val isMuted by vm.isMuted.collectAsState()
         var headerMenuOpen by remember { mutableStateOf(false) }
         var relaysDialogOpen by remember { mutableStateOf(false) }
         val peerRelays by remember(pubkey) { dmVm.peerDmRelays(pubkey) }.collectAsState()
@@ -274,6 +276,14 @@ fun DmPageScreen(
                         onClick = {
                             headerMenuOpen = false
                             vm.toggleFollow()
+                        },
+                    )
+                    DropdownMenuItem(
+                        text = { Text(if (isMuted) "Unmute user" else "Mute user") },
+                        leadingIcon = { Icon(Icons.Outlined.NotificationsOff, contentDescription = null) },
+                        onClick = {
+                            headerMenuOpen = false
+                            vm.toggleMute()
                         },
                     )
                     DropdownMenuItem(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
@@ -136,6 +136,8 @@ fun UserProfileModal(
     // Follow state from the active account's kind:3 contact list (fetched once on open).
     val scope = rememberCoroutineScope()
     val following by AppModule.nostrRepository.following.collectAsState()
+    val mutedPubkeys by AppModule.nostrRepository.mutedPubkeys.collectAsState()
+    val isMuted = pubkey in mutedPubkeys
     val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     val isFollowing = pubkey in following
     var followBusy by remember(pubkey) { mutableStateOf(false) }
@@ -346,8 +348,8 @@ fun UserProfileModal(
                                 }
                                 // Mention only exists inside a group chat (where a composer
                                 // can receive it); elsewhere (home sidebar, etc.) the row is
-                                // absent rather than shown disabled. Mute / report join when
-                                // their backends land (mute list, NIP-56 reports).
+                                // absent rather than shown disabled. Report joins when its
+                                // backend lands (NIP-56 reports).
                                 if (onMention != null) {
                                     ProfileActionRow(
                                         label = "Mention",
@@ -356,7 +358,18 @@ fun UserProfileModal(
                                         onMention.invoke(pubkey)
                                     }
                                 }
-                                ProfileActionRow(label = "Mute user", emoji = "🔕", enabled = false) {}
+                                ProfileActionRow(
+                                    label = if (isMuted) "Unmute user" else "Mute user",
+                                    emoji = "🔕",
+                                ) {
+                                    scope.launch {
+                                        if (isMuted) {
+                                            AppModule.nostrRepository.unmuteUser(pubkey)
+                                        } else {
+                                            AppModule.nostrRepository.muteUser(pubkey)
+                                        }
+                                    }
+                                }
                                 ProfileActionRow(label = "Report user", icon = Icons.Default.Shield, enabled = false) {}
 
                                 if (iAmAdmin && onRemoveFromGroup != null) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageScreen.kt
@@ -215,11 +215,12 @@ fun ProfilePageScreen(
                                 IdentifierField(pubkey = pubkey, nip05 = metadata?.nip05)
 
                                 if (!vm.isSelf) {
-                                    // Zaps require a signer + a lightning address; mute list
-                                    // and NIP-56 reports aren't wired yet (disabled).
+                                    // Zaps require a signer + a lightning address;
+                                    // NIP-56 reports aren't wired yet (disabled).
                                     val activeSession by ActiveAccountManager.session.collectAsState()
                                     val canZap = activeSession != null &&
                                         Nip57.resolvePayEndpoint(metadata?.lud16, metadata?.lud06) != null
+                                    val isMuted by vm.isMuted.collectAsState()
                                     Spacer(modifier = Modifier.height(Spacing.md))
                                     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
                                         AppButton(
@@ -231,9 +232,8 @@ fun ProfilePageScreen(
                                             icon = Icons.Outlined.Bolt,
                                         )
                                         AppButton(
-                                            text = "Mute",
-                                            onClick = {},
-                                            enabled = false,
+                                            text = if (isMuted) "Unmute" else "Mute",
+                                            onClick = { vm.toggleMute() },
                                             variant = AppButtonVariant.Ghost,
                                             size = AppButtonSize.Small,
                                             icon = Icons.Outlined.NotificationsOff,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersPanelContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersPanelContent.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.ui.screens.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -14,6 +16,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -22,6 +27,8 @@ import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.navigation.LocalFrameNavigator
+import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.Spacing
 
@@ -33,11 +40,13 @@ import org.nostr.nostrord.ui.theme.Spacing
 fun MutedUsersPanelContent(vm: MutedUsersViewModel) {
     val muted by vm.muted.collectAsState()
     val userMetadata by vm.userMetadata.collectAsState()
+    // Row click opens the user's profile page; the route change closes the settings overlay.
+    val frameNavigator = LocalFrameNavigator.current
 
     Column(modifier = Modifier.fillMaxWidth()) {
         Text(
             text = "Muted users don't appear in chats, direct messages, or notifications. " +
-                "Mutes sync to your other Nostr clients.",
+                "Mutes are stored encrypted (nobody can see who you muted) and sync to your other Nostr clients.",
             color = NostrordColors.TextSecondary,
             fontSize = 13.sp,
         )
@@ -59,7 +68,19 @@ fun MutedUsersPanelContent(vm: MutedUsersViewModel) {
                             ?: meta?.name?.takeIf { it.isNotBlank() }
                             ?: (npub.take(12) + "…")
                     Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .then(
+                                if (frameNavigator != null) {
+                                    Modifier
+                                        .clickable { frameNavigator(UserRoute(pubkey)) }
+                                        .pointerHoverIcon(PointerIcon.Hand)
+                                } else {
+                                    Modifier
+                                },
+                            )
+                            .padding(vertical = 2.dp),
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(Spacing.md),
                     ) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersPanelContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedUsersPanelContent.kt
@@ -1,0 +1,99 @@
+package org.nostr.nostrord.ui.screens.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * Settings "Muted users" panel: the account's NIP-51 kind:10000 mute list with an
+ * Unmute action per user. Web parity: MutedUsersPanel in web/screens/SettingsScreen.kt.
+ */
+@Composable
+fun MutedUsersPanelContent(vm: MutedUsersViewModel) {
+    val muted by vm.muted.collectAsState()
+    val userMetadata by vm.userMetadata.collectAsState()
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Muted users don't appear in chats, direct messages, or notifications. " +
+                "Mutes sync to your other Nostr clients.",
+            color = NostrordColors.TextSecondary,
+            fontSize = 13.sp,
+        )
+        Spacer(Modifier.height(Spacing.lg))
+
+        if (muted.isEmpty()) {
+            Text(
+                text = "You haven't muted anyone. Mute someone from their profile to hide their messages.",
+                color = NostrordColors.TextMuted,
+                fontSize = 13.sp,
+            )
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                muted.forEach { pubkey ->
+                    val meta = userMetadata[pubkey]
+                    val npub = remember(pubkey) { Nip19.encodeNpub(pubkey) }
+                    val displayName =
+                        meta?.displayName?.takeIf { it.isNotBlank() }
+                            ?: meta?.name?.takeIf { it.isNotBlank() }
+                            ?: (npub.take(12) + "…")
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                    ) {
+                        ProfileAvatar(
+                            imageUrl = meta?.picture,
+                            displayName = displayName,
+                            pubkey = pubkey,
+                            size = 36.dp,
+                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = displayName,
+                                color = NostrordColors.TextPrimary,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = npub.take(20) + "…",
+                                color = NostrordColors.TextMuted,
+                                fontSize = 12.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        AppButton(
+                            text = "Unmute",
+                            onClick = { vm.unmute(pubkey) },
+                            variant = AppButtonVariant.Secondary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -86,6 +86,7 @@ enum class SettingsSection(val label: String) {
     Appearance("Appearance"),
     Media("Media"),
     Notifications("Notifications"),
+    MutedUsers("Muted users"),
     Security("Security"),
 }
 
@@ -252,6 +253,11 @@ fun SettingsScreen(
         )
     }
 
+    val mutedUsersVm = viewModel { MutedUsersViewModel(AppModule.nostrRepository) }
+    val mutedUsersContent: @Composable () -> Unit = {
+        MutedUsersPanelContent(mutedUsersVm)
+    }
+
     val securityContent: @Composable () -> Unit = {
         SecurityPanelContent()
     }
@@ -305,6 +311,7 @@ fun SettingsScreen(
                 appearanceContent = appearanceContent,
                 mediaContent = mediaContent,
                 notificationsContent = notificationsContent,
+                mutedUsersContent = mutedUsersContent,
                 securityContent = securityContent,
             )
         } else {
@@ -321,6 +328,7 @@ fun SettingsScreen(
                 appearanceContent = appearanceContent,
                 mediaContent = mediaContent,
                 notificationsContent = notificationsContent,
+                mutedUsersContent = mutedUsersContent,
                 securityContent = securityContent,
             )
         }
@@ -343,6 +351,7 @@ private fun DesktopSettings(
     appearanceContent: @Composable () -> Unit,
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    mutedUsersContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
@@ -390,7 +399,7 @@ private fun DesktopSettings(
                         .padding(top = 24.dp, start = 40.dp, end = 20.dp, bottom = 80.dp),
                 ) {
                     Box(modifier = Modifier.widthIn(max = 660.dp)) {
-                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, securityContent)
+                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, securityContent)
                     }
                 }
 
@@ -420,6 +429,7 @@ private fun MobileSettings(
     appearanceContent: @Composable () -> Unit,
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    mutedUsersContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     if (!showPanel) {
@@ -461,7 +471,7 @@ private fun MobileSettings(
                     .verticalScroll(rememberScrollState())
                     .padding(horizontal = 20.dp, vertical = 24.dp),
             ) {
-                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, securityContent)
+                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, securityContent)
             }
         }
     }
@@ -518,6 +528,9 @@ private fun SettingsSidebar(
     }
     SettingsNavItem("Notifications", activeSection == SettingsSection.Notifications, compact = compact) {
         onSelectSection(SettingsSection.Notifications)
+    }
+    SettingsNavItem("Muted users", activeSection == SettingsSection.MutedUsers, compact = compact) {
+        onSelectSection(SettingsSection.MutedUsers)
     }
     if (PassphraseSettings.isApplicable) {
         SettingsNavItem("Security", activeSection == SettingsSection.Security, compact = compact) {
@@ -633,6 +646,7 @@ private fun SettingsPanel(
     appearanceContent: @Composable () -> Unit,
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
+    mutedUsersContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -654,6 +668,7 @@ private fun SettingsPanel(
             SettingsSection.Appearance -> appearanceContent()
             SettingsSection.Media -> mediaContent()
             SettingsSection.Notifications -> notificationsContent()
+            SettingsSection.MutedUsers -> mutedUsersContent()
             SettingsSection.Security -> securityContent()
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatMessageList.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatMessageList.kt
@@ -332,6 +332,13 @@ val ChatMessageList =
                 // 80px threshold matches the prototype: the jump pill appears once the
                 // user is more than ~80px up from the bottom.
                 val isAtBottom = (sh - st - ch) < 80.0
+                // Being at the bottom ends any scroll-up intent, however we got here — including
+                // the browser CLAMPING scrollTop when content above shrinks (muting an author),
+                // which reads as a scrollTop decrease and set the flag above. There is no at-bottom
+                // TRANSITION in that case, so this must run unconditionally: with the flag stuck
+                // true, the next growth (unmute re-inserting that author's history) would skip the
+                // pin and strand the view mid-feed.
+                if (isAtBottom) userScrolledUp.current = false
                 // During the open settle window, ignore a transient "not at bottom" reading caused
                 // by content still growing/reflowing — flipping the latch there would disarm the pin
                 // and strand the open above the true bottom. But a genuine scroll-up (scrollTop
@@ -339,7 +346,6 @@ val ChatMessageList =
                 // `true` and the next growth snaps the reader back to the bottom.
                 if (!(settling() && !isAtBottom && !scrolledUpNow) && atBottom.current != isAtBottom) {
                     atBottom.current = isAtBottom
-                    if (isAtBottom) userScrolledUp.current = false
                     props.onAtBottomChange(isAtBottom)
                     // Anchoring ON while reading history (holds position across prepends and
                     // late image layout), OFF at the bottom where it would fight the pin.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
@@ -72,6 +72,8 @@ val UserProfileModal =
         val (removeError, setRemoveError) = useState<String?> { null }
         val following = useStateFlow(AppModule.nostrRepository.following)
         val isFollowing = pubkey in following
+        val mutedPubkeys = useStateFlow(AppModule.nostrRepository.mutedPubkeys)
+        val isMuted = pubkey in mutedPubkeys
         val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         val (followBusy, setFollowBusy) = useState { false }
 
@@ -206,14 +208,21 @@ val UserProfileModal =
                             }
                             // Mention only exists inside a group chat (where a composer can
                             // receive it); elsewhere the row is absent rather than shown
-                            // disabled. Mute / report join when their backends land (mute
-                            // list, NIP-56 reports).
+                            // disabled. Report joins when its backend lands (NIP-56 reports).
                             props.onMention?.let { onMention ->
                                 actionRow(Ic.Reply, "Mention") {
                                     onMention(pubkey)
                                 }
                             }
-                            actionRow(null, "Mute user", disabled = true, emoji = "🔕") {}
+                            actionRow(null, if (isMuted) "Unmute user" else "Mute user", emoji = "🔕") {
+                                launchApp {
+                                    if (isMuted) {
+                                        AppModule.nostrRepository.unmuteUser(pubkey)
+                                    } else {
+                                        AppModule.nostrRepository.muteUser(pubkey)
+                                    }
+                                }
+                            }
                             actionRow(Ic.Shield, "Report user", disabled = true) {}
 
                             val groupId = props.groupId

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -178,6 +178,7 @@ val DmPage =
 
         // Header kebab menu + its DM-relays modal.
         val isFollowing = useStateFlow(vm.isFollowing)
+        val isMutedPeer = useStateFlow(vm.isMuted)
         val peerRelays = useStateFlow(dmVm.dmRelaysByPubkey)[pubkey].orEmpty()
         val (headerMenuOpen, setHeaderMenuOpen) = useState { false }
         val (relaysOpen, setRelaysOpen) = useState { false }
@@ -283,6 +284,10 @@ val DmPage =
                             ctxItem(if (isFollowing) Ic.PersonRemove else Ic.PersonAdd, if (isFollowing) "Unfollow" else "Follow") {
                                 setHeaderMenuOpen(false)
                                 vm.toggleFollow()
+                            }
+                            ctxItem(Ic.NotificationsOff, if (isMutedPeer) "Unmute user" else "Mute user") {
+                                setHeaderMenuOpen(false)
+                                vm.toggleMute()
                             }
                             ctxItem(Ic.ContentCopy, "Copy npub") {
                                 setHeaderMenuOpen(false)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
@@ -57,6 +57,7 @@ val ProfilePage =
         val metadata = useStateFlow(vm.metadata)
         val groups = useStateFlow(vm.userGroups)
         val isFollowing = useStateFlow(vm.isFollowing)
+        val isMuted = useStateFlow(vm.isMuted)
         val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         val isFollowBusy = useStateFlow(vm.isFollowBusy)
         val allMeta = useStateFlow(AppModule.nostrRepository.userMetadata)
@@ -187,13 +188,12 @@ val ProfilePage =
                                         icon(Ic.Bolt)
                                         +"Zap"
                                     }
-                                    // Mute list and NIP-56 reports aren't wired yet.
+                                    // NIP-56 reports aren't wired yet.
                                     button {
                                         className = ClassName("btn-ghost profile-btn sm")
-                                        disabled = true
-                                        title = "Coming soon"
+                                        onClick = { vm.toggleMute() }
                                         icon(Ic.NotificationsOff)
-                                        +"Mute"
+                                        +(if (isMuted) "Unmute" else "Mute")
                                     }
                                     button {
                                         className = ClassName("btn-ghost profile-btn sm")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -5,16 +5,17 @@ import org.nostr.nostrord.auth.logoutConfirmBody
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.notifications.NotificationPermission
 import org.nostr.nostrord.notifications.playNotificationSound
 import org.nostr.nostrord.settings.AppTheme
 import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.ui.Identifier
+import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.screens.backup.BackupViewModel
 import org.nostr.nostrord.ui.screens.backup.MIN_BACKUP_PASSWORD
 import org.nostr.nostrord.ui.screens.backup.backupSecurityTips
 import org.nostr.nostrord.ui.screens.profile.EditProfileViewModel
-import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.screens.settings.DmRelaySettingsViewModel
 import org.nostr.nostrord.ui.screens.settings.MutedUsersViewModel
 import org.nostr.nostrord.ui.screens.settings.SecurityViewModel
@@ -30,6 +31,7 @@ import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.useEscClose
+import org.nostr.nostrord.web.navigation.pushRoute
 import react.FC
 import react.Props
 import react.dom.html.ReactHTML.button
@@ -769,7 +771,7 @@ private val MutedUsersPanel =
                 className = ClassName("settings-info-text")
                 +(
                     "Muted users don't appear in chats, direct messages, or notifications. " +
-                        "Mutes sync to your other Nostr clients."
+                        "Mutes are stored encrypted (nobody can see who you muted) and sync to your other Nostr clients."
                     )
             }
         }
@@ -796,6 +798,8 @@ private val MutedUsersPanel =
                 div {
                     key = pubkey
                     className = ClassName("member-row")
+                    // Row opens the profile page; the route change closes the settings overlay.
+                    onClick = { pushRoute(UserRoute(pubkey)) }
                     WebAvatar {
                         url = meta?.picture
                         seed = pubkey
@@ -808,7 +812,10 @@ private val MutedUsersPanel =
                     }
                     button {
                         className = ClassName("btn-ghost")
-                        onClick = { vm.unmute(pubkey) }
+                        onClick = {
+                            it.stopPropagation()
+                            vm.unmute(pubkey)
+                        }
                         +"Unmute"
                     }
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -14,7 +14,9 @@ import org.nostr.nostrord.ui.screens.backup.BackupViewModel
 import org.nostr.nostrord.ui.screens.backup.MIN_BACKUP_PASSWORD
 import org.nostr.nostrord.ui.screens.backup.backupSecurityTips
 import org.nostr.nostrord.ui.screens.profile.EditProfileViewModel
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.screens.settings.DmRelaySettingsViewModel
+import org.nostr.nostrord.ui.screens.settings.MutedUsersViewModel
 import org.nostr.nostrord.ui.screens.settings.SecurityViewModel
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.isValidRelayUrl
@@ -55,7 +57,7 @@ external interface SettingsScreenProps : Props {
 }
 
 private val sections =
-    listOf("Profile", "Backup Keys", "Relays (NIP-65)", "Direct Messages", "Appearance", "Media", "Notifications", "Security")
+    listOf("Profile", "Backup Keys", "Relays (NIP-65)", "Direct Messages", "Appearance", "Media", "Notifications", "Muted users", "Security")
 
 /**
  * Settings — real port of the Compose SettingsScreen: a full-screen overlay with a section
@@ -152,6 +154,7 @@ val SettingsScreen =
                     "Appearance" -> AppearancePanel()
                     "Media" -> MediaPanel()
                     "Notifications" -> NotificationsPanel()
+                    "Muted users" -> MutedUsersPanel()
                     "Security" -> SecurityPanel()
                 }
             }
@@ -747,6 +750,71 @@ private fun react.ChildrenBuilder.relayChip(label: String, active: Boolean, onTo
         +label
     }
 }
+
+// ── Muted users ──────────────────────────────────────────────────────────────
+
+/**
+ * The account's NIP-51 kind:10000 mute list with an Unmute action per user.
+ * Compose parity: MutedUsersPanelContent.kt.
+ */
+private val MutedUsersPanel =
+    FC<Props> {
+        val vm = useViewModel { MutedUsersViewModel(AppModule.nostrRepository) }
+        val muted = useStateFlow(vm.muted)
+        val userMetadata = useStateFlow(vm.userMetadata)
+
+        div {
+            className = ClassName("settings-card")
+            div {
+                className = ClassName("settings-info-text")
+                +(
+                    "Muted users don't appear in chats, direct messages, or notifications. " +
+                        "Mutes sync to your other Nostr clients."
+                    )
+            }
+        }
+
+        div {
+            className = ClassName("settings-card")
+            div {
+                className = ClassName("settings-section-head")
+                +"MUTED USERS"
+            }
+            if (muted.isEmpty()) {
+                div {
+                    className = ClassName("settings-info-text")
+                    +"You haven't muted anyone. Mute someone from their profile to hide their messages."
+                }
+            }
+            muted.forEach { pubkey ->
+                val meta = userMetadata[pubkey]
+                val npub = Nip19.encodeNpub(pubkey)
+                val name =
+                    meta?.displayName?.takeIf { it.isNotBlank() }
+                        ?: meta?.name?.takeIf { it.isNotBlank() }
+                        ?: (npub.take(12) + "…")
+                div {
+                    key = pubkey
+                    className = ClassName("member-row")
+                    WebAvatar {
+                        url = meta?.picture
+                        seed = pubkey
+                        this.name = name
+                        cls = "member-avatar"
+                    }
+                    span {
+                        className = ClassName("member-name")
+                        +name
+                    }
+                    button {
+                        className = ClassName("btn-ghost")
+                        onClick = { vm.unmute(pubkey) }
+                        +"Unmute"
+                    }
+                }
+            }
+        }
+    }
 
 // ── Notifications ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Adds a NIP-51 mute list (kind:10000) with private mutes by default. Muting a user hides their messages and reactions in group chats, drops their DM conversations and unread badges, and suppresses their notifications, on Android, desktop, iOS, and web. Mute/unmute is available from the profile modal, the full profile page, and the DM header menu; Settings > Muted users lists the mutes with per-user Unmute and rows that open the profile. Manually tested on web (mute, unmute, encrypted publish, scroll behavior).

| Piece | Where |
|---|---|
| Tag parse/rebuild + private-section codec | `nostr/Nip51.kt` (+ tests) |
| Fetch / ingest / publish / per-account snapshot | `NostrRepository`, mirroring the kind:3 contact-list block; the kind:10000 rides the kind:3 REQ as a second filter so the retry machinery is shared |
| Private mutes | new mutes go to the NIP-44 self-encrypted `content`; filtering unions public `p` tags with the decrypted private set; one decrypt per received list, one encrypt per publish |
| Foreign-data safety | non-`p` tags carried over; an undecryptable `content` (NIP-04-era/foreign) is republished verbatim, never rebuilt, with new mutes falling back to a public `p` tag; the full last-known list is persisted per account so a publish after restart never rebuilds from a partial base |
| Staleness guard | persisted kind:10000 timestamp floors ingest so a lagging relay can't resurrect removed mutes |
| Filtering | `GroupViewModel` (messages + reactions, raw cache intact so unmute is instant), `DmManager` (conversations/unread at the source), `UnreadManager` (badges + notifications, incl. reactions) |
| UI | profile modal + profile page + DM header kebab toggles, Settings > Muted users panel, Compose and web over shared ViewModels (`MutedUsersViewModel`, `ProfilePageViewModel`) |
| Web scroll fix | muting shrank the feed, the scrollTop clamp read as a scroll-up gesture and latched `userScrolledUp`, so the unmute growth skipped the bottom pin and stranded the view mid-history |

Commits:
- feat: NIP-51 mute list (kind:10000) with muted-author filtering
- feat(ui): mute/unmute action + Muted users settings panel (Compose + web)
- fix(web): unmute stranded the chat scroll mid-history
- feat: hide muted authors' reactions in chat
- feat(ui): mute toggle on the profile page and DM header menu
- feat: private (NIP-44) mutes and full mute-list snapshot persistence
- feat(ui): settings muted list opens profiles; encrypted-mutes copy
- fix(native): navigate from the settings overlay (muted users -> profile)
- feat: re-fetch kind:3/kind:10000 on app foreground

Deferred: reading NIP-04-encrypted private sections (kept verbatim, not filtered), NIP-56 reports, hiding muted users from member lists / DM thread page / mention autocomplete.
