### PR TITLE
feat(relay): accept Tor .onion relay URLs without wss

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/StringUtils.kt
@@ -162,7 +162,8 @@ fun String.normalizeRelayUrl(): String {
 
 /**
  * Validate a relay URL. Accepts `wss://` always, and `ws://` only for
- * localhost / loopback hosts (useful for local development relays).
+ * localhost / loopback hosts (local development relays) and `.onion` hosts
+ * (Tor encrypts the transport itself).
  */
 /**
  * Add (or correct) the scheme on a relay host. Loopback hosts always get `ws://`
@@ -180,10 +181,14 @@ fun String.toRelayUrl(): String {
     if ('@' in authority) return ""
     val host = authority.substringBefore(':').lowercase()
     val loopback = host == "localhost" || host == "127.0.0.1" || host == "0.0.0.0" || host == "[::1]" || host == "::1"
+    // Tor onion services encrypt the transport themselves and rarely carry a TLS cert,
+    // so a bare .onion host defaults to ws:// (a typed wss:// is kept).
+    val onion = host.endsWith(".onion")
     val scheme = when {
         loopback -> "ws"
         typedWss -> "wss"
         typedWs -> "ws"
+        onion -> "ws"
         else -> "wss"
     }
     return "$scheme://$body"
@@ -218,7 +223,8 @@ fun isValidRelayUrl(url: String): Boolean {
     val host = authority.substringBefore(':').lowercase()
     if (host.isBlank()) return false
     val isLoopback = host == "localhost" || host == "127.0.0.1" || host == "0.0.0.0" || host == "[::1]" || host == "::1"
-    if (trimmed.startsWith("ws://")) return isLoopback
+    // ws:// (no TLS) is allowed only where the transport is already safe: loopback and Tor onion.
+    if (trimmed.startsWith("ws://")) return isLoopback || host.endsWith(".onion")
     if (isLoopback) return true
     val labels = host.split('.')
     return labels.size >= 2 &&

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/RelayUrlTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/RelayUrlTest.kt
@@ -42,6 +42,27 @@ class RelayUrlTest {
     }
 
     @Test
+    fun `toRelayUrl adds ws to bare onion host`() {
+        assertEquals(
+            "ws://relayabc123def456ghi789jkl012mno345pqr678stu901vwx234yz.onion",
+            "relayabc123def456ghi789jkl012mno345pqr678stu901vwx234yz.onion".toRelayUrl(),
+        )
+        assertEquals("ws://relay.onion:8080", "relay.onion:8080".toRelayUrl())
+        // A typed scheme on an onion host is kept as-is.
+        assertEquals("ws://relay.onion", "ws://relay.onion".toRelayUrl())
+        assertEquals("wss://relay.onion", "wss://relay.onion".toRelayUrl())
+    }
+
+    @Test
+    fun `isValidRelayUrl accepts ws onion host`() {
+        assertTrue(isValidRelayUrl("ws://relayabc123def456ghi789jkl012mno345pqr678stu901vwx234yz.onion"))
+        assertTrue(isValidRelayUrl("ws://relay.onion:8080"))
+        assertTrue(isValidRelayUrl("wss://relay.onion"))
+        // .onion only exempts the ws:// TLS requirement, not the userinfo check.
+        assertFalse(isValidRelayUrl("ws://foo.onion@evil.com"))
+    }
+
+    @Test
     fun `isValidRelayUrl accepts wss public host`() {
         assertTrue(isValidRelayUrl("wss://relay.damus.io"))
     }


### PR DESCRIPTION
Relay URL inputs rejected Tor onion relays: `isValidRelayUrl` required `wss://` for anything non-loopback, and a bare `.onion` host got normalized to `wss://`, which never connects (onion services encrypt the transport themselves and rarely carry a TLS cert). Both helpers live in `StringUtils.kt` and back every relay input, so one change covers the Create Group custom relay, the Settings NIP-65 editor and the Settings DM relay editor, on Compose and web.

| Change | Behavior |
|---|---|
| `toRelayUrl()` | bare `.onion` host defaults to `ws://`; a typed `wss://` is kept |
| `isValidRelayUrl()` | `ws://` accepted for `.onion` hosts (was loopback-only); userinfo check still applies |

Reaching the relay still requires Tor routing (Orbot VPN on mobile, Tor Browser on web, torsocks on desktop); the app itself only validates and dials the URL.

Commits:
- 16d9c4cd feat(relay): accept Tor .onion relay URLs without wss

Tested with `RelayUrlTest` (new onion cases) via `:composeApp:jvmTest`; `compileKotlinJvm` + `compileKotlinJs` pass.