### PR TITLE
fix: self-heal deaf subs, DM inbox and signer loss across relogin and outages

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
@@ -118,6 +118,9 @@ interface NostrSigner {
                 val signedJson = nip46Client.signEvent(event.toJsonString())
                 parseSignedEventJson(signedJson)
             } catch (e: Exception) {
+                // A cancelled sign (scope teardown, account switch) must propagate as
+                // cancellation, not read as a signer failure to callers that count them.
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 if (e is SigningException) throw e
                 throw SigningException("Bunker signing failed: ${e.message}", e)
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -53,6 +53,10 @@ private const val AUTO_RECONNECT_BASE_MS = 3_000L
 private const val AUTO_RECONNECT_MAX_MS = 60_000L
 private const val AUTO_RECONNECT_MAX_ATTEMPTS = 5
 
+// Consecutive bunker sign failures (timeouts/transport, not explicit permission
+// rejections) before background signs raise the Unreachable banner.
+private const val BUNKER_SIGN_FAILURE_BANNER_THRESHOLD = 3
+
 /**
  * Manages authentication state and signing operations.
  *
@@ -909,22 +913,26 @@ class AuthManager(
         val sessionSigner = ActiveAccountManager.session.value?.signer
         if (sessionSigner != null) {
             return try {
-                sessionSigner.signEvent(event)
+                sessionSigner.signEvent(event).also {
+                    if (sessionSigner is NostrSigner.Bunker) noteBunkerSignSuccess()
+                }
             } catch (e: NostrSigner.SigningException) {
                 if (isPermissionError(e)) {
                     if (sessionSigner is NostrSigner.Bunker) {
-                        // Can't tell an offline signer from a deleted connection
-                        // apart — surface a reconnectable error, never log out.
-                        // Only a user-initiated sign raises the banner: background
-                        // NIP-42 AUTH (kind 22242) signs pass interactive=false, so a
-                        // transient relay/AUTH hiccup never flips the UI to "can't
-                        // reach your signer". (banner-flicker fix)
-                        if (interactive) markSignerUnreachable()
+                        // An explicit permission rejection is deterministic evidence the
+                        // signer revoked this connection — not the transient relay hiccup
+                        // the interactive gate guards against — so raise the banner even
+                        // for background signs (NIP-42 AUTH). A reading-only session has
+                        // no interactive signs: without this, AUTH quietly fails and the
+                        // feed goes deaf with no cue. Never log out: an offline signer
+                        // is indistinguishable and the banner offers Reconnect/Log out.
+                        markSignerUnreachable()
                         throw Exception("Couldn't reach your signer. Please reconnect.")
                     }
                     handlePermissionDenied()
                     throw Exception("Signing permission denied. Please login again.")
                 }
+                if (sessionSigner is NostrSigner.Bunker) noteBunkerSignFailure(interactive)
                 throw e
             }
         }
@@ -965,14 +973,17 @@ class AuthManager(
         try {
             val eventJson = event.toJsonString()
             val signedEventJson = bunker.signEvent(eventJson)
+            noteBunkerSignSuccess()
             return parseSignedEvent(signedEventJson)
         } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
             if (isPermissionError(e)) {
-                // Can't tell an offline signer from a deleted connection apart —
-                // surface a reconnectable error, never log out (issue #85).
-                if (interactive) markSignerUnreachable()
+                // Deterministic revocation — banner even for background signs (see
+                // signEvent). Never log out: an offline signer looks identical.
+                markSignerUnreachable()
                 throw Exception("Couldn't reach your signer. Please reconnect.")
             }
+            noteBunkerSignFailure(interactive)
             throw e
         }
     }
@@ -990,6 +1001,30 @@ class AuthManager(
     }
 
     /**
+     * Bunker sign failures that are NOT explicit permission rejections (timeouts,
+     * transport errors). One background failure is no evidence — NIP-42 AUTH
+     * re-challenges hit transient hiccups all the time (the banner-flicker guard) —
+     * but a signer that keeps not answering while nothing succeeds is revoked or
+     * offline, and a reading-only session never signs interactively to find out:
+     * AUTH quietly fails and auth-gated relays withhold events with no cue. After
+     * [BUNKER_SIGN_FAILURE_BANNER_THRESHOLD] consecutive failures the banner is
+     * raised. An interactive failure raises it immediately — the user just watched
+     * the action fail, and the banner carries the recovery path (Reconnect).
+     */
+    private var consecutiveBunkerSignFailures = 0
+
+    private fun noteBunkerSignSuccess() {
+        consecutiveBunkerSignFailures = 0
+    }
+
+    private fun noteBunkerSignFailure(interactive: Boolean) {
+        consecutiveBunkerSignFailures++
+        if (interactive || consecutiveBunkerSignFailures >= BUNKER_SIGN_FAILURE_BANNER_THRESHOLD) {
+            markSignerUnreachable()
+        }
+    }
+
+    /**
      * The bunker signer can't be reached or refused a request. The app cannot
      * tell "signer offline" from "connection deleted on the signer" apart — both
      * surface as a timeout or an error — so this NEVER logs the user out or wipes
@@ -1000,6 +1035,9 @@ class AuthManager(
     private fun markSignerUnreachable(
         reason: BunkerUnreachableReason = BunkerUnreachableReason.SignerNotResponding,
     ) {
+        // Fresh window after a reconnect: a still-broken signer re-trips the
+        // threshold instead of instantly re-raising the banner on its first miss.
+        consecutiveBunkerSignFailures = 0
         nip46Client?.disconnect()
         nip46Client = null
         _isBunkerVerifying.value = false

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -54,8 +54,15 @@ private const val AUTO_RECONNECT_MAX_MS = 60_000L
 private const val AUTO_RECONNECT_MAX_ATTEMPTS = 5
 
 // Consecutive bunker sign failures (timeouts/transport, not explicit permission
-// rejections) before background signs raise the Unreachable banner.
-private const val BUNKER_SIGN_FAILURE_BANNER_THRESHOLD = 3
+// rejections) before background signs raise the Unreachable banner. The count alone
+// is not enough: N relays re-challenging AUTH can burn through it in one burst
+// during a single hiccup, so the streak must also SPAN the window below.
+private const val BUNKER_SIGN_FAILURE_BANNER_THRESHOLD = 5
+private const val BUNKER_SIGN_FAILURE_BANNER_WINDOW_MS = 90_000L
+
+// A failure this long after the previous one starts a NEW streak: stale counts from
+// an old burst must not let a single later failure trip the threshold.
+private const val BUNKER_SIGN_FAILURE_STREAK_RESET_MS = 5 * 60_000L
 
 /**
  * Manages authentication state and signing operations.
@@ -924,10 +931,10 @@ class AuthManager(
                         // the interactive gate guards against — so raise the banner even
                         // for background signs (NIP-42 AUTH). A reading-only session has
                         // no interactive signs: without this, AUTH quietly fails and the
-                        // feed goes deaf with no cue. Never log out: an offline signer
-                        // is indistinguishable and the banner offers Reconnect/Log out.
-                        markSignerUnreachable()
-                        throw Exception("Couldn't reach your signer. Please reconnect.")
+                        // feed goes deaf with no cue. Never log out: the banner offers
+                        // Reconnect/Log out, and its copy points at the signer app.
+                        markSignerUnreachable(BunkerUnreachableReason.PermissionDenied)
+                        throw Exception("Your signer refused to sign. Check its permissions.")
                     }
                     handlePermissionDenied()
                     throw Exception("Signing permission denied. Please login again.")
@@ -979,9 +986,9 @@ class AuthManager(
             if (e is kotlinx.coroutines.CancellationException) throw e
             if (isPermissionError(e)) {
                 // Deterministic revocation — banner even for background signs (see
-                // signEvent). Never log out: an offline signer looks identical.
-                markSignerUnreachable()
-                throw Exception("Couldn't reach your signer. Please reconnect.")
+                // signEvent), with copy that points at the signer app's permissions.
+                markSignerUnreachable(BunkerUnreachableReason.PermissionDenied)
+                throw Exception("Your signer refused to sign. Check its permissions.")
             }
             noteBunkerSignFailure(interactive)
             throw e
@@ -1006,20 +1013,35 @@ class AuthManager(
      * re-challenges hit transient hiccups all the time (the banner-flicker guard) —
      * but a signer that keeps not answering while nothing succeeds is revoked or
      * offline, and a reading-only session never signs interactively to find out:
-     * AUTH quietly fails and auth-gated relays withhold events with no cue. After
-     * [BUNKER_SIGN_FAILURE_BANNER_THRESHOLD] consecutive failures the banner is
-     * raised. An interactive failure raises it immediately — the user just watched
-     * the action fail, and the banner carries the recovery path (Reconnect).
+     * AUTH quietly fails and auth-gated relays withhold events with no cue. The
+     * banner is raised only when [BUNKER_SIGN_FAILURE_BANNER_THRESHOLD] consecutive
+     * failures ALSO span [BUNKER_SIGN_FAILURE_BANNER_WINDOW_MS] — a multi-relay AUTH
+     * burst reaches the count in seconds during one hiccup and must not trip it. An
+     * interactive failure raises it immediately: the user just watched the action
+     * fail, and the banner carries the recovery path (Reconnect).
      */
     private var consecutiveBunkerSignFailures = 0
+    private var bunkerSignFailStreakStartMs = 0L
+    private var bunkerSignLastFailureAtMs = 0L
 
     private fun noteBunkerSignSuccess() {
         consecutiveBunkerSignFailures = 0
+        bunkerSignFailStreakStartMs = 0L
     }
 
     private fun noteBunkerSignFailure(interactive: Boolean) {
+        // A signer that answered with an auth_url is alive and waiting on the USER
+        // (approval screen); failures racked up during that wait prove nothing.
+        if (_authUrl.value != null) return
+        val now = epochMillis()
+        if (consecutiveBunkerSignFailures == 0 || now - bunkerSignLastFailureAtMs > BUNKER_SIGN_FAILURE_STREAK_RESET_MS) {
+            consecutiveBunkerSignFailures = 0
+            bunkerSignFailStreakStartMs = now
+        }
+        bunkerSignLastFailureAtMs = now
         consecutiveBunkerSignFailures++
-        if (interactive || consecutiveBunkerSignFailures >= BUNKER_SIGN_FAILURE_BANNER_THRESHOLD) {
+        val streakSpansWindow = now - bunkerSignFailStreakStartMs >= BUNKER_SIGN_FAILURE_BANNER_WINDOW_MS
+        if (interactive || (consecutiveBunkerSignFailures >= BUNKER_SIGN_FAILURE_BANNER_THRESHOLD && streakSpansWindow)) {
             markSignerUnreachable()
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/BunkerState.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/BunkerState.kt
@@ -8,6 +8,9 @@ enum class BunkerUnreachableReason {
     /** Relays connected but the signer never answered (offline or connection revoked). */
     SignerNotResponding,
 
+    /** The signer answered but explicitly refused to sign (permission revoked in the signer app). */
+    PermissionDenied,
+
     /** Cause couldn't be determined (e.g. corrupt saved credentials). */
     Unknown,
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1066,9 +1066,11 @@ class NostrRepository(
         scope.launch {
             while (true) {
                 delay(5 * 60 * 1000L) // 5 minutes
-                if (connectionManager.connectionState.value is ConnectionManager.ConnectionState.Connected) {
-                    groupManager.refreshLiveSubscriptions()
-                }
+                // Not gated on the FOCUSED relay's state: that gate starved the pool
+                // relays' staleness re-arm whenever the focused relay sat in
+                // Reconnecting/Error. Each relay is individually guarded inside
+                // (no client / not connected → skip), so this is safe when offline.
+                groupManager.refreshLiveSubscriptions()
                 liveCursorStore?.persistAll()
             }
         }
@@ -2296,10 +2298,15 @@ class NostrRepository(
                 is ConnectionManager.ConnectionState.Error,
                 -> reconnect()
 
-                // Auto-reconnect or initial connect in progress — don't interrupt.
+                // Auto-reconnect or initial connect in progress — don't interrupt the
+                // FOCUSED relay, but the pool sockets still deserve the zombie check:
+                // they can be deaf from the same background period, and skipping them
+                // here left their recovery to the periodic staleness net.
                 is ConnectionManager.ConnectionState.Reconnecting,
                 is ConnectionManager.ConnectionState.Connecting,
                 -> {
+                    probeIdleSockets()
+                    groupManager.refreshLiveSubscriptions()
                     reconnectDroppedNip29PoolRelays()
                 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -363,8 +363,10 @@ class NostrRepository(
     // relays in connectedPoolRelays are scheduled for reconnection. Resubscribing is NOT
     // done here: getOrConnectRelay fires onRelayConnected for whichever caller lands the
     // socket (this scheduler included), and that hook re-arms the subs exactly once.
+    // On connectionWorkScope (not the shared app scope): clearAll() on logout cancels
+    // pending retries without touching unrelated app-wide collectors.
     private val relayReconnectScheduler = RelayReconnectScheduler(
-        scope = scope,
+        scope = connectionManager.connectionWorkScope,
         isRelayActive = { relayUrl -> relayUrl in connectedPoolRelays },
         doReconnect = { relayUrl ->
             connectionManager.getOrConnectRelay(relayUrl) { msg, c ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1677,7 +1677,7 @@ class NostrRepository(
 
         // Hydrate from the CacheStore before the inbox streams so old conversations render instantly
         // and already-seen gift wraps are never re-decrypted.
-        hydrateDmCache(myPub)
+        val hydratedCount = hydrateDmCache(myPub)
         wireDmPersistence(myPub)
         // Resume any wraps that never reached a relay before the app last closed.
         resumeDmSendQueue(myPub)
@@ -1689,6 +1689,19 @@ class NostrRepository(
         dmFailCounts = emptyMap()
         dmGivenUpWrapIds = emptySet()
         dmInboxEosedRelays = emptySet()
+
+        // Consistency guard: decrypt progress claims processed wraps, but the message store
+        // came back empty (wiped/lost store, or a failed cache read — hydrateDmCache swallows
+        // it). Trusting the progress here is fatal: the full-sync flag keeps the REQ
+        // incremental so the history is never re-requested, and any re-delivered wrap is
+        // skipped by the dedup — the inbox looks synced and stays empty until the user
+        // manually wipes storage. Drop the sync state so the REQ below streams from 0 and
+        // rebuilds the two stores together.
+        if (hydratedCount == 0 && dmProcessedWrapIds.isNotEmpty()) {
+            dmProcessedWrapIds = emptySet()
+            SecureStorage.saveDmProcessedWrapIds(myPub, emptySet())
+            SecureStorage.saveBooleanPref(dmFullSyncKey(myPub), false)
+        }
 
         _myDmRelays.value = dmRelaysFor(myPub)
         fetchDmRelays(myPub)
@@ -1727,6 +1740,26 @@ class NostrRepository(
                         resendDmInboxReq(pub)
                     }
                 }
+            }
+
+        // A signer outage (revoked permission, offline bunker) burns every backlog wrap's
+        // decrypt attempts into the given-up set, which parks those DMs until an app
+        // restart. When the bunker comes back (banner Reconnect, auto-reconnect), give
+        // them a fresh run: the persisted dedup keeps already-decrypted wraps cheap, so
+        // re-streaming only re-attempts what's actually missing.
+        dmPersistenceJobs +=
+            scope.launch {
+                sessionManager.bunkerState
+                    .map { it is BunkerState.Connected }
+                    .distinctUntilChanged()
+                    .drop(1)
+                    .collect { connected ->
+                        if (!connected) return@collect
+                        if (dmGivenUpWrapIds.isEmpty() && dmFailCounts.isEmpty()) return@collect
+                        dmGivenUpWrapIds = emptySet()
+                        dmFailCounts = emptyMap()
+                        sessionManager.getPublicKey()?.let { resendDmInboxReq(it) }
+                    }
             }
     }
 
@@ -1801,7 +1834,8 @@ class NostrRepository(
      * DMs are stored in the message cache as kind:14 keyed by peer pubkey, so one query rebuilds
      * every conversation without knowing the peers up front.
      */
-    private suspend fun hydrateDmCache(myPub: String) {
+    /** Returns how many cached DMs were hydrated, so the caller can sanity-check sync state. */
+    private suspend fun hydrateDmCache(myPub: String): Int {
         if (!SecureStorage.isDmCacheMigratedFor(myPub)) {
             val legacy = SecureStorage.loadDmMessages(myPub)
             val migrated =
@@ -1837,6 +1871,7 @@ class NostrRepository(
             SecureStorage.loadDmSeenRelays(myPub),
             SecureStorage.loadDmWrapRumor(myPub),
         )
+        return cached.size
     }
 
     /** Persist decrypted messages + read state whenever they change (one collector per session). */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ConnectionManager.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.network.managers
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,6 +32,17 @@ class ConnectionManager(
     private val connStats: ConnectionStats? = null,
     private val adaptiveConfig: AdaptiveConfig? = null,
 ) {
+    /**
+     * Owned child of [scope] for cancellable connection work: in-flight connects,
+     * lost-socket handling, send fan-outs, and the reconnect scheduler's retries.
+     * [clearAll] cancels ONLY this scope's children. It used to cancelChildren() on
+     * the SHARED app scope, which killed every collector in the app on logout (DM
+     * inbox lifecycle, mux refresh timers, eager stateIn derivations), so a re-login
+     * came up without its plumbing until a process restart.
+     */
+    val connectionWorkScope: CoroutineScope =
+        CoroutineScope(scope.coroutineContext + SupervisorJob(scope.coroutineContext[Job]))
+
     private var currentMessageHandler: ((String, NostrGroupClient) -> Unit)? = null
 
     // Serialises connectFocused so two coroutines cannot both pass the "already connecting"
@@ -190,7 +202,7 @@ class ConnectionManager(
         val success = connectFocused(url, handler)
         if (success) {
             adaptiveConfig?.recordReconnect()
-            focusedClient()?.let { client -> scope.launch { onReconnected?.invoke(client) } }
+            focusedClient()?.let { client -> connectionWorkScope.launch { onReconnected?.invoke(client) } }
         } else {
             // Hand off to the same backoff driver a passive drop would use (see
             // [handleClientLost]) instead of retrying in a loop of our own.
@@ -337,7 +349,7 @@ class ConnectionManager(
      */
     private fun wireConnectionLost(client: NostrGroupClient, url: String) {
         client.onConnectionLost = {
-            scope.launch { handleClientLost(client, url) }
+            connectionWorkScope.launch { handleClientLost(client, url) }
         }
     }
 
@@ -400,7 +412,7 @@ class ConnectionManager(
         if (_currentRelayUrl.value != client.getRelayUrl().normalizeRelayUrl()) return
         _connectionState.value = ConnectionState.Connected
         adaptiveConfig?.recordReconnect()
-        scope.launch { onReconnected?.invoke(client) }
+        connectionWorkScope.launch { onReconnected?.invoke(client) }
     }
 
     /**
@@ -632,7 +644,7 @@ class ConnectionManager(
         onMessage: (String, NostrGroupClient) -> Unit,
     ) {
         relayUrls.forEach { relayUrl ->
-            scope.launch {
+            connectionWorkScope.launch {
                 try {
                     val client = getOrConnectRelay(relayUrl, onMessage)
                     client?.send(message)
@@ -651,7 +663,7 @@ class ConnectionManager(
         timeoutMs: Long = 2000,
     ) {
         relayUrls.map { relayUrl ->
-            scope.launch {
+            connectionWorkScope.launch {
                 try {
                     getOrConnectRelay(relayUrl, onMessage)
                 } catch (_: Exception) {
@@ -699,7 +711,9 @@ class ConnectionManager(
         // discovery/DM/metadata job on a surviving scope can't reconnect a relay
         // right after we drain the pool. resumeConnections() re-opens on login.
         acceptingConnections = false
-        scope.coroutineContext.cancelChildren()
+        // Cancel only the connection work (in-flight connects, reconnect retries) —
+        // never the shared app scope's children (see connectionWorkScope).
+        connectionWorkScope.coroutineContext.cancelChildren()
         disconnectFocused()
 
         // Get clients to disconnect while holding lock, then disconnect outside lock
@@ -713,7 +727,7 @@ class ConnectionManager(
         // onConnectionLost first, same hazard as every other intentional-disconnect site.
         clientsToDisconnect
             .map { client ->
-                scope.launch {
+                connectionWorkScope.launch {
                     try {
                         client.onConnectionLost = null
                         client.disconnect()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -732,6 +732,13 @@ class GroupManager(
         // feed heals without user action.
         const val MUX_STALE_REARM_MS = 600_000L
 
+        // Quiet window before OPENING a group re-arms its relay's mux, much tighter
+        // than MUX_STALE_REARM_MS because the user is actively looking at the screen.
+        // A quiet-but-alive relay answers the re-sent REQ with one EOSE (which resets
+        // the activity mark, so group-hopping costs at most one round trip per window);
+        // a frame-silent socket additionally gets a liveness probe.
+        const val MUX_OPEN_REARM_MS = 120_000L
+
         // Disk budget for the persistent history cache (messages + events), per account.
         // Evicted oldest-first once exceeded; the eviction is debounced behind writes.
         const val CACHE_BYTE_BUDGET = 75L * 1024 * 1024
@@ -906,6 +913,22 @@ class GroupManager(
                 }
             }
             client = connectionManager.getClientForRelay(url)
+
+            // A socket can sit "Connected" while deaf (zombie after a radio nap, or a
+            // relay that silently dropped its subs): the tracker then no-ops the mux
+            // refresh below and the entry REQs go into the void. The user is looking
+            // at this group right now, so don't leave recovery to the 10-minute
+            // staleness net: re-arm a mux-quiet relay immediately, and probe a
+            // frame-silent socket (a zombie is marked dead, driving reconnect +
+            // resubscribe + pending flush).
+            val nowMs = epochMillis()
+            if (muxTracker.isStale(url, nowMs, MUX_OPEN_REARM_MS)) {
+                muxTracker.clearRelay(url)
+                val probeClient = client
+                if (probeClient != null && (probeClient.inboundSilenceMs(nowMs) ?: 0L) > MUX_OPEN_REARM_MS) {
+                    scope.launch { probeClient.probeLiveness() }
+                }
+            }
 
             // Fire mux refresh in parallel — covers ongoing delivery for ALL groups.
             val muxJob = scope.launch { refreshMuxSubscriptionsForRelay(url) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayReconnectScheduler.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayReconnectScheduler.kt
@@ -17,11 +17,11 @@ import kotlin.random.Random
  * - Transparently transitions from fast retries to a 30 s slow-retry loop
  * - Stops retrying when the user removes a relay from their list
  *
- * All coroutines run on [scope]; cancelling scope (e.g. on logout) automatically
- * cancels all pending retries. New retries can be scheduled on the same scope
- * after it is restored via [CoroutineScope.cancelChildren].
+ * All coroutines run on [scope] (the ConnectionManager's connectionWorkScope);
+ * clearAll() on logout cancels its children, dropping all pending retries. New
+ * retries can be scheduled on the same scope afterwards.
  *
- * @param scope         Coroutine scope shared with the owning repository.
+ * @param scope         The connection-work scope owned by ConnectionManager.
  * @param isRelayActive Returns true if [relayUrl] should still be retried (e.g. still
  *                      in the user's saved relay list).
  * @param doReconnect   Performs one connection attempt; returns true on success.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt
@@ -83,6 +83,7 @@ fun BunkerStatusBanner(modifier: Modifier = Modifier) {
         when {
             reconnecting -> "Reconnecting to your signer…"
             reason == BunkerUnreachableReason.RelaysUnreachable -> "Can't reach the bunker relays"
+            reason == BunkerUnreachableReason.PermissionDenied -> "Your signer refused to sign"
             else -> "Can't reach your signer"
         }
     val body =
@@ -90,6 +91,9 @@ fun BunkerStatusBanner(modifier: Modifier = Modifier) {
             reconnecting -> "Trying to restore the connection to your bunker…"
             reason == BunkerUnreachableReason.RelaysUnreachable ->
                 "Your bunker's relays didn't respond. Check your internet or VPN, then reconnect."
+            reason == BunkerUnreachableReason.PermissionDenied ->
+                "The signer rejected this app's request. Re-grant permissions in your " +
+                    "signer app, then reconnect."
             else ->
                 "Your bunker didn't respond. It may be offline, or its connection was " +
                     "removed. Reconnect to try again."

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -105,6 +105,7 @@ import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.ui.components.BunkerStatusBanner
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.accounts.AddAccountSheet
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
@@ -591,6 +592,15 @@ fun AppFrame() {
                     }
                 }
             }
+
+            // Floating signer-health warning, drawn over the content on every page
+            // when the bunker is Unreachable/Reconnecting.
+            BunkerStatusBanner(
+                modifier =
+                Modifier
+                    .align(Alignment.TopCenter)
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top)),
+            )
 
             // Add-group flow (rail "+"): the new-design chooser, then the existing
             // create / join modals, landing on the group's chat afterwards.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -26,6 +26,7 @@ import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
+import org.nostr.nostrord.web.components.BunkerStatusBanner
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.ImageViewerHost
 import org.nostr.nostrord.web.components.WebAvatar
@@ -260,6 +261,9 @@ val AppFrame =
 
         div {
             className = ClassName(if (drawerOpen) "app-frame drawer-open" else "app-frame")
+            // Floating signer-health warning (position: fixed, top-center): visible on
+            // every logged-in page when the bunker is Unreachable/Reconnecting.
+            BunkerStatusBanner {}
             // Always mounted so it can fade in/out with the drawer slide (CSS toggles it via
             // .drawer-open); conditionally rendering it would pop instantly and feel abrupt.
             div {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/BunkerStatusBanner.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/BunkerStatusBanner.kt
@@ -48,12 +48,16 @@ val BunkerStatusBanner =
         val title = when {
             reconnecting -> "Reconnecting to your signer…"
             reason == BunkerUnreachableReason.RelaysUnreachable -> "Can't reach the bunker relays"
+            reason == BunkerUnreachableReason.PermissionDenied -> "Your signer refused to sign"
             else -> "Can't reach your signer"
         }
         val body = when {
             reconnecting -> "Trying to restore the connection to your bunker…"
             reason == BunkerUnreachableReason.RelaysUnreachable ->
                 "Your bunker's relays didn't respond. Check your internet or VPN, then reconnect."
+            reason == BunkerUnreachableReason.PermissionDenied ->
+                "The signer rejected this app's request. Re-grant permissions in your signer app, " +
+                    "then reconnect."
             else ->
                 "Your bunker didn't respond. It may be offline, or its connection was removed. " +
                     "Reconnect to try again."


### PR DESCRIPTION
A day of bunker and relogin testing exposed a family of silent-death states: subscriptions, collectors and DM decrypts died with no path back short of restarting the app, always behind a green connection dot. Six fixes, one per commit, all commonMain-first.

| Commit | Fix |
| --- | --- |
| 77e443d7 | Deaf relay subs heal on user gesture: opening a group re-arms its relay's mux after 2 min of quiet and probes a frame-silent socket; the 5-min refresh no longer requires the FOCUSED relay to be Connected (it starved pool relays); onForeground also probes pool sockets while the focused relay is mid-reconnect |
| d38849b1 | A revoked/unresponsive bunker signer is detected from background NIP-42 signs; previously only interactive signs raised the state, so reading-only sessions went deaf with no cue. Bunker signEvent also rethrows CancellationException instead of wrapping it as a failure |
| 0ab763dc | BunkerStatusBanner mounted on both UIs; it existed since #85 with its state machine and actions, but neither shell rendered it |
| 1d303bc4 | DM inbox self-heals a wiped or unreadable message store (0 hydrated messages + non-empty processed-wrap dedup is a contradiction: reset sync state and stream from 0) and re-tries given-up wraps when the bunker recovers |
| 01638133 | logout's clearAll ran cancelChildren() on the SHARED app scope, killing every collector in the app (DM inbox lifecycle, mux timers, eager stateIn derivations): a relogin showed a frozen conversation list and empty threads until process restart. Connection work now runs on an owned child scope and only that is cancelled |
| a1986098 | Signer banner calmed: background failures need 5 consecutive misses spanning 90s (multi-relay AUTH bursts no longer trip it), failures while an auth_url awaits the user are ignored, and explicit permission denials get their own reason and actionable copy |

Validated with compileKotlinJvm + compileKotlinJs + :composeApp:jvmTest on the rebased branch. Device/browser validation notes: relogin now restores DMs without a reload; revoking the app's permission in the signer surfaces the banner within ~2 minutes on an idle session.