### PR TITLE
fix: wire and surface NIP-29 moderation actions on all UIs

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ChatTimeline.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ChatTimeline.kt
@@ -24,3 +24,12 @@ fun clampSystemEventsToLoadedWindow(
     val oldestMessageTs = sorted.filter { it.kind == 9 }.minOfOrNull { it.createdAt } ?: return sorted
     return sorted.filter { it.kind == 9 || it.createdAt >= oldestMessageTs }
 }
+
+/**
+ * Subject-verb agreement for a merged system row: the action strings are written for a
+ * single subject ("was removed", "is now admin") but a multi-user merge renders "N members"
+ * as the subject.
+ */
+fun pluralizeSystemAction(action: String): String = action
+    .replaceFirst("was ", "were ")
+    .replaceFirst("is now", "are now")

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
@@ -474,55 +476,99 @@ class GroupViewModel(
     private val _moderationError = MutableStateFlow<String?>(null)
     val moderationError: StateFlow<String?> = _moderationError
 
+    /** True while a kind:9000/9001 is awaiting the relay's OK; gates the moderation buttons. */
+    private val _moderationBusy = MutableStateFlow(false)
+    val moderationBusy: StateFlow<Boolean> = _moderationBusy
+
+    // Counted, not boolean: approve-join and profile-modal actions can overlap, and the
+    // first one finishing must not un-gate the UI while another is still in flight.
+    // viewModelScope is main-confined, so plain increments are safe.
+    private var moderationInFlight = 0
+
+    private suspend fun trackModeration(block: suspend () -> Unit) {
+        moderationInFlight++
+        _moderationBusy.value = true
+        try {
+            block()
+        } finally {
+            moderationInFlight--
+            if (moderationInFlight == 0) _moderationBusy.value = false
+        }
+    }
+
+    init {
+        // A moderation event queued while offline is flushed by the connection layer after
+        // its sendAndAwaitOk already timed out, so the action can succeed with a stale
+        // timeout error still on screen. The kind:9000/9001 echo updating the member or
+        // admin list is the visible success signal; a change invalidates the error.
+        viewModelScope.launch {
+            combine(repo.groupMembers, repo.groupAdmins) { members, admins ->
+                members[groupId] to admins[groupId]
+            }
+                .distinctUntilChanged()
+                .drop(1)
+                .collect { _moderationError.value = null }
+        }
+    }
+
     fun clearModerationError() {
         _moderationError.value = null
+    }
+
+    /** Relay OK reasons come prefixed ("blocked: not an admin"); surface them readable. */
+    private fun surfaceModerationError(error: AppError) {
+        val raw = error.cause?.message?.takeIf { it.isNotBlank() } ?: error.message
+        _moderationError.value =
+            raw
+                .removePrefix("blocked: ")
+                .removePrefix("error: ")
+                .replaceFirstChar { it.uppercaseChar() }
     }
 
     fun addUser(
         targetPubkey: String,
         roles: List<String> = emptyList(),
         successMessage: String = "User added to the group",
+        onSuccess: () -> Unit = {},
     ) {
         viewModelScope.launch {
-            when (val result = repo.addUser(groupId, targetPubkey, roles)) {
-                is Result.Error -> {
-                    val raw = result.error.cause?.message ?: result.error.toString()
-                    _moderationError.value =
-                        raw
-                            .removePrefix("blocked: ")
-                            .removePrefix("error: ")
-                            .replaceFirstChar { it.uppercaseChar() }
+            _moderationError.value = null
+            trackModeration {
+                when (val result = repo.addUser(groupId, targetPubkey, roles)) {
+                    is Result.Error -> surfaceModerationError(result.error)
+                    // A kind:9000 (add / role change) is not reliably rendered in the
+                    // timeline, so confirm the action to the admin who triggered it.
+                    is Result.Success -> {
+                        AppModule.postSystemMessage(successMessage)
+                        onSuccess()
+                    }
                 }
-                // A kind:9000 (add / role change) is not reliably rendered in the
-                // timeline, so confirm the action to the admin who triggered it.
-                is Result.Success -> AppModule.postSystemMessage(successMessage)
             }
         }
     }
 
-    fun removeUser(targetPubkey: String) {
+    fun removeUser(targetPubkey: String, onSuccess: () -> Unit = {}) {
         viewModelScope.launch {
-            when (val result = repo.removeUser(groupId, targetPubkey)) {
-                is Result.Error -> {
-                    val raw = result.error.cause?.message ?: result.error.toString()
-                    _moderationError.value =
-                        raw
-                            .removePrefix("blocked: ")
-                            .removePrefix("error: ")
-                            .replaceFirstChar { it.uppercaseChar() }
+            _moderationError.value = null
+            trackModeration {
+                when (val result = repo.removeUser(groupId, targetPubkey)) {
+                    is Result.Error -> surfaceModerationError(result.error)
+                    is Result.Success -> {
+                        AppModule.postSystemMessage("User removed from the group")
+                        onSuccess()
+                    }
                 }
-                is Result.Success -> AppModule.postSystemMessage("User removed from the group")
             }
         }
     }
 
-    fun promoteToAdmin(targetPubkey: String) {
-        addUser(targetPubkey, listOf("admin"), successMessage = "User promoted to admin")
+    fun promoteToAdmin(targetPubkey: String, onSuccess: () -> Unit = {}) {
+        addUser(targetPubkey, listOf("admin"), successMessage = "User promoted to admin", onSuccess = onSuccess)
     }
 
-    fun demoteFromAdmin(targetPubkey: String) {
+    fun demoteFromAdmin(targetPubkey: String, onSuccess: () -> Unit = {}) {
         // Re-add user without admin role to demote
-        addUser(targetPubkey, emptyList(), successMessage = "Admin role removed")
+        addUser(targetPubkey, emptyList(), successMessage = "Admin role removed", onSuccess = onSuccess)
     }
 
     fun approveJoinRequest(targetPubkey: String) {
@@ -532,14 +578,7 @@ class GroupViewModel(
     fun rejectJoinRequest(joinRequestEventId: String) {
         viewModelScope.launch {
             when (val result = repo.rejectJoinRequest(groupId, joinRequestEventId)) {
-                is Result.Error -> {
-                    val raw = result.error.cause?.message ?: result.error.toString()
-                    _moderationError.value =
-                        raw
-                            .removePrefix("blocked: ")
-                            .removePrefix("error: ")
-                            .replaceFirstChar { it.uppercaseChar() }
-                }
+                is Result.Error -> surfaceModerationError(result.error)
                 is Result.Success -> Unit
             }
         }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.network
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -526,16 +527,28 @@ class FakeNostrRepository : NostrRepositoryApi {
 
     override fun setActiveGroup(groupId: String?) {}
 
+    var addUserResult: Result<Unit> = Result.Success(Unit)
+    var addUserCalls = mutableListOf<Triple<String, String, List<String>>>()
+
+    /** When set, addUser suspends until completed — lets tests observe in-flight state. */
+    var addUserGate: CompletableDeferred<Unit>? = null
+
     override suspend fun addUser(
         groupId: String,
         targetPubkey: String,
         roles: List<String>,
-    ): Result<Unit> = Result.Success(Unit)
+    ): Result<Unit> {
+        addUserCalls.add(Triple(groupId, targetPubkey, roles))
+        addUserGate?.await()
+        return addUserResult
+    }
+
+    var removeUserResult: Result<Unit> = Result.Success(Unit)
 
     override suspend fun removeUser(
         groupId: String,
         targetPubkey: String,
-    ): Result<Unit> = Result.Success(Unit)
+    ): Result<Unit> = removeUserResult
 
     override suspend fun rejectJoinRequest(
         groupId: String,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.ui
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -10,11 +11,14 @@ import org.nostr.nostrord.network.FakeNostrRepository
 import org.nostr.nostrord.ui.screens.group.GroupMembership
 import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.deriveMembershipStatus
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -54,6 +58,107 @@ class GroupViewModelTest {
     fun `isLoadingMore starts false for group`() = runTest {
         val vm = vm()
         assertFalse(vm.isLoadingMore.value["test-group"] ?: false)
+    }
+
+    // -------------------------------------------------------------------------
+    // Moderation actions (#174): errors must surface, never fail silently
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `promoteToAdmin sends the admin role and reports success`() = runTest {
+        val fake = FakeNostrRepository()
+        val vm = vm(fake)
+
+        var succeeded = false
+        vm.promoteToAdmin("target") { succeeded = true }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(Triple("test-group", "target", listOf("admin")), fake.addUserCalls.single())
+        assertTrue(succeeded)
+        assertNull(vm.moderationError.value)
+    }
+
+    @Test
+    fun `promote failure surfaces the relay reason without the blocked prefix`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.addUserResult =
+            Result.Error(AppError.Group.SendFailed("test-group", Exception("blocked: not an admin")))
+        val vm = vm(fake)
+
+        var succeeded = false
+        vm.promoteToAdmin("target") { succeeded = true }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(succeeded)
+        assertEquals("Not an admin", vm.moderationError.value)
+    }
+
+    @Test
+    fun `remove timeout surfaces the friendly AppError message`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.removeUserResult = Result.Error(AppError.Group.SendTimeout("test-group"))
+        val vm = vm(fake)
+
+        vm.removeUser("target")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            "Timed out waiting for relay confirmation (group: test-group)",
+            vm.moderationError.value,
+        )
+    }
+
+    @Test
+    fun `moderation is busy while awaiting the relay and idle after`() = runTest {
+        val fake = FakeNostrRepository()
+        val gate = CompletableDeferred<Unit>()
+        fake.addUserGate = gate
+        val vm = vm(fake)
+
+        vm.promoteToAdmin("target")
+        testDispatcher.scheduler.runCurrent()
+        assertTrue(vm.moderationBusy.value)
+
+        gate.complete(Unit)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(vm.moderationBusy.value)
+    }
+
+    @Test
+    fun `a member list change clears a stale moderation error`() = runTest {
+        // Offline remove: the await times out (error shown), but the queued event is
+        // flushed on reconnect and the relay echo updates the member list. The stale
+        // error must not outlive the visible success.
+        val fake = FakeNostrRepository()
+        fake.removeUserResult = Result.Error(AppError.Group.SendTimeout("test-group"))
+        val vm = vm(fake)
+
+        vm.removeUser("target")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(
+            "Timed out waiting for relay confirmation (group: test-group)",
+            vm.moderationError.value,
+        )
+
+        fake._groupMembers.value = mapOf("test-group" to listOf("someone-else"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(vm.moderationError.value)
+    }
+
+    @Test
+    fun `a successful action clears the previous moderation error`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.removeUserResult = Result.Error(AppError.Group.SendTimeout("test-group"))
+        val vm = vm(fake)
+
+        vm.removeUser("target")
+        testDispatcher.scheduler.advanceUntilIdle()
+        fake.removeUserResult = Result.Success(Unit)
+        vm.removeUser("target")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(vm.moderationError.value)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItemSystemEventTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItemSystemEventTest.kt
@@ -50,6 +50,64 @@ class ChatItemSystemEventTest {
     }
 
     @Test
+    fun duplicateRemoval_ofSameUser_isNotCountedTwice() {
+        // An offline-queued 9001 flushed on reconnect can land beside a fresh one for
+        // the same user; the merged row must not read "2 members".
+        val events = systemEvents(
+            listOf(
+                msg(9001, createdAt = 1000, tags = listOf(listOf("p", "bob"))),
+                msg(9001, createdAt = 1010, tags = listOf(listOf("p", "bob"))),
+            ),
+        )
+        assertEquals(1, events.size)
+        assertTrue(events[0].additionalUsers.isEmpty())
+        assertEquals("bob", events[0].pubkey)
+    }
+
+    @Test
+    fun removalsOfDifferentUsers_renderSeparateRows() {
+        // Moderation is an audit trail: each removal names its target, never "2 members".
+        val events = systemEvents(
+            listOf(
+                msg(9001, createdAt = 1000, tags = listOf(listOf("p", "bob"))),
+                msg(9001, createdAt = 1010, tags = listOf(listOf("p", "carol"))),
+            ),
+        )
+        assertEquals(2, events.size)
+        assertEquals("bob", events[0].pubkey)
+        assertEquals("carol", events[1].pubkey)
+        assertTrue(events.all { it.additionalUsers.isEmpty() })
+    }
+
+    @Test
+    fun joinsOfDifferentUsers_stillMergeIntoOneRow() {
+        val events = systemEvents(
+            listOf(
+                msg(9021, pubkey = "bob", createdAt = 1000),
+                msg(9021, pubkey = "carol", createdAt = 1010),
+            ),
+        )
+        assertEquals(1, events.size)
+        assertEquals(listOf("carol"), events[0].additionalUsers)
+    }
+
+    @Test
+    fun pluralizeSystemAction_agreesWithMembersSubject() {
+        assertEquals(
+            "were removed from the group",
+            org.nostr.nostrord.ui.screens.group.pluralizeSystemAction("was removed from the group"),
+        )
+        assertEquals(
+            "are now admin",
+            org.nostr.nostrord.ui.screens.group.pluralizeSystemAction("is now admin"),
+        )
+        assertEquals(
+            "joined the group",
+            org.nostr.nostrord.ui.screens.group.pluralizeSystemAction("joined the group"),
+        )
+    }
+
+    @Test
     fun putUser_withoutRole_isSuppressed() {
         // A no-role 9000 is ambiguous (plain add vs. role removal) and the relay does
         // not serve it back reliably, so it is never displayed (issue #66).

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/SystemEventItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/SystemEventItem.kt
@@ -34,6 +34,7 @@ import coil3.request.crossfade
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.ui.components.avatars.UserGradientAvatar
 import org.nostr.nostrord.ui.screens.group.model.SystemEventType
+import org.nostr.nostrord.ui.screens.group.pluralizeSystemAction
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.utils.formatTimestamp
 import org.nostr.nostrord.utils.shortNpub
@@ -153,7 +154,7 @@ fun SystemEventItem(
                 )
                 Spacer(modifier = Modifier.width(4.dp))
                 Text(
-                    text = action,
+                    text = pluralizeSystemAction(action),
                     color = NostrordColors.TextMuted,
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 1,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -96,6 +96,7 @@ fun GroupScreen(
     val reactionError by vm.reactionError.collectAsState()
     val joinError by vm.joinError.collectAsState()
     val moderationError by vm.moderationError.collectAsState()
+    val moderationBusy by vm.moderationBusy.collectAsState()
     val connectionState by vm.connectionState.collectAsState()
     // Cross-relay membership view. `vm.joinedGroups` is filtered by
     // _currentRelayUrl, which is null/stale during fresh-login bootstrap (kind:10009
@@ -198,6 +199,7 @@ fun GroupScreen(
     // Desktop members column visibility, toggled from the header (prototype behavior).
     var membersVisible by remember { mutableStateOf(true) }
     var memberToRemove by remember { mutableStateOf<MemberInfo?>(null) }
+    var memberToChangeRole by remember { mutableStateOf<MemberInfo?>(null) }
     var showJoinRequestsModal by remember { mutableStateOf(false) }
     var showMemberManagementModal by remember { mutableStateOf(false) }
     var showInviteCodesModal by remember { mutableStateOf(false) }
@@ -727,6 +729,14 @@ fun GroupScreen(
                     memberToRemove = member
                 }
             },
+            // Pipes into the role-change confirmation dialog below.
+            onToggleAdminRole =
+            targetMember?.let { member ->
+                {
+                    selectedUserPubkey = null
+                    memberToChangeRole = member
+                }
+            },
             // Inserts a resolved @mention into the composer draft (prototype behavior).
             onMention = { pk ->
                 val meta = userMetadata[pk]
@@ -752,12 +762,48 @@ fun GroupScreen(
             message = "Remove ${member.displayName} from this group?",
             confirmLabel = "Remove",
             destructive = true,
+            confirmEnabled = !moderationBusy,
             onConfirm = {
                 vm.removeUser(member.pubkey)
                 memberToRemove = null
             },
             onDismiss = { memberToRemove = null },
         )
+    }
+
+    // Role-change confirmation dialog (same copy as the manage modal's member list).
+    memberToChangeRole?.let { member ->
+        ConfirmDialog(
+            title = if (member.isAdmin) "Remove Admin Role" else "Promote to Admin",
+            message =
+            if (member.isAdmin) {
+                "${member.displayName} will lose admin privileges."
+            } else {
+                "${member.displayName} will be able to manage members and group settings."
+            },
+            confirmLabel = if (member.isAdmin) "Demote" else "Promote",
+            confirmEnabled = !moderationBusy,
+            onConfirm = {
+                if (member.isAdmin) vm.demoteFromAdmin(member.pubkey) else vm.promoteToAdmin(member.pubkey)
+                memberToChangeRole = null
+            },
+            onDismiss = { memberToChangeRole = null },
+        )
+    }
+
+    // Moderation errors from actions launched at this level (remove / role change). The
+    // manage and invite modals render the same VM error inline, so defer to them when open.
+    if (!showMemberManagementModal && !showJoinRequestsModal && !showInviteCodesModal) {
+        moderationError?.let { error ->
+            ConfirmDialog(
+                title = "Action Failed",
+                message = error,
+                confirmLabel = "OK",
+                cancelLabel = null,
+                onConfirm = { vm.clearModerationError() },
+                onDismiss = { vm.clearModerationError() },
+            )
+        }
     }
 
     // Join requests open the unified Manage group modal on its Requests tab (parity with the
@@ -806,6 +852,7 @@ fun GroupScreen(
             selectedUserPubkey != null ||
             showMemberSheet ||
             memberToRemove != null ||
+            memberToChangeRole != null ||
             showJoinRequestsModal ||
             showInviteCodesModal ||
             inputOverlayOpen

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ManageGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ManageGroupModal.kt
@@ -463,6 +463,9 @@ private fun ManageMembersSection(
     var filter by remember { mutableStateOf("All") }
     // (member, action) whose promote/demote/remove is awaiting confirmation.
     var confirmAction by remember { mutableStateOf<Pair<MemberInfo, String>?>(null) }
+    // Gate Confirm while a kind:9000/9001 awaits its OK so a slow relay can't
+    // collect a second, duplicate action.
+    val moderationBusy by vm.moderationBusy.collectAsState()
 
     val adminSet = admins[groupId].orEmpty().toSet()
     val memberInfos =
@@ -551,6 +554,7 @@ private fun ManageMembersSection(
             title = title,
             message = desc,
             destructive = action == "remove",
+            confirmEnabled = !moderationBusy,
             onConfirm = {
                 when (action) {
                     "promote" -> vm.promoteToAdmin(member.pubkey)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
@@ -122,6 +122,7 @@ fun UserProfileModal(
     iAmAdmin: Boolean = false,
     targetIsAdmin: Boolean = false,
     onRemoveFromGroup: (() -> Unit)? = null,
+    onToggleAdminRole: (() -> Unit)? = null,
     onMention: ((String) -> Unit)? = null,
     onUserClick: ((String) -> Unit)? = null,
     onDismiss: () -> Unit,
@@ -372,24 +373,28 @@ fun UserProfileModal(
                                 }
                                 ProfileActionRow(label = "Report user", icon = Icons.Default.Shield, enabled = false) {}
 
-                                if (iAmAdmin && onRemoveFromGroup != null) {
+                                if (iAmAdmin && (onToggleAdminRole != null || onRemoveFromGroup != null)) {
                                     HorizontalDivider(
                                         color = NostrordColors.Divider,
                                         thickness = 1.dp,
                                         modifier = Modifier.padding(vertical = 4.dp),
                                     )
-                                    // Role changes (kind:9000 with roles) aren't wired yet.
-                                    ProfileActionRow(
-                                        label = if (targetIsAdmin) "Demote from admin" else "Promote to admin",
-                                        icon = Icons.Default.Shield,
-                                        enabled = false,
-                                    ) {}
-                                    ProfileActionRow(
-                                        label = "Remove from group",
-                                        icon = Icons.Default.Delete,
-                                        danger = true,
-                                    ) {
-                                        onRemoveFromGroup()
+                                    if (onToggleAdminRole != null) {
+                                        ProfileActionRow(
+                                            label = if (targetIsAdmin) "Demote from admin" else "Promote to admin",
+                                            icon = Icons.Default.Shield,
+                                        ) {
+                                            onToggleAdminRole()
+                                        }
+                                    }
+                                    if (onRemoveFromGroup != null) {
+                                        ProfileActionRow(
+                                            label = "Remove from group",
+                                            icon = Icons.Default.Delete,
+                                            danger = true,
+                                        ) {
+                                            onRemoveFromGroup()
+                                        }
                                     }
                                 }
                             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
@@ -232,12 +232,14 @@ fun buildChatItems(
                     val action = "is now ${roles.joinToString(", ")}"
                     val pending = pendingSystemEvent
 
-                    if (pending != null &&
+                    // Moderation rows are never merged across users: each promote names its
+                    // target. Only an exact duplicate (same user, same action in-window, e.g.
+                    // an offline-queued event flushed beside a fresh one) collapses.
+                    val isDuplicate = pending != null &&
                         pending.action == action &&
+                        pending.pubkey == targetPubkey &&
                         message.createdAt - pending.createdAt <= SYSTEM_EVENT_GROUP_WINDOW_SECONDS
-                    ) {
-                        pendingSystemEventUsers.add(targetPubkey)
-                    } else {
+                    if (!isDuplicate) {
                         flushPendingSystemEvent()
                         pendingSystemEvent = ChatItem.SystemEvent(
                             pubkey = targetPubkey,
@@ -265,12 +267,13 @@ fun buildChatItems(
                     val action = "was removed from the group"
                     val pending = pendingSystemEvent
 
-                    if (pending != null &&
+                    // Never merged across users (each removal names its target); only an
+                    // exact same-user duplicate in-window collapses.
+                    val isDuplicate = pending != null &&
                         pending.action == action &&
+                        pending.pubkey == targetPubkey &&
                         message.createdAt - pending.createdAt <= SYSTEM_EVENT_GROUP_WINDOW_SECONDS
-                    ) {
-                        pendingSystemEventUsers.add(targetPubkey)
-                    } else {
+                    if (!isDuplicate) {
                         flushPendingSystemEvent()
                         pendingSystemEvent = ChatItem.SystemEvent(
                             pubkey = targetPubkey,
@@ -294,8 +297,10 @@ fun buildChatItems(
                     pending.action == action &&
                     message.createdAt - pending.createdAt <= SYSTEM_EVENT_GROUP_WINDOW_SECONDS
                 ) {
-                    // Add to existing group
-                    pendingSystemEventUsers.add(message.pubkey)
+                    // Add to existing group (same user twice is one fact, not "2 members")
+                    if (message.pubkey != pending.pubkey && message.pubkey !in pendingSystemEventUsers) {
+                        pendingSystemEventUsers.add(message.pubkey)
+                    }
                 } else {
                     // Flush previous and start new group
                     flushPendingSystemEvent()
@@ -321,8 +326,10 @@ fun buildChatItems(
                     pending.action == action &&
                     message.createdAt - pending.createdAt <= SYSTEM_EVENT_GROUP_WINDOW_SECONDS
                 ) {
-                    // Add to existing group
-                    pendingSystemEventUsers.add(message.pubkey)
+                    // Add to existing group (same user twice is one fact, not "2 members")
+                    if (message.pubkey != pending.pubkey && message.pubkey !in pendingSystemEventUsers) {
+                        pendingSystemEventUsers.add(message.pubkey)
+                    }
                 } else {
                     // Flush previous and start new group
                     flushPendingSystemEvent()

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
@@ -6,12 +6,14 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.groupIdentifiers
 import org.nostr.nostrord.ui.screens.group.GroupAccessCopy
+import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.pendingJoinRequests
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.shortNpub
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.AvatarKind
 import org.nostr.nostrord.web.components.GroupAvatarUploadRow
 import org.nostr.nostrord.web.components.Ic
@@ -354,6 +356,11 @@ private external interface ManageGroupIdProps : Props {
 private val ManageMembersSection =
     FC<ManageGroupIdProps> { props ->
         val repo = AppModule.nostrRepository
+        // Same shared VM as the native manage modal: moderation actions surface relay
+        // rejections/timeouts in moderationError instead of failing silently (#174).
+        val vm = useViewModel(props.groupId) { GroupViewModel(repo, props.groupId) }
+        val moderationError = useStateFlow(vm.moderationError)
+        val moderationBusy = useStateFlow(vm.moderationBusy)
         val members = useStateFlow(repo.groupMembers)[props.groupId].orEmpty()
         val admins = useStateFlow(repo.groupAdmins)[props.groupId].orEmpty().toSet()
         val userMetadata = useStateFlow(repo.userMetadata)
@@ -404,6 +411,12 @@ private val ManageMembersSection =
             tabItem(tab == "All", null, "All · ${members.size}") { setTab("All") }
             tabItem(tab == "Admins", null, "Admins · $adminCount") { setTab("Admins") }
             tabItem(tab == "Members", null, "Members · $memberCount") { setTab("Members") }
+        }
+        moderationError?.let { err ->
+            div {
+                className = ClassName("modal-error")
+                +err
+            }
         }
         div {
             className = ClassName("mod-list member-list")
@@ -469,8 +482,11 @@ private val ManageMembersSection =
                                 }
                                 div {
                                     className = ClassName("mod-menu")
+                                    // Gated while a kind:9000/9001 awaits its OK so a slow relay
+                                    // can't collect a second, duplicate action.
                                     button {
                                         className = ClassName("mod-menu-item")
+                                        disabled = moderationBusy
                                         onClick = {
                                             setOpenMenu(null)
                                             setConfirmAction(pubkey to if (isAdmin) "demote" else "promote")
@@ -480,6 +496,7 @@ private val ManageMembersSection =
                                     }
                                     button {
                                         className = ClassName("mod-menu-item danger")
+                                        disabled = moderationBusy
                                         onClick = {
                                             setOpenMenu(null)
                                             setConfirmAction(pubkey to "remove")
@@ -516,12 +533,10 @@ private val ManageMembersSection =
                 onCancel = { setConfirmAction(null) },
                 onConfirm = {
                     setConfirmAction(null)
-                    launchApp {
-                        when (action) {
-                            "promote" -> repo.addUser(props.groupId, pubkey, listOf("admin"))
-                            "demote" -> repo.addUser(props.groupId, pubkey, emptyList())
-                            else -> repo.removeUser(props.groupId, pubkey)
-                        }
+                    when (action) {
+                        "promote" -> vm.promoteToAdmin(pubkey)
+                        "demote" -> vm.demoteFromAdmin(pubkey)
+                        else -> vm.removeUser(pubkey)
                     }
                 },
             )

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
@@ -7,9 +7,10 @@ import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.ui.isValidNip05
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
-import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.IdentifierField
 import org.nostr.nostrord.web.components.WebAvatar
@@ -68,8 +69,6 @@ val UserProfileModal =
         // with a usable signer is active AND the profile has a lightning address.
         val canSign = useStateFlow(ActiveAccountManager.session) != null
         val canZap = canSign && Nip57.resolvePayEndpoint(meta?.lud16, meta?.lud06) != null
-        val (confirmRemove, setConfirmRemove) = useState { false }
-        val (removeError, setRemoveError) = useState<String?> { null }
         val following = useStateFlow(AppModule.nostrRepository.following)
         val isFollowing = pubkey in following
         val mutedPubkeys = useStateFlow(AppModule.nostrRepository.mutedPubkeys)
@@ -78,8 +77,6 @@ val UserProfileModal =
         val (followBusy, setFollowBusy) = useState { false }
 
         useEffect(pubkey) {
-            setConfirmRemove(false)
-            setRemoveError(null)
             launchApp { AppModule.nostrRepository.requestUserMetadata(setOf(pubkey)) }
             launchApp { AppModule.nostrRepository.requestContactList() }
         }
@@ -227,54 +224,12 @@ val UserProfileModal =
 
                             val groupId = props.groupId
                             if (props.iAmAdmin && groupId != null) {
-                                div { className = ClassName("info-divider profile-actions-divider") }
-                                // Role changes (kind:9000 with roles) aren't wired yet.
-                                actionRow(
-                                    Ic.Shield,
-                                    if (props.targetIsAdmin) "Demote from admin" else "Promote to admin",
-                                    disabled = true,
-                                ) {}
-                                if (confirmRemove) {
-                                    div {
-                                        className = ClassName("info-leave-confirm")
-                                        div {
-                                            className = ClassName("info-leave-text")
-                                            +"Remove "
-                                            b { +name }
-                                            +" from the group? They lose access; you can invite them again later."
-                                        }
-                                        removeError?.let { err ->
-                                            div {
-                                                className = ClassName("modal-error")
-                                                +err
-                                            }
-                                        }
-                                        div {
-                                            className = ClassName("info-leave-actions")
-                                            button {
-                                                className = ClassName("btn-danger")
-                                                onClick = {
-                                                    launchApp {
-                                                        when (val r = AppModule.nostrRepository.removeUser(groupId, pubkey)) {
-                                                            is Result.Success -> props.onClose()
-                                                            is Result.Error ->
-                                                                setRemoveError(r.error.message.ifBlank { "Failed to remove member." })
-                                                        }
-                                                    }
-                                                }
-                                                +"Remove"
-                                            }
-                                            button {
-                                                className = ClassName("btn-ghost")
-                                                onClick = { setConfirmRemove(false) }
-                                                +"Cancel"
-                                            }
-                                        }
-                                    }
-                                } else {
-                                    actionRow(Ic.Delete, "Remove from group", danger = true) {
-                                        setConfirmRemove(true)
-                                    }
+                                GroupModerationSection {
+                                    this.groupId = groupId
+                                    this.pubkey = pubkey
+                                    this.displayName = name
+                                    this.targetIsAdmin = props.targetIsAdmin
+                                    this.onClose = props.onClose
                                 }
                             }
                         }
@@ -287,6 +242,134 @@ val UserProfileModal =
                         }
                     }
                 }
+            }
+        }
+    }
+
+private external interface GroupModerationSectionProps : Props {
+    var groupId: String
+    var pubkey: String
+    var displayName: String
+    var targetIsAdmin: Boolean
+    var onClose: () -> Unit
+}
+
+/**
+ * Admin-only moderation rows (role change + removal), routed through the shared
+ * [GroupViewModel] like the manage modal: relay rejections surface readable (the
+ * "blocked:" prefix stripped), a stale timeout error is invalidated by the
+ * kind:9000/9001 echo, and success posts the confirmation snackbar (#174).
+ */
+private val GroupModerationSection =
+    FC<GroupModerationSectionProps> { props ->
+        val vm = useViewModel(props.groupId) { GroupViewModel(AppModule.nostrRepository, props.groupId) }
+        val moderationError = useStateFlow(vm.moderationError)
+        val busy = useStateFlow(vm.moderationBusy)
+        val (confirmRemove, setConfirmRemove) = useState { false }
+        val (confirmRole, setConfirmRole) = useState { false }
+
+        // The modal can swap to another profile in place (mention tap); drop any half-open
+        // confirmation aimed at the previous user.
+        useEffect(props.pubkey) {
+            setConfirmRemove(false)
+            setConfirmRole(false)
+            vm.clearModerationError()
+        }
+
+        div { className = ClassName("info-divider profile-actions-divider") }
+        if (confirmRole) {
+            div {
+                className = ClassName("info-leave-confirm")
+                div {
+                    className = ClassName("info-leave-text")
+                    b { +props.displayName }
+                    +(
+                        if (props.targetIsAdmin) {
+                            " will lose admin privileges."
+                        } else {
+                            " will be able to manage members and group settings."
+                        }
+                        )
+                }
+                moderationError?.let { err ->
+                    div {
+                        className = ClassName("modal-error")
+                        +err
+                    }
+                }
+                div {
+                    className = ClassName("info-leave-actions")
+                    button {
+                        className = ClassName("btn-primary")
+                        disabled = busy
+                        onClick = {
+                            if (props.targetIsAdmin) {
+                                vm.demoteFromAdmin(props.pubkey) { props.onClose() }
+                            } else {
+                                vm.promoteToAdmin(props.pubkey) { props.onClose() }
+                            }
+                        }
+                        +(
+                            when {
+                                busy && props.targetIsAdmin -> "Demoting…"
+                                busy -> "Promoting…"
+                                props.targetIsAdmin -> "Demote"
+                                else -> "Promote"
+                            }
+                            )
+                    }
+                    button {
+                        className = ClassName("btn-ghost")
+                        onClick = { setConfirmRole(false) }
+                        +"Cancel"
+                    }
+                }
+            }
+        } else {
+            actionRow(
+                Ic.Shield,
+                if (props.targetIsAdmin) "Demote from admin" else "Promote to admin",
+            ) {
+                vm.clearModerationError()
+                setConfirmRemove(false)
+                setConfirmRole(true)
+            }
+        }
+        if (confirmRemove) {
+            div {
+                className = ClassName("info-leave-confirm")
+                div {
+                    className = ClassName("info-leave-text")
+                    +"Remove "
+                    b { +props.displayName }
+                    +" from the group? They lose access; you can invite them again later."
+                }
+                moderationError?.let { err ->
+                    div {
+                        className = ClassName("modal-error")
+                        +err
+                    }
+                }
+                div {
+                    className = ClassName("info-leave-actions")
+                    button {
+                        className = ClassName("btn-danger")
+                        disabled = busy
+                        onClick = { vm.removeUser(props.pubkey) { props.onClose() } }
+                        +(if (busy) "Removing…" else "Remove")
+                    }
+                    button {
+                        className = ClassName("btn-ghost")
+                        onClick = { setConfirmRemove(false) }
+                        +"Cancel"
+                    }
+                }
+            }
+        } else {
+            actionRow(Ic.Delete, "Remove from group", danger = true) {
+                vm.clearModerationError()
+                setConfirmRole(false)
+                setConfirmRemove(true)
             }
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatItems.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatItems.kt
@@ -75,14 +75,22 @@ fun buildWebChatItems(
         pendingUsers.clear()
     }
 
-    // Append a system event, merging with the pending one when it's the same action in-window.
+    // Append a system event. Joins/leaves with the same action in-window merge into one
+    // "N members" row; moderation rows (role change / removal) never merge across users,
+    // each names its target. An exact same-user duplicate in-window (e.g. an
+    // offline-queued event flushed beside a fresh one) collapses for every type.
     fun addSystemEvent(pubkey: String, action: String, createdAt: Long, id: String, type: SystemEventType) {
         val p = pending
-        if (p != null && p.action == action && createdAt - p.createdAt <= SYSTEM_EVENT_GROUP_WINDOW) {
-            pendingUsers.add(pubkey)
-        } else {
-            flush()
-            pending = WebChatItem.SystemEvent(pubkey, action, createdAt, id, type)
+        val sameActionInWindow = p != null && p.action == action && createdAt - p.createdAt <= SYSTEM_EVENT_GROUP_WINDOW
+        val isDuplicate = sameActionInWindow && (pubkey == p.pubkey || pubkey in pendingUsers)
+        val mergeable = type == SystemEventType.JOINED || type == SystemEventType.LEFT
+        when {
+            isDuplicate -> {}
+            sameActionInWindow && mergeable -> pendingUsers.add(pubkey)
+            else -> {
+                flush()
+                pending = WebChatItem.SystemEvent(pubkey, action, createdAt, id, type)
+            }
         }
         lastMessagePubkey = null
         lastMessageTime = null

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -26,6 +26,7 @@ import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.screens.group.GroupMembership
 import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.MentionableGroup
+import org.nostr.nostrord.ui.screens.group.pluralizeSystemAction
 import org.nostr.nostrord.ui.scroll.ChatScrollPolicy
 import org.nostr.nostrord.ui.scroll.JumpPillTarget
 import org.nostr.nostrord.utils.ChatSearch
@@ -3323,7 +3324,7 @@ private fun ChildrenBuilder.systemEventRow(
                 className = ClassName("sys-event-name")
                 +(if (event.totalUsers > 1) "${event.totalUsers} members" else displayName(event.pubkey, userMetadata[event.pubkey]))
             }
-            +" ${event.action}"
+            +" ${if (event.totalUsers > 1) pluralizeSystemAction(event.action) else event.action}"
         }
         span {
             className = ClassName("sys-event-time")

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -8648,6 +8648,15 @@ body {
     background: var(--color-hover);
 }
 
+.mod-menu-item:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.mod-menu-item:disabled:hover {
+    background: transparent;
+}
+
 .mod-menu-item svg {
     width: 18px;
     height: 18px;


### PR DESCRIPTION
Remove user and Promote to admin did nothing on click (#174): the web manage modal swallowed the repo `Result`, and the profile modals' role actions were disabled stubs on both UIs. All moderation now flows through the shared `GroupViewModel`, so failures surface and successes confirm.

| Area | Change |
| --- | --- |
| `GroupViewModel` (commonMain) | `moderationError` surfaces the relay OK reason (`blocked:`/`error:` prefixes stripped) and is invalidated by the kind:9000/9001 echo; a counted `moderationBusy` gates the buttons while an action awaits its OK (no duplicate sends); actions take `onSuccess` callbacks |
| Web | ManageGroupModal members section and UserProfileModal promote/demote/remove routed through the VM, with inline errors and busy labels |
| Native | UserProfileModal promote/demote wired (was a disabled "not wired yet" stub) via GroupScreen confirm dialogs; moderation errors from those flows get an Action Failed dialog (they were silent) |
| Chat timeline | moderation system rows never merge across users (each names its target), an offline-queued duplicate of the same user collapses, and merged join/leave rows get subject-verb agreement |

Commits:
- 4010f0a0 fix(group): surface moderation errors and wire promote/demote on all UIs (#174)
- aa47a2b5 fix(chat): keep moderation system rows per-target and dedupe merges

Covered by new `GroupViewModelTest` moderation tests and `ChatItemSystemEventTest` cases; validated with `compileKotlinJvm` + `compileKotlinJs` + `:composeApp:jvmTest`.

Closes #174.