### PR TITLE
Use NIP-11 `self` as the group naddr author, falling back to `pubkey`

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip11.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip11.kt
@@ -30,6 +30,8 @@ data class Nip11RelayInfo(
     val description: String? = null,
     val icon: String? = null,
     val pubkey: String? = null,
+    /** NIP-29 `self`: the key the relay signs group metadata (kind:39xxx) with. */
+    val self: String? = null,
     val contact: String? = null,
     val supportedNips: List<Int> = emptyList(),
     val software: String? = null,
@@ -43,6 +45,12 @@ data class Nip11RelayInfo(
      */
     val supportsSubgroups: Boolean? = null,
 ) {
+    /**
+     * Author pubkey for group naddr encoding: `self`, falling back to `pubkey` for
+     * relays (e.g. 0xchat) that don't publish `self`.
+     */
+    val groupNaddrAuthor: String? get() = self ?: pubkey
+
     companion object
 }
 
@@ -106,6 +114,7 @@ suspend fun fetchNip11RelayInfo(relayUrl: String): Nip11RelayInfo? {
                 description = obj["description"]?.jsonPrimitive?.contentOrNull,
                 icon = icon,
                 pubkey = obj["pubkey"]?.jsonPrimitive?.contentOrNull,
+                self = obj["self"]?.jsonPrimitive?.contentOrNull,
                 contact = obj["contact"]?.jsonPrimitive?.contentOrNull,
                 supportedNips =
                 obj["supported_nips"]

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -842,7 +842,7 @@ fun GroupScreen(
                         val imetaTags = pendingUploads.map { it.toImetaTag() }
                         var content = text
                         groupMentions.forEach { (name, group) ->
-                            val relayPubkey = relayMetadata[group.relay]?.pubkey
+                            val relayPubkey = relayMetadata[group.relay]?.groupNaddrAuthor
                             val naddr = Nip19.encodeNaddr(group.id, group.relay, pubkeyHex = relayPubkey)
                             content = content.replace("%$name", "nostr:$naddr")
                         }
@@ -982,7 +982,7 @@ fun GroupScreen(
                         val imetaTags = pendingUploads.map { it.toImetaTag() }
                         var content = text
                         groupMentions.forEach { (name, group) ->
-                            val relayPubkey = relayMetadata[group.relay]?.pubkey
+                            val relayPubkey = relayMetadata[group.relay]?.groupNaddrAuthor
                             val naddr = Nip19.encodeNaddr(group.id, group.relay, pubkeyHex = relayPubkey)
                             content = content.replace("%$name", "nostr:$naddr")
                         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/InviteCodesModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/InviteCodesModal.kt
@@ -62,7 +62,7 @@ fun InviteCodesModal(
     val copyToClipboard = rememberClipboardWriter()
     // Author = the relay's own pubkey (NIP-11) for the naddr share format.
     val relayMetadata by AppModule.nostrRepository.relayMetadata.collectAsState()
-    val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
+    val relayPubkey = relayMetadata[relayUrl]?.groupNaddrAuthor ?: relayMetadata[relayUrl.trimEnd('/')]?.groupNaddrAuthor
 
     Dialog(
         onDismissRequest = onDismiss,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ManageGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ManageGroupModal.kt
@@ -750,7 +750,7 @@ private fun ManageInvitesSection(
                 Triple(code, m.id, m.createdAt)
             }
             .sortedByDescending { it.third }
-    val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
+    val relayPubkey = relayMetadata[relayUrl]?.groupNaddrAuthor ?: relayMetadata[relayUrl.trimEnd('/')]?.groupNaddrAuthor
 
     Column(modifier = Modifier.fillMaxSize()) {
         Button(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ShareGroupModal.kt
@@ -40,7 +40,7 @@ fun ShareGroupModal(
     onDismiss: () -> Unit,
 ) {
     val relayMetadata by AppModule.nostrRepository.relayMetadata.collectAsState()
-    val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
+    val relayPubkey = relayMetadata[relayUrl]?.groupNaddrAuthor ?: relayMetadata[relayUrl.trimEnd('/')]?.groupNaddrAuthor
 
     Dialog(
         onDismissRequest = onDismiss,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/InviteCodesModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/InviteCodesModal.kt
@@ -49,7 +49,7 @@ val InviteCodesModal =
 
         // Author = the relay's own pubkey (NIP-11) for the naddr format.
         val relayMetadata = useStateFlow(repo.relayMetadata)
-        val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
+        val relayPubkey = relayMetadata[relayUrl]?.groupNaddrAuthor ?: relayMetadata[relayUrl.trimEnd('/')]?.groupNaddrAuthor
 
         useEscClose { props.onClose() }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
@@ -760,7 +760,7 @@ private val ManageInvitesSection =
                     Triple(code, m.id, m.createdAt)
                 }
                 .sortedByDescending { it.third }
-        val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
+        val relayPubkey = relayMetadata[relayUrl]?.groupNaddrAuthor ?: relayMetadata[relayUrl.trimEnd('/')]?.groupNaddrAuthor
 
         button {
             className = ClassName("btn-primary block")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt
@@ -28,8 +28,8 @@ val ShareGroupModal =
         val group = props.group
         val relayUrl = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
         val relayMetadata = useStateFlow(AppModule.nostrRepository.relayMetadata)
-        // Author = the relay's own pubkey (NIP-11), like native; falls back to zero bytes inside encodeNaddr.
-        val relayPubkey = relayMetadata[relayUrl]?.pubkey ?: relayMetadata[relayUrl.trimEnd('/')]?.pubkey
+        // Author = NIP-11 `self` (relay signing key), else `pubkey`; falls back to zero bytes inside encodeNaddr.
+        val relayPubkey = relayMetadata[relayUrl]?.groupNaddrAuthor ?: relayMetadata[relayUrl.trimEnd('/')]?.groupNaddrAuthor
 
         useEscClose { props.onClose() }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2256,7 +2256,7 @@ val ChatScreen =
                     this.allGroups = allGroups
                     this.userMetadata = userMetadata
                     this.relayUrl = relayUrl
-                    this.relayPubkeyOf = { r -> relayMetadata[r]?.pubkey ?: relayMetadata[r.normalizeRelayUrl()]?.pubkey }
+                    this.relayPubkeyOf = { r -> relayMetadata[r]?.groupNaddrAuthor ?: relayMetadata[r.normalizeRelayUrl()]?.groupNaddrAuthor }
                     this.replyingToId = replyingToId
                     this.replyParentName =
                         replyingToId?.let { id -> messagesById[id]?.let { p -> displayName(p.pubkey, userMetadata[p.pubkey]) } }


### PR DESCRIPTION
Closes #172.

The group naddr author was always the NIP-11 `pubkey` (the relay's admin contact). NIP-29 expects the key the relay signs kind:39xxx group metadata with, published as NIP-11 `self`. This parses `self` into `Nip11RelayInfo` and adds a `groupNaddrAuthor` helper (`self ?: pubkey`); the fallback covers relays like 0xchat that don't publish `self`. If neither exists, `encodeNaddr` keeps the zero-bytes fallback.

All nine naddr/identifier call sites now use it:

| Surface | Files |
|---|---|
| Compose | GroupScreen, ShareGroupModal, ManageGroupModal, InviteCodesModal |
| Web | ShareGroupModal, ManageGroupModal, InviteCodesModal, ChatScreen (`relayPubkeyOf`) |

The cached relay metadata deserializes unchanged (`self` is optional with a default); old cache entries use the `pubkey` fallback until refetched. Verified with `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid` and `:composeApp:jvmTest`.

- ba49ffd6 fix(share): use NIP-11 self as naddr author, falling back to pubkey