### PR TITLE
fix(chat): stop the composer hints from blocking "?" and close them on outside click

### DIFF
--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -130,9 +130,13 @@ fun MessageInput(
     var groupMentionQuery by remember { mutableStateOf("") }
     var groupMentionSelectedIndex by remember { mutableStateOf(0) }
     var showEmojiPicker by remember { mutableStateOf(false) }
-    // Keyboard-shortcuts hint, opened by typing "?" in an empty field or clicking the
-    // footer pill (web parity: ChatScreen showHints).
+    // Keyboard-shortcuts hint, opened by Ctrl+/ or clicking the footer pill
+    // (web parity: ChatScreen showHints).
     var showHints by remember { mutableStateOf(false) }
+    // Consuming the Ctrl+/ KeyDown does not stop desktop's typed-char pipeline: the
+    // "/" (or "?") still reaches the field and would land AND instantly close the
+    // hints. One-shot flag so handleTextFieldValueChange drops that glyph.
+    var swallowChordGlyph by remember { mutableStateOf(false) }
     val anyOverlayOpen = showMentionPopup || showGroupMentionPopup || showEmojiPicker
     val currentOnOverlayVisibilityChange by rememberUpdatedState(onOverlayVisibilityChange)
     LaunchedEffect(anyOverlayOpen) {
@@ -296,13 +300,20 @@ fun MessageInput(
             }
             return
         }
-        // "?" in an empty field opens the shortcuts hint instead of typing the glyph
-        // (web parity). Works across platforms since it keys off the resulting value,
-        // not a physical key code.
-        if (textFieldValue.text.isEmpty() && newValue.text == "?") {
-            showHints = true
-            return
+        // Drop the glyph the Ctrl+/ chord injected (see swallowChordGlyph).
+        if (swallowChordGlyph) {
+            swallowChordGlyph = false
+            val pos = newValue.selection.start - 1
+            if (pos >= 0 && pos < newValue.text.length &&
+                (newValue.text[pos] == '/' || newValue.text[pos] == '?') &&
+                newValue.text.removeRange(pos, pos + 1) == textFieldValue.text
+            ) {
+                return
+            }
         }
+        // Typing closes the hints card; it opens via Ctrl+/ or the footer pill only,
+        // never a typed character, so every glyph ("?" included) stays a normal
+        // message character (web parity).
         if (showHints) showHints = false
         textFieldValue = newValue
         updateMentionState(newValue)
@@ -316,6 +327,7 @@ fun MessageInput(
     fun submit() {
         val text = textFieldValue.text
         if (text.isBlank() || isSending || isUploadingPaste) return
+        showHints = false
         showEmojiPicker = false
         showMentionPopup = false
         showGroupMentionPopup = false
@@ -483,7 +495,7 @@ fun MessageInput(
         val textFieldInteractionSource = remember { MutableInteractionSource() }
         val isAndroid = remember { getPlatform().name.startsWith("Android") }
         // Landscape on a phone has little vertical room, so the discoverability footer is
-        // dropped there (the "?" trigger still works); cross-platform via the window size.
+        // dropped there; cross-platform via the window size.
         val windowSize = LocalWindowInfo.current.containerSize
         val isLandscape = windowSize.width > windowSize.height
 
@@ -652,6 +664,29 @@ fun MessageInput(
             ) {
                 // Shortcuts hint card, floating just above the pill (web .composer-hints).
                 if (showHints) {
+                    // Transparent full-window scrim so a click/tap anywhere outside the card
+                    // dismisses it (same pattern as the mention scrims). Non-focusable so the
+                    // soft keyboard stays up; back press also closes. Only while the field is
+                    // empty: with text present the scrim would swallow the tap on Send
+                    // (typing, Esc and submit() close the card in that state).
+                    if (textFieldValue.text.isEmpty()) {
+                        Popup(
+                            alignment = Alignment.Center,
+                            onDismissRequest = { showHints = false },
+                            properties = PopupProperties(focusable = false, dismissOnClickOutside = false, dismissOnBackPress = true),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(Color.Transparent)
+                                    .clickable(
+                                        interactionSource = remember { MutableInteractionSource() },
+                                        indication = null,
+                                        onClick = { showHints = false },
+                                    ),
+                            )
+                        }
+                    }
                     ComposerHints(isTouch = isAndroid)
                     Spacer(modifier = Modifier.height(Spacing.xs))
                 }
@@ -728,6 +763,22 @@ fun MessageInput(
                                     }
                                 }
                                 .onPreviewKeyEvent { event ->
+                                    // AWT keyCodes for punctuation are layout-dependent (the ABNT2
+                                    // "/" key can even report VK_UNDEFINED), so besides Key.Slash
+                                    // also match the produced character; "?" is the shifted variant.
+                                    val isHintsChord = event.isCtrlPressed &&
+                                        (
+                                            event.key == Key.Slash ||
+                                                event.key == Key.NumPadDivide ||
+                                                event.utf16CodePoint == '/'.code ||
+                                                event.utf16CodePoint == '?'.code
+                                            )
+                                    // The swallow flag lives only until the next KeyDown: the
+                                    // chord's typed glyph (when the platform delivers one) arrives
+                                    // in between, so a later legit "/" is never eaten.
+                                    if (event.type == KeyEventType.KeyDown && !isHintsChord) {
+                                        swallowChordGlyph = false
+                                    }
                                     val filteredMembers = getFilteredMembers(groupMembers, mentionQuery)
                                     val filteredGroups = getFilteredGroups(availableGroups, groupMentionQuery)
                                     when {
@@ -770,6 +821,12 @@ fun MessageInput(
                                             event.key == Key.Escape &&
                                             replyingToMessage != null -> {
                                             onCancelReply()
+                                            true
+                                        }
+                                        // Ctrl+/ toggles the shortcuts hint.
+                                        event.type == KeyEventType.KeyDown && isHintsChord -> {
+                                            swallowChordGlyph = true
+                                            showHints = !showHints
                                             true
                                         }
                                         event.type == KeyEventType.KeyDown &&
@@ -1158,9 +1215,9 @@ private fun KbdChip(label: String) {
 }
 
 /**
- * Shortcuts / mention-triggers card shown above the composer when "?" is typed in an
- * empty field (web .composer-hints). Touch shows only the mention triggers (Enter is a
- * newline there); desktop adds the Enter / Shift+Enter send shortcuts.
+ * Shortcuts / mention-triggers card shown above the composer, opened by Ctrl+/ or
+ * the footer pill (web .composer-hints). Touch shows only the mention triggers
+ * (Enter is a newline there); desktop adds the Enter / Shift+Enter send shortcuts.
  */
 @Composable
 private fun ComposerHints(isTouch: Boolean) {
@@ -1200,7 +1257,7 @@ private fun ComposerHints(isTouch: Boolean) {
     }
 }
 
-/** "Type ? to see shortcuts" cue below the composer, clickable to toggle the hints. */
+/** Discoverability cue below the composer, clickable to toggle the hints. */
 @Composable
 private fun ComposerHintFooter(showHints: Boolean, isTouch: Boolean, onToggle: () -> Unit) {
     Row(
@@ -1212,18 +1269,23 @@ private fun ComposerHintFooter(showHints: Boolean, isTouch: Boolean, onToggle: (
             .pointerHoverIcon(PointerIcon.Hand)
             .padding(horizontal = Spacing.xs, vertical = 2.dp),
     ) {
-        if (showHints && !isTouch) {
-            Text("Press ", color = NostrordColors.TextMuted, fontSize = 11.sp)
-            KbdChip("Esc")
-            Text(" to close", color = NostrordColors.TextMuted, fontSize = 11.sp)
-        } else {
-            Text("Type ", color = NostrordColors.TextMuted, fontSize = 11.sp)
-            KbdChip("?")
-            Text(
-                if (isTouch) " to see mention triggers" else " to see shortcuts",
-                color = NostrordColors.TextMuted,
-                fontSize = 11.sp,
-            )
+        when {
+            showHints && !isTouch -> {
+                Text("Press ", color = NostrordColors.TextMuted, fontSize = 11.sp)
+                KbdChip("Esc")
+                Text(" to close", color = NostrordColors.TextMuted, fontSize = 11.sp)
+            }
+            showHints -> {
+                Text("Tap outside to close", color = NostrordColors.TextMuted, fontSize = 11.sp)
+            }
+            isTouch -> {
+                Text("Tap to see mention triggers", color = NostrordColors.TextMuted, fontSize = 11.sp)
+            }
+            else -> {
+                Text("Press ", color = NostrordColors.TextMuted, fontSize = 11.sp)
+                KbdChip("Ctrl + /")
+                Text(" to see shortcuts", color = NostrordColors.TextMuted, fontSize = 11.sp)
+            }
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -304,7 +304,8 @@ fun MessageInput(
         if (swallowChordGlyph) {
             swallowChordGlyph = false
             val pos = newValue.selection.start - 1
-            if (pos >= 0 && pos < newValue.text.length &&
+            if (pos >= 0 &&
+                pos < newValue.text.length &&
                 (newValue.text[pos] == '/' || newValue.text[pos] == '?') &&
                 newValue.text.removeRange(pos, pos + 1) == textFieldValue.text
             ) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -506,11 +506,33 @@ private val ChatComposer =
         // Markdown toolbar (prototype Composer): wraps the selection via execCommand
         // so edits join the textarea's NATIVE undo stack (Ctrl+Z works).
         val (toolbarOpen, setToolbarOpen) = useState { false }
-        // Hints popup (keyboard shortcuts on desktop, mention triggers on touch). It is an
-        // explicit toggle, not derived from the draft: "?" opens it without landing in the
-        // field, Esc (or typing) closes it, so "?" stays a normal message character.
+        // Hints popup (keyboard shortcuts on desktop, mention triggers on touch).
+        // Opened by Ctrl+/ or the footer pill; Esc, typing, or clicking outside
+        // closes it. Never triggered by a typed character, so every glyph
+        // ("?" included) stays a normal message character.
         val (showHints, setShowHints) = useState { false }
-        val isTouch = window.matchMedia("(pointer: coarse)").matches
+        // Touch-first device: coarse pointer OR no hover. Phones always match at least
+        // one; a touchscreen laptop (fine pointer + hover) stays on the keyboard-first
+        // behavior (Enter sends, Ctrl+/ shortcut hint).
+        val isTouch = window.matchMedia("(pointer: coarse)").matches ||
+            window.matchMedia("(hover: none)").matches
+        // Click/tap anywhere outside the hints box (or its footer toggle, which would
+        // otherwise close-then-reopen) dismisses it. pointerdown covers touch too.
+        useEffect(showHints) {
+            if (showHints) {
+                val handler: (dynamic) -> Unit = { e ->
+                    if (e.target?.closest(".composer-hints, .composer-hint-footer") == null) {
+                        setShowHints(false)
+                    }
+                }
+                document.asDynamic().addEventListener("pointerdown", handler)
+                try {
+                    awaitCancellation()
+                } finally {
+                    document.asDynamic().removeEventListener("pointerdown", handler)
+                }
+            }
+        }
 
         fun insertAtCursor(replacement: String, caretBack: Int = 0) {
             val ta = composerInputRef.current
@@ -643,8 +665,8 @@ private val ChatComposer =
                 // are conditional siblings rendered before the frame, and without keys
                 // React reconciles by index and REMOUNTS the frame - the focused
                 // textarea included (same failure mode as the chat-header note).
-                // Type "?" to surface hints (keyboard shortcuts on desktop, mention
-                // triggers on touch, where Enter is a newline).
+                // Hints box (keyboard shortcuts on desktop, mention triggers on touch,
+                // where Enter is a newline), opened by Ctrl+/ or the footer pill.
                 if (showHints) {
                     div {
                         key = "composer-hints"
@@ -847,18 +869,11 @@ private val ChatComposer =
                                 rows = 1
                                 onChange = { event ->
                                     val v = event.currentTarget.value
-                                    if (isTouch && draft.isEmpty() && v == "?") {
-                                        // Touch keyboards don't emit a reliable keydown for "?", so open
-                                        // the hints from the value instead and keep the glyph out of the
-                                        // field (matches the desktop intercept below).
-                                        setShowHints(true)
-                                    } else {
-                                        if (showHints) setShowHints(false)
-                                        setDraft(v)
-                                        val cursor = (event.currentTarget.asDynamic().selectionStart as? Int) ?: v.length
-                                        setMention(detectMention(v, cursor))
-                                        setMentionSelected(0)
-                                    }
+                                    if (showHints) setShowHints(false)
+                                    setDraft(v)
+                                    val cursor = (event.currentTarget.asDynamic().selectionStart as? Int) ?: v.length
+                                    setMention(detectMention(v, cursor))
+                                    setMentionSelected(0)
                                 }
                                 onKeyDown = { event ->
                                     val hasMentions = mention != null && mentionMatches.isNotEmpty()
@@ -891,10 +906,12 @@ private val ChatComposer =
                                             event.preventDefault()
                                             props.onCancelReply()
                                         }
-                                        !isTouch && event.key == "?" && draft.isEmpty() && !hasMentions -> {
-                                            // Open the shortcuts box; the glyph never lands in the field.
+                                        event.ctrlKey && (event.key == "/" || event.key == "?") -> {
+                                            // Ctrl+/ toggles the shortcuts box ("?" accepted too, the
+                                            // same physical key shifted). Never a plain typed
+                                            // character, so any glyph can be typed and sent.
                                             event.preventDefault()
-                                            setShowHints(true)
+                                            setShowHints(!showHints)
                                         }
                                         event.key == "Enter" && !event.shiftKey -> {
                                             // Inside a list: continue / exit it, never send. On touch,
@@ -981,17 +998,21 @@ private val ChatComposer =
                 div {
                     key = "composer-footer"
                     className = ClassName("composer-hint-footer")
-                    // Clickable affordance: toggles the same box, the only reliable opener on
-                    // touch (where "?" never reaches a keydown).
+                    // Clickable affordance: toggles the same box.
                     onClick = { setShowHints(!showHints) }
-                    if (showHints && !isTouch) {
-                        +"Press "
-                        kbd { +"Esc" }
-                        +" to close"
-                    } else {
-                        +"Type "
-                        kbd { +"?" }
-                        +(if (isTouch) " to see mention triggers" else " to see shortcuts")
+                    when {
+                        showHints && !isTouch -> {
+                            +"Press "
+                            kbd { +"Esc" }
+                            +" to close"
+                        }
+                        showHints -> +"Tap outside to close"
+                        isTouch -> +"Tap to see mention triggers"
+                        else -> {
+                            +"Press "
+                            kbd { +"Ctrl + /" }
+                            +" to see shortcuts"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Typing "?" in an empty composer was intercepted to open the hints box and the glyph never reached the field, so a message of just "?" could not be sent. The box is now opened by Ctrl+/ on desktop or the clickable footer pill on touch, never by a typed character, and clicking or tapping outside it dismisses it.

| Concern | Before | After |
|---|---|---|
| Sending a lone "?" | impossible (glyph swallowed) | works; no typed character opens the box |
| Desktop opener | typing "?" in an empty field | Ctrl+/ (Ctrl+? too), matched by key and produced char since AWT punctuation keyCodes are layout-dependent; the glyph the chord injects through the typed-char pipeline is dropped |
| Touch opener | typing "?" (value intercept) | footer pill tap only |
| Closing | Esc / typing | plus click/tap outside: document pointerdown listener on web, transparent scrim Popup on native (field-empty only, so it never swallows the Send tap); submit also closes |
| Web touch detection | pointer: coarse | pointer: coarse or hover: none |

Both sides changed in lockstep: `MessageInput.kt` (Compose) and `ChatScreen.kt` (web). Validated on desktop JVM (Ctrl+/ toggles cleanly, field stays clean) and compiles on jvm + js.

Commits:
- a7eb2383 fix(chat): stop the composer hints from blocking "?" and close them on outside click