### PR TITLE
Group invites: consent-gated adds, cross-relay detection, and list sync

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -247,6 +247,11 @@ tasks.withType<org.gradle.api.tasks.testing.Test>().configureEach {
         showCauses = true
         showExceptions = true
     }
+    // Keep unit tests off the real OS keyring: java-keyring's Secret Service (dbus-java)
+    // reader thread races its own executor shutdown and the stray RejectedExecutionException
+    // poisons a later runTest as UncaughtExceptionsBeforeTest (intermittent cross-class
+    // failure). KeychainStore honors this and SecureStorage uses its no-keychain fallback.
+    systemProperty("nostrord.disableKeychain", "true")
 }
 
 val appVersion = project.property("app.version") as String

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/AppViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/AppViewModel.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -26,6 +27,9 @@ private const val GROUP_RESOLVE_GRACE_MS = 3_000L
 
 class AppViewModel(
     private val repo: NostrRepositoryApi,
+    // Injectable so tests can run the boot launch on the test dispatcher; with the
+    // real Default dispatcher the launch races advanceUntilIdle and flakes on CI.
+    private val bootDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
     val isInitialized = repo.isInitialized
     val isLoggedIn = repo.isLoggedIn
@@ -147,7 +151,7 @@ class AppViewModel(
         // init, storage reads) that, if run on Main (viewModelScope's default), stalls the Compose
         // frame clock and freezes the loading spinner mid-arc. StateFlow collectors still deliver on
         // Main, so the UI updates normally.
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch(bootDispatcher) {
             withTimeoutOrNull(30_000) {
                 repo.initialize()
             } ?: repo.forceInitialized()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -48,6 +48,7 @@ import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.CacheStore
 import org.nostr.nostrord.storage.cache.createCacheStore
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
  * Simple dependency injection container.
@@ -268,9 +269,26 @@ object AppModule {
      * silent. Catch-up adds (offline at put time) enter the feed but skip sound/popup via
      * [isRealtime], like every other notification type.
      */
+    // Feed-entry age cap for external adds, matching the put-user watch's own 7-day
+    // catch-up lookback. The no-since 39002 membership sweep has no such bound: on a
+    // first connect it surfaces relay-side memberships from months ago, and their
+    // enrichment 9000s carry the original timestamps — real pending invites, but
+    // "added you 213d ago" is history, not news.
+    private val GROUP_ADD_FEED_MAX_AGE_S = 7L * 24 * 3600
+
     private suspend fun onExternalGroupAdd(add: GroupManager.ExternalGroupAdd) {
         val actor = add.actorPubkey ?: return
         if (actor == sessionManager.getPublicKey()) return
+        if (epochSeconds() - add.createdAtSeconds > GROUP_ADD_FEED_MAX_AGE_S) return
+        // A relay-authored put-user (creator echo / relay backfill) is not a person adding
+        // you: skip the "<relay key> added you" feed entry. The pending invite itself still
+        // surfaces in the group screen prompt. Both key forms, like the VM's label lookup —
+        // the metadata map is keyed by whatever URL the NIP-11 fetch received.
+        val relayMeta = relayMetadataManager.relayMetadata.value
+        val relayKey = (relayMeta[add.relayUrl] ?: relayMeta[add.relayUrl.normalizeRelayUrl()])
+            ?.pubkey
+            ?.takeIf { it.isNotBlank() }
+        if (actor == relayKey) return
         // Give the repo's preview fetch a moment to land the kind:39000 so the entry
         // snapshots a real group name instead of a truncated id.
         kotlinx.coroutines.withTimeoutOrNull(3_000) {
@@ -278,6 +296,9 @@ object AppModule {
                 byRelay.values.any { list -> list.any { it.id == add.groupId } }
             }
         }
+        // Settled while we waited (create/join bookkeeping claimed its own echo, or the
+        // user already decided): a notification for it would be noise.
+        if (add.groupId !in groupManager.pendingGroupInvites.value) return
         val groupName = groupDisplayName(add.groupId)
         notificationHistoryStore.add(
             NotificationEntry(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.auth.AccountManager
@@ -251,7 +252,66 @@ object AppModule {
             onNewMessagesFlushed = { groupId, newMessages ->
                 unreadManager.onMessagesFlushed(groupId, newMessages)
             },
+        ).also { gm ->
+            // Feed + popup for "an admin added you to a group" (kind:9000, live or catch-up).
+            appScope.launch {
+                gm.externalMembershipAdopted.collect { add -> onExternalGroupAdd(add) }
+            }
+        }
+    }
+
+    /**
+     * Notify an externally granted membership. Only the kind:9000 path carries an actor;
+     * 39002-inferred adoptions (the user opened the group link and is looking at it) stay
+     * silent. Catch-up adds (offline at put time) enter the feed but skip sound/popup via
+     * [isRealtime], like every other notification type.
+     */
+    private suspend fun onExternalGroupAdd(add: GroupManager.ExternalGroupAdd) {
+        val actor = add.actorPubkey ?: return
+        if (actor == sessionManager.getPublicKey()) return
+        // Give the adoption's mux refresh a moment to land the kind:39000 so the entry
+        // snapshots a real group name instead of a truncated id.
+        kotlinx.coroutines.withTimeoutOrNull(3_000) {
+            groupManager.groupsByRelay.first { byRelay ->
+                byRelay.values.any { list -> list.any { it.id == add.groupId } }
+            }
+        }
+        val groupName = groupDisplayName(add.groupId)
+        notificationHistoryStore.add(
+            NotificationEntry(
+                id = add.eventId ?: "gadd_${add.groupId}",
+                type = NotificationType.GROUP_ADD,
+                groupId = add.groupId,
+                relayUrl = add.relayUrl,
+                actorPubkey = actor,
+                createdAt = add.createdAtSeconds,
+                preview = "",
+                groupName = groupName,
+                relayName = relayDisplayName(add.relayUrl),
+            ),
         )
+        if (displayLabelFor(actor, prefixAt = false) == null) {
+            appScope.launch { nostrRepository.requestUserMetadata(setOf(actor)) }
+        }
+        val realtime = isRealtime(add.createdAtSeconds)
+        if (realtime && notificationSettings.soundEnabled.value) {
+            playNotificationSound()
+        }
+        if (realtime &&
+            notificationSettings.systemNotificationsEnabled.value &&
+            notificationService.isSupported() &&
+            notificationService.permission.value == NotificationPermission.Granted
+        ) {
+            val actorName = displayLabelFor(actor, prefixAt = false) ?: (actor.take(8) + "…")
+            notificationService.notify(
+                NotificationRequest(
+                    relayUrl = add.relayUrl,
+                    groupId = add.groupId,
+                    title = groupName,
+                    body = "$actorName added you to this group",
+                ),
+            )
+        }
     }
 
     val metadataManager: MetadataManager by lazy {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -254,22 +254,24 @@ object AppModule {
             },
         ).also { gm ->
             // Feed + popup for "an admin added you to a group" (kind:9000, live or catch-up).
+            // Fires when the add lands as a PENDING invite; the group itself is only adopted
+            // when the user accepts it from the group screen.
             appScope.launch {
-                gm.externalMembershipAdopted.collect { add -> onExternalGroupAdd(add) }
+                gm.externalAddPending.collect { add -> onExternalGroupAdd(add) }
             }
         }
     }
 
     /**
      * Notify an externally granted membership. Only the kind:9000 path carries an actor;
-     * 39002-inferred adoptions (the user opened the group link and is looking at it) stay
+     * 39002-inferred invites (the user opened the group link and is looking at it) stay
      * silent. Catch-up adds (offline at put time) enter the feed but skip sound/popup via
      * [isRealtime], like every other notification type.
      */
     private suspend fun onExternalGroupAdd(add: GroupManager.ExternalGroupAdd) {
         val actor = add.actorPubkey ?: return
         if (actor == sessionManager.getPublicKey()) return
-        // Give the adoption's mux refresh a moment to land the kind:39000 so the entry
+        // Give the repo's preview fetch a moment to land the kind:39000 so the entry
         // snapshots a real group name instead of a truncated id.
         kotlinx.coroutines.withTimeoutOrNull(3_000) {
             groupManager.groupsByRelay.first { byRelay ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -1185,6 +1185,11 @@ class NostrGroupClient(
     fun muxDeleteSubId(): String = "mux_del_${relayUrl.hashCode().toUInt()}"
 
 /**
+     * Deterministic sub ID for the relay-level put-user watch (kind:9000, #p = self).
+     */
+    fun muxPutUserSubId(): String = "mux_padd_${relayUrl.hashCode().toUInt()}"
+
+/**
      * Send (or refresh) the three relay-level multiplexed subscriptions.
      *
      * Replaces per-group `live_<id>` + `reactions_<id>` with three relay-scoped REQs that cover
@@ -1199,17 +1204,48 @@ class NostrGroupClient(
      * @param metadataGroupIds Group IDs for the metadata mux (kind:39000 — all joined groups).
      * @param chatGroupIds     Group IDs for chat + reactions mux (opened groups).
      * @param chatSinceSeconds Unix-seconds `since` for chat/reactions (cursor for opened groups).
+     * @param putUserPubkey    Self pubkey for the kind:9000 put-user watch (null when logged out).
+     * @param putUserSinceSeconds Unix-seconds `since` for the put-user watch (persisted cursor).
      */
     suspend fun sendMuxSubscriptions(
         metadataGroupIds: List<String>,
         chatGroupIds: List<String>,
         chatSinceSeconds: Long,
+        putUserPubkey: String? = null,
+        putUserSinceSeconds: Long = 0L,
     ) {
-        if (metadataGroupIds.isEmpty() && chatGroupIds.isEmpty()) return
+        if (metadataGroupIds.isEmpty() && chatGroupIds.isEmpty() && putUserPubkey == null) return
         val chatSubId = muxChatSubId()
         val reactSubId = muxReactionsSubId()
         val metaSubId = muxMetaSubId()
         val delSubId = muxDeleteSubId()
+        val putUserSubId = muxPutUserSubId()
+
+        // Put-user watch: how we learn an admin added us to a group on this relay (kind:9000
+        // with #p = us), live or as catch-up after an offline window — including groups we
+        // never opened, which no other subscription covers. Kept independent of the group
+        // batches so it stays armed on a relay where we have zero groups yet.
+        send(
+            buildJsonArray {
+                add("CLOSE")
+                add(putUserSubId)
+            }.toString(),
+        )
+        if (putUserPubkey != null) {
+            send(
+                buildJsonArray {
+                    add("REQ")
+                    add(putUserSubId)
+                    add(
+                        buildJsonObject {
+                            putJsonArray("kinds") { add(9000) }
+                            putJsonArray("#p") { add(putUserPubkey) }
+                            put("since", putUserSinceSeconds)
+                        },
+                    )
+                }.toString(),
+            )
+        }
 
         // Close the previous mux slots first (idempotent — no-op if not open).
         send(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -801,6 +801,31 @@ class NostrGroupClient(
     }
 
     /**
+     * One-shot fetch of the put-user event that added [pubkey] to [groupId] — the actor
+     * enrichment for a 39002-inferred pending invite. Bare-#p kind:9000 queries are blocked
+     * on 0xchat-style relays, but #p + #h passes their h/e/a rule. Closed after EOSE by
+     * closeOneShotSubAfterEose (padd_one_ prefix).
+     */
+    suspend fun requestSelfPutUser(groupId: String, pubkey: String): String {
+        val subId = "padd_one_${groupId.take(8)}"
+        trySendClose(subId)
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
+            add(
+                buildJsonObject {
+                    putJsonArray("kinds") { add(9000) }
+                    put("#h", buildJsonArray { add(groupId) })
+                    put("#p", buildJsonArray { add(pubkey) })
+                    put("limit", 1)
+                },
+            )
+        }
+        sendJson(req)
+        return subId
+    }
+
+    /**
      * Subscribe for kind:39000 metadata for a specific group.
      * Called when entering a group screen to ensure metadata is fresh.
      *
@@ -1225,6 +1250,16 @@ class NostrGroupClient(
         // with #p = us), live or as catch-up after an offline window — including groups we
         // never opened, which no other subscription covers. Kept independent of the group
         // batches so it stays armed on a relay where we have zero groups yet.
+        //
+        // Two filters, because 0xchat's relay gates STORED queries on having an h/e/a tag
+        // (a bare-#p kind:9000 REQ is CLOSED "invalid query") while its LIVE broadcast does
+        // plain filter matching:
+        //  - kinds 9000+39002 with since: live adds on every relay (the 39002 alongside makes
+        //    0xchat accept the REQ instead of closing it) + stored catch-up on relays that
+        //    serve bare-#p queries.
+        //  - kinds 39002 no-since: membership sweep at every (re)subscribe — the offline
+        //    catch-up for relays like 0xchat, which never advance a 39002's created_at
+        //    (pinned at group creation), making any `since` filter blind to adds there.
         send(
             buildJsonArray {
                 add("CLOSE")
@@ -1238,9 +1273,18 @@ class NostrGroupClient(
                     add(putUserSubId)
                     add(
                         buildJsonObject {
-                            putJsonArray("kinds") { add(9000) }
+                            putJsonArray("kinds") {
+                                add(9000)
+                                add(39002)
+                            }
                             putJsonArray("#p") { add(putUserPubkey) }
                             put("since", putUserSinceSeconds)
+                        },
+                    )
+                    add(
+                        buildJsonObject {
+                            putJsonArray("kinds") { add(39002) }
+                            putJsonArray("#p") { add(putUserPubkey) }
                         },
                     )
                 }.toString(),

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -67,6 +67,7 @@ import org.nostr.nostrord.storage.clearDmMessages
 import org.nostr.nostrord.storage.getLastActiveAt
 import org.nostr.nostrord.storage.isDmCacheMigratedFor
 import org.nostr.nostrord.storage.isGroupFetchLazy
+import org.nostr.nostrord.storage.isKind10009RepublishPendingFor
 import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
@@ -910,6 +911,31 @@ class NostrRepository(
             groupManager.externalAddPending.collect { add ->
                 try {
                     fetchGroupPreview(add.groupId, add.relayUrl)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (_: Exception) {}
+            }
+        }
+
+        // A kind:10009 publish no relay accepted (offline leave, zombie socket, or the
+        // NIP-29-focused fallback rejecting it) retries on every (re)connect while the
+        // pending flag holds — in memory for this session, persisted across restarts.
+        // Always publishes the CURRENT list, never the lost snapshot (replaceable event).
+        scope.launch {
+            connectionManager.connectionState.collect { st ->
+                if (st !is ConnectionManager.ConnectionState.Connected) return@collect
+                val pk = sessionManager.getPublicKey() ?: return@collect
+                val pending = outboxManager.kind10009NeedsRepublish.value ||
+                    try {
+                        SecureStorage.isKind10009RepublishPendingFor(pk)
+                    } catch (_: Exception) {
+                        false
+                    }
+                if (!pending) return@collect
+                // Let AUTH and the reconnect subscription burst settle first.
+                delay(2_000)
+                try {
+                    publishJoinedGroupsList()
                 } catch (e: kotlinx.coroutines.CancellationException) {
                     throw e
                 } catch (_: Exception) {}
@@ -3144,6 +3170,12 @@ class NostrRepository(
             } ?: return
             connectedPoolRelays.add(relayUrl)
             client.requestGroupMetadata(groupId)
+            // Same AUTH-gated re-send as fetchGroupPreviews: a private group's kind:39000 is
+            // withheld pre-AUTH (0xchat answers with an empty EOSE, not a CLOSED), so for
+            // them the first REQ yields nothing and only the authenticated retry lands.
+            if (client.awaitAuthSigned(signerAuthBudgetMs())) client.requestGroupMetadata(groupId)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
         } catch (_: Exception) {}
     }
 
@@ -3398,11 +3430,17 @@ class NostrRepository(
         try {
             val relayUrl = groupManager.getRelayForGroup(groupId)
                 ?: connectionManager.currentRelayUrl.value
-            val relayPubkey = relayMetadata.value[relayUrl]?.groupNaddrAuthor
-                ?: relayMetadata.value[relayUrl.trimEnd('/')]?.groupNaddrAuthor
+            val relayPubkey = (relayMetadata.value[relayUrl] ?: relayMetadata.value[relayUrl.normalizeRelayUrl()])
+                ?.groupNaddrAuthor
             val naddr = Nip19.encodeNaddr(identifier = groupId, relay = relayUrl, kind = 39000, pubkeyHex = relayPubkey)
-            val groupName = groupManager.groupsByRelay.value.values
-                .firstNotNullOfOrNull { list -> list.firstOrNull { it.id == groupId }?.name?.takeIf { it.isNotBlank() } }
+            // The group's own relay first: NIP-29 ids are relay-local, so an any-relay scan
+            // could name a same-id group from another relay.
+            val byRelay = groupManager.groupsByRelay.value
+            val groupName = (byRelay[relayUrl.normalizeRelayUrl()] ?: byRelay[relayUrl])
+                ?.firstOrNull { it.id == groupId }
+                ?.name
+                ?.takeIf { it.isNotBlank() }
+                ?: byRelay.values.firstNotNullOfOrNull { list -> list.firstOrNull { it.id == groupId }?.name?.takeIf { it.isNotBlank() } }
             val title = groupName?.let { "the group \"$it\"" } ?: "a group"
             sendDm(targetPubkey, "You've been added to $title.\nnostr:$naddr")
         } catch (e: kotlinx.coroutines.CancellationException) {
@@ -3965,7 +4003,9 @@ class NostrRepository(
 
     /**
      * Build a NIP-98 Authorization header value for HTTP requests.
-     * Returns "Nostr <base64>" or null if not authenticated.
+     * Returns "Nostr <base64>", or null only when no account is signed in. A signer
+     * failure (bunker timeout, extension denial) propagates so the caller can surface
+     * the real cause instead of a false "not authenticated".
      */
     @OptIn(kotlin.io.encoding.ExperimentalEncodingApi::class)
     suspend fun buildNip98AuthHeader(url: String, method: String): String? {
@@ -3977,11 +4017,7 @@ class NostrRepository(
             tags = listOf(listOf("u", url), listOf("method", method)),
             content = "",
         )
-        val signed = try {
-            sessionManager.signEvent(event)
-        } catch (_: Throwable) {
-            return null
-        }
+        val signed = sessionManager.signEvent(event)
         val json = signed.toJsonObject().toString()
         val encoded = kotlin.io.encoding.Base64.encode(json.encodeToByteArray())
         return "Nostr $encoded"
@@ -4899,7 +4935,9 @@ class NostrRepository(
             subId.startsWith("reactions_") ||
             subId.startsWith("zaps_") ||
             subId.startsWith("threadfocus_") ||
-            subId.startsWith("event_")
+            subId.startsWith("event_") ||
+            // requestSelfPutUser's actor-enrichment fetch (distinct from the live mux_padd_ watch).
+            subId.startsWith("padd_one_")
         ) {
             scope.launch {
                 try {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -48,6 +48,7 @@ import org.nostr.nostrord.network.managers.LiveCursorStore
 import org.nostr.nostrord.network.managers.MetadataManager
 import org.nostr.nostrord.network.managers.OutboxManager
 import org.nostr.nostrord.network.managers.PendingDmWrap
+import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.RelayMetadataManager
 import org.nostr.nostrord.network.managers.RelayReconnectScheduler
 import org.nostr.nostrord.network.managers.SessionManager
@@ -419,6 +420,11 @@ class NostrRepository(
     override val loadingMembers: StateFlow<Set<String>> = groupManager.loadingMembers
     override val restrictedGroups: StateFlow<Map<String, String>> = groupManager.restrictedGroups
     override val leftGroups: StateFlow<Set<String>> = groupManager.leftGroups
+    override val pendingGroupInvites: StateFlow<Map<String, PendingGroupInvite>> = groupManager.pendingGroupInvites
+
+    override suspend fun acceptGroupInvite(groupId: String) {
+        groupManager.acceptPendingInvite(groupId)
+    }
 
     // Expose auth state
     override val isLoggedIn: StateFlow<Boolean> = sessionManager.isLoggedIn
@@ -889,12 +895,24 @@ class NostrRepository(
             }
         }
 
-        // Membership granted by an admin's kind:9000 (no join request of ours): GroupManager
+        // Membership granted by an admin's kind:9000 and ACCEPTED by the user: GroupManager
         // adopted it into the joined set; mirror it into our kind:10009 so it survives
         // restarts and reaches the account's other devices.
         scope.launch {
             groupManager.externalMembershipAdopted.collect {
                 publishJoinedGroupsList()
+            }
+        }
+
+        // A pending external add is in no group list yet; pull its kind:39000 so the
+        // invite notification and the accept/decline prompt show the group's real name.
+        scope.launch {
+            groupManager.externalAddPending.collect { add ->
+                try {
+                    fetchGroupPreview(add.groupId, add.relayUrl)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (_: Exception) {}
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -57,6 +57,7 @@ import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.DM_CACHE_KIND
@@ -3346,10 +3347,15 @@ class NostrRepository(
         )
     }
 
-    override suspend fun addUser(groupId: String, targetPubkey: String, roles: List<String>): Result<Unit> {
+    override suspend fun addUser(
+        groupId: String,
+        targetPubkey: String,
+        roles: List<String>,
+        notifyViaDm: Boolean,
+    ): Result<Unit> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
-        return groupManager.addUser(
+        val result = groupManager.addUser(
             groupId = groupId,
             targetPubkey = targetPubkey,
             roles = roles,
@@ -3357,6 +3363,33 @@ class NostrRepository(
             currentRelayUrl = connectionManager.currentRelayUrl.value,
             signEvent = { sessionManager.signEvent(it) },
         )
+        if (notifyViaDm && result is Result.Success && targetPubkey != pubKey) {
+            // Fire-and-forget: the DM is a courtesy reach-out; its failure must not fail the add.
+            scope.launch { sendGroupAddedDm(groupId, targetPubkey) }
+        }
+        return result
+    }
+
+    /**
+     * NIP-17 DM telling [targetPubkey] they were added to [groupId], carrying the group
+     * naddr. It travels over the recipient's own DM relays, so it reaches users who don't
+     * connect to the group's NIP-29 relay (the put-user #p watch can't). The naddr sits on
+     * its own line so clients that card-preview group links render the invite card.
+     */
+    private suspend fun sendGroupAddedDm(groupId: String, targetPubkey: String) {
+        try {
+            val relayUrl = groupManager.getRelayForGroup(groupId)
+                ?: connectionManager.currentRelayUrl.value
+            val relayPubkey = relayMetadata.value[relayUrl]?.groupNaddrAuthor
+                ?: relayMetadata.value[relayUrl.trimEnd('/')]?.groupNaddrAuthor
+            val naddr = Nip19.encodeNaddr(identifier = groupId, relay = relayUrl, kind = 39000, pubkeyHex = relayPubkey)
+            val groupName = groupManager.groupsByRelay.value.values
+                .firstNotNullOfOrNull { list -> list.firstOrNull { it.id == groupId }?.name?.takeIf { it.isNotBlank() } }
+            val title = groupName?.let { "the group \"$it\"" } ?: "a group"
+            sendDm(targetPubkey, "You've been added to $title.\nnostr:$naddr")
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (_: Throwable) {}
     }
 
     override suspend fun removeUser(groupId: String, targetPubkey: String): Result<Unit> {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -925,6 +925,9 @@ class NostrRepository(
             connectionManager.connectionState.collect { st ->
                 if (st !is ConnectionManager.ConnectionState.Connected) return@collect
                 val pk = sessionManager.getPublicKey() ?: return@collect
+                // Reconnects drop the standing own-kind:10009 sub with the socket; re-arm it
+                // so lists published by another device keep applying live.
+                outboxManager.armKind10009LiveSub(pk)
                 val pending = outboxManager.kind10009NeedsRepublish.value ||
                     try {
                         SecureStorage.isKind10009RepublishPendingFor(pk)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -888,6 +888,15 @@ class NostrRepository(
             }
         }
 
+        // Membership granted by an admin's kind:9000 (no join request of ours): GroupManager
+        // adopted it into the joined set; mirror it into our kind:10009 so it survives
+        // restarts and reaches the account's other devices.
+        scope.launch {
+            groupManager.externalMembershipAdopted.collect {
+                publishJoinedGroupsList()
+            }
+        }
+
         // Bunker (NIP-46) signer-ready recovery. On session restore / account-add
         // the account is marked logged-in optimistically while the remote signer
         // connects asynchronously (issue #85). connect() + NIP-42 AUTH for the
@@ -4722,7 +4731,7 @@ class NostrRepository(
                     39002 -> {
                         val groupMembers = client.parseGroupMembers(event) ?: return
                         val createdAt = event["created_at"]?.jsonPrimitive?.long ?: 0L
-                        val memberPubkeys = groupManager.handleGroupMembers(groupMembers, createdAt)
+                        val memberPubkeys = groupManager.handleGroupMembers(groupMembers, createdAt, client.getRelayUrl())
                         val pubkeysNeedingMetadata = memberPubkeys.filter { !metadataManager.hasMetadata(it) }
                         if (pubkeysNeedingMetadata.isNotEmpty()) {
                             scope.launch {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -557,10 +557,17 @@ interface NostrRepositoryApi {
         content: String,
     ): Result<Unit>
 
+    /**
+     * Add a user to the group (kind:9000, admin only). With [notifyViaDm] a NIP-17 DM
+     * carrying the group naddr is sent to the added user after the relay accepts, the
+     * only signal that reaches someone who doesn't connect to this NIP-29 relay. Keep
+     * it false for role changes and join-request approvals.
+     */
     suspend fun addUser(
         groupId: String,
         targetPubkey: String,
         roles: List<String> = emptyList(),
+        notifyViaDm: Boolean = false,
     ): Result<Unit>
 
     suspend fun removeUser(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -7,6 +7,7 @@ import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
@@ -122,6 +123,16 @@ interface NostrRepositoryApi {
 
     /** Groups the user explicitly LEFT (durable, survives restart); membership reads NONE for these. */
     val leftGroups: StateFlow<Set<String>>
+
+    /**
+     * External adds (an admin's kind:9000) awaiting the user's accept/decline, keyed by
+     * groupId. Accept via [acceptGroupInvite]; decline via [leaveGroup] (kind:9022 + durable
+     * left marker, which also drops the pending entry).
+     */
+    val pendingGroupInvites: StateFlow<Map<String, PendingGroupInvite>>
+
+    /** Adopt a pending external add into the joined set and republish kind:10009. */
+    suspend fun acceptGroupInvite(groupId: String)
 
     // --- Metadata state ---
     val userMetadata: StateFlow<Map<String, UserMetadata>>

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3,9 +3,12 @@ package org.nostr.nostrord.network.managers
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -3642,7 +3645,7 @@ class GroupManager(
      * Handle incoming group members (kind 39002)
      * Returns list of member pubkeys that need metadata fetching
      */
-    fun handleGroupMembers(members: GroupMembers, createdAt: Long = 0L): List<String> {
+    fun handleGroupMembers(members: GroupMembers, createdAt: Long = 0L, relayUrl: String? = null): List<String> {
         if (isRecentlyLeft(members.groupId)) {
             _loadingMembers.value = _loadingMembers.value - members.groupId
             return emptyList()
@@ -3705,7 +3708,59 @@ class GroupManager(
             }
         }
 
+        // An admin added us via kind:9000 (no kind:9021 of ours): the relay's 39002 is the
+        // ground truth of membership, but nothing ever wrote the group into
+        // _joinedGroupsByRelay, so it is absent from the group list and mux and Leave is
+        // unreachable. Adopt it as a join.
+        if (selfNowMember && self != null) {
+            adoptExternalMembership(members.groupId, self, relayUrl)
+        }
+
         return members.members
+    }
+
+    /**
+     * Emits the groupId whenever a membership granted externally (an admin's kind:9000)
+     * is adopted into the joined set. NostrRepository republishes kind:10009 on it so the
+     * group survives restarts and reaches the account's other devices.
+     */
+    private val _externalMembershipAdopted = MutableSharedFlow<String>(extraBufferCapacity = 16)
+    val externalMembershipAdopted: SharedFlow<String> = _externalMembershipAdopted.asSharedFlow()
+
+    /**
+     * Adopt a membership created by an admin's kind:9000 (put-user) instead of our own
+     * join request. The durable left marker wins: a relay that keeps listing us after our
+     * kind:9022 must not resurrect the group (B2), and a rejoin has to be the user's call.
+     */
+    private fun adoptExternalMembership(groupId: String, pubkey: String, relayUrl: String?) {
+        if (groupId in _leftGroups.value) return
+        if (isRecentlyLeft(groupId) || groupId in deletedGroupIds) return
+        if (_joinedGroupsByRelay.value.values.any { groupId in it }) return
+        val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
+        scope.launch {
+            // Re-check inside the launch: two 39002s (or a 39002 + a live 9000) can both pass
+            // the synchronous guard and only the first may adopt.
+            if (_joinedGroupsByRelay.value.values.any { groupId in it }) return@launch
+            // Merge with the persisted slot like joinGroup: the in-memory map can be partial
+            // early in a session and a memory-only write would clobber the slot.
+            val stored = try {
+                SecureStorage.getJoinedGroupsForRelay(pubkey, relay)
+            } catch (_: Exception) {
+                emptySet()
+            }
+            val updated = (_joinedGroupsByRelay.value[relay] ?: emptySet()) + stored + groupId
+            try {
+                SecureStorage.saveJoinedGroupsForRelay(pubkey, relay, updated)
+            } catch (_: Exception) {}
+            _joinedGroupsByRelay.update { it + (relay to updated) }
+            // Grace against the orphan auto-forget while this group's kind:39000 is in flight.
+            markRecentlyJoined(groupId)
+            clearGroupRestricted(groupId)
+            _externalMembershipAdopted.tryEmit(groupId)
+            try {
+                refreshMuxSubscriptionsForRelay(relay)
+            } catch (_: Exception) {}
+        }
     }
 
     // Pre-approval CLOSED("restricted") drove the loader to Exhausted. Reset it (so
@@ -3847,7 +3902,11 @@ class GroupManager(
      * Only applies changes from events newer than the last authoritative kind:39002 member
      * list to avoid re-adding users that were removed (historical replays after AUTH).
      */
-    private fun applyMemberChangeIfAdmin(message: NostrGroupClient.NostrMessage, groupId: String) {
+    private fun applyMemberChangeIfAdmin(
+        message: NostrGroupClient.NostrMessage,
+        groupId: String,
+        relayUrl: String? = null,
+    ) {
         val targetPubkey = message.tags.firstOrNull { it.firstOrNull() == "p" }?.getOrNull(1)
             ?: return
         // Skip historical events older than the authoritative member list.
@@ -3856,6 +3915,11 @@ class GroupManager(
 
         when (message.kind) {
             9000 -> { // add-user
+                // A live put-user targeting US is an external add; adopt it without
+                // waiting for the next kind:39002 refresh.
+                if (targetPubkey == currentPubkey) {
+                    adoptExternalMembership(groupId, targetPubkey, relayUrl)
+                }
                 _groupMembers.update { current ->
                     val members = current[groupId] ?: return@update current
                     if (targetPubkey in members) {
@@ -3983,7 +4047,7 @@ class GroupManager(
 
         // Inline member list updates from admin events — provides immediate UI feedback
         // without waiting for a new kind:39002 event from the relay.
-        applyMemberChangeIfAdmin(message, groupId)
+        applyMemberChangeIfAdmin(message, groupId, relayUrl)
 
         // Enqueue to the ordering buffer; the buffer flushes after 300 ms of inactivity
         // for this group, applying the entire batch in one sorted StateFlow update.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -43,6 +43,7 @@ import org.nostr.nostrord.storage.cache.InMemoryCacheStore
 import org.nostr.nostrord.storage.clearGroupMembershipFor
 import org.nostr.nostrord.storage.clearMessageBlobMigratedFor
 import org.nostr.nostrord.storage.getLeftGroupsForRelay
+import org.nostr.nostrord.storage.getPutUserCursorForRelay
 import org.nostr.nostrord.storage.getRestrictedGroupsForRelay
 import org.nostr.nostrord.storage.isFullGroupListCacheFresh
 import org.nostr.nostrord.storage.isGroupListCacheFresh
@@ -55,6 +56,7 @@ import org.nostr.nostrord.storage.saveDroppedGroupIds
 import org.nostr.nostrord.storage.saveFullGroupListEoseTimestamp
 import org.nostr.nostrord.storage.saveGroupListEoseTimestamp
 import org.nostr.nostrord.storage.saveGroupMembershipFor
+import org.nostr.nostrord.storage.savePutUserCursorForRelay
 import org.nostr.nostrord.storage.setMessageBlobMigratedFor
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
@@ -1033,7 +1035,10 @@ class GroupManager(
         // silencing metadata/delete updates for the groups we DO belong to.
         val restricted = _restrictedGroups.value.keys
         val allGroupIds = getGroupIdsForMux(relayUrl).filter { it !in restricted }
-        if (allGroupIds.isEmpty()) return
+        // The put-user watch must be armed even with zero groups on this relay —
+        // that is exactly the state in which an external add can only arrive via #p.
+        val selfPubkey = currentPubkey
+        if (allGroupIds.isEmpty() && selfPubkey == null) return
         val client = connectionManager.getClientForRelay(relayUrl) ?: return
         if (!client.isConnected()) return
 
@@ -1054,10 +1059,13 @@ class GroupManager(
         // `since` as a refresh trigger, so the CLOSE+REQ cycle fires here.
         val chatSince = if (catchUp == null) baseChatSince else minOf(baseChatSince, catchUp)
 
+        val putUserSince = selfPubkey?.let { putUserWatchSince(it, relayUrl) } ?: 0L
         val desired = MuxSubscriptionTracker.MuxState(
             metadataGroupIds = allGroupIds.toSet(),
             chatGroupIds = chatGroupIds.toSet(),
             chatSinceSeconds = chatSince,
+            putUserPubkey = selfPubkey,
+            putUserSinceSeconds = putUserSince,
         )
 
         if (!muxTracker.needsRefresh(relayUrl, desired)) {
@@ -1066,9 +1074,44 @@ class GroupManager(
         }
 
         try {
-            client.sendMuxSubscriptions(allGroupIds, chatGroupIds, chatSince)
+            client.sendMuxSubscriptions(allGroupIds, chatGroupIds, chatSince, selfPubkey, putUserSince)
             muxTracker.update(relayUrl, desired, epochMillis())
             connStats?.onSubscriptionSent(relayUrl)
+        } catch (_: Exception) {}
+    }
+
+    // First-arm lookback for the put-user watch: catch adds from up to a week offline
+    // without replaying the relay's whole put-user history.
+    private val PUT_USER_INITIAL_LOOKBACK_S = 7L * 24 * 3600
+
+    /**
+     * `since` for [relayUrl]'s put-user watch: the persisted cursor, initialized to
+     * now minus [PUT_USER_INITIAL_LOOKBACK_S] on first use. Inclusive replay of the
+     * last processed event is fine — adoption is idempotent and skips joined groups.
+     */
+    private fun putUserWatchSince(pubkey: String, relayUrl: String): Long {
+        val key = relayUrl.normalizeRelayUrl()
+        val stored = try {
+            SecureStorage.getPutUserCursorForRelay(pubkey, key)
+        } catch (_: Exception) {
+            0L
+        }
+        if (stored > 0L) return stored
+        val initial = epochSeconds() - PUT_USER_INITIAL_LOOKBACK_S
+        try {
+            SecureStorage.savePutUserCursorForRelay(pubkey, key, initial)
+        } catch (_: Exception) {}
+        return initial
+    }
+
+    /** Advance the put-user cursor so processed adds are not replayed on the next REQ. */
+    private fun advancePutUserCursor(pubkey: String, relayUrl: String, createdAtSeconds: Long) {
+        if (createdAtSeconds <= 0L) return
+        val key = relayUrl.normalizeRelayUrl()
+        try {
+            if (createdAtSeconds > SecureStorage.getPutUserCursorForRelay(pubkey, key)) {
+                SecureStorage.savePutUserCursorForRelay(pubkey, key, createdAtSeconds)
+            }
         } catch (_: Exception) {}
     }
 
@@ -3713,26 +3756,45 @@ class GroupManager(
         // _joinedGroupsByRelay, so it is absent from the group list and mux and Leave is
         // unreachable. Adopt it as a join.
         if (selfNowMember && self != null) {
-            adoptExternalMembership(members.groupId, self, relayUrl)
+            adoptExternalMembership(members.groupId, self, relayUrl, createdAtSeconds = createdAt)
         }
 
         return members.members
     }
 
     /**
-     * Emits the groupId whenever a membership granted externally (an admin's kind:9000)
-     * is adopted into the joined set. NostrRepository republishes kind:10009 on it so the
-     * group survives restarts and reaches the account's other devices.
+     * A membership granted externally (an admin's kind:9000), adopted into the joined set.
+     * [actorPubkey]/[eventId] are null when the adoption was inferred from a kind:39002
+     * listing instead of the put-user event itself.
      */
-    private val _externalMembershipAdopted = MutableSharedFlow<String>(extraBufferCapacity = 16)
-    val externalMembershipAdopted: SharedFlow<String> = _externalMembershipAdopted.asSharedFlow()
+    data class ExternalGroupAdd(
+        val groupId: String,
+        val relayUrl: String,
+        val actorPubkey: String?,
+        val eventId: String?,
+        val createdAtSeconds: Long,
+    )
+
+    /**
+     * Emits on every adopted external membership. NostrRepository republishes kind:10009 on
+     * it so the group survives restarts; AppModule turns it into a user notification.
+     */
+    private val _externalMembershipAdopted = MutableSharedFlow<ExternalGroupAdd>(extraBufferCapacity = 16)
+    val externalMembershipAdopted: SharedFlow<ExternalGroupAdd> = _externalMembershipAdopted.asSharedFlow()
 
     /**
      * Adopt a membership created by an admin's kind:9000 (put-user) instead of our own
      * join request. The durable left marker wins: a relay that keeps listing us after our
      * kind:9022 must not resurrect the group (B2), and a rejoin has to be the user's call.
      */
-    private fun adoptExternalMembership(groupId: String, pubkey: String, relayUrl: String?) {
+    private fun adoptExternalMembership(
+        groupId: String,
+        pubkey: String,
+        relayUrl: String?,
+        actorPubkey: String? = null,
+        eventId: String? = null,
+        createdAtSeconds: Long = 0L,
+    ) {
         if (groupId in _leftGroups.value) return
         if (isRecentlyLeft(groupId) || groupId in deletedGroupIds) return
         if (_joinedGroupsByRelay.value.values.any { groupId in it }) return
@@ -3756,7 +3818,15 @@ class GroupManager(
             // Grace against the orphan auto-forget while this group's kind:39000 is in flight.
             markRecentlyJoined(groupId)
             clearGroupRestricted(groupId)
-            _externalMembershipAdopted.tryEmit(groupId)
+            _externalMembershipAdopted.tryEmit(
+                ExternalGroupAdd(
+                    groupId = groupId,
+                    relayUrl = relay,
+                    actorPubkey = actorPubkey,
+                    eventId = eventId,
+                    createdAtSeconds = createdAtSeconds.takeIf { it > 0L } ?: epochSeconds(),
+                ),
+            )
             try {
                 refreshMuxSubscriptionsForRelay(relay)
             } catch (_: Exception) {}
@@ -3909,16 +3979,28 @@ class GroupManager(
     ) {
         val targetPubkey = message.tags.firstOrNull { it.firstOrNull() == "p" }?.getOrNull(1)
             ?: return
+        // Advance the put-user watch cursor for EVERY kind:9000 targeting us, even when the
+        // staleness guard below skips it — replays must stop arriving on the next REQ.
+        if (message.kind == 9000 && targetPubkey == currentPubkey && relayUrl != null) {
+            advancePutUserCursor(targetPubkey, relayUrl, message.createdAt)
+        }
         // Skip historical events older than the authoritative member list.
         val memberListTimestamp = memberEventTimestamps[groupId] ?: 0L
         if (message.createdAt <= memberListTimestamp) return
 
         when (message.kind) {
             9000 -> { // add-user
-                // A live put-user targeting US is an external add; adopt it without
+                // A put-user targeting US is an external add; adopt it without
                 // waiting for the next kind:39002 refresh.
                 if (targetPubkey == currentPubkey) {
-                    adoptExternalMembership(groupId, targetPubkey, relayUrl)
+                    adoptExternalMembership(
+                        groupId,
+                        targetPubkey,
+                        relayUrl,
+                        actorPubkey = message.pubkey,
+                        eventId = message.id,
+                        createdAtSeconds = message.createdAt,
+                    )
                 }
                 _groupMembers.update { current ->
                     val members = current[groupId] ?: return@update current

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -1163,8 +1163,15 @@ class GroupManager(
     fun getUncachedJoinedGroups(relayUrl: String): List<String> {
         val normalized = relayUrl.normalizeRelayUrl()
         val joined = _joinedGroupsByRelay.value[normalized] ?: emptySet()
+        // Pending external adds sit outside the joined set but are already readable
+        // relay-side (we are a member). Without them here the post-AUTH private-group
+        // heal never fetches their withheld 39000/39002 and the invite's group screen
+        // stays on skeletons / "no longer available" when opened from the notification.
+        val pending = _pendingGroupInvites.value.values
+            .filter { it.relayUrl.normalizeRelayUrl() == normalized }
+            .map { it.groupId }
         val cached = _groupsByRelay.value[normalized]?.map { it.id }?.toSet() ?: emptySet()
-        return (joined - cached).toList()
+        return (joined + pending - cached).toList()
     }
 
     /**
@@ -1377,20 +1384,15 @@ class GroupManager(
         inviteCode: String? = null,
     ): Result<Unit> {
         val groupRelayUrl = getRelayForGroup(groupId) ?: currentRelayUrl
+        // The 9021 must reach the group's OWN relay — a foreign fallback (the focused
+        // client) can OK a group it doesn't host, minting a phantom local joined+pending
+        // state the real relay never sees (same class as the #136 send-routing bug).
+        // Leaving a relay's last group drops it from the pool, so reconnect on demand.
         val currentClient = connectionManager.getClientForRelay(groupRelayUrl)
-            ?: connectionManager.getFocusedClient()
+            ?: messageHandler?.let { handler -> connectionManager.getOrConnectRelay(groupRelayUrl, handler) }
             ?: return Result.Error(AppError.Network.Disconnected(groupRelayUrl))
 
         return try {
-            deletedGroupIds.remove(groupId)
-            persistDroppedGroups()
-            recentlyLeftAt.remove(groupId)
-            // Rejoining clears the durable left marker BEFORE the optimistic bookkeeping below adds
-            // the group back, so the additive kind:10009 merge can't drop the fresh join.
-            _leftGroups.update { it - groupId }
-            try {
-                SecureStorage.removeLeftGroupForRelay(pubKey, groupRelayUrl.normalizeRelayUrl(), groupId)
-            } catch (_: Exception) {}
             val tags = mutableListOf(listOf("h", groupId))
             val effectiveCode = inviteCode?.takeIf { it.isNotBlank() }
             if (effectiveCode != null) {
@@ -1433,6 +1435,18 @@ class GroupManager(
                 is org.nostr.nostrord.network.PublishResult.Error ->
                     return Result.Error(AppError.Group.JoinFailed(groupId, publish.exception))
             }
+
+            // The relay accepted the join: only now clear the leave/delete markers. Clearing
+            // them before the OK (the old order) silently dropped the durable left protection
+            // when the relay rejected or timed out the request. Still BEFORE the joined-set
+            // write below, so the additive kind:10009 merge can't drop the fresh join.
+            deletedGroupIds.remove(groupId)
+            persistDroppedGroups()
+            recentlyLeftAt.remove(groupId)
+            _leftGroups.update { it - groupId }
+            try {
+                SecureStorage.removeLeftGroupForRelay(pubKey, groupRelayUrl.normalizeRelayUrl(), groupId)
+            } catch (_: Exception) {}
 
             // Normalized key, like every other _joinedGroupsByRelay writer: a raw URL
             // variant ("wss://x/" vs "wss://x") would start a parallel entry whose set
@@ -1611,6 +1625,10 @@ class GroupManager(
             val updatedAfterCreate = relayGroups + confirmedGroupId
             SecureStorage.saveJoinedGroupsForRelay(pubKey, normalizedCreateRelay, updatedAfterCreate)
             _joinedGroupsByRelay.update { it + (normalizedCreateRelay to updatedAfterCreate) }
+            // The relay's creation-time 39002 (listing us) races this bookkeeping on the
+            // #p sweep and registers a pending "invite" for our own group; settle it so
+            // the creator never sees the accept/decline prompt.
+            discardPendingInvite(confirmedGroupId)
             publishJoinedGroups()
             currentClient.requestGroupMessages(confirmedGroupId)
 
@@ -3808,9 +3826,31 @@ class GroupManager(
      * Emits when an external add first lands in the pending set (or a silent 39002-inferred
      * entry learns its actor from the put-user event). AppModule turns it into a user
      * notification; NostrRepository fetches the group's kind:39000 so the prompt has a name.
+     * Buffer sized for a catch-up burst: AppModule's collector waits up to 3s per event for
+     * the group name, and tryEmit silently drops what doesn't fit.
      */
-    private val _externalAddPending = MutableSharedFlow<ExternalGroupAdd>(extraBufferCapacity = 16)
+    private val _externalAddPending = MutableSharedFlow<ExternalGroupAdd>(extraBufferCapacity = 64)
     val externalAddPending: SharedFlow<ExternalGroupAdd> = _externalAddPending.asSharedFlow()
+
+    init {
+        // This init block sits AFTER _pendingGroupInvites' declaration on purpose: init
+        // blocks run in declaration order, and the collector reads the field from another
+        // thread — launched any earlier it can observe the not-yet-assigned field mid-
+        // construction (an uncaught NPE that poisoned unrelated runTests).
+        //
+        // A group that becomes joined by ANY path settles its pending invite. The write
+        // sites can't all know about invites — the key case is our own kind:10009 from
+        // another device (create/accept there) landing AFTER the relay's put-user echo
+        // registered an "invite" here; without this the creator is prompted to accept
+        // their own group.
+        scope.launch {
+            _joinedGroupsByRelay.collect { byRelay ->
+                if (_pendingGroupInvites.value.isEmpty()) return@collect
+                val joined = byRelay.values.flatten().toSet()
+                _pendingGroupInvites.value.keys.filter { it in joined }.forEach { discardPendingInvite(it) }
+            }
+        }
+    }
 
     private fun persistPendingInvites() {
         val pk = currentPubkey ?: return
@@ -3850,6 +3890,9 @@ class GroupManager(
         eventId: String? = null,
         createdAtSeconds: Long = 0L,
     ) {
+        // Our own put-user echoed back (some relays emit one for the group creator, and we
+        // are the actor when we add ourselves) is not an external add.
+        if (actorPubkey != null && actorPubkey == currentPubkey) return
         if (isRecentlyLeft(groupId) || groupId in deletedGroupIds) return
         if (_joinedGroupsByRelay.value.values.any { groupId in it }) return
         val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
@@ -3867,18 +3910,28 @@ class GroupManager(
         }
         val existing = _pendingGroupInvites.value[groupId]
         if (existing != null) {
-            // A 39002-inferred entry carries no actor; the put-user event does. Upgrade it
-            // so the prompt can say who added us, and notify (the silent entry never did).
-            if (actorPubkey == null || existing.actorPubkey != null) return
-            val upgraded = existing.copy(
+            if (actorPubkey == null) return
+            // The same put-user replayed by the inclusive since-cursor: nothing new.
+            if (eventId != null && eventId == existing.eventId) return
+            val isNewerAdd = createdAtSeconds > existing.createdAtSeconds
+            // Two cases refresh the entry and re-notify: a 39002-inferred entry learning its
+            // actor from the put-user event (the silent entry never announced anyone), and a
+            // NEWER put-user for an invite we already hold — a remove-then-re-add whose
+            // removal we may never have seen (the watch carries no kind:9001, and a removal's
+            // 39002 stops matching #p=self). Anything older is a historical replay. A role
+            // edit of a still-pending invitee is also a put-user and re-notifies too: it is
+            // indistinguishable from a re-add in this stream, and a reminder while the user
+            // hasn't decided is acceptable.
+            if (existing.actorPubkey != null && !isNewerAdd) return
+            val refreshed = existing.copy(
                 actorPubkey = actorPubkey,
                 eventId = eventId ?: existing.eventId,
                 createdAtSeconds = createdAtSeconds.takeIf { it > 0L } ?: existing.createdAtSeconds,
             )
-            _pendingGroupInvites.update { it + (groupId to upgraded) }
+            _pendingGroupInvites.update { it + (groupId to refreshed) }
             persistPendingInvites()
             _externalAddPending.tryEmit(
-                ExternalGroupAdd(groupId, relay, actorPubkey, upgraded.eventId, upgraded.createdAtSeconds),
+                ExternalGroupAdd(groupId, relay, actorPubkey, refreshed.eventId, refreshed.createdAtSeconds),
             )
             return
         }
@@ -3898,6 +3951,19 @@ class GroupManager(
         _externalAddPending.tryEmit(
             ExternalGroupAdd(groupId, relay, actorPubkey, eventId, invite.createdAtSeconds),
         )
+        // 39002-inferred invites carry no actor. Fetch the put-user event itself (#p + #h
+        // passes the h/e/a query rule that blocks the bare-#p watch on 0xchat) so the
+        // invite can name who added us; its arrival upgrades the entry and notifies.
+        if (actorPubkey == null) {
+            val self = currentPubkey ?: return
+            scope.launch {
+                try {
+                    connectionManager.getClientForRelay(relay)?.requestSelfPutUser(groupId, self)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Exception) {}
+            }
+        }
     }
 
     /** Accept a pending external add: adopt it into the joined set + kind:10009. */
@@ -4125,23 +4191,36 @@ class GroupManager(
         if (message.kind == 9000 && targetPubkey == currentPubkey && relayUrl != null) {
             advancePutUserCursor(targetPubkey, relayUrl, message.createdAt)
         }
+        // A put-user targeting US registers a pending invite BEFORE the staleness guard:
+        // the 39002 that the add produced usually carries a created_at >= the 9000's (0xchat
+        // even pins it at group creation), so gating on it would eat the actor enrichment
+        // fetched after a 39002-inferred invite. registerExternalAdd has its own replay
+        // guards (joined / left / already-pending).
+        if (message.kind == 9000 && targetPubkey == currentPubkey) {
+            registerExternalAdd(
+                groupId,
+                relayUrl,
+                actorPubkey = message.pubkey,
+                eventId = message.id,
+                createdAtSeconds = message.createdAt,
+            )
+        }
+        // A remove targeting US settles the pending invite — also before the staleness
+        // guard, since the removal's own 39002 usually outdates the kind:9001. Only a
+        // remove NEWER than the invite counts: a historical 9001 replay must not kill an
+        // invite created by a later re-add.
+        if (message.kind == 9001 && targetPubkey == currentPubkey) {
+            val invite = _pendingGroupInvites.value[groupId]
+            if (invite != null && message.createdAt > invite.createdAtSeconds) {
+                discardPendingInvite(groupId)
+            }
+        }
         // Skip historical events older than the authoritative member list.
         val memberListTimestamp = memberEventTimestamps[groupId] ?: 0L
         if (message.createdAt <= memberListTimestamp) return
 
         when (message.kind) {
             9000 -> { // add-user
-                // A put-user targeting US is an external add; register it as a pending
-                // invite without waiting for the next kind:39002 refresh.
-                if (targetPubkey == currentPubkey) {
-                    registerExternalAdd(
-                        groupId,
-                        relayUrl,
-                        actorPubkey = message.pubkey,
-                        eventId = message.id,
-                        createdAtSeconds = message.createdAt,
-                    )
-                }
                 _groupMembers.update { current ->
                     val members = current[groupId] ?: return@update current
                     if (targetPubkey in members) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -43,6 +43,7 @@ import org.nostr.nostrord.storage.cache.InMemoryCacheStore
 import org.nostr.nostrord.storage.clearGroupMembershipFor
 import org.nostr.nostrord.storage.clearMessageBlobMigratedFor
 import org.nostr.nostrord.storage.getLeftGroupsForRelay
+import org.nostr.nostrord.storage.getPendingGroupInvitesFor
 import org.nostr.nostrord.storage.getPutUserCursorForRelay
 import org.nostr.nostrord.storage.getRestrictedGroupsForRelay
 import org.nostr.nostrord.storage.isFullGroupListCacheFresh
@@ -56,6 +57,7 @@ import org.nostr.nostrord.storage.saveDroppedGroupIds
 import org.nostr.nostrord.storage.saveFullGroupListEoseTimestamp
 import org.nostr.nostrord.storage.saveGroupListEoseTimestamp
 import org.nostr.nostrord.storage.saveGroupMembershipFor
+import org.nostr.nostrord.storage.savePendingGroupInvitesFor
 import org.nostr.nostrord.storage.savePutUserCursorForRelay
 import org.nostr.nostrord.storage.setMessageBlobMigratedFor
 import org.nostr.nostrord.utils.AppError
@@ -1296,6 +1298,7 @@ class GroupManager(
             val key = relayUrl.normalizeRelayUrl()
             current + (key to (current[key].orEmpty() + groups))
         }
+        loadPendingInvitesFromStorage(pubKey)
     }
 
     /**
@@ -1320,6 +1323,7 @@ class GroupManager(
                 current + updates.mapValues { (relay, groups) -> current[relay].orEmpty() + groups }
             }
         }
+        loadPendingInvitesFromStorage(pubKey)
     }
 
     /** Persist [deletedGroupIds] so the dropped-group guard survives a restart (see its callers). */
@@ -1445,6 +1449,8 @@ class GroupManager(
             SecureStorage.saveJoinedGroupsForRelay(pubKey, normalizedGroupRelay, updated)
             _joinedGroupsByRelay.update { it + (normalizedGroupRelay to updated) }
             markRecentlyJoined(groupId)
+            // An explicit join settles any pending external add for the same group.
+            discardPendingInvite(groupId)
 
             publishJoinedGroups()
 
@@ -2355,6 +2361,8 @@ class GroupManager(
             publishJoinedGroups()
 
             recentlyLeftAt[groupId] = epochMillis()
+            // Leaving also settles a pending external add (this IS the decline path).
+            discardPendingInvite(groupId)
             // Durable leave intent: outlives recentlyLeftAt (5s) and a restart, so the membership
             // derivation keeps reporting NONE even when the relay still lists us in kind:39002.
             _leftGroups.update { it + (groupId to epochSeconds()) }
@@ -3752,11 +3760,14 @@ class GroupManager(
         }
 
         // An admin added us via kind:9000 (no kind:9021 of ours): the relay's 39002 is the
-        // ground truth of membership, but nothing ever wrote the group into
-        // _joinedGroupsByRelay, so it is absent from the group list and mux and Leave is
-        // unreachable. Adopt it as a join.
+        // ground truth of relay-side membership, but locally the group only becomes a
+        // PENDING invite — nothing enters the joined set / our kind:10009 until the user
+        // accepts it (declining leaves via kind:9022).
         if (selfNowMember && self != null) {
-            adoptExternalMembership(members.groupId, self, relayUrl, createdAtSeconds = createdAt)
+            registerExternalAdd(members.groupId, relayUrl, createdAtSeconds = createdAt)
+        } else if (self != null && !selfNowMember) {
+            // No longer listed (admin removed us before we decided): the invite is moot.
+            discardPendingInvite(members.groupId)
         }
 
         return members.members
@@ -3776,16 +3787,146 @@ class GroupManager(
     )
 
     /**
-     * Emits on every adopted external membership. NostrRepository republishes kind:10009 on
-     * it so the group survives restarts; AppModule turns it into a user notification.
+     * Emits on every adopted external membership (i.e. on [acceptPendingInvite]).
+     * NostrRepository republishes kind:10009 on it so the group survives restarts.
      */
     private val _externalMembershipAdopted = MutableSharedFlow<ExternalGroupAdd>(extraBufferCapacity = 16)
     val externalMembershipAdopted: SharedFlow<ExternalGroupAdd> = _externalMembershipAdopted.asSharedFlow()
 
     /**
+     * External adds (an admin's kind:9000 / a 39002 listing us) awaiting the user's
+     * accept/decline, keyed by groupId. Nothing enters the joined set or the kind:10009
+     * list until [acceptPendingInvite] — otherwise any group admin could make this client
+     * publish a kind:10009 naming their group without the user's consent. Declining goes
+     * through leaveGroup, whose durable left marker stops the relay's recurring 39002
+     * from re-registering the invite.
+     */
+    private val _pendingGroupInvites = MutableStateFlow<Map<String, PendingGroupInvite>>(emptyMap())
+    val pendingGroupInvites: StateFlow<Map<String, PendingGroupInvite>> = _pendingGroupInvites.asStateFlow()
+
+    /**
+     * Emits when an external add first lands in the pending set (or a silent 39002-inferred
+     * entry learns its actor from the put-user event). AppModule turns it into a user
+     * notification; NostrRepository fetches the group's kind:39000 so the prompt has a name.
+     */
+    private val _externalAddPending = MutableSharedFlow<ExternalGroupAdd>(extraBufferCapacity = 16)
+    val externalAddPending: SharedFlow<ExternalGroupAdd> = _externalAddPending.asSharedFlow()
+
+    private fun persistPendingInvites() {
+        val pk = currentPubkey ?: return
+        try {
+            SecureStorage.savePendingGroupInvitesFor(pk, _pendingGroupInvites.value.values.toList())
+        } catch (_: Exception) {}
+    }
+
+    /** Restore pending invites for [pubKey], dropping any resolved while we were away. */
+    fun loadPendingInvitesFromStorage(pubKey: String) {
+        val stored = try {
+            SecureStorage.getPendingGroupInvitesFor(pubKey)
+        } catch (_: Exception) {
+            emptyList()
+        }
+        if (stored.isEmpty()) return
+        val joined = _joinedGroupsByRelay.value.values.flatten().toSet()
+        val valid = stored.filter {
+            it.groupId !in joined && it.groupId !in _leftGroups.value && it.groupId !in deletedGroupIds
+        }
+        if (valid.isEmpty()) return
+        // Keep in-memory entries: a live registration this session is fresher than the slot.
+        _pendingGroupInvites.update { current -> valid.associateBy { it.groupId } + current }
+    }
+
+    /**
+     * Record a membership granted by an admin's kind:9000 (put-user) or inferred from a
+     * kind:39002 listing as a pending invite. The durable left marker wins over 39002
+     * listings: a relay that keeps listing us after our kind:9022 must not resurrect the
+     * invite (B2). A put-user NEWER than our leave is different — it is a deliberate
+     * re-add, and with adds consent-gated behind the prompt it re-opens the invite.
+     */
+    private fun registerExternalAdd(
+        groupId: String,
+        relayUrl: String?,
+        actorPubkey: String? = null,
+        eventId: String? = null,
+        createdAtSeconds: Long = 0L,
+    ) {
+        if (isRecentlyLeft(groupId) || groupId in deletedGroupIds) return
+        if (_joinedGroupsByRelay.value.values.any { groupId in it }) return
+        val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
+        val leftAt = _leftGroups.value[groupId]
+        if (leftAt != null) {
+            // Only an actual put-user event dated after the leave re-opens; 39002 listings
+            // carry no causality (the relay may simply have never processed our 9022).
+            if (actorPubkey == null || createdAtSeconds <= leftAt) return
+            _leftGroups.update { it - groupId }
+            currentPubkey?.let { pk ->
+                try {
+                    SecureStorage.removeLeftGroupForRelay(pk, relay, groupId)
+                } catch (_: Exception) {}
+            }
+        }
+        val existing = _pendingGroupInvites.value[groupId]
+        if (existing != null) {
+            // A 39002-inferred entry carries no actor; the put-user event does. Upgrade it
+            // so the prompt can say who added us, and notify (the silent entry never did).
+            if (actorPubkey == null || existing.actorPubkey != null) return
+            val upgraded = existing.copy(
+                actorPubkey = actorPubkey,
+                eventId = eventId ?: existing.eventId,
+                createdAtSeconds = createdAtSeconds.takeIf { it > 0L } ?: existing.createdAtSeconds,
+            )
+            _pendingGroupInvites.update { it + (groupId to upgraded) }
+            persistPendingInvites()
+            _externalAddPending.tryEmit(
+                ExternalGroupAdd(groupId, relay, actorPubkey, upgraded.eventId, upgraded.createdAtSeconds),
+            )
+            return
+        }
+        val invite = PendingGroupInvite(
+            groupId = groupId,
+            relayUrl = relay,
+            actorPubkey = actorPubkey,
+            eventId = eventId,
+            createdAtSeconds = createdAtSeconds.takeIf { it > 0L } ?: epochSeconds(),
+        )
+        _pendingGroupInvites.update { it + (groupId to invite) }
+        persistPendingInvites()
+        // Pre-add the relay may have CLOSED our reads "restricted"; we are a member now, so
+        // the preview (opening the group from the notification / DM card) must get a fresh
+        // read attempt while the decision is pending.
+        clearGroupRestricted(groupId)
+        _externalAddPending.tryEmit(
+            ExternalGroupAdd(groupId, relay, actorPubkey, eventId, invite.createdAtSeconds),
+        )
+    }
+
+    /** Accept a pending external add: adopt it into the joined set + kind:10009. */
+    fun acceptPendingInvite(groupId: String) {
+        val self = currentPubkey ?: return
+        val invite = _pendingGroupInvites.value[groupId] ?: return
+        discardPendingInvite(groupId)
+        adoptExternalMembership(
+            groupId = groupId,
+            pubkey = self,
+            relayUrl = invite.relayUrl,
+            actorPubkey = invite.actorPubkey,
+            eventId = invite.eventId,
+            createdAtSeconds = invite.createdAtSeconds,
+        )
+    }
+
+    /** Drop a pending invite without adopting (decline path, or the add became moot). */
+    fun discardPendingInvite(groupId: String) {
+        if (groupId !in _pendingGroupInvites.value) return
+        _pendingGroupInvites.update { it - groupId }
+        persistPendingInvites()
+    }
+
+    /**
      * Adopt a membership created by an admin's kind:9000 (put-user) instead of our own
-     * join request. The durable left marker wins: a relay that keeps listing us after our
-     * kind:9022 must not resurrect the group (B2), and a rejoin has to be the user's call.
+     * join request — the [acceptPendingInvite] path. The durable left marker wins: a relay
+     * that keeps listing us after our kind:9022 must not resurrect the group (B2), and a
+     * rejoin has to be the user's call.
      */
     private fun adoptExternalMembership(
         groupId: String,
@@ -3990,12 +4131,11 @@ class GroupManager(
 
         when (message.kind) {
             9000 -> { // add-user
-                // A put-user targeting US is an external add; adopt it without
-                // waiting for the next kind:39002 refresh.
+                // A put-user targeting US is an external add; register it as a pending
+                // invite without waiting for the next kind:39002 refresh.
                 if (targetPubkey == currentPubkey) {
-                    adoptExternalMembership(
+                    registerExternalAdd(
                         groupId,
-                        targetPubkey,
                         relayUrl,
                         actorPubkey = message.pubkey,
                         eventId = message.id,
@@ -4012,6 +4152,8 @@ class GroupManager(
                 }
             }
             9001 -> { // remove-user
+                // Removed before we decided on a pending external add: the invite is moot.
+                if (targetPubkey == currentPubkey) discardPendingInvite(groupId)
                 _groupMembers.update { current ->
                     val members = current[groupId] ?: return@update current
                     if (targetPubkey !in members) {
@@ -4673,6 +4815,8 @@ class GroupManager(
         _joinedGroupsByRelay.value = emptyMap()
         _restrictedGroups.value = emptyMap()
         _leftGroups.value = emptyMap()
+        // Pubkey-scoped like the joined set; the next account reloads its own from storage.
+        _pendingGroupInvites.value = emptyMap()
         // Per-group state from the previous account must be cleared too.
         // Without this, an account switch leaves stale kind:39002/39001/39003
         // caches that don't include the new account's pubkey, so opening a

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MuxSubscriptionTracker.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MuxSubscriptionTracker.kt
@@ -23,6 +23,9 @@ class MuxSubscriptionTracker {
         val metadataGroupIds: Set<String>,
         val chatGroupIds: Set<String>,
         val chatSinceSeconds: Long,
+        // kind:9000 put-user watch (#p = self). null when logged out.
+        val putUserPubkey: String? = null,
+        val putUserSinceSeconds: Long = 0L,
     )
 
     private val activeMuxState = mutableMapOf<String, MuxState>()
@@ -42,6 +45,9 @@ class MuxSubscriptionTracker {
         if (active.metadataGroupIds != desired.metadataGroupIds) return true
         if (active.chatGroupIds != desired.chatGroupIds) return true
         if (desired.chatSinceSeconds < active.chatSinceSeconds) return true
+        if (active.putUserPubkey != desired.putUserPubkey) return true
+        // An ADVANCED put-user cursor alone is not a trigger: the live watch already streams.
+        if (desired.putUserSinceSeconds < active.putUserSinceSeconds) return true
         return false
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -46,6 +46,14 @@ class OutboxManager(
     private var kind10009SubId: String? = null
     private var kind10009Received = false
 
+    // Best "stale" own kind:10009 seen during a fetch (newer than every other received
+    // event but still <= the local guard) and the relays that served that exact version.
+    // Feeds the stale-guard self-heal in [loadJoinedGroupsFromNostr]: a guard poisoned by
+    // a publish no relay stored (older builds advanced it unconditionally) would otherwise
+    // reject the network's real list forever, keeping this device divergent.
+    private var pendingBestStaleTs = 0L
+    private val pendingBestStaleRelays = mutableSetOf<String>()
+
     private val groupsMutex = Mutex()
     private var allRelayGroups: Map<String, Set<String>> = emptyMap()
     private var latestKind10009CreatedAt: Long = 0
@@ -118,7 +126,7 @@ class OutboxManager(
 
             coroutineScope {
                 launch { loadUserRelayList(pubKey, messageHandler) }
-                launch { loadJoinedGroupsFromNostr(pubKey, messageHandler) }
+                launch { loadJoinedGroupsFromNostr(pubKey, messageHandler = messageHandler) }
             }
             onDiscoveryComplete?.invoke()
         }
@@ -146,13 +154,20 @@ class OutboxManager(
      */
     suspend fun loadJoinedGroupsFromNostr(
         pubKey: String,
+        allowHeal: Boolean = true,
         messageHandler: (String, NostrGroupClient) -> Unit,
     ): Set<String> {
         val relaysToQuery = (relayListManager.selectPublishRelays() + bootstrapRelays).distinct()
 
         kind10009Received = false
+        groupsMutex.withLock {
+            pendingBestStaleTs = 0L
+            pendingBestStaleRelays.clear()
+        }
 
-        val subId = "joined-groups-${epochMillis()}"
+        // Fixed id: relays REPLACE a re-used subscription id, so repeated loads
+        // (re-login, account switch) never leak a stack of open subs.
+        val subId = "joined-groups"
         kind10009SubId = subId
 
         val reqMessage =
@@ -208,8 +223,66 @@ class OutboxManager(
             }
         }
 
+        // Stale-guard self-heal: every received event was rejected as "stale", at least two
+        // relays agree on the same newest version, and we have no unconfirmed publish of our
+        // own — the guard is a phantom (a publish no relay stored, from builds that advanced
+        // it unconditionally). Regress it just below the consensus version and refetch once:
+        // the same events then pass the guard and apply through the normal authoritative
+        // path. Without this, the device rejects the network's real list forever and two
+        // devices never converge.
+        if (allowHeal) {
+            val regressed =
+                groupsMutex.withLock {
+                    val consensus = pendingBestStaleTs > 0L && pendingBestStaleRelays.size >= 2
+                    if (consensus && !_kind10009NeedsRepublish.value && pendingBestStaleTs < latestKind10009CreatedAt) {
+                        latestKind10009CreatedAt = pendingBestStaleTs - 1
+                        true
+                    } else {
+                        false
+                    }
+                }
+            if (regressed) {
+                return loadJoinedGroupsFromNostr(pubKey, allowHeal = false, messageHandler = messageHandler)
+            }
+        }
+
+        // Live cross-device sync: a standing sub for our own kind:10009 so a list published
+        // by another device applies while this app is OPEN (the fetch above is one-shot and
+        // CLOSEd; without this, two open devices only converge on restart).
+        armKind10009LiveSub(pubKey)
+
         return groupsMutex.withLock {
             allRelayGroups.values.flatten().toSet()
+        }
+    }
+
+    /**
+     * (Re)arm the standing own-kind:10009 subscription on every connected publish/bootstrap
+     * relay. Fixed sub id, so re-arming replaces instead of stacking; safe to call on each
+     * reconnect. NOT in the one-shot EOSE-close set — it must stay open for live pushes.
+     */
+    fun armKind10009LiveSub(pubKey: String) {
+        if (pubKey.isBlank()) return
+        val reqMessage =
+            buildJsonArray {
+                add("REQ")
+                add("own-grouplist-live")
+                add(
+                    buildJsonObject {
+                        putJsonArray("kinds") { add(10009) }
+                        putJsonArray("authors") { add(pubKey) }
+                        put("limit", 1)
+                    },
+                )
+            }.toString()
+        val targets = (relayListManager.selectPublishRelays() + bootstrapRelays).distinct()
+        scope.launch {
+            targets.forEach { relayUrl ->
+                try {
+                    connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }?.send(reqMessage)
+                } catch (_: Exception) {
+                }
+            }
         }
     }
 
@@ -369,8 +442,24 @@ class OutboxManager(
             groupsMutex.withLock {
                 if (createdAt > latestKind10009CreatedAt) {
                     latestKind10009CreatedAt = createdAt
+                    // Durable acceptance: without this, only a publish OK ever persisted the
+                    // guard, so a network-accepted newer list was forgotten on restart (and a
+                    // phantom persisted guard kept poisoning every session).
+                    try {
+                        SecureStorage.saveKind10009Timestamp(pubKey, createdAt)
+                    } catch (_: Exception) {}
+                    pendingBestStaleTs = 0L
+                    pendingBestStaleRelays.clear()
                     true
                 } else {
+                    // Track the strongest stale candidate for the guard self-heal.
+                    if (createdAt > pendingBestStaleTs) {
+                        pendingBestStaleTs = createdAt
+                        pendingBestStaleRelays.clear()
+                        pendingBestStaleRelays.add(currentRelayUrl.normalizeRelayUrl())
+                    } else if (createdAt == pendingBestStaleTs && createdAt > 0L) {
+                        pendingBestStaleRelays.add(currentRelayUrl.normalizeRelayUrl())
+                    }
                     false
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -58,6 +58,12 @@ class OutboxManager(
     private var allRelayGroups: Map<String, Set<String>> = emptyMap()
     private var latestKind10009CreatedAt: Long = 0
 
+    // Newest kind:10009 createdAt actually SEEN this session (events received or
+    // published), unlike the guard above which can rehydrate from storage without
+    // any event backing it. Gates the stale additive merge: a version older than
+    // one already seen must never resurrect groups the newer list omits.
+    private var newestSeenKind10009CreatedAt: Long = 0
+
     private val _kind10009Relays = MutableStateFlow<Set<String>>(emptySet())
     val kind10009Relays: StateFlow<Set<String>> = _kind10009Relays.asStateFlow()
 
@@ -100,6 +106,7 @@ class OutboxManager(
         // before login so we don't always know the pubkey yet — just start at
         // 0 and let initialize() rehydrate the right scope when login completes.
         latestKind10009CreatedAt = 0
+        newestSeenKind10009CreatedAt = 0
     }
 
     fun initialize(
@@ -112,6 +119,7 @@ class OutboxManager(
         // account's (legitimately older) kind:10009 as "stale", leaving the
         // sidebar empty until restart.
         latestKind10009CreatedAt = SecureStorage.loadKind10009Timestamp(pubKey)
+        newestSeenKind10009CreatedAt = 0
         scope.launch {
             coroutineScope {
                 bootstrapRelays.forEach { url ->
@@ -398,6 +406,9 @@ class OutboxManager(
                                 if (event.createdAt > latestKind10009CreatedAt) {
                                     latestKind10009CreatedAt = event.createdAt
                                 }
+                                if (event.createdAt > newestSeenKind10009CreatedAt) {
+                                    newestSeenKind10009CreatedAt = event.createdAt
+                                }
                             }
                             SecureStorage.saveKind10009Timestamp(pubKey, event.createdAt)
                             _kind10009NeedsRepublish.value = false
@@ -438,16 +449,29 @@ class OutboxManager(
         val tags = event["tags"]?.jsonArray ?: return
 
         val createdAt = event["created_at"]?.jsonPrimitive?.longOrNull ?: 0L
+        var supersededByNewerSeen = false
         val isNewest =
             groupsMutex.withLock {
-                if (createdAt > latestKind10009CreatedAt) {
-                    latestKind10009CreatedAt = createdAt
-                    // Durable acceptance: without this, only a publish OK ever persisted the
-                    // guard, so a network-accepted newer list was forgotten on restart (and a
-                    // phantom persisted guard kept poisoning every session).
-                    try {
-                        SecureStorage.saveKind10009Timestamp(pubKey, createdAt)
-                    } catch (_: Exception) {}
+                supersededByNewerSeen = createdAt < newestSeenKind10009CreatedAt
+                if (createdAt > newestSeenKind10009CreatedAt) {
+                    newestSeenKind10009CreatedAt = createdAt
+                }
+                // >= not >: re-applying the guard's own event is idempotent and heals local
+                // state poisoned by a stale-version merge — a buggy relay can keep serving
+                // superseded versions of the replaceable event alongside the newest one,
+                // and with a strict > a ghost group re-added by that merge survived every
+                // restart (nothing ever outran the persisted guard again) until the next
+                // real publish.
+                if (createdAt > 0L && createdAt >= latestKind10009CreatedAt) {
+                    if (createdAt > latestKind10009CreatedAt) {
+                        latestKind10009CreatedAt = createdAt
+                        // Durable acceptance: without this, only a publish OK ever persisted the
+                        // guard, so a network-accepted newer list was forgotten on restart (and a
+                        // phantom persisted guard kept poisoning every session).
+                        try {
+                            SecureStorage.saveKind10009Timestamp(pubKey, createdAt)
+                        } catch (_: Exception) {}
+                    }
                     pendingBestStaleTs = 0L
                     pendingBestStaleRelays.clear()
                     true
@@ -496,8 +520,12 @@ class OutboxManager(
             // The freshness guard can outrun what relays actually stored (a publish
             // accepted by only some relays, clock skew, another client's list); a
             // strict drop then hides the user's real groups behind localStorage
-            // forever. Trade-off: a lagging relay can resurrect a group left on
-            // another device until the next confirmed publish supersedes it.
+            // forever.
+            // Only the newest version SEEN this session may merge: a relay serving a
+            // superseded version alongside the newest (chat.wisp.talk does) would
+            // otherwise resurrect — in memory AND in the persisted slots — a group the
+            // newer list just removed on another device.
+            if (supersededByNewerSeen) return
             val known = groupsMutex.withLock { allRelayGroups }
             val additions =
                 immutableRelayGroups
@@ -535,10 +563,16 @@ class OutboxManager(
         // group lingering in memory + storage, and the next publish (which unions storage
         // and memory) resurrected it. Capture those relays before swapping the map.
         val droppedRelays: Set<String>
+        val contentUnchanged: Boolean
         groupsMutex.withLock {
             droppedRelays = allRelayGroups.keys - immutableRelayGroups.keys
+            contentUnchanged = allRelayGroups == immutableRelayGroups
             allRelayGroups = immutableRelayGroups
         }
+        // Every connected relay re-delivers the applied event on each fetch (and
+        // equal-createdAt now re-applies): identical content with the relay set already
+        // in place changes nothing — skip the storage rewrites and callback refires.
+        if (contentUnchanged && _kind10009Relays.value == newRelayGroups.keys + explicitNip29Relays) return
 
         // Persisted relay list must include EVERY relay the kind:10009 event
         // references — both explicit "r" tags AND relays implied by "group" tags

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -17,6 +17,7 @@ import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.loadKind10009Timestamp
 import org.nostr.nostrord.storage.loadRelayListFor
+import org.nostr.nostrord.storage.saveKind10009RepublishPendingFor
 import org.nostr.nostrord.storage.saveKind10009Timestamp
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.utils.AppError
@@ -212,6 +213,16 @@ class OutboxManager(
         }
     }
 
+    /**
+     * True while no relay has ACCEPTED the most recent kind:10009 publish. Set at every
+     * attempt, cleared on the first relay OK (also mirrored to storage so a restart keeps
+     * the retry intent). The reconnect hook in NostrRepository republishes the CURRENT
+     * list — never the stale snapshot: the event is replaceable and an old snapshot could
+     * resurrect a since-left group.
+     */
+    private val _kind10009NeedsRepublish = MutableStateFlow(false)
+    val kind10009NeedsRepublish: StateFlow<Boolean> = _kind10009NeedsRepublish.asStateFlow()
+
     suspend fun publishJoinedGroupsList(
         pubKey: String,
         joinedGroupsByRelay: Map<String, Set<String>>,
@@ -265,6 +276,12 @@ class OutboxManager(
                     add(signedEvent.toJsonObject())
                 }.toString()
 
+            // Assume lost until a relay OKs it; the reconnect hook retries while this holds.
+            _kind10009NeedsRepublish.value = true
+            try {
+                SecureStorage.saveKind10009RepublishPendingFor(pubKey, true)
+            } catch (_: Exception) {}
+
             val targets = (relayListManager.selectPublishRelays() + bootstrapRelays).distinct()
             var published =
                 targets.mapNotNull { relayUrl ->
@@ -310,6 +327,10 @@ class OutboxManager(
                                 }
                             }
                             SecureStorage.saveKind10009Timestamp(pubKey, event.createdAt)
+                            _kind10009NeedsRepublish.value = false
+                            try {
+                                SecureStorage.saveKind10009RepublishPendingFor(pubKey, false)
+                            } catch (_: Exception) {}
                         }
                     } catch (_: Exception) {
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/PendingGroupInvite.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/PendingGroupInvite.kt
@@ -1,0 +1,19 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A membership granted externally (an admin's kind:9000 put-user, or a kind:39002 listing
+ * us with no join request of ours) that the user has not accepted or declined yet. Relay-side
+ * we are already a member; accepting adopts the group into the joined set + kind:10009,
+ * declining leaves (kind:9022). [actorPubkey]/[eventId] are null when the add was inferred
+ * from a 39002 listing instead of the put-user event itself.
+ */
+@Serializable
+data class PendingGroupInvite(
+    val groupId: String,
+    val relayUrl: String,
+    val actorPubkey: String? = null,
+    val eventId: String? = null,
+    val createdAtSeconds: Long = 0L,
+)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/NostrBuildUploader.kt
@@ -95,8 +95,15 @@ object NostrBuildUploader {
         val isCached = isBlobRef(filename)
 
         val authHeader =
-            buildAuthHeader(UPLOAD_URL, "POST")
-                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+            try {
+                buildAuthHeader(UPLOAD_URL, "POST")
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // Signer failure (bunker unreachable/timeout, extension denial) — surface
+                // the actual cause; "not authenticated" would be false and misleading.
+                return Result.Error(AppError.Unknown("Upload authorization failed: ${e.message}", e))
+            } ?: return Result.Error(AppError.Auth.NotAuthenticated)
 
         // Blob-ref uploads can't be retried — the JS cache entry is consumed on first use
         val maxAttempts = if (isCached) 1 else 3

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
@@ -10,7 +10,7 @@ import org.nostr.nostrord.storage.getPersistedNotifications
 import org.nostr.nostrord.storage.savePersistedNotifications
 
 @Serializable
-enum class NotificationType { REPLY, MENTION, REACTION, MESSAGE }
+enum class NotificationType { REPLY, MENTION, REACTION, MESSAGE, GROUP_ADD }
 
 @Serializable
 data class NotificationEntry(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.nostr.Crypto
 import org.nostr.nostrord.nostr.toHexString
 
@@ -794,6 +795,28 @@ fun SecureStorage.addLeftGroupForRelay(
     try {
         saveStringPref(key, Json.encodeToString<Map<String, Long>>(current))
     } catch (_: Exception) {
+    }
+}
+
+// ── Pending group invites ────────────────────────────────────────────────────
+// External adds (an admin's kind:9000) the user hasn't accepted or declined yet. One JSON
+// slot per account; entries are dropped on accept/decline/join/leave.
+private fun pendingGroupInvitesKey(pubkey: String) = "pending_group_invites_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.savePendingGroupInvitesFor(
+    pubkey: String,
+    invites: List<PendingGroupInvite>,
+) {
+    saveStringPref(pendingGroupInvitesKey(pubkey), Json.encodeToString(invites))
+}
+
+fun SecureStorage.getPendingGroupInvitesFor(pubkey: String): List<PendingGroupInvite> {
+    val raw = getStringPref(pendingGroupInvitesKey(pubkey), "")
+    if (raw.isBlank()) return emptyList()
+    return try {
+        Json.decodeFromString(raw)
+    } catch (_: Exception) {
+        emptyList()
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -798,6 +798,20 @@ fun SecureStorage.addLeftGroupForRelay(
     }
 }
 
+// ── kind:10009 republish-pending flag ────────────────────────────────────────
+// True while no relay has ACCEPTED the latest kind:10009 publish (offline leave, zombie
+// socket): the reconnect hook republishes the CURRENT list and clears it on the first OK.
+private fun kind10009RepublishPendingKey(pubkey: String) = "kind10009_republish_pending_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.saveKind10009RepublishPendingFor(
+    pubkey: String,
+    pending: Boolean,
+) {
+    saveStringPref(kind10009RepublishPendingKey(pubkey), if (pending) "true" else "")
+}
+
+fun SecureStorage.isKind10009RepublishPendingFor(pubkey: String): Boolean = getStringPref(kind10009RepublishPendingKey(pubkey), "") == "true"
+
 // ── Pending group invites ────────────────────────────────────────────────────
 // External adds (an admin's kind:9000) the user hasn't accepted or declined yet. One JSON
 // slot per account; entries are dropped on accept/decline/join/leave.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -797,6 +797,28 @@ fun SecureStorage.addLeftGroupForRelay(
     }
 }
 
+// ── Put-user watch cursor ────────────────────────────────────────────────────
+// Unix-seconds `since` for the per-relay kind:9000 (put-user, #p self) watch. Advances
+// as adds are processed so historical put-user replays stop arriving on reconnect;
+// without it a very old add could re-adopt a group after the left marker's TTL expires.
+private fun putUserCursorKey(
+    pubkey: String,
+    relayUrl: String,
+): String = "put_user_cursor_${pubkeyDigest(pubkey)}_${relayUrl.hashCode()}"
+
+fun SecureStorage.savePutUserCursorForRelay(
+    pubkey: String,
+    relayUrl: String,
+    seconds: Long,
+) {
+    saveStringPref(putUserCursorKey(pubkey, relayUrl), seconds.toString())
+}
+
+fun SecureStorage.getPutUserCursorForRelay(
+    pubkey: String,
+    relayUrl: String,
+): Long = getStringPref(putUserCursorKey(pubkey, relayUrl), "").toLongOrNull() ?: 0L
+
 fun SecureStorage.removeLeftGroupForRelay(
     pubkey: String,
     relayUrl: String,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/DmGroupInvite.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/DmGroupInvite.kt
@@ -1,0 +1,44 @@
+package org.nostr.nostrord.ui
+
+import org.nostr.nostrord.nostr.Nip19
+
+/**
+ * A group reference carried by a DM, split out of the text so the DM screens can render
+ * the prototype invite card (eyebrow + name + about + "View group" button) instead of the
+ * generic inline preview. [remainingText] is the message body without the naddr line.
+ */
+data class DmGroupInvite(
+    val groupId: String,
+    val relayUrl: String?,
+    val remainingText: String,
+)
+
+private val NADDR_LINE = Regex("^(?:nostr:)?(naddr1[0-9a-z]+)$", RegexOption.IGNORE_CASE)
+
+/**
+ * First kind:39000 naddr standing alone on its own line of [content], or null. Matches the
+ * shape `sendGroupAddedDm` produces ("You've been added ...\nnostr:naddr1...") and any
+ * other client that shares a group link as its own line.
+ */
+fun extractDmGroupInvite(content: String): DmGroupInvite? {
+    val lines = content.lines()
+    for ((index, line) in lines.withIndex()) {
+        val bech = NADDR_LINE.matchEntire(line.trim())?.groupValues?.get(1) ?: continue
+        val entity = try {
+            Nip19.decode(bech)
+        } catch (_: Exception) {
+            null
+        } as? Nip19.Entity.Naddr ?: continue
+        if (entity.kind != 39000) continue
+        val remaining = lines
+            .filterIndexed { i, _ -> i != index }
+            .joinToString("\n")
+            .trim()
+        return DmGroupInvite(
+            groupId = entity.identifier,
+            relayUrl = entity.relays.firstOrNull(),
+            remainingText = remaining,
+        )
+    }
+    return null
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/DmGroupInvite.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/DmGroupInvite.kt
@@ -6,10 +6,12 @@ import org.nostr.nostrord.nostr.Nip19
  * A group reference carried by a DM, split out of the text so the DM screens can render
  * the prototype invite card (eyebrow + name + about + "View group" button) instead of the
  * generic inline preview. [remainingText] is the message body without the naddr line.
+ * [relayUrl] is always present: navigation needs the host relay, so a hint-less naddr is
+ * not extracted (it stays inline text) rather than rendering a card with a dead button.
  */
 data class DmGroupInvite(
     val groupId: String,
-    val relayUrl: String?,
+    val relayUrl: String,
     val remainingText: String,
 )
 
@@ -30,13 +32,15 @@ fun extractDmGroupInvite(content: String): DmGroupInvite? {
             null
         } as? Nip19.Entity.Naddr ?: continue
         if (entity.kind != 39000) continue
+        // Relay TLVs are optional in NIP-19; without one the card could not open the group.
+        val relayUrl = entity.relays.firstOrNull { it.isNotBlank() } ?: continue
         val remaining = lines
             .filterIndexed { i, _ -> i != index }
             .joinToString("\n")
             .trim()
         return DmGroupInvite(
             groupId = entity.identifier,
-            relayUrl = entity.relays.firstOrNull(),
+            relayUrl = relayUrl,
             remainingText = remaining,
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -24,6 +25,7 @@ import org.nostr.nostrord.network.UserGroupRef
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
@@ -49,17 +51,16 @@ data class FriendCandidate(
 fun buildFriendCandidates(
     following: Set<String>,
     metadata: Map<String, UserMetadata>,
-): List<FriendCandidate> =
-    following
-        .map { pk ->
-            val meta = metadata[pk]
-            FriendCandidate(
-                pubkey = pk,
-                name = meta?.displayName?.takeIf { it.isNotBlank() }
-                    ?: meta?.name?.takeIf { it.isNotBlank() },
-                picture = meta?.picture,
-            )
-        }.sortedWith(compareBy({ it.name == null }, { it.name?.lowercase() ?: it.pubkey }))
+): List<FriendCandidate> = following
+    .map { pk ->
+        val meta = metadata[pk]
+        FriendCandidate(
+            pubkey = pk,
+            name = meta?.displayName?.takeIf { it.isNotBlank() }
+                ?: meta?.name?.takeIf { it.isNotBlank() },
+            picture = meta?.picture,
+        )
+    }.sortedWith(compareBy({ it.name == null }, { it.name?.lowercase() ?: it.pubkey }))
 
 /** Case-insensitive name / hex-prefix filter; a blank query returns everything. */
 fun filterFriendCandidates(
@@ -445,6 +446,28 @@ class GroupViewModel(
         viewModelScope.launch {
             repo.leaveGroup(groupId)
             onSuccess()
+        }
+    }
+
+    /**
+     * This group's pending external add (an admin's kind:9000 awaiting accept/decline),
+     * if any. Both UIs prompt on it: [acceptInvite] adopts the group into the joined set
+     * + kind:10009; declining routes through [leaveGroup] (kind:9022 + durable left marker).
+     */
+    val pendingInvite: StateFlow<PendingGroupInvite?> =
+        repo.pendingGroupInvites
+            .map { it[groupId] }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, repo.pendingGroupInvites.value[groupId])
+
+    fun acceptInvite() {
+        viewModelScope.launch { repo.acceptGroupInvite(groupId) }
+    }
+
+    /** Decline a pending external add: leave relay-side (kind:9022), which drops the invite. */
+    fun declineInvite(onDone: () -> Unit = {}) {
+        viewModelScope.launch {
+            repo.leaveGroup(groupId)
+            onDone()
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -30,6 +30,7 @@ import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.normalizeRelayUrl
+import org.nostr.nostrord.utils.shortNpub
 
 /** A group offered in the `%group` mention autocomplete (with its hosting relay). */
 data class MentionableGroup(
@@ -61,6 +62,27 @@ fun buildFriendCandidates(
             picture = meta?.picture,
         )
     }.sortedWith(compareBy({ it.name == null }, { it.name?.lowercase() ?: it.pubkey }))
+
+/** Relay hosting [groupId] (the relay whose group list carries it), else [fallbackRelay]. */
+fun groupHostRelay(
+    groupId: String,
+    groupsByRelay: Map<String, List<GroupMetadata>>,
+    fallbackRelay: String?,
+): String? = groupsByRelay.entries.firstOrNull { (_, groups) -> groups.any { it.id == groupId } }?.key ?: fallbackRelay
+
+/**
+ * True when [target]'s public kind:10009 pins any group on [groupRelayUrl]: their client
+ * connects to that relay, so the in-app add notification reaches them without the DM.
+ * Unknown or unfetched lists read false — the DM stays the safe default.
+ */
+fun pubkeyUsesRelay(
+    target: String,
+    groupRelayUrl: String?,
+    userGroupLists: Map<String, List<UserGroupRef>>,
+): Boolean {
+    val relay = groupRelayUrl?.normalizeRelayUrl() ?: return false
+    return userGroupLists[target].orEmpty().any { it.relayUrl.normalizeRelayUrl() == relay }
+}
 
 /** Case-insensitive name / hex-prefix filter; a blank query returns everything. */
 fun filterFriendCandidates(
@@ -157,6 +179,7 @@ class GroupViewModel(
     val groups = repo.groups
     val groupsByRelay = repo.groupsByRelay
     val userMetadata = repo.userMetadata
+    val userGroupLists = repo.userGroupLists
 
     /**
      * Reactions with NIP-51 muted reactors removed, same contract as [messages]: the raw
@@ -459,8 +482,40 @@ class GroupViewModel(
             .map { it[groupId] }
             .stateIn(viewModelScope, SharingStarted.Eagerly, repo.pendingGroupInvites.value[groupId])
 
+    /**
+     * Who invited us, for the pending-invite prompt: display name, short-npub fallback,
+     * or null when there is no actor or the "actor" is the relay itself (relays author
+     * the creator/backfill put-users; a relay key is not a person worth naming).
+     */
+    val pendingInviteActorLabel: StateFlow<String?> =
+        combine(pendingInvite, repo.userMetadata, repo.relayMetadata) { invite, meta, relayMeta ->
+            val actor = invite?.actorPubkey ?: return@combine null
+            val relayKey = (relayMeta[invite.relayUrl] ?: relayMeta[invite.relayUrl.normalizeRelayUrl()])
+                ?.pubkey
+                ?.takeIf { it.isNotBlank() }
+            if (actor == relayKey) return@combine null
+            meta[actor]?.displayName?.takeIf { it.isNotBlank() }
+                ?: meta[actor]?.name?.takeIf { it.isNotBlank() }
+                ?: shortNpub(actor)
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    init {
+        // Resolve the inviter's profile for the prompt (no-op when already cached).
+        viewModelScope.launch {
+            pendingInvite.collect { invite ->
+                val actor = invite?.actorPubkey ?: return@collect
+                if (repo.userMetadata.value[actor] == null) repo.requestUserMetadata(setOf(actor))
+            }
+        }
+    }
+
     fun acceptInvite() {
         viewModelScope.launch { repo.acceptGroupInvite(groupId) }
+    }
+
+    /** Fetch [pubkey]'s public kind:10009 so the add-member "on this relay" hint has data. */
+    fun prefetchUserGroupList(pubkey: String) {
+        viewModelScope.launch { repo.requestUserGroupList(pubkey) }
     }
 
     /** Decline a pending external add: leave relay-side (kind:9022), which drops the invite. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.nostr.nostrord.di.AppModule
@@ -20,6 +21,7 @@ import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.network.UserGroupRef
+import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.ui.screens.withMinDuration
@@ -32,6 +34,44 @@ data class MentionableGroup(
     val relayUrl: String,
     val meta: GroupMetadata,
 )
+
+/** A follow offered in the add-member friend picker. */
+data class FriendCandidate(
+    val pubkey: String,
+    val name: String?,
+    val picture: String?,
+)
+
+/**
+ * Follows joined with their cached profiles for the add-member picker: named entries
+ * first (alphabetical), unnamed after. Shared by the Compose and web modals.
+ */
+fun buildFriendCandidates(
+    following: Set<String>,
+    metadata: Map<String, UserMetadata>,
+): List<FriendCandidate> =
+    following
+        .map { pk ->
+            val meta = metadata[pk]
+            FriendCandidate(
+                pubkey = pk,
+                name = meta?.displayName?.takeIf { it.isNotBlank() }
+                    ?: meta?.name?.takeIf { it.isNotBlank() },
+                picture = meta?.picture,
+            )
+        }.sortedWith(compareBy({ it.name == null }, { it.name?.lowercase() ?: it.pubkey }))
+
+/** Case-insensitive name / hex-prefix filter; a blank query returns everything. */
+fun filterFriendCandidates(
+    candidates: List<FriendCandidate>,
+    query: String,
+): List<FriendCandidate> {
+    val q = query.trim().lowercase()
+    if (q.isEmpty()) return candidates
+    return candidates.filter {
+        it.name?.lowercase()?.contains(q) == true || it.pubkey.lowercase().startsWith(q)
+    }
+}
 
 /**
  * The current account's relationship to a group, derived once in commonMain so the Compose
@@ -525,16 +565,26 @@ class GroupViewModel(
                 .replaceFirstChar { it.uppercaseChar() }
     }
 
+    /**
+     * Follows for the add-member friend picker, profiles resolved from the metadata cache.
+     * The first subscription kicks a refresh for any follows whose kind:0 isn't cached.
+     */
+    val friends: StateFlow<List<FriendCandidate>> =
+        combine(repo.following, repo.userMetadata) { follows, meta -> buildFriendCandidates(follows, meta) }
+            .onStart { repo.requestUserMetadata(repo.following.value) }
+            .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+
     fun addUser(
         targetPubkey: String,
         roles: List<String> = emptyList(),
         successMessage: String = "User added to the group",
+        notifyViaDm: Boolean = false,
         onSuccess: () -> Unit = {},
     ) {
         viewModelScope.launch {
             _moderationError.value = null
             trackModeration {
-                when (val result = repo.addUser(groupId, targetPubkey, roles)) {
+                when (val result = repo.addUser(groupId, targetPubkey, roles, notifyViaDm)) {
                     is Result.Error -> surfaceModerationError(result.error)
                     // A kind:9000 (add / role change) is not reliably rendered in the
                     // timeline, so confirm the action to the admin who triggered it.

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -10,6 +10,7 @@ import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
@@ -566,6 +567,15 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val groupRoles: StateFlow<Map<String, List<RoleDefinition>>> = MutableStateFlow(emptyMap())
     override val restrictedGroups: StateFlow<Map<String, String>> = MutableStateFlow(emptyMap())
     override val leftGroups: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+
+    val pendingGroupInvitesFlow = MutableStateFlow<Map<String, PendingGroupInvite>>(emptyMap())
+    override val pendingGroupInvites: StateFlow<Map<String, PendingGroupInvite>> = pendingGroupInvitesFlow
+    val acceptedInvites = mutableListOf<String>()
+
+    override suspend fun acceptGroupInvite(groupId: String) {
+        acceptedInvites += groupId
+        pendingGroupInvitesFlow.update { it - groupId }
+    }
 
     override suspend fun sendReaction(
         groupId: String,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -537,6 +537,7 @@ class FakeNostrRepository : NostrRepositoryApi {
         groupId: String,
         targetPubkey: String,
         roles: List<String>,
+        notifyViaDm: Boolean,
     ): Result<Unit> {
         addUserCalls.add(Triple(groupId, targetPubkey, roles))
         addUserGate?.await()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
@@ -1,0 +1,96 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.network.GroupMembers
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.addLeftGroupForRelay
+import org.nostr.nostrord.storage.removeLeftGroupForRelay
+import org.nostr.nostrord.utils.epochSeconds
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+// Regression guards for adopting a membership granted by an admin's kind:9000 (put-user):
+// the relay lists us in kind:39002 without any kind:9021 of ours, and the group must still
+// land in the joined set (group list, mux, Leave) instead of existing only relay-side.
+@OptIn(ExperimentalCoroutinesApi::class)
+class GroupExternalMembershipAdoptionTest {
+    private val pubkey = "00000000000000000000000000000000000000000000000000000000deadbeef"
+    private val relay = "wss://test.relay"
+    private val group = "external-add-group"
+
+    private fun makeManager(scope: TestScope): GroupManager = GroupManager(connectionManager = ConnectionManager(scope), scope = scope)
+
+    private fun reset() {
+        SecureStorage.saveJoinedGroupsForRelay(pubkey, relay, emptySet())
+        SecureStorage.removeLeftGroupForRelay(pubkey, relay, group)
+    }
+
+    @BeforeTest fun before() = reset()
+
+    @AfterTest fun after() = reset()
+
+    @Test
+    fun `39002 listing self adopts the membership into the joined set and storage`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey, "someone-else")), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(group in gm.getGroupIdsForMux(relay), "adopted group joins the mux for its relay")
+        assertTrue(
+            group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay),
+            "adopted group is persisted so it survives a restart",
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `durable left marker blocks adoption - a stale relay listing must not resurrect a left group`() = runTest {
+        val scope = TestScope(testScheduler)
+        SecureStorage.addLeftGroupForRelay(pubkey, relay, group, nowSeconds = epochSeconds())
+
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        gm.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay))
+        testScheduler.advanceUntilIdle()
+        assertTrue(group in gm.leftGroups.value)
+
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        assertFalse(group in gm.getGroupIdsForMux(relay), "left group stays out of the mux")
+        assertFalse(
+            group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay),
+            "left group is not re-persisted as joined",
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `39002 without self does not adopt`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.handleGroupMembers(GroupMembers(group, listOf("someone-else")), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        assertFalse(group in gm.getGroupIdsForMux(relay))
+        assertFalse(group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay))
+
+        scope.cancel()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.network.managers
 
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.nostr.nostrord.network.GroupMembers
@@ -228,6 +229,146 @@ class GroupExternalMembershipAdoptionTest {
         testScheduler.advanceUntilIdle()
 
         assertTrue(group in second.pendingGroupInvites.value, "undecided invite survives a restart")
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a put-user older than the member list still enriches a 39002-inferred invite with its actor`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        // Sweep-delivered 39002 registers the silent, actorless invite (0xchat path).
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 200, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+        assertEquals(null, gm.pendingGroupInvites.value[group]?.actorPubkey)
+
+        // The enrichment fetch returns the put-user that caused it — dated BEFORE the 39002
+        // (0xchat pins the list's created_at; relay29 bumps it after the add). The staleness
+        // guard must not eat it: the invite gains its actor and the notification can name them.
+        val msg = NostrGroupClient.NostrMessage(
+            id = "evt-put-user-2",
+            pubkey = "admin-pubkey",
+            content = "",
+            createdAt = 150,
+            kind = 9000,
+            tags = listOf(listOf("p", pubkey), listOf("h", group)),
+        )
+        val raw = """["EVENT","padd_one_x",{"tags":[["p","$pubkey"],["h","$group"]]}]"""
+        gm.handleMessage(msg, raw, subscriptionId = "padd_one_x", relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        assertEquals("admin-pubkey", gm.pendingGroupInvites.value[group]?.actorPubkey)
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `pending invite groups are included in the private-group metadata heal set`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        // A private group's 39000 is withheld pre-AUTH and it is absent from the public
+        // listing; the post-AUTH heal must fetch it for a pending invite too, or the
+        // group screen opened from the notification stays blank.
+        assertTrue(group in gm.getUncachedJoinedGroups(relay))
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a newer put-user refreshes an existing invite so a re-add notifies again`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        val emitted = mutableListOf<GroupManager.ExternalGroupAdd>()
+        val collector = scope.launch { gm.externalAddPending.collect { emitted += it } }
+        testScheduler.advanceUntilIdle()
+
+        fun putUser(id: String, createdAt: Long) {
+            val msg = NostrGroupClient.NostrMessage(
+                id = id,
+                pubkey = "admin-pubkey",
+                content = "",
+                createdAt = createdAt,
+                kind = 9000,
+                tags = listOf(listOf("p", pubkey), listOf("h", group)),
+            )
+            val raw = """["EVENT","mux_padd_x",{"tags":[["p","$pubkey"],["h","$group"]]}]"""
+            gm.handleMessage(msg, raw, subscriptionId = "mux_padd_x", relayUrl = relay)
+        }
+
+        putUser("evt-add-1", 1_000L)
+        testScheduler.advanceUntilIdle()
+        assertEquals("evt-add-1", gm.pendingGroupInvites.value[group]?.eventId)
+
+        // The same event replayed by the inclusive since-cursor: silent.
+        putUser("evt-add-1", 1_000L)
+        testScheduler.advanceUntilIdle()
+        assertEquals(1, emitted.size)
+
+        // A remove we never saw (the watch carries no 9001), then a re-add: the newer
+        // put-user refreshes the invite and notifies again.
+        putUser("evt-add-2", 2_000L)
+        testScheduler.advanceUntilIdle()
+        assertEquals("evt-add-2", gm.pendingGroupInvites.value[group]?.eventId)
+        assertEquals(2_000L, gm.pendingGroupInvites.value[group]?.createdAtSeconds)
+        assertEquals(2, emitted.size)
+
+        collector.cancel()
+        scope.cancel()
+    }
+
+    @Test
+    fun `a group that becomes joined by any path dissolves its pending invite`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+        assertTrue(group in gm.pendingGroupInvites.value)
+
+        // Our own kind:10009 from another device lands (we created or accepted the group
+        // there): the local "invite" from the relay's put-user echo is moot.
+        SecureStorage.saveJoinedGroupsForRelay(pubkey, relay, setOf(group))
+        gm.loadJoinedGroupsFromStorage(pubkey, relay)
+        testScheduler.advanceUntilIdle()
+
+        assertFalse(group in gm.pendingGroupInvites.value, "a joined group never keeps a pending invite")
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a put-user we authored ourselves does not register an invite`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        // Some relays echo a creator put-user; we are both actor and target there.
+        val msg = NostrGroupClient.NostrMessage(
+            id = "evt-self-add",
+            pubkey = pubkey,
+            content = "",
+            createdAt = 1_000L,
+            kind = 9000,
+            tags = listOf(listOf("p", pubkey), listOf("h", group)),
+        )
+        val raw = """["EVENT","mux_padd_x",{"tags":[["p","$pubkey"],["h","$group"]]}]"""
+        gm.handleMessage(msg, raw, subscriptionId = "mux_padd_x", relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        assertFalse(group in gm.pendingGroupInvites.value)
 
         scope.cancel()
     }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
@@ -6,13 +6,16 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.nostr.nostrord.network.GroupMembers
+import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.addLeftGroupForRelay
+import org.nostr.nostrord.storage.getPutUserCursorForRelay
 import org.nostr.nostrord.storage.removeLeftGroupForRelay
 import org.nostr.nostrord.utils.epochSeconds
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -73,6 +76,36 @@ class GroupExternalMembershipAdoptionTest {
         assertFalse(
             group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay),
             "left group is not re-persisted as joined",
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `live kind-9000 targeting self adopts and advances the watch cursor`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        val createdAt = 1_000_000L
+        val msg = NostrGroupClient.NostrMessage(
+            id = "evt-put-user-1",
+            pubkey = "admin-pubkey",
+            content = "",
+            createdAt = createdAt,
+            kind = 9000,
+            tags = listOf(listOf("p", pubkey), listOf("h", group)),
+        )
+        val raw = """["EVENT","mux_padd_x",{"tags":[["p","$pubkey"],["h","$group"]]}]"""
+        gm.handleMessage(msg, raw, subscriptionId = "mux_padd_x", relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(group in gm.getGroupIdsForMux(relay), "put-user targeting self adopts the group")
+        assertEquals(
+            createdAt,
+            SecureStorage.getPutUserCursorForRelay(pubkey, relay),
+            "cursor advances so the add is not replayed on the next REQ",
         )
 
         scope.cancel()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
@@ -3,14 +3,16 @@ package org.nostr.nostrord.network.managers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.nostr.nostrord.network.GroupMembers
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.addLeftGroupForRelay
+import org.nostr.nostrord.storage.getPendingGroupInvitesFor
 import org.nostr.nostrord.storage.getPutUserCursorForRelay
 import org.nostr.nostrord.storage.removeLeftGroupForRelay
+import org.nostr.nostrord.storage.savePendingGroupInvitesFor
+import org.nostr.nostrord.storage.savePutUserCursorForRelay
 import org.nostr.nostrord.utils.epochSeconds
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -19,9 +21,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-// Regression guards for adopting a membership granted by an admin's kind:9000 (put-user):
-// the relay lists us in kind:39002 without any kind:9021 of ours, and the group must still
-// land in the joined set (group list, mux, Leave) instead of existing only relay-side.
+// Regression guards for a membership granted by an admin's kind:9000 (put-user): the add
+// becomes a PENDING invite (never a silent adoption — a third party must not be able to
+// make this client publish a kind:10009 naming their group). Accepting adopts it into the
+// joined set (group list, mux, Leave); declining routes through leaveGroup, whose durable
+// left marker keeps the relay's recurring 39002 from resurrecting the invite.
 @OptIn(ExperimentalCoroutinesApi::class)
 class GroupExternalMembershipAdoptionTest {
     private val pubkey = "00000000000000000000000000000000000000000000000000000000deadbeef"
@@ -33,6 +37,8 @@ class GroupExternalMembershipAdoptionTest {
     private fun reset() {
         SecureStorage.saveJoinedGroupsForRelay(pubkey, relay, emptySet())
         SecureStorage.removeLeftGroupForRelay(pubkey, relay, group)
+        SecureStorage.savePendingGroupInvitesFor(pubkey, emptyList())
+        SecureStorage.savePutUserCursorForRelay(pubkey, relay, 0L)
     }
 
     @BeforeTest fun before() = reset()
@@ -40,7 +46,7 @@ class GroupExternalMembershipAdoptionTest {
     @AfterTest fun after() = reset()
 
     @Test
-    fun `39002 listing self adopts the membership into the joined set and storage`() = runTest {
+    fun `39002 listing self registers a pending invite without adopting`() = runTest {
         val scope = TestScope(testScheduler)
         val gm = makeManager(scope)
         gm.setCurrentPubkey(pubkey)
@@ -49,6 +55,36 @@ class GroupExternalMembershipAdoptionTest {
         gm.handleGroupMembers(GroupMembers(group, listOf(pubkey, "someone-else")), createdAt = 100, relayUrl = relay)
         testScheduler.advanceUntilIdle()
 
+        val invite = gm.pendingGroupInvites.value[group]
+        assertEquals(relay, invite?.relayUrl, "the add lands as a pending invite")
+        assertEquals(null, invite?.actorPubkey, "39002-inferred invites carry no actor")
+        assertFalse(group in gm.getGroupIdsForMux(relay), "not adopted into the mux until accepted")
+        assertFalse(
+            group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay),
+            "not persisted as joined until accepted",
+        )
+        assertTrue(
+            SecureStorage.getPendingGroupInvitesFor(pubkey).any { it.groupId == group },
+            "pending invite is persisted so it survives a restart",
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `accepting a pending invite adopts the membership into the joined set and storage`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        gm.acceptPendingInvite(group)
+        testScheduler.advanceUntilIdle()
+
+        assertFalse(group in gm.pendingGroupInvites.value, "accepted invite leaves the pending set")
         assertTrue(group in gm.getGroupIdsForMux(relay), "adopted group joins the mux for its relay")
         assertTrue(
             group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay),
@@ -59,7 +95,7 @@ class GroupExternalMembershipAdoptionTest {
     }
 
     @Test
-    fun `durable left marker blocks adoption - a stale relay listing must not resurrect a left group`() = runTest {
+    fun `durable left marker blocks the invite - a stale relay listing must not resurrect a left group`() = runTest {
         val scope = TestScope(testScheduler)
         SecureStorage.addLeftGroupForRelay(pubkey, relay, group, nowSeconds = epochSeconds())
 
@@ -72,6 +108,7 @@ class GroupExternalMembershipAdoptionTest {
         gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
         testScheduler.advanceUntilIdle()
 
+        assertFalse(group in gm.pendingGroupInvites.value, "left group never re-enters the pending set")
         assertFalse(group in gm.getGroupIdsForMux(relay), "left group stays out of the mux")
         assertFalse(
             group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay),
@@ -82,7 +119,7 @@ class GroupExternalMembershipAdoptionTest {
     }
 
     @Test
-    fun `live kind-9000 targeting self adopts and advances the watch cursor`() = runTest {
+    fun `live kind-9000 targeting self registers the invite with its actor and advances the watch cursor`() = runTest {
         val scope = TestScope(testScheduler)
         val gm = makeManager(scope)
         gm.setCurrentPubkey(pubkey)
@@ -101,7 +138,9 @@ class GroupExternalMembershipAdoptionTest {
         gm.handleMessage(msg, raw, subscriptionId = "mux_padd_x", relayUrl = relay)
         testScheduler.advanceUntilIdle()
 
-        assertTrue(group in gm.getGroupIdsForMux(relay), "put-user targeting self adopts the group")
+        val invite = gm.pendingGroupInvites.value[group]
+        assertEquals("admin-pubkey", invite?.actorPubkey, "put-user invite records who added us")
+        assertFalse(group in gm.getGroupIdsForMux(relay), "not adopted into the mux until accepted")
         assertEquals(
             createdAt,
             SecureStorage.getPutUserCursorForRelay(pubkey, relay),
@@ -112,7 +151,89 @@ class GroupExternalMembershipAdoptionTest {
     }
 
     @Test
-    fun `39002 without self does not adopt`() = runTest {
+    fun `declining via leaveGroup drops the invite and blocks re-registration`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+        assertTrue(group in gm.pendingGroupInvites.value)
+
+        gm.leaveGroup(group, pubkey, relay, signEvent = { it }, publishJoinedGroups = {})
+        testScheduler.advanceUntilIdle()
+        assertFalse(group in gm.pendingGroupInvites.value, "declined invite leaves the pending set")
+
+        // The relay still lists us (its member removal races the 9022): must not re-prompt.
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 200, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+        assertFalse(group in gm.pendingGroupInvites.value, "left marker blocks 39002 re-registration")
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a put-user newer than the leave re-opens the invite - a stale one does not`() = runTest {
+        val scope = TestScope(testScheduler)
+        // Durable marker from a past-session leave (leaveGroup itself also arms the 5s
+        // isRecentlyLeft churn guard, which would mask the marker logic under test).
+        val leftAt = epochSeconds()
+        SecureStorage.addLeftGroupForRelay(pubkey, relay, group, nowSeconds = leftAt)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        gm.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay))
+        testScheduler.advanceUntilIdle()
+        assertTrue(group in gm.leftGroups.value)
+
+        fun putUser(createdAt: Long) {
+            val msg = NostrGroupClient.NostrMessage(
+                id = "evt-readd-$createdAt",
+                pubkey = "admin-pubkey",
+                content = "",
+                createdAt = createdAt,
+                kind = 9000,
+                tags = listOf(listOf("p", pubkey), listOf("h", group)),
+            )
+            val raw = """["EVENT","mux_padd_x",{"tags":[["p","$pubkey"],["h","$group"]]}]"""
+            gm.handleMessage(msg, raw, subscriptionId = "mux_padd_x", relayUrl = relay)
+        }
+
+        // Historical replay from before the leave: stays blocked.
+        putUser(leftAt - 100)
+        testScheduler.advanceUntilIdle()
+        assertFalse(group in gm.pendingGroupInvites.value, "a put-user older than the leave stays blocked")
+
+        // Deliberate re-add after the leave: re-opens the invite and clears the marker.
+        putUser(leftAt + 100)
+        testScheduler.advanceUntilIdle()
+        assertTrue(group in gm.pendingGroupInvites.value, "a fresh put-user re-opens the invite")
+        assertFalse(group in gm.leftGroups.value, "the durable left marker is cleared")
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `pending invite is restored from storage on the next session`() = runTest {
+        val scope = TestScope(testScheduler)
+        val first = makeManager(scope)
+        first.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+        first.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+
+        val second = makeManager(scope)
+        second.setCurrentPubkey(pubkey)
+        second.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay))
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(group in second.pendingGroupInvites.value, "undecided invite survives a restart")
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `39002 without self does not register an invite`() = runTest {
         val scope = TestScope(testScheduler)
         val gm = makeManager(scope)
         gm.setCurrentPubkey(pubkey)
@@ -121,6 +242,7 @@ class GroupExternalMembershipAdoptionTest {
         gm.handleGroupMembers(GroupMembers(group, listOf("someone-else")), createdAt = 100, relayUrl = relay)
         testScheduler.advanceUntilIdle()
 
+        assertFalse(group in gm.pendingGroupInvites.value)
         assertFalse(group in gm.getGroupIdsForMux(relay))
         assertFalse(group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay))
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/AppViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/AppViewModelTest.kt
@@ -37,14 +37,14 @@ class AppViewModelTest {
     fun `isInitialized starts false`() = runTest {
         val fake = FakeNostrRepository()
         fake.initializeAction = {} // don't flip to true
-        val vm = AppViewModel(fake)
+        val vm = AppViewModel(fake, bootDispatcher = testDispatcher)
         assertFalse(vm.isInitialized.value)
     }
 
     @Test
     fun `isInitialized becomes true after initialize completes`() = runTest {
         val fake = FakeNostrRepository()
-        val vm = AppViewModel(fake)
+        val vm = AppViewModel(fake, bootDispatcher = testDispatcher)
         testDispatcher.scheduler.advanceUntilIdle()
         assertTrue(vm.isInitialized.value)
     }
@@ -52,7 +52,7 @@ class AppViewModelTest {
     @Test
     fun `initialize is called on construction`() = runTest {
         val fake = FakeNostrRepository()
-        AppViewModel(fake)
+        AppViewModel(fake, bootDispatcher = testDispatcher)
         testDispatcher.scheduler.advanceUntilIdle()
         assertTrue(fake.calls.contains("initialize"))
     }
@@ -60,7 +60,7 @@ class AppViewModelTest {
     @Test
     fun `isLoggedIn reflects repo state`() = runTest {
         val fake = FakeNostrRepository()
-        val vm = AppViewModel(fake)
+        val vm = AppViewModel(fake, bootDispatcher = testDispatcher)
         assertFalse(vm.isLoggedIn.value)
         fake._isLoggedIn.value = true
         assertTrue(vm.isLoggedIn.value)
@@ -69,7 +69,7 @@ class AppViewModelTest {
     @Test
     fun `needsOnboarding is true only while the kind10009 group list is empty`() = runTest {
         val fake = FakeNostrRepository()
-        val vm = AppViewModel(fake)
+        val vm = AppViewModel(fake, bootDispatcher = testDispatcher)
         testDispatcher.scheduler.advanceUntilIdle()
         assertTrue(vm.needsOnboarding.value)
 
@@ -86,7 +86,7 @@ class AppViewModelTest {
     @Test
     fun `skipOnboarding flips the session override`() = runTest {
         val fake = FakeNostrRepository()
-        val vm = AppViewModel(fake)
+        val vm = AppViewModel(fake, bootDispatcher = testDispatcher)
         assertFalse(vm.onboardingSkipped.value)
         vm.skipOnboarding()
         assertTrue(vm.onboardingSkipped.value)
@@ -97,7 +97,7 @@ class AppViewModelTest {
         val fake = FakeNostrRepository()
         fake._activePubkey.value = "a".repeat(64)
         fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("g1"))
-        val vm = AppViewModel(fake)
+        val vm = AppViewModel(fake, bootDispatcher = testDispatcher)
         testDispatcher.scheduler.advanceUntilIdle()
         // Account A has groups: resolved, so neither pending (loading) nor onboarding.
         assertFalse(vm.onboardingDecisionPending.value)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmGroupInviteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmGroupInviteTest.kt
@@ -1,0 +1,34 @@
+package org.nostr.nostrord.ui
+
+import org.nostr.nostrord.nostr.Nip19
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DmGroupInviteTest {
+    private val relay = "wss://groups.example.com"
+    private val naddr = Nip19.encodeNaddr(identifier = "mygroup", relay = relay, kind = 39000)
+
+    @Test
+    fun `extracts the naddr line and keeps the rest as text`() {
+        val invite = extractDmGroupInvite("You've been added to the group \"X\".\nnostr:$naddr")
+        assertEquals("mygroup", invite?.groupId)
+        assertEquals(relay, invite?.relayUrl)
+        assertEquals("You've been added to the group \"X\".", invite?.remainingText)
+    }
+
+    @Test
+    fun `bare naddr as the whole message works too`() {
+        val invite = extractDmGroupInvite(naddr)
+        assertEquals("mygroup", invite?.groupId)
+        assertEquals("", invite?.remainingText)
+    }
+
+    @Test
+    fun `inline naddr or non-39000 naddr is not an invite`() {
+        assertNull(extractDmGroupInvite("check nostr:$naddr out"))
+        val article = Nip19.encodeNaddr(identifier = "post", relay = relay, kind = 30023)
+        assertNull(extractDmGroupInvite("nostr:$article"))
+        assertNull(extractDmGroupInvite("plain text only"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmGroupInviteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmGroupInviteTest.kt
@@ -25,6 +25,14 @@ class DmGroupInviteTest {
     }
 
     @Test
+    fun `a naddr without a relay hint is not an invite card`() {
+        // Relay TLVs are optional in NIP-19; a card without a host relay could not open
+        // the group, so the line must stay inline text instead of a dead button.
+        val hintless = Nip19.encodeNaddr(identifier = "mygroup", relay = "", kind = 39000)
+        assertNull(extractDmGroupInvite("nostr:$hintless"))
+    }
+
+    @Test
     fun `inline naddr or non-39000 naddr is not an invite`() {
         assertNull(extractDmGroupInvite("check nostr:$naddr out"))
         val article = Nip19.encodeNaddr(identifier = "post", relay = relay, kind = 30023)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/FriendCandidatesTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/FriendCandidatesTest.kt
@@ -1,0 +1,43 @@
+package org.nostr.nostrord.ui
+
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.ui.screens.group.buildFriendCandidates
+import org.nostr.nostrord.ui.screens.group.filterFriendCandidates
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+// Add-member friend picker derivation, shared by the Compose and web modals.
+class FriendCandidatesTest {
+    private fun meta(pubkey: String, name: String? = null, displayName: String? = null, picture: String? = null) = UserMetadata(
+        pubkey = pubkey,
+        name = name,
+        displayName = displayName,
+        picture = picture,
+        about = null,
+        nip05 = null,
+    )
+
+    @Test
+    fun `named follows sort first alphabetically, unnamed after, displayName wins`() {
+        val following = setOf("pk-zoe", "pk-anon", "pk-bob")
+        val metadata = mapOf(
+            "pk-zoe" to meta("pk-zoe", name = "zoe"),
+            "pk-bob" to meta("pk-bob", name = "ignored", displayName = "Bob"),
+        )
+        val candidates = buildFriendCandidates(following, metadata)
+        assertEquals(listOf("Bob", "zoe", null), candidates.map { it.name })
+        assertEquals("pk-anon", candidates.last().pubkey)
+    }
+
+    @Test
+    fun `filter matches name case-insensitively and pubkey prefix, blank returns all`() {
+        val candidates = buildFriendCandidates(
+            setOf("abc123", "def456"),
+            mapOf("abc123" to meta("abc123", name = "Alice")),
+        )
+        assertEquals(2, filterFriendCandidates(candidates, "  ").size)
+        assertEquals(listOf("abc123"), filterFriendCandidates(candidates, "aLiCe").map { it.pubkey })
+        assertEquals(listOf("def456"), filterFriendCandidates(candidates, "def").map { it.pubkey })
+        assertEquals(emptyList(), filterFriendCandidates(candidates, "nobody").map { it.pubkey })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.ui.screens.group.GroupMembership
 import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.deriveMembershipStatus
@@ -159,6 +160,64 @@ class GroupViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertNull(vm.moderationError.value)
+    }
+
+    // -------------------------------------------------------------------------
+    // Pending external add (admin kind:9000) accept / decline
+    // -------------------------------------------------------------------------
+
+    private fun invite(groupId: String) = PendingGroupInvite(
+        groupId = groupId,
+        relayUrl = "wss://relay",
+        actorPubkey = "admin-pk",
+        eventId = "ev1",
+        createdAtSeconds = 100L,
+    )
+
+    @Test
+    fun `pendingInvite surfaces only this group's invite`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.pendingGroupInvitesFlow.value = mapOf(
+            "test-group" to invite("test-group"),
+            "other" to invite("other"),
+        )
+        val vm = vm(fake)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals("test-group", vm.pendingInvite.value?.groupId)
+        assertEquals("admin-pk", vm.pendingInvite.value?.actorPubkey)
+    }
+
+    @Test
+    fun `acceptInvite delegates to the repo and the prompt clears`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.pendingGroupInvitesFlow.value = mapOf("test-group" to invite("test-group"))
+        val vm = vm(fake)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.acceptInvite()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("test-group"), fake.acceptedInvites)
+        assertEquals(null, vm.pendingInvite.value)
+    }
+
+    @Test
+    fun `declineInvite leaves the group and then reports done`() = runTest {
+        val fake = FakeNostrRepository()
+        val left = mutableListOf<String>()
+        fake.leaveGroupAction = { groupId, _ ->
+            left += groupId
+            org.nostr.nostrord.utils.Result.Success(Unit)
+        }
+        val vm = vm(fake)
+        var done = false
+
+        vm.declineInvite { done = true }
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("test-group"), left)
+        assertTrue(done)
     }
 
     @Test

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/KeychainStore.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/KeychainStore.kt
@@ -10,6 +10,13 @@ internal object KeychainStore {
     private const val ACCOUNT_MASTER_KEY = "master_encryption_key"
 
     private val keyring: Keyring? by lazy {
+        // Unit tests must not touch the real OS keyring: java-keyring's Secret Service
+        // connection (dbus-java) has a reader thread that races its own executor shutdown,
+        // and the uncaught RejectedExecutionException poisons a LATER kotlinx runTest as
+        // UncaughtExceptionsBeforeTest — an intermittent, cross-class suite failure. The
+        // Gradle Test tasks set this property; SecureStorage falls back to its
+        // no-keychain path.
+        if (System.getProperty("nostrord.disableKeychain") == "true") return@lazy null
         try {
             Keyring.create()
         } catch (_: BackendNotSupportedException) {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
@@ -80,6 +80,17 @@ actual object SecureStorage {
     }
 
     private fun initialize() {
+        // Test mode (set by the Gradle Test tasks): never touch the OS keyring (its dbus-java
+        // thread poisons kotlinx runTest, see KeychainStore) and never inherit this machine's
+        // real prefs unlock state (a dev box with legacy app data would park the whole suite
+        // on NeedsLegacyMigration, killing every encrypted slot). Ephemeral key, unlocked —
+        // the state a fresh keychainless install runs in.
+        if (System.getProperty("nostrord.disableKeychain") == "true") {
+            masterKey = SecretKeySpec(randomKeyBytes(), "AES")
+            keySource = KeySource.Ephemeral
+            _unlockState.value = UnlockState.Unlocked
+            return
+        }
         legacyKey = loadLegacyKey()
 
         val existingKeychainKey = KeychainStore.getMasterKey()

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ConfirmDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ConfirmDialog.kt
@@ -29,10 +29,6 @@ import org.nostr.nostrord.ui.theme.NostrordColors
  * [confirmEnabled] gates the confirm action (e.g. while an async op is in flight). Dialogs that host
  * their own input field or bespoke content (rename, add-relay, the delete-group warning) keep their
  * own AlertDialog.
- *
- * [onCancel], when set, makes the cancel button an ACTION of its own instead of a close
- * (backdrop/Esc still run [onDismiss]) — for prompts whose two buttons are both decisions,
- * like the group-invite Accept/Decline.
  */
 @Composable
 fun ConfirmDialog(
@@ -45,7 +41,6 @@ fun ConfirmDialog(
     destructive: Boolean = false,
     confirmEnabled: Boolean = true,
     cancelEnabled: Boolean = true,
-    onCancel: (() -> Unit)? = null,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -75,7 +70,7 @@ fun ConfirmDialog(
         cancelLabel?.let { label ->
             {
                 Button(
-                    onClick = onCancel ?: onDismiss,
+                    onClick = onDismiss,
                     enabled = cancelEnabled,
                     colors =
                     ButtonDefaults.buttonColors(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ConfirmDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ConfirmDialog.kt
@@ -29,6 +29,10 @@ import org.nostr.nostrord.ui.theme.NostrordColors
  * [confirmEnabled] gates the confirm action (e.g. while an async op is in flight). Dialogs that host
  * their own input field or bespoke content (rename, add-relay, the delete-group warning) keep their
  * own AlertDialog.
+ *
+ * [onCancel], when set, makes the cancel button an ACTION of its own instead of a close
+ * (backdrop/Esc still run [onDismiss]) — for prompts whose two buttons are both decisions,
+ * like the group-invite Accept/Decline.
  */
 @Composable
 fun ConfirmDialog(
@@ -41,6 +45,7 @@ fun ConfirmDialog(
     destructive: Boolean = false,
     confirmEnabled: Boolean = true,
     cancelEnabled: Boolean = true,
+    onCancel: (() -> Unit)? = null,
 ) {
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -70,7 +75,7 @@ fun ConfirmDialog(
         cancelLabel?.let { label ->
             {
                 Button(
-                    onClick = onDismiss,
+                    onClick = onCancel ?: onDismiss,
                     enabled = cancelEnabled,
                     colors =
                     ButtonDefaults.buttonColors(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt
@@ -34,6 +34,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
  * DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name,
@@ -53,8 +54,11 @@ fun GroupInviteCard(
     val groups by repo.groups.collectAsState()
     val groupsByRelay by repo.groupsByRelay.collectAsState()
 
+    // The card's own relay first: NIP-29 ids are relay-local, and a flattened scan could
+    // resolve a same-id group from another relay.
     val groupMeta =
-        groups.find { it.id == groupId }
+        relayUrl?.let { url -> groupsByRelay[url.normalizeRelayUrl()]?.find { it.id == groupId } }
+            ?: groups.find { it.id == groupId }
             ?: groupsByRelay.values.flatten().find { it.id == groupId }
 
     LaunchedEffect(groupId, relayUrl) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt
@@ -1,0 +1,135 @@
+package org.nostr.nostrord.ui.components.chat
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name,
+ * two-line about, and a full-width primary "View group" button. Rendered by DmPageScreen
+ * when a message carries a kind:39000 naddr on its own line; the button (and the card)
+ * navigate to the group. Metadata resolves from the group caches with a preview fetch
+ * when unknown (same contract as GroupLinkCard).
+ */
+@Composable
+fun GroupInviteCard(
+    groupId: String,
+    relayUrl: String?,
+    onOpen: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val repo = AppModule.nostrRepository
+    val groups by repo.groups.collectAsState()
+    val groupsByRelay by repo.groupsByRelay.collectAsState()
+
+    val groupMeta =
+        groups.find { it.id == groupId }
+            ?: groupsByRelay.values.flatten().find { it.id == groupId }
+
+    LaunchedEffect(groupId, relayUrl) {
+        if (relayUrl != null && groupMeta?.name == null) {
+            repo.fetchGroupPreview(groupId, relayUrl)
+        }
+    }
+
+    val displayName = groupMeta?.name?.takeIf { it.isNotBlank() } ?: groupId
+
+    Column(
+        modifier =
+        modifier
+            .widthIn(max = 280.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(NostrordColors.Surface)
+            .clickable { onOpen() }
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(Spacing.md),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            GroupHeaderIcon(
+                pictureUrl = groupMeta?.picture,
+                groupId = groupId,
+                displayName = displayName,
+                size = 40.dp,
+                cornerRadius = 8.dp,
+            )
+            Column {
+                Text(
+                    text = "GROUP INVITE",
+                    color = NostrordColors.TextMuted,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = 0.5.sp,
+                )
+                Text(
+                    text = displayName,
+                    color = NostrordColors.TextPrimary,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+        groupMeta?.about?.takeIf { it.isNotBlank() }?.let { about ->
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = about,
+                color = NostrordColors.TextMuted,
+                fontSize = 12.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Button(
+            onClick = onOpen,
+            colors = ButtonDefaults.buttonColors(containerColor = NostrordColors.Primary),
+            shape = RoundedCornerShape(8.dp),
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .pointerHoverIcon(PointerIcon.Hand),
+        ) {
+            Text("View group", fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                modifier = Modifier.height(16.dp),
+            )
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -749,6 +749,7 @@ private fun FrameContent(
                         pubkey = route.pubkey,
                         onOpenProfile = onNavigate,
                         onOpenConversation = onNavigate,
+                        onOpenGroup = { relay, gid -> onNavigate(GroupRoute(relay, gid)) },
                         onOpenDrawer = onOpenDrawer,
                     )
                 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/sidebars/MemberSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/sidebars/MemberSidebar.kt
@@ -46,6 +46,7 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import org.nostr.nostrord.network.UserGroupRef
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.avatars.UserGradientAvatar
 import org.nostr.nostrord.ui.components.forms.AppSearchField
@@ -73,8 +74,11 @@ fun MemberSidebar(
     isCurrentUserAdmin: Boolean = false,
     currentUserPubkey: String? = null,
     onRemoveMember: (MemberInfo) -> Unit = {},
-    onAddMember: (String) -> Unit = {},
+    onAddMember: (pubkey: String, notifyViaDm: Boolean) -> Unit = { _, _ -> },
     friends: List<FriendCandidate> = emptyList(),
+    groupRelay: String? = null,
+    userGroupLists: Map<String, List<UserGroupRef>> = emptyMap(),
+    onPrefetchTarget: (String) -> Unit = {},
     onManage: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -181,6 +185,9 @@ fun MemberSidebar(
                 onAddMember = onAddMember,
                 onDismiss = { showAddMemberModal = false },
                 friends = friends,
+                groupRelay = groupRelay,
+                userGroupLists = userGroupLists,
+                onPrefetchTarget = onPrefetchTarget,
             )
         }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/sidebars/MemberSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/sidebars/MemberSidebar.kt
@@ -52,6 +52,7 @@ import org.nostr.nostrord.ui.components.forms.AppSearchField
 import org.nostr.nostrord.ui.components.forms.InputSize
 import org.nostr.nostrord.ui.components.loading.MemberSkeleton
 import org.nostr.nostrord.ui.components.scrollbar.VerticalScrollbarWrapper
+import org.nostr.nostrord.ui.screens.group.FriendCandidate
 import org.nostr.nostrord.ui.screens.group.components.AddMemberModal
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -73,6 +74,7 @@ fun MemberSidebar(
     currentUserPubkey: String? = null,
     onRemoveMember: (MemberInfo) -> Unit = {},
     onAddMember: (String) -> Unit = {},
+    friends: List<FriendCandidate> = emptyList(),
     onManage: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -178,6 +180,7 @@ fun MemberSidebar(
             AddMemberModal(
                 onAddMember = onAddMember,
                 onDismiss = { showAddMemberModal = false },
+                friends = friends,
             )
         }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -414,9 +414,7 @@ fun DmPageScreen(
                                             GroupInviteCard(
                                                 groupId = invite.groupId,
                                                 relayUrl = invite.relayUrl,
-                                                onOpen = {
-                                                    invite.relayUrl?.let { onOpenGroup(it, invite.groupId) }
-                                                },
+                                                onOpen = { onOpenGroup(invite.relayUrl, invite.groupId) },
                                                 modifier = Modifier.padding(vertical = Spacing.xxs),
                                             )
                                         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -52,7 +52,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
-import org.nostr.nostrord.ui.extractDmGroupInvite
 import org.nostr.nostrord.ui.components.chat.DateSeparator
 import org.nostr.nostrord.ui.components.chat.DmEventSourceDialog
 import org.nostr.nostrord.ui.components.chat.DmMessageContextMenu
@@ -65,6 +64,7 @@ import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
 import org.nostr.nostrord.ui.components.layout.DmConversationList
 import org.nostr.nostrord.ui.components.layout.FrameMenuButton
 import org.nostr.nostrord.ui.components.layout.PageHeader
+import org.nostr.nostrord.ui.extractDmGroupInvite
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.screens.profile.ProfilePageViewModel

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -52,10 +52,12 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
+import org.nostr.nostrord.ui.extractDmGroupInvite
 import org.nostr.nostrord.ui.components.chat.DateSeparator
 import org.nostr.nostrord.ui.components.chat.DmEventSourceDialog
 import org.nostr.nostrord.ui.components.chat.DmMessageContextMenu
 import org.nostr.nostrord.ui.components.chat.DmRelaysDialog
+import org.nostr.nostrord.ui.components.chat.GroupInviteCard
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.chat.MessageContent
 import org.nostr.nostrord.ui.components.chat.SendStateIcon
@@ -82,6 +84,7 @@ fun DmPageScreen(
     pubkey: String?,
     onOpenProfile: (UserRoute) -> Unit,
     onOpenConversation: (DmRoute) -> Unit = {},
+    onOpenGroup: (relayUrl: String, groupId: String) -> Unit = { _, _ -> },
     // Non-null only on compact/mobile (sidebar is in the drawer). Drives the hamburger and, on the
     // empty landing, the conversation list shown in the page body (no visible DM sidebar there),
     // mirroring the web `.dm-page-convos` media query.
@@ -394,13 +397,29 @@ fun DmPageScreen(
                                     color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
                                 ) {
                                     Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
-                                        // Rich body: inline images/video/audio/links/mentions/markdown,
-                                        // reusing the group chat renderer. White text on the "mine" bubble.
-                                        MessageContent(
-                                            content = m.content,
-                                            onMentionClick = { onOpenProfile(UserRoute(it)) },
-                                            textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
-                                        )
+                                        // A group naddr on its own line renders as the prototype
+                                        // invite card (text above, card + View group button below).
+                                        val invite = remember(m.content) { extractDmGroupInvite(m.content) }
+                                        val body = invite?.remainingText ?: m.content
+                                        if (body.isNotBlank()) {
+                                            // Rich body: inline images/video/audio/links/mentions/markdown,
+                                            // reusing the group chat renderer. White text on the "mine" bubble.
+                                            MessageContent(
+                                                content = body,
+                                                onMentionClick = { onOpenProfile(UserRoute(it)) },
+                                                textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
+                                            )
+                                        }
+                                        if (invite != null) {
+                                            GroupInviteCard(
+                                                groupId = invite.groupId,
+                                                relayUrl = invite.relayUrl,
+                                                onOpen = {
+                                                    invite.relayUrl?.let { onOpenGroup(it, invite.groupId) }
+                                                },
+                                                modifier = Modifier.padding(vertical = Spacing.xxs),
+                                            )
+                                        }
                                         // Time + send-state (clock while Sending, check once Delivered),
                                         // reusing the group chat's SendStateIcon on own messages.
                                         Row(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -688,6 +688,31 @@ fun GroupScreen(
         )
     }
 
+    // Accept/decline prompt for an external add (an admin's kind:9000). The group stays
+    // readable as a preview while undecided; backdrop/Esc = decide later (the prompt
+    // returns on the next open). Accept adopts it into the joined list; Decline leaves.
+    val pendingInvite by vm.pendingInvite.collectAsState()
+    var invitePromptDismissed by remember(groupId) { mutableStateOf(false) }
+    if (!invitePromptDismissed) {
+        pendingInvite?.let { invite ->
+            val actorLabel =
+                invite.actorPubkey?.let { pk ->
+                    userMetadata[pk]?.displayName?.takeIf { it.isNotBlank() }
+                        ?: userMetadata[pk]?.name?.takeIf { it.isNotBlank() }
+                        ?: (pk.take(8) + "…")
+                } ?: "An admin"
+            ConfirmDialog(
+                title = "Group Invitation",
+                message = "$actorLabel added you to this group. Accept to add it to your groups, or decline to leave.",
+                confirmLabel = "Accept",
+                cancelLabel = "Decline",
+                onConfirm = { vm.acceptInvite() },
+                onCancel = { vm.declineInvite { onNavigateHome() } },
+                onDismiss = { invitePromptDismissed = true },
+            )
+        }
+    }
+
     // Join error dialog (relay rejected the kind:9021 join request)
     joinError?.let { error ->
         ConfirmDialog(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -2,13 +2,21 @@ package org.nostr.nostrord.ui.screens.group
 
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.delay
 import org.nostr.nostrord.di.AppModule
@@ -18,6 +26,7 @@ import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.ConfirmDialog
+import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.screens.group.components.CreateGroupModal
 import org.nostr.nostrord.ui.screens.group.components.GroupInfoModal
@@ -112,6 +121,10 @@ fun GroupScreen(
     val groups by vm.groups.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()
     val userMetadata by vm.userMetadata.collectAsState()
+    // The add-member DM default: whether the target's kind:10009 pins a group on this
+    // group's host relay (in-app notification reaches them there, DM redundant).
+    val userGroupLists by vm.userGroupLists.collectAsState()
+    val allGroupsByRelay by vm.groupsByRelay.collectAsState()
     val allReactions by vm.reactions.collectAsState()
     val pendingReactions by vm.pendingReactions.collectAsState()
     val messageStatus by vm.messageStatus.collectAsState()
@@ -692,22 +705,20 @@ fun GroupScreen(
     // readable as a preview while undecided; backdrop/Esc = decide later (the prompt
     // returns on the next open). Accept adopts it into the joined list; Decline leaves.
     val pendingInvite by vm.pendingInvite.collectAsState()
+    val inviteActorLabel by vm.pendingInviteActorLabel.collectAsState()
     var invitePromptDismissed by remember(groupId) { mutableStateOf(false) }
     if (!invitePromptDismissed) {
         pendingInvite?.let { invite ->
-            val actorLabel =
-                invite.actorPubkey?.let { pk ->
-                    userMetadata[pk]?.displayName?.takeIf { it.isNotBlank() }
-                        ?: userMetadata[pk]?.name?.takeIf { it.isNotBlank() }
-                        ?: (pk.take(8) + "…")
-                } ?: "An admin"
-            ConfirmDialog(
-                title = "Group Invitation",
-                message = "$actorLabel added you to this group. Accept to add it to your groups, or decline to leave.",
-                confirmLabel = "Accept",
-                cancelLabel = "Decline",
-                onConfirm = { vm.acceptInvite() },
-                onCancel = { vm.declineInvite { onNavigateHome() } },
+            GroupInviteDialog(
+                groupName = currentGroupMetadata?.name?.takeIf { it.isNotBlank() }
+                    ?: groupName?.takeIf { it.isNotBlank() }
+                    ?: "#${groupId.take(8)}",
+                groupPicture = currentGroupMetadata?.picture,
+                groupId = groupId,
+                relayHost = invite.relayUrl.removePrefix("wss://").removePrefix("ws://").trimEnd('/'),
+                actorLabel = inviteActorLabel,
+                onAccept = { vm.acceptInvite() },
+                onDecline = { vm.declineInvite { onNavigateHome() } },
                 onDismiss = { invitePromptDismissed = true },
             )
         }
@@ -1007,8 +1018,11 @@ fun GroupScreen(
                     },
                     isCurrentUserAdmin = isAdmin,
                     onRemoveMember = { member -> memberToRemove = member },
-                    onAddMember = { pubkey -> vm.addUser(pubkey, notifyViaDm = true) },
+                    onAddMember = { pubkey, notify -> vm.addUser(pubkey, notifyViaDm = notify) },
                     friends = friends,
+                    groupRelay = groupHostRelay(groupId, allGroupsByRelay, currentRelayUrl),
+                    userGroupLists = userGroupLists,
+                    onPrefetchTarget = { vm.prefetchUserGroupList(it) },
                     pendingJoinRequestCount = pendingRequests.size,
                     onJoinRequestsClick = { showJoinRequestsModal = true },
                     isPendingApproval = isPendingApproval,
@@ -1158,8 +1172,11 @@ fun GroupScreen(
                     onShowMemberSheet = { showMemberSheet = it },
                     isCurrentUserAdmin = isAdmin,
                     onRemoveMember = { member -> memberToRemove = member },
-                    onAddMember = { pubkey -> vm.addUser(pubkey, notifyViaDm = true) },
+                    onAddMember = { pubkey, notify -> vm.addUser(pubkey, notifyViaDm = notify) },
                     friends = friends,
+                    groupRelay = groupHostRelay(groupId, allGroupsByRelay, currentRelayUrl),
+                    userGroupLists = userGroupLists,
+                    onPrefetchTarget = { vm.prefetchUserGroupList(it) },
                     pendingJoinRequestCount = pendingRequests.size,
                     onJoinRequestsClick = { showJoinRequestsModal = true },
                     isPendingApproval = isPendingApproval,
@@ -1184,4 +1201,102 @@ fun GroupScreen(
             }
         }
     } // CompositionLocalProvider
+}
+
+/**
+ * The pending-invite prompt (Compose counterpart of the web GroupInviteModal): "GROUP
+ * INVITE" eyebrow + group avatar/name/relay, one line saying who invited (or a neutral
+ * "You were added" when the actor is unknown or the relay itself), and Decline / Accept.
+ * Backdrop/Esc runs [onDismiss] = decide later.
+ */
+@Composable
+private fun GroupInviteDialog(
+    groupName: String,
+    groupPicture: String?,
+    groupId: String,
+    relayHost: String,
+    actorLabel: String?,
+    onAccept: () -> Unit,
+    onDecline: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        modifier = Modifier.width(480.dp),
+        containerColor = NostrordColors.Surface,
+        shape = RoundedCornerShape(16.dp),
+        title = {
+            // Same eyebrow as the DM GroupInviteCard (muted, 11sp bold, tight tracking).
+            Text(
+                text = "GROUP INVITE",
+                color = NostrordColors.TextMuted,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = 0.5.sp,
+            )
+        },
+        text = {
+            Column {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    OptimizedSmallAvatar(
+                        imageUrl = groupPicture?.ifBlank { null },
+                        identifier = groupId,
+                        displayName = groupName,
+                        size = 44.dp,
+                        shape = RoundedCornerShape(10.dp),
+                        isGroup = true,
+                    )
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            text = groupName,
+                            color = NostrordColors.TextPrimary,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = relayHost,
+                            color = NostrordColors.TextMuted,
+                            style = MaterialTheme.typography.labelSmall,
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text =
+                    if (actorLabel != null) {
+                        "$actorLabel invited you to this group. Accept to add it to your groups, or decline to leave."
+                    } else {
+                        "You were added to this group. Accept to add it to your groups, or decline to leave."
+                    },
+                    color = NostrordColors.TextSecondary,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        },
+        confirmButton = {
+            Button(
+                onClick = onAccept,
+                colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = NostrordColors.Primary,
+                    contentColor = Color.White,
+                ),
+                shape = RoundedCornerShape(8.dp),
+            ) { Text("Accept", fontWeight = FontWeight.SemiBold) }
+        },
+        dismissButton = {
+            Button(
+                onClick = onDecline,
+                colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = NostrordColors.SurfaceVariant,
+                    contentColor = NostrordColors.TextPrimary,
+                ),
+                shape = RoundedCornerShape(8.dp),
+            ) { Text("Decline", fontWeight = FontWeight.SemiBold) }
+        },
+    )
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -91,6 +91,7 @@ fun GroupScreen(
     }
 
     val isSending by vm.isSending.collectAsState()
+    val friends by vm.friends.collectAsState()
     val sendError by vm.sendError.collectAsState()
     val deleteMessageError by vm.deleteMessageError.collectAsState()
     val reactionError by vm.reactionError.collectAsState()
@@ -981,7 +982,8 @@ fun GroupScreen(
                     },
                     isCurrentUserAdmin = isAdmin,
                     onRemoveMember = { member -> memberToRemove = member },
-                    onAddMember = { pubkey -> vm.addUser(pubkey) },
+                    onAddMember = { pubkey -> vm.addUser(pubkey, notifyViaDm = true) },
+                    friends = friends,
                     pendingJoinRequestCount = pendingRequests.size,
                     onJoinRequestsClick = { showJoinRequestsModal = true },
                     isPendingApproval = isPendingApproval,
@@ -1131,7 +1133,8 @@ fun GroupScreen(
                     onShowMemberSheet = { showMemberSheet = it },
                     isCurrentUserAdmin = isAdmin,
                     onRemoveMember = { member -> memberToRemove = member },
-                    onAddMember = { pubkey -> vm.addUser(pubkey) },
+                    onAddMember = { pubkey -> vm.addUser(pubkey, notifyViaDm = true) },
+                    friends = friends,
                     pendingJoinRequestCount = pendingRequests.size,
                     onJoinRequestsClick = { showJoinRequestsModal = true },
                     isPendingApproval = isPendingApproval,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -116,8 +116,11 @@ fun GroupScreenDesktop(
     onShowMemberSheet: (Boolean) -> Unit = {},
     isCurrentUserAdmin: Boolean = false,
     onRemoveMember: (MemberInfo) -> Unit = {},
-    onAddMember: (String) -> Unit = {},
+    onAddMember: (pubkey: String, notifyViaDm: Boolean) -> Unit = { _, _ -> },
     friends: List<FriendCandidate> = emptyList(),
+    groupRelay: String? = null,
+    userGroupLists: Map<String, List<org.nostr.nostrord.network.UserGroupRef>> = emptyMap(),
+    onPrefetchTarget: (String) -> Unit = {},
     pendingJoinRequestCount: Int = 0,
     onJoinRequestsClick: () -> Unit = {},
     isPendingApproval: Boolean = false,
@@ -301,6 +304,9 @@ fun GroupScreenDesktop(
                     onRemoveMember = onRemoveMember,
                     onAddMember = onAddMember,
                     friends = friends,
+                    groupRelay = groupRelay,
+                    userGroupLists = userGroupLists,
+                    onPrefetchTarget = onPrefetchTarget,
                     onManage = if (isCurrentUserAdmin) onManageMembers else null,
                 )
             }
@@ -328,6 +334,9 @@ fun GroupScreenDesktop(
                 onRemoveMember = onRemoveMember,
                 onAddMember = onAddMember,
                 friends = friends,
+                groupRelay = groupRelay,
+                userGroupLists = userGroupLists,
+                onPrefetchTarget = onPrefetchTarget,
                 onManage = if (isCurrentUserAdmin) onManageMembers else null,
             )
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -117,6 +117,7 @@ fun GroupScreenDesktop(
     isCurrentUserAdmin: Boolean = false,
     onRemoveMember: (MemberInfo) -> Unit = {},
     onAddMember: (String) -> Unit = {},
+    friends: List<FriendCandidate> = emptyList(),
     pendingJoinRequestCount: Int = 0,
     onJoinRequestsClick: () -> Unit = {},
     isPendingApproval: Boolean = false,
@@ -299,6 +300,7 @@ fun GroupScreenDesktop(
                     currentUserPubkey = currentUserPubkey,
                     onRemoveMember = onRemoveMember,
                     onAddMember = onAddMember,
+                    friends = friends,
                     onManage = if (isCurrentUserAdmin) onManageMembers else null,
                 )
             }
@@ -325,6 +327,7 @@ fun GroupScreenDesktop(
                 currentUserPubkey = currentUserPubkey,
                 onRemoveMember = onRemoveMember,
                 onAddMember = onAddMember,
+                friends = friends,
                 onManage = if (isCurrentUserAdmin) onManageMembers else null,
             )
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -119,8 +119,11 @@ fun GroupScreenMobile(
     onMediaUploaded: (org.nostr.nostrord.network.upload.UploadResult) -> Unit = {},
     isCurrentUserAdmin: Boolean = false,
     onRemoveMember: (MemberInfo) -> Unit = {},
-    onAddMember: (String) -> Unit = {},
+    onAddMember: (pubkey: String, notifyViaDm: Boolean) -> Unit = { _, _ -> },
     friends: List<FriendCandidate> = emptyList(),
+    groupRelay: String? = null,
+    userGroupLists: Map<String, List<org.nostr.nostrord.network.UserGroupRef>> = emptyMap(),
+    onPrefetchTarget: (String) -> Unit = {},
     pendingJoinRequestCount: Int = 0,
     onJoinRequestsClick: () -> Unit = {},
     isPendingApproval: Boolean = false,
@@ -351,6 +354,9 @@ fun GroupScreenMobile(
                     onRemoveMember = onRemoveMember,
                     onAddMember = onAddMember,
                     friends = friends,
+                    groupRelay = groupRelay,
+                    userGroupLists = userGroupLists,
+                    onPrefetchTarget = onPrefetchTarget,
                     onManage = if (isCurrentUserAdmin) onManageMembers else null,
                 )
             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -120,6 +120,7 @@ fun GroupScreenMobile(
     isCurrentUserAdmin: Boolean = false,
     onRemoveMember: (MemberInfo) -> Unit = {},
     onAddMember: (String) -> Unit = {},
+    friends: List<FriendCandidate> = emptyList(),
     pendingJoinRequestCount: Int = 0,
     onJoinRequestsClick: () -> Unit = {},
     isPendingApproval: Boolean = false,
@@ -349,6 +350,7 @@ fun GroupScreenMobile(
                     currentUserPubkey = currentUserPubkey,
                     onRemoveMember = onRemoveMember,
                     onAddMember = onAddMember,
+                    friends = friends,
                     onManage = if (isCurrentUserAdmin) onManageMembers else null,
                 )
             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/AddMemberModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/AddMemberModal.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -22,23 +24,31 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.forms.AppField
+import org.nostr.nostrord.ui.screens.group.FriendCandidate
+import org.nostr.nostrord.ui.screens.group.filterFriendCandidates
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 
 /**
- * Modal for adding a user to the group via npub or hex pubkey.
+ * Modal for adding a user to the group: pick a follow from the searchable list, or
+ * paste an npub / hex pubkey. The input doubles as the friend-search field.
  */
 @Composable
 fun AddMemberModal(
     onAddMember: (String) -> Unit,
     onDismiss: () -> Unit,
+    friends: List<FriendCandidate> = emptyList(),
 ) {
     var input by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
@@ -140,7 +150,7 @@ fun AddMemberModal(
 
                     // Description
                     Text(
-                        text = "Enter the user's npub or hex public key to add them to this group.",
+                        text = "Pick a friend below, or enter the user's npub or hex public key.",
                         style = MaterialTheme.typography.bodyMedium,
                         color = NostrordColors.TextSecondary,
                     )
@@ -154,7 +164,7 @@ fun AddMemberModal(
                             input = it
                             error = null
                         },
-                        placeholder = "npub1... or hex pubkey",
+                        placeholder = "Search friends, or npub1... / hex pubkey",
                         modifier =
                         Modifier
                             .fillMaxWidth()
@@ -180,6 +190,52 @@ fun AddMemberModal(
                             color = NostrordColors.Error,
                             style = MaterialTheme.typography.labelSmall,
                         )
+                    }
+
+                    // Friend picker: follows filtered by the same input (until it turns
+                    // into a parseable key, at which point the button flow takes over).
+                    val shownFriends = if (isValidKey) emptyList() else filterFriendCandidates(friends, input)
+                    if (shownFriends.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "FRIENDS",
+                            color = NostrordColors.TextMuted,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.Bold,
+                        )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        LazyColumn(modifier = Modifier.heightIn(max = 260.dp)) {
+                            items(shownFriends, key = { it.pubkey }) { friend ->
+                                Row(
+                                    modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .clickable {
+                                            onAddMember(friend.pubkey)
+                                            onDismiss()
+                                        }
+                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .padding(horizontal = 8.dp, vertical = 6.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    OptimizedSmallAvatar(
+                                        imageUrl = friend.picture,
+                                        identifier = friend.pubkey,
+                                        displayName = friend.name ?: friend.pubkey,
+                                        size = 32.dp,
+                                    )
+                                    Spacer(modifier = Modifier.width(12.dp))
+                                    Text(
+                                        text = friend.name ?: (friend.pubkey.take(8) + "…"),
+                                        color = NostrordColors.TextPrimary,
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
+                            }
+                        }
                     }
 
                     Spacer(modifier = Modifier.height(20.dp))

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/AddMemberModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/AddMemberModal.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -24,7 +25,6 @@ import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/AddMemberModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/AddMemberModal.kt
@@ -31,11 +31,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import org.nostr.nostrord.network.UserGroupRef
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.forms.AppField
 import org.nostr.nostrord.ui.screens.group.FriendCandidate
 import org.nostr.nostrord.ui.screens.group.filterFriendCandidates
+import org.nostr.nostrord.ui.screens.group.pubkeyUsesRelay
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
@@ -43,18 +45,41 @@ import org.nostr.nostrord.ui.theme.Spacing
 /**
  * Modal for adding a user to the group: pick a follow from the searchable list, or
  * paste an npub / hex pubkey. The input doubles as the friend-search field.
+ *
+ * The "Send a DM invite" checkbox defaults per target: someone whose public kind:10009
+ * pins a group on this relay already gets the in-app add notification there, so the DM
+ * defaults off for them and on for everyone else. Toggling it is an explicit choice
+ * that applies to whoever is added next.
  */
 @Composable
 fun AddMemberModal(
-    onAddMember: (String) -> Unit,
+    onAddMember: (pubkey: String, notifyViaDm: Boolean) -> Unit,
     onDismiss: () -> Unit,
     friends: List<FriendCandidate> = emptyList(),
+    groupRelay: String? = null,
+    userGroupLists: Map<String, List<UserGroupRef>> = emptyMap(),
+    onPrefetchTarget: (String) -> Unit = {},
 ) {
     var input by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     val focusRequester = remember { FocusRequester() }
     // Submit only unlocks for a key that actually parses (npub/nprofile/hex).
-    val isValidKey = Nip19.parsePubkeyInput(input) is Nip19.PubkeyParse.Ok
+    val parsedHex = (Nip19.parsePubkeyInput(input) as? Nip19.PubkeyParse.Ok)?.hex
+    val isValidKey = parsedHex != null
+
+    var notifyViaDm by remember { mutableStateOf(true) }
+    var notifyTouched by remember { mutableStateOf(false) }
+
+    fun targetOnRelay(pubkey: String) = pubkeyUsesRelay(pubkey, groupRelay, userGroupLists)
+    val typedOnRelay = parsedHex != null && targetOnRelay(parsedHex)
+
+    // Fetch the typed key's kind:10009 so the on-relay check has data (friends' lists
+    // are already fetched by the home discovery).
+    LaunchedEffect(parsedHex) { parsedHex?.let(onPrefetchTarget) }
+    // Smart default; an explicit toggle wins from then on.
+    LaunchedEffect(parsedHex, typedOnRelay) {
+        if (!notifyTouched && parsedHex != null) notifyViaDm = !typedOnRelay
+    }
 
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
@@ -66,7 +91,7 @@ fun AddMemberModal(
         // case) and reject nsec with a specific warning.
         when (val parsed = Nip19.parsePubkeyInput(input)) {
             is Nip19.PubkeyParse.Ok -> {
-                onAddMember(parsed.hex)
+                onAddMember(parsed.hex, notifyViaDm)
                 onDismiss()
             }
             Nip19.PubkeyParse.Empty -> error = "Enter an npub or hex pubkey."
@@ -212,7 +237,10 @@ fun AddMemberModal(
                                         .fillMaxWidth()
                                         .clip(RoundedCornerShape(8.dp))
                                         .clickable {
-                                            onAddMember(friend.pubkey)
+                                            // Untouched checkbox = per-target auto (the row's
+                                            // "on this relay" tag shows why no DM goes out).
+                                            val notify = if (notifyTouched) notifyViaDm else !targetOnRelay(friend.pubkey)
+                                            onAddMember(friend.pubkey, notify)
                                             onDismiss()
                                         }
                                         .pointerHoverIcon(PointerIcon.Hand)
@@ -232,13 +260,69 @@ fun AddMemberModal(
                                         style = MaterialTheme.typography.bodyMedium,
                                         maxLines = 1,
                                         overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f, fill = false),
                                     )
+                                    if (targetOnRelay(friend.pubkey)) {
+                                        Spacer(modifier = Modifier.width(8.dp))
+                                        Text(
+                                            text = "on this relay",
+                                            color = NostrordColors.TextMuted,
+                                            fontSize = 11.sp,
+                                        )
+                                    }
                                 }
                             }
                         }
                     }
 
-                    Spacer(modifier = Modifier.height(20.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // DM courtesy toggle. The DM is the only signal that reaches a user
+                    // whose client does not connect to this relay.
+                    Row(
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable {
+                                notifyViaDm = !notifyViaDm
+                                notifyTouched = true
+                            }
+                            .pointerHoverIcon(PointerIcon.Hand),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(
+                            checked = notifyViaDm,
+                            onCheckedChange = {
+                                notifyViaDm = it
+                                notifyTouched = true
+                            },
+                            colors =
+                            CheckboxDefaults.colors(
+                                checkedColor = NostrordColors.Primary,
+                                uncheckedColor = NostrordColors.TextMuted,
+                            ),
+                        )
+                        Column {
+                            Text(
+                                text = "Send a DM invite",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = NostrordColors.TextPrimary,
+                            )
+                            Text(
+                                text =
+                                if (typedOnRelay) {
+                                    "This user is already on this relay and gets the in-app notification."
+                                } else {
+                                    "A DM is how someone outside this relay finds out."
+                                },
+                                style = MaterialTheme.typography.labelSmall,
+                                color = NostrordColors.TextMuted,
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
 
                     // Buttons
                     Row(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
@@ -225,4 +225,5 @@ private fun actionLabel(entry: NotificationEntry): String = when (entry.type) {
     NotificationType.REPLY -> "replied"
     NotificationType.MESSAGE -> "posted"
     NotificationType.REACTION -> "reacted ${entry.emoji ?: ""}".trim()
+    NotificationType.GROUP_ADD -> "added you"
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
@@ -16,6 +16,9 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.InlineTextContent
+import androidx.compose.foundation.text.appendInlineContent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Notifications
@@ -30,6 +33,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.Placeholder
+import androidx.compose.ui.text.PlaceholderVerticalAlign
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
@@ -127,15 +132,19 @@ fun NotificationsPage(
                         val groupMeta =
                             groupsByRelay[entry.relayUrl]?.firstOrNull { it.id == entry.groupId }
                                 ?: groupsByRelay.values.firstNotNullOfOrNull { list -> list.firstOrNull { it.id == entry.groupId } }
+                        // Live metadata first: the snapshot taken at notification time can be
+                        // the truncated id (metadata hadn't landed yet, e.g. a private group
+                        // pre-AUTH) and would otherwise shadow the real name forever.
                         val groupName =
-                            entry.groupName?.takeIf { it.isNotBlank() }
-                                ?: groupMeta?.name?.takeIf { it.isNotBlank() }
+                            groupMeta?.name?.takeIf { it.isNotBlank() }
+                                ?: entry.groupName?.takeIf { it.isNotBlank() }
                                 ?: entry.groupId.take(8)
                         NotificationRow(
                             entry = entry,
                             authorName = authorName,
                             avatarUrl = meta?.picture,
                             groupName = groupName,
+                            groupPicture = groupMeta?.picture,
                             onClick = {
                                 vm.markRead(entry.id)
                                 onOpenGroupAtRelay(entry.groupId, groupName, entry.relayUrl, entry.messageId)
@@ -148,12 +157,16 @@ fun NotificationsPage(
     }
 }
 
+// Inline-content slot id for the tiny group avatar inside the row header text.
+private const val GROUP_AVATAR_INLINE = "groupAvatar"
+
 @Composable
 private fun NotificationRow(
     entry: NotificationEntry,
     authorName: String,
     avatarUrl: String?,
     groupName: String,
+    groupPicture: String?,
     onClick: () -> Unit,
 ) {
     Row(
@@ -194,11 +207,35 @@ private fun NotificationRow(
                         append(actionLabel(entry))
                         append(" in ")
                     }
+                    // The group identity: its standard rounded-square avatar + name.
+                    appendInlineContent(GROUP_AVATAR_INLINE, "▢")
+                    append(' ')
                     withStyle(SpanStyle(color = NostrordColors.TextLink, fontWeight = FontWeight.Medium)) {
-                        append("#$groupName")
+                        append(groupName)
                     }
                 }
-            Text(text = header, fontSize = 14.sp, maxLines = 2, overflow = TextOverflow.Ellipsis)
+            Text(
+                text = header,
+                fontSize = 14.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                inlineContent =
+                mapOf(
+                    GROUP_AVATAR_INLINE to
+                        InlineTextContent(
+                            Placeholder(16.sp, 16.sp, PlaceholderVerticalAlign.TextCenter),
+                        ) {
+                            OptimizedSmallAvatar(
+                                imageUrl = groupPicture?.ifBlank { null },
+                                identifier = entry.groupId,
+                                displayName = groupName,
+                                size = 16.dp,
+                                shape = RoundedCornerShape(4.dp),
+                                isGroup = true,
+                            )
+                        },
+                ),
+            )
             val preview = entry.preview.takeIf { it.isNotBlank() }
             if (preview != null) {
                 Spacer(modifier = Modifier.height(2.dp))

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -652,6 +652,7 @@ val AppFrame =
                             pubkey = r.pubkey
                             onOpenProfile = { pushRoute(it) }
                             onOpenConversation = { pushRoute(it) }
+                            onOpenGroup = { pushRoute(it) }
                             onOpenDrawer = { setDrawerOpen(true) }
                         }
                     r is RelayRoute ->

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/Forms.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/Forms.kt
@@ -184,9 +184,6 @@ private external interface ConfirmDialogProps : Props {
     var cancelDisabled: Boolean
     var onCancel: () -> Unit
     var onConfirm: () -> Unit
-
-    /** Backdrop/Esc handler when the cancel button is an action of its own; defaults to [onCancel]. */
-    var onDismiss: (() -> Unit)?
 }
 
 /**
@@ -196,11 +193,10 @@ private external interface ConfirmDialogProps : Props {
  */
 private val ConfirmDialogFc =
     FC<ConfirmDialogProps> { props ->
-        val dismiss = props.onDismiss ?: props.onCancel
-        useEscClose { if (!props.cancelDisabled) dismiss() }
+        useEscClose { if (!props.cancelDisabled) props.onCancel() }
         div {
             className = ClassName("modal-overlay")
-            onClick = { if (!props.cancelDisabled) dismiss() }
+            onClick = { if (!props.cancelDisabled) props.onCancel() }
             div {
                 className = ClassName("modal-card sm")
                 onClick = { it.stopPropagation() }
@@ -238,10 +234,6 @@ private val ConfirmDialogFc =
  * remove member, leave group, log out) routes through this so the dialogs read identically and the
  * overlay markup is not re-hand-rolled per call site. Clicking the backdrop (or Escape) cancels,
  * unless [cancelDisabled] (e.g. an action is in flight); [confirmDisabled] gates the confirm button.
- *
- * [onDismiss], when set, makes the cancel button an ACTION of its own instead of a close
- * (backdrop/Esc run [onDismiss]) — for prompts whose two buttons are both decisions, like
- * the group-invite Accept/Decline.
  */
 fun ChildrenBuilder.confirmDialog(
     title: String,
@@ -253,7 +245,6 @@ fun ChildrenBuilder.confirmDialog(
     cancelLabel: String = "Cancel",
     confirmDisabled: Boolean = false,
     cancelDisabled: Boolean = false,
-    onDismiss: (() -> Unit)? = null,
 ) {
     ConfirmDialogFc {
         this.title = title
@@ -265,6 +256,5 @@ fun ChildrenBuilder.confirmDialog(
         this.cancelDisabled = cancelDisabled
         this.onCancel = onCancel
         this.onConfirm = onConfirm
-        this.onDismiss = onDismiss
     }
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/Forms.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/Forms.kt
@@ -184,6 +184,9 @@ private external interface ConfirmDialogProps : Props {
     var cancelDisabled: Boolean
     var onCancel: () -> Unit
     var onConfirm: () -> Unit
+
+    /** Backdrop/Esc handler when the cancel button is an action of its own; defaults to [onCancel]. */
+    var onDismiss: (() -> Unit)?
 }
 
 /**
@@ -193,10 +196,11 @@ private external interface ConfirmDialogProps : Props {
  */
 private val ConfirmDialogFc =
     FC<ConfirmDialogProps> { props ->
-        useEscClose { if (!props.cancelDisabled) props.onCancel() }
+        val dismiss = props.onDismiss ?: props.onCancel
+        useEscClose { if (!props.cancelDisabled) dismiss() }
         div {
             className = ClassName("modal-overlay")
-            onClick = { if (!props.cancelDisabled) props.onCancel() }
+            onClick = { if (!props.cancelDisabled) dismiss() }
             div {
                 className = ClassName("modal-card sm")
                 onClick = { it.stopPropagation() }
@@ -234,6 +238,10 @@ private val ConfirmDialogFc =
  * remove member, leave group, log out) routes through this so the dialogs read identically and the
  * overlay markup is not re-hand-rolled per call site. Clicking the backdrop (or Escape) cancels,
  * unless [cancelDisabled] (e.g. an action is in flight); [confirmDisabled] gates the confirm button.
+ *
+ * [onDismiss], when set, makes the cancel button an ACTION of its own instead of a close
+ * (backdrop/Esc run [onDismiss]) — for prompts whose two buttons are both decisions, like
+ * the group-invite Accept/Decline.
  */
 fun ChildrenBuilder.confirmDialog(
     title: String,
@@ -245,6 +253,7 @@ fun ChildrenBuilder.confirmDialog(
     cancelLabel: String = "Cancel",
     confirmDisabled: Boolean = false,
     cancelDisabled: Boolean = false,
+    onDismiss: (() -> Unit)? = null,
 ) {
     ConfirmDialogFc {
         this.title = title
@@ -256,5 +265,6 @@ fun ChildrenBuilder.confirmDialog(
         this.cancelDisabled = cancelDisabled
         this.onCancel = onCancel
         this.onConfirm = onConfirm
+        this.onDismiss = onDismiss
     }
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.web.components
 
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import react.FC
@@ -27,7 +28,11 @@ val GroupInviteCard =
     FC<GroupInviteCardProps> { props ->
         val repo = AppModule.nostrRepository
         val groupsByRelay = useStateFlow(repo.groupsByRelay)
-        val meta = groupsByRelay.values.flatten().firstOrNull { it.id == props.groupId }
+        // The card's own relay first: NIP-29 ids are relay-local, and a flattened scan
+        // could resolve a same-id group from another relay.
+        val meta =
+            props.relayUrl?.let { url -> groupsByRelay[url.normalizeRelayUrl()]?.firstOrNull { it.id == props.groupId } }
+                ?: groupsByRelay.values.flatten().firstOrNull { it.id == props.groupId }
         val name = meta?.name?.takeIf { it.isNotBlank() } ?: props.groupId
 
         useEffect(props.groupId, props.relayUrl, meta?.name) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt
@@ -1,0 +1,80 @@
+package org.nostr.nostrord.web.components
+
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.web.bridge.launchApp
+import org.nostr.nostrord.web.bridge.useStateFlow
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.p
+import react.useEffect
+import web.cssom.ClassName
+
+external interface GroupInviteCardProps : Props {
+    var groupId: String
+    var relayUrl: String?
+    var onOpen: () -> Unit
+}
+
+/**
+ * DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name,
+ * two-line about, and a full-width primary "View group" button. Rendered by DmPage when a
+ * message carries a kind:39000 naddr on its own line; the button (and the card) navigate
+ * to the group. Metadata resolves from groupsByRelay with a preview fetch when unknown.
+ */
+val GroupInviteCard =
+    FC<GroupInviteCardProps> { props ->
+        val repo = AppModule.nostrRepository
+        val groupsByRelay = useStateFlow(repo.groupsByRelay)
+        val meta = groupsByRelay.values.flatten().firstOrNull { it.id == props.groupId }
+        val name = meta?.name?.takeIf { it.isNotBlank() } ?: props.groupId
+
+        useEffect(props.groupId, props.relayUrl, meta?.name) {
+            val relay = props.relayUrl
+            if (relay != null && meta?.name == null) {
+                launchApp { repo.fetchGroupPreview(props.groupId, relay) }
+            }
+        }
+
+        div {
+            className = ClassName("group-invite-card")
+            onClick = { props.onOpen() }
+            div {
+                className = ClassName("gic-head")
+                WebAvatar {
+                    url = meta?.picture
+                    seed = props.groupId
+                    kind = AvatarKind.GROUP
+                    this.name = name
+                    cls = "gic-avatar"
+                }
+                div {
+                    className = ClassName("gic-titles")
+                    div {
+                        className = ClassName("gic-eyebrow")
+                        +"Group invite"
+                    }
+                    div {
+                        className = ClassName("gic-name")
+                        +name
+                    }
+                }
+            }
+            meta?.about?.takeIf { it.isNotBlank() }?.let { about ->
+                p {
+                    className = ClassName("gic-about")
+                    +about
+                }
+            }
+            button {
+                className = ClassName("btn-primary gic-btn")
+                onClick = {
+                    it.stopPropagation()
+                    props.onOpen()
+                }
+                +"View group"
+                icon(Ic.ChevronRight, cls = "ico gic-btn-chevron")
+            }
+        }
+    }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
@@ -73,10 +73,19 @@ val WebAvatar =
         // this render before it commits, so the stale picture never shows.
         if (lastSeedRef.current != seed) {
             lastSeedRef.current = seed
-            lastUrlRef.current = null
-            setLoaded(false)
-            setErrored(false)
-            setAttempts(0)
+            // Same non-blank url across the seed change is the same picture — e.g. the
+            // create-group modal reseeds per Group Name keystroke while the uploaded
+            // preview url stays. Resetting there would hide the photo FOREVER: the url
+            // effect below is keyed on the (unchanged) url and never re-runs to set
+            // `loaded` back. Only a different/absent url is a real identity swap that
+            // must drop the previous photo.
+            val samePicture = lastUrlRef.current != null && props.url?.takeIf { it.isNotBlank() } == lastUrlRef.current
+            if (!samePicture) {
+                lastUrlRef.current = null
+                setLoaded(false)
+                setErrored(false)
+                setAttempts(0)
+            }
         }
         // Keep the last good picture if the URL transiently drops to null/blank for the SAME
         // identity (metadata churn, an LRU eviction that briefly removes the entry, or a parent

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/AddMemberModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/AddMemberModal.kt
@@ -2,13 +2,17 @@ package org.nostr.nostrord.web.modals
 
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.nostr.Nip19
-import org.nostr.nostrord.ui.screens.group.buildFriendCandidates
+import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.filterFriendCandidates
+import org.nostr.nostrord.ui.screens.group.groupHostRelay
+import org.nostr.nostrord.ui.screens.group.pubkeyUsesRelay
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.components.formHint
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.useEscClose
 import react.FC
@@ -16,9 +20,12 @@ import react.Props
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.input
+import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.span
 import react.useState
 import web.cssom.ClassName
+import web.html.InputType
+import web.html.checkbox
 
 external interface AddMemberModalProps : Props {
     var groupId: String
@@ -28,28 +35,57 @@ external interface AddMemberModalProps : Props {
 /**
  * Add-member modal — real port of the Compose AddMemberModal: a searchable friend picker
  * over the follows list plus an npub / hex pubkey field, both calling
- * `addUser(groupId, pubkey, notifyViaDm = true)`. Closes on success. Validation and the
+ * `addUser(groupId, pubkey, notifyViaDm)`. Closes on success. Validation and the
  * friend-candidate derivation live in commonMain so this and the native modal stay in sync.
+ *
+ * The "Send a DM invite" checkbox defaults per target: someone whose public kind:10009
+ * pins a group on this relay already gets the in-app add notification there, so the DM
+ * defaults off for them and on for everyone else. Toggling it is an explicit choice
+ * that applies to whoever is added next.
  */
 val AddMemberModal =
     FC<AddMemberModalProps> { props ->
         val (value, setValue) = useState { "" }
         val (busy, setBusy) = useState { false }
         val (error, setError) = useState<String?> { null }
-        val following = useStateFlow(AppModule.nostrRepository.following)
-        val userMetadata = useStateFlow(AppModule.nostrRepository.userMetadata)
+        // Same keyed GroupViewModel instance as the hosting ChatScreen: its `friends` flow
+        // carries the onStart metadata kick and the ordering the Compose picker gets.
+        val vm = useViewModel(props.groupId) { GroupViewModel(AppModule.nostrRepository, props.groupId) }
+        val friends = useStateFlow(vm.friends)
+        val userGroupLists = useStateFlow(AppModule.nostrRepository.userGroupLists)
+        val groupsByRelay = useStateFlow(AppModule.nostrRepository.groupsByRelay)
+        val currentRelay = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
+        val (notifyViaDm, setNotifyViaDm) = useState { true }
+        val (notifyTouched, setNotifyTouched) = useState { false }
+        val (prefetchedKey, setPrefetchedKey) = useState<String?> { null }
         // Submit only unlocks for a key that actually parses (npub/nprofile/hex).
-        val isValidKey = Nip19.parsePubkeyInput(value) is Nip19.PubkeyParse.Ok
+        val parsedHex = (Nip19.parsePubkeyInput(value) as? Nip19.PubkeyParse.Ok)?.hex
+        val isValidKey = parsedHex != null
+        val groupRelay = groupHostRelay(props.groupId, groupsByRelay, currentRelay)
+
+        fun targetOnRelay(pubkey: String) = pubkeyUsesRelay(pubkey, groupRelay, userGroupLists)
+        val typedOnRelay = parsedHex != null && targetOnRelay(parsedHex)
+
+        // Fetch the typed key's kind:10009 so the on-relay check has data (friends' lists
+        // are already fetched by the home discovery). Guarded per key, so the render-time
+        // call fires once per typed identity.
+        if (parsedHex != null && parsedHex != prefetchedKey) {
+            setPrefetchedKey(parsedHex)
+            launchApp { AppModule.nostrRepository.requestUserGroupList(parsedHex) }
+        }
+        // Smart default; an explicit toggle wins from then on.
+        if (!notifyTouched && parsedHex != null && notifyViaDm != !typedOnRelay) {
+            setNotifyViaDm(!typedOnRelay)
+        }
         // Friend picker: follows filtered by the same input (until it turns into a
         // parseable key, at which point the button flow takes over).
-        val shownFriends =
-            if (isValidKey) emptyList() else filterFriendCandidates(buildFriendCandidates(following, userMetadata), value)
+        val shownFriends = if (isValidKey) emptyList() else filterFriendCandidates(friends, value)
 
-        fun addPubkey(pubkey: String) {
+        fun addPubkey(pubkey: String, notify: Boolean) {
             setError(null)
             setBusy(true)
             launchApp {
-                val result = AppModule.nostrRepository.addUser(props.groupId, pubkey, notifyViaDm = true)
+                val result = AppModule.nostrRepository.addUser(props.groupId, pubkey, notifyViaDm = notify)
                 setBusy(false)
                 when (result) {
                     is Result.Success -> props.onClose()
@@ -79,7 +115,7 @@ val AddMemberModal =
                         return
                     }
                 }
-            addPubkey(pubkey)
+            addPubkey(pubkey, notifyViaDm)
         }
 
         useEscClose { props.onClose() }
@@ -143,7 +179,12 @@ val AddMemberModal =
                                 key = friend.pubkey
                                 className = ClassName("member-row-btn")
                                 disabled = busy
-                                onClick = { addPubkey(friend.pubkey) }
+                                onClick = {
+                                    // Untouched checkbox = per-target auto (the row's tag
+                                    // shows why no DM goes out for on-relay friends).
+                                    val notify = if (notifyTouched) notifyViaDm else !targetOnRelay(friend.pubkey)
+                                    addPubkey(friend.pubkey, notify)
+                                }
                                 WebAvatar {
                                     url = friend.picture
                                     seed = friend.pubkey
@@ -154,10 +195,38 @@ val AddMemberModal =
                                     className = ClassName("mod-name")
                                     +(friend.name ?: (friend.pubkey.take(8) + "…"))
                                 }
+                                if (targetOnRelay(friend.pubkey)) {
+                                    span {
+                                        className = ClassName("mod-you")
+                                        +"ON THIS RELAY"
+                                    }
+                                }
                             }
                         }
                     }
                 }
+
+                // DM courtesy toggle. The DM is the only signal that reaches a user whose
+                // client does not connect to this relay.
+                label {
+                    className = ClassName("relay-check modal-dm-check")
+                    input {
+                        type = InputType.checkbox
+                        checked = notifyViaDm
+                        onChange = { event ->
+                            setNotifyViaDm(event.currentTarget.checked)
+                            setNotifyTouched(true)
+                        }
+                    }
+                    +"Send a DM invite"
+                }
+                formHint(
+                    if (typedOnRelay) {
+                        "This user is already on this relay and gets the in-app notification."
+                    } else {
+                        "A DM is how someone outside this relay finds out."
+                    },
+                )
 
                 div {
                     className = ClassName("modal-footer")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/AddMemberModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/AddMemberModal.kt
@@ -2,9 +2,13 @@ package org.nostr.nostrord.web.modals
 
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.screens.group.buildFriendCandidates
+import org.nostr.nostrord.ui.screens.group.filterFriendCandidates
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.web.bridge.launchApp
+import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.useEscClose
 import react.FC
@@ -22,17 +26,37 @@ external interface AddMemberModalProps : Props {
 }
 
 /**
- * Add-member modal — real port of the Compose AddMemberModal: an npub / hex pubkey field
- * that calls `addUser(groupId, pubkey)`. Closes on success. Validation lives in commonMain
- * (Nip19.parsePubkeyInput) so this and the native modal stay in sync.
+ * Add-member modal — real port of the Compose AddMemberModal: a searchable friend picker
+ * over the follows list plus an npub / hex pubkey field, both calling
+ * `addUser(groupId, pubkey, notifyViaDm = true)`. Closes on success. Validation and the
+ * friend-candidate derivation live in commonMain so this and the native modal stay in sync.
  */
 val AddMemberModal =
     FC<AddMemberModalProps> { props ->
         val (value, setValue) = useState { "" }
         val (busy, setBusy) = useState { false }
         val (error, setError) = useState<String?> { null }
+        val following = useStateFlow(AppModule.nostrRepository.following)
+        val userMetadata = useStateFlow(AppModule.nostrRepository.userMetadata)
         // Submit only unlocks for a key that actually parses (npub/nprofile/hex).
         val isValidKey = Nip19.parsePubkeyInput(value) is Nip19.PubkeyParse.Ok
+        // Friend picker: follows filtered by the same input (until it turns into a
+        // parseable key, at which point the button flow takes over).
+        val shownFriends =
+            if (isValidKey) emptyList() else filterFriendCandidates(buildFriendCandidates(following, userMetadata), value)
+
+        fun addPubkey(pubkey: String) {
+            setError(null)
+            setBusy(true)
+            launchApp {
+                val result = AppModule.nostrRepository.addUser(props.groupId, pubkey, notifyViaDm = true)
+                setBusy(false)
+                when (result) {
+                    is Result.Success -> props.onClose()
+                    is Result.Error -> setError(result.error.message.ifBlank { "Failed to add member." })
+                }
+            }
+        }
 
         fun submit() {
             val pubkey =
@@ -55,16 +79,7 @@ val AddMemberModal =
                         return
                     }
                 }
-            setError(null)
-            setBusy(true)
-            launchApp {
-                val result = AppModule.nostrRepository.addUser(props.groupId, pubkey)
-                setBusy(false)
-                when (result) {
-                    is Result.Success -> props.onClose()
-                    is Result.Error -> setError(result.error.message.ifBlank { "Failed to add member." })
-                }
-            }
+            addPubkey(pubkey)
         }
 
         useEscClose { props.onClose() }
@@ -101,11 +116,11 @@ val AddMemberModal =
 
                 div {
                     className = ClassName("modal-subtitle tight")
-                    +"Enter the user's npub or hex public key to add them to this group."
+                    +"Pick a friend below, or enter the user's npub or hex public key."
                 }
                 input {
                     className = ClassName("modal-input")
-                    placeholder = "npub1... or hex pubkey"
+                    placeholder = "Search friends, or npub1... / hex pubkey"
                     this.value = value
                     onChange = { event ->
                         setValue(event.currentTarget.value)
@@ -117,6 +132,30 @@ val AddMemberModal =
                     div {
                         className = ClassName("modal-error")
                         +error
+                    }
+                }
+
+                if (shownFriends.isNotEmpty()) {
+                    div {
+                        className = ClassName("modal-friend-list")
+                        shownFriends.forEach { friend ->
+                            button {
+                                key = friend.pubkey
+                                className = ClassName("member-row-btn")
+                                disabled = busy
+                                onClick = { addPubkey(friend.pubkey) }
+                                WebAvatar {
+                                    url = friend.picture
+                                    seed = friend.pubkey
+                                    name = friend.name ?: friend.pubkey
+                                    cls = "mod-avatar"
+                                }
+                                span {
+                                    className = ClassName("mod-name")
+                                    +(friend.name ?: (friend.pubkey.take(8) + "…"))
+                                }
+                            }
+                        }
                     }
                 }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/GroupInviteModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/GroupInviteModal.kt
@@ -1,0 +1,85 @@
+package org.nostr.nostrord.web.modals
+
+import org.nostr.nostrord.web.components.AvatarKind
+import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.components.useEscClose
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import web.cssom.ClassName
+
+external interface GroupInviteModalProps : Props {
+    var groupId: String
+    var groupName: String
+    var picture: String?
+    var relayHost: String
+    var actorLabel: String?
+    var onAccept: () -> Unit
+    var onDecline: () -> Unit
+    var onDismiss: () -> Unit
+}
+
+/**
+ * The pending-invite prompt (web counterpart of GroupScreen's GroupInviteDialog), in the
+ * DM invite card's visual language (`.gic-*`): "GROUP INVITE" eyebrow + group avatar/name
+ * + relay host, one line saying who invited (or a neutral "You were added" when the actor
+ * is unknown or the relay itself), and Decline / Accept. Backdrop/Esc = decide later.
+ */
+val GroupInviteModal =
+    FC<GroupInviteModalProps> { props ->
+        useEscClose { props.onDismiss() }
+        div {
+            className = ClassName("modal-overlay")
+            onClick = { props.onDismiss() }
+            div {
+                className = ClassName("modal-card sm")
+                onClick = { it.stopPropagation() }
+                div {
+                    className = ClassName("gic-head")
+                    WebAvatar {
+                        url = props.picture
+                        seed = props.groupId
+                        kind = AvatarKind.GROUP
+                        name = props.groupName
+                        cls = "gic-avatar"
+                    }
+                    div {
+                        className = ClassName("gic-titles")
+                        div {
+                            className = ClassName("gic-eyebrow")
+                            +"Group invite"
+                        }
+                        div {
+                            className = ClassName("gic-name")
+                            +props.groupName
+                        }
+                        div {
+                            className = ClassName("mod-npub")
+                            +props.relayHost
+                        }
+                    }
+                }
+                div {
+                    className = ClassName("modal-subtitle tight")
+                    +(
+                        props.actorLabel?.let { "$it invited you to this group. Accept to add it to your groups, or decline to leave." }
+                            ?: "You were added to this group. Accept to add it to your groups, or decline to leave."
+                        )
+                }
+                div {
+                    className = ClassName("modal-footer")
+                    button {
+                        className = ClassName("btn-text")
+                        onClick = { props.onDecline() }
+                        +"Decline"
+                    }
+                    button {
+                        className = ClassName("btn-primary")
+                        onClick = { props.onAccept() }
+                        +"Accept"
+                    }
+                }
+            }
+        }
+    }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -1136,6 +1136,10 @@ val ChatScreen =
         // outstanding kind:9021 on a closed group, so it shows immediately instead of sitting blank
         // until the member list arrives. Authoritative for BOTH composer and chat/members panels.
         val membership = useStateFlow(vm.membershipState)
+        // Pending external add (an admin's kind:9000): the accept/decline prompt below.
+        // Dismissal is per group id (the component stays mounted across group switches).
+        val pendingInvite = useStateFlow(vm.pendingInvite)
+        val (dismissedInviteGroupId, setDismissedInviteGroupId) = useState<String?>(null)
         // Access shape for the Private/Closed labels: trusts kind:39000 when present, else infers
         // from the relay's restricted signal (metadata is withheld from non-members). Replaces the
         // raw group.isPublic/isOpen so an outsider sees Private/Closed even before any placeholder.
@@ -2496,6 +2500,28 @@ val ChatScreen =
                         onClose = { setModal(null) }
                     }
                 "children" -> ManageChildrenModal { onClose = { setModal(null) } }
+            }
+            // Accept/decline prompt for an external add (an admin's kind:9000). Mirrors the
+            // native GroupScreen dialog: Accept adopts the group into the joined list +
+            // kind:10009, Decline leaves (kind:9022), backdrop/Esc = decide later (the
+            // group stays readable as a preview and the prompt returns on the next open).
+            if (pendingInvite != null && dismissedInviteGroupId != group.id) {
+                val actorLabel =
+                    pendingInvite.actorPubkey?.let { pk -> displayName(pk, userMetadata[pk]) } ?: "An admin"
+                confirmDialog(
+                    title = "Group Invitation",
+                    body = "$actorLabel added you to this group. Accept to add it to your groups, or decline to leave.",
+                    confirmLabel = "Accept",
+                    cancelLabel = "Decline",
+                    onConfirm = { vm.acceptInvite() },
+                    onCancel = {
+                        // launchApp, not the VM: onLeave() unmounts and viewModelScope would
+                        // cancel the kind:9022 publish mid-flight (same rule as leaveGroup above).
+                        launchApp { repo.leaveGroup(group.id) }
+                        props.onLeave()
+                    },
+                    onDismiss = { setDismissedInviteGroupId(group.id) },
+                )
             }
             // Delete-message confirm. Mirrors the native AlertDialog
             // (GroupScreen.kt:523-545): destructive action, red confirm,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -67,6 +67,7 @@ import org.nostr.nostrord.web.components.zapBadge
 import org.nostr.nostrord.web.modals.AddMemberModal
 import org.nostr.nostrord.web.modals.CreateGroupModal
 import org.nostr.nostrord.web.modals.GroupInfoModal
+import org.nostr.nostrord.web.modals.GroupInviteModal
 import org.nostr.nostrord.web.modals.InviteCodesModal
 import org.nostr.nostrord.web.modals.JoinWithCodeModal
 import org.nostr.nostrord.web.modals.ManageChildrenModal
@@ -1139,7 +1140,13 @@ val ChatScreen =
         // Pending external add (an admin's kind:9000): the accept/decline prompt below.
         // Dismissal is per group id (the component stays mounted across group switches).
         val pendingInvite = useStateFlow(vm.pendingInvite)
+        val inviteActorLabel = useStateFlow(vm.pendingInviteActorLabel)
         val (dismissedInviteGroupId, setDismissedInviteGroupId) = useState<String?>(null)
+        // Mirror Compose (remember(groupId)): leaving the group forgets the dismissal, so
+        // the prompt returns on the NEXT open. Guarded render-time adjustment.
+        if (dismissedInviteGroupId != null && dismissedInviteGroupId != group.id) {
+            setDismissedInviteGroupId(null)
+        }
         // Access shape for the Private/Closed labels: trusts kind:39000 when present, else infers
         // from the relay's restricted signal (metadata is withheld from non-members). Replaces the
         // raw group.isPublic/isOpen so an outsider sees Private/Closed even before any placeholder.
@@ -2506,22 +2513,21 @@ val ChatScreen =
             // kind:10009, Decline leaves (kind:9022), backdrop/Esc = decide later (the
             // group stays readable as a preview and the prompt returns on the next open).
             if (pendingInvite != null && dismissedInviteGroupId != group.id) {
-                val actorLabel =
-                    pendingInvite.actorPubkey?.let { pk -> displayName(pk, userMetadata[pk]) } ?: "An admin"
-                confirmDialog(
-                    title = "Group Invitation",
-                    body = "$actorLabel added you to this group. Accept to add it to your groups, or decline to leave.",
-                    confirmLabel = "Accept",
-                    cancelLabel = "Decline",
-                    onConfirm = { vm.acceptInvite() },
-                    onCancel = {
+                GroupInviteModal {
+                    this.groupId = group.id
+                    this.groupName = group.name?.takeIf { it.isNotBlank() } ?: "#${group.id.take(8)}"
+                    this.picture = group.picture
+                    relayHost = pendingInvite.relayUrl.removePrefix("wss://").removePrefix("ws://").trimEnd('/')
+                    actorLabel = inviteActorLabel
+                    onAccept = { vm.acceptInvite() }
+                    onDecline = {
                         // launchApp, not the VM: onLeave() unmounts and viewModelScope would
                         // cancel the kind:9022 publish mid-flight (same rule as leaveGroup above).
                         launchApp { repo.leaveGroup(group.id) }
                         props.onLeave()
-                    },
-                    onDismiss = { setDismissedInviteGroupId(group.id) },
-                )
+                    }
+                    onDismiss = { setDismissedInviteGroupId(group.id) }
+                }
             }
             // Delete-message confirm. Mirrors the native AlertDialog
             // (GroupScreen.kt:523-545): destructive action, red confirm,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -3609,10 +3609,11 @@ private fun ChildrenBuilder.renderEntities(
                 onNavigate = onGroupRef
             }
         } else {
-            // A mention standing alone (the whole message) keeps the rich form (group card,
+            // A mention standing alone (on its own line) keeps the rich form (group card,
             // @name); inline with other text it becomes a compact avatar+name chip, matching
-            // the prototype.
-            val standalone = content.trim() == token
+            // the prototype. Per-line, not whole-message, so an invite DM ("You've been
+            // added to X" + the naddr on the next line) still renders the group card.
+            val standalone = content.split('\n').any { it.trim() == token }
             when (val entity = Nip19.decode(token.removePrefix("nostr:"))) {
                 is Nip19.Entity.Npub ->
                     if (standalone) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -433,9 +433,7 @@ val DmPage =
                                         GroupInviteCard {
                                             groupId = invite.groupId
                                             relayUrl = invite.relayUrl
-                                            onOpen = {
-                                                invite.relayUrl?.let { props.onOpenGroup(GroupRoute(it, invite.groupId)) }
-                                            }
+                                            onOpen = { props.onOpenGroup(GroupRoute(invite.relayUrl, invite.groupId)) }
                                         }
                                     }
                                     span {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -4,7 +4,9 @@ import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.awaitCancellation
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.extractDmGroupInvite
 import org.nostr.nostrord.ui.navigation.DmRoute
+import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.screens.dm.DmChatItem
 import org.nostr.nostrord.ui.screens.dm.DmViewModel
@@ -20,6 +22,7 @@ import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.EmojiPicker
+import org.nostr.nostrord.web.components.GroupInviteCard
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
@@ -52,6 +55,7 @@ external interface DmPageProps : Props {
     var pubkey: String?
     var onOpenProfile: (UserRoute) -> Unit
     var onOpenConversation: (DmRoute) -> Unit
+    var onOpenGroup: (GroupRoute) -> Unit
     var onOpenDrawer: () -> Unit
 }
 
@@ -408,17 +412,32 @@ val DmPage =
                                 div {
                                     className = ClassName("dm-bubble")
                                     title = formatDateTime(m.createdAt)
-                                    // Rich body: inline images/video/audio/links/mentions/markdown,
-                                    // reusing the group chat renderer (same package).
-                                    renderMessageContent(
-                                        m.content,
-                                        emptyList(),
-                                        userMetadata,
-                                        emptyMap(),
-                                        { props.onOpenProfile(UserRoute(it)) },
-                                        {},
-                                        { _, _ -> },
-                                    )
+                                    // A group naddr on its own line renders as the prototype
+                                    // invite card (text above, card + View group button below).
+                                    val invite = extractDmGroupInvite(m.content)
+                                    val body = invite?.remainingText ?: m.content
+                                    if (body.isNotBlank()) {
+                                        // Rich body: inline images/video/audio/links/mentions/markdown,
+                                        // reusing the group chat renderer (same package).
+                                        renderMessageContent(
+                                            body,
+                                            emptyList(),
+                                            userMetadata,
+                                            emptyMap(),
+                                            { props.onOpenProfile(UserRoute(it)) },
+                                            {},
+                                            { gid, relay -> relay?.let { props.onOpenGroup(GroupRoute(it, gid)) } },
+                                        )
+                                    }
+                                    if (invite != null) {
+                                        GroupInviteCard {
+                                            groupId = invite.groupId
+                                            relayUrl = invite.relayUrl
+                                            onOpen = {
+                                                invite.relayUrl?.let { props.onOpenGroup(GroupRoute(it, invite.groupId)) }
+                                            }
+                                        }
+                                    }
                                     span {
                                         className = ClassName("dm-bubble-time")
                                         +formatTime(m.createdAt)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
@@ -112,6 +112,7 @@ private fun actionLabel(entry: NotificationEntry): String = when (entry.type) {
     NotificationType.REPLY -> "replied"
     NotificationType.MESSAGE -> "posted"
     NotificationType.REACTION -> "reacted ${entry.emoji ?: ""}".trim()
+    NotificationType.GROUP_ADD -> "added you"
 }
 
 private fun ChildrenBuilder.notifRow(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
@@ -86,13 +86,21 @@ val NotificationsPage =
                     } else {
                         shown.forEach { entry ->
                             val meta = userMetadata[entry.actorPubkey]
-                            val groupName =
-                                entry.groupName?.takeIf { it.isNotBlank() }
+                            // Live metadata first: the snapshot taken at notification time can
+                            // be the truncated id (metadata hadn't landed yet) and would
+                            // otherwise shadow the real name forever. The entry's own relay is
+                            // checked first — NIP-29 group ids are relay-local, and an any-relay
+                            // scan could name a same-id group from another relay.
+                            val groupMeta =
+                                groupsByRelay[entry.relayUrl]?.firstOrNull { it.id == entry.groupId }
                                     ?: groupsByRelay.values.firstNotNullOfOrNull { list ->
-                                        list.firstOrNull { it.id == entry.groupId }?.name
-                                    }?.takeIf { it.isNotBlank() }
+                                        list.firstOrNull { it.id == entry.groupId }
+                                    }
+                            val groupName =
+                                groupMeta?.name?.takeIf { it.isNotBlank() }
+                                    ?: entry.groupName?.takeIf { it.isNotBlank() }
                                     ?: entry.groupId.take(8)
-                            notifRow(entry, meta, groupName) {
+                            notifRow(entry, meta, groupName, groupMeta?.picture) {
                                 vm.markRead(entry.id)
                                 props.onOpen(entry.relayUrl, entry.groupId, entry.messageId)
                             }
@@ -119,6 +127,7 @@ private fun ChildrenBuilder.notifRow(
     entry: NotificationEntry,
     meta: UserMetadata?,
     groupName: String,
+    groupPicture: String?,
     onSelect: () -> Unit,
 ) {
     val actor = actorName(meta, entry.actorPubkey)
@@ -147,7 +156,14 @@ private fun ChildrenBuilder.notifRow(
                 }
                 span {
                     className = ClassName("npage-group")
-                    +"#$groupName"
+                    WebAvatar {
+                        url = groupPicture
+                        seed = entry.groupId
+                        name = groupName
+                        kind = AvatarKind.GROUP
+                        cls = "npage-group-avatar"
+                    }
+                    +groupName
                 }
             }
             entry.preview.takeIf { it.isNotBlank() }?.let { preview ->

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -6017,6 +6017,71 @@ body {
 }
 
 /* naddr group reference card (mirrors native GroupLinkCard) */
+/* DM group-invite card (prototype InviteCard): eyebrow + name, two-line about,
+   full-width primary "View group" button. */
+.group-invite-card {
+    width: 256px;
+    max-width: 100%;
+    margin: 4px 0;
+    padding: 12px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-divider);
+    border-radius: 12px;
+    cursor: pointer;
+}
+.gic-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+.gic-avatar {
+    width: 40px;
+    height: 40px;
+    flex-shrink: 0;
+    border-radius: 8px;
+    font-size: 18px;
+    font-weight: 700;
+}
+.gic-titles {
+    min-width: 0;
+}
+.gic-eyebrow {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+}
+.gic-name {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.gic-about {
+    margin: 8px 0 0;
+    font-size: 12px;
+    color: var(--color-text-muted);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+.gic-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    width: 100%;
+    margin-top: 12px;
+}
+.gic-btn-chevron {
+    width: 15px;
+    height: 15px;
+}
+
 .group-link-card {
     display: flex;
     align-items: flex-start;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -1613,6 +1613,12 @@ body {
     gap: 2px;
 }
 
+/* Add-member "Send a DM invite" toggle: relay-check's look plus breathing room so it
+   doesn't sit flush against the input / scrollable friend list above it. */
+.modal-dm-check {
+    margin-top: 14px;
+}
+
 .group-side-banner-scrim {
     position: absolute;
     inset: auto 0 0 0;
@@ -9525,6 +9531,18 @@ body {
 .npage-group {
     font-weight: 500;
     color: var(--color-text-link);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    vertical-align: text-bottom;
+}
+
+/* Tiny group identity in the row header: the standard rounded-square group avatar. */
+.npage-group-avatar {
+    flex-shrink: 0;
+    width: 16px;
+    height: 16px;
+    border-radius: var(--radius-sm);
 }
 
 .npage-preview {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -1603,6 +1603,16 @@ body {
     background: var(--color-hover);
 }
 
+/* Add-member friend picker: scrollable follows list inside the modal. */
+.modal-friend-list {
+    margin-top: 8px;
+    max-height: 280px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
 .group-side-banner-scrim {
     position: absolute;
     inset: auto 0 0 0;

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -120,6 +120,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `GroupAvatarUploadRow` | webMain/kotlin/org/nostr/nostrord/web/components/GroupAvatarUploadRow.kt | Group avatar preview + "Change photo" upload. Shared by Create Group and Manage > Info so the |
 | `GroupInfoModal` | webMain/kotlin/org/nostr/nostrord/web/modals/GroupInfoModal.kt | Group info modal — prototype GroupInfoModal: title bar, gradient cover with the |
 | `GroupInviteCard` | webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt | DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name, |
+| `GroupInviteModal` | webMain/kotlin/org/nostr/nostrord/web/modals/GroupInviteModal.kt | The pending-invite prompt (web counterpart of GroupScreen's GroupInviteDialog), in the |
 | `IdentifierField` | webMain/kotlin/org/nostr/nostrord/web/components/IdentifierField.kt | [IdentifierRow] over the pubkey formats (npub / nprofile / nostrord link / |
 | `IdentifierRow` | webMain/kotlin/org/nostr/nostrord/web/components/IdentifierField.kt | Cycling identifier field (prototype IdentifierField, the .identifier-* OOCSS |
 | `ImageViewerHost` | webMain/kotlin/org/nostr/nostrord/web/components/ImageViewer.kt | Place once at the app root. Renders the fullscreen overlay whenever an image is open. |

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -18,13 +18,15 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `AppSearchField` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt | Standardized search / filter input (web `searchInput` over `.input-group`): floating surface with |
 | `AppSegmentedTabs` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt | Segmented pill tabs (web `.tab-strip` + `.tab`): floating container, brand pill on |
 | `AppTextField` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt | Prototype-styled input (web `.input-group` + `.input`): floating surface, |
-| `AudioPlayerContent` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/media/AudioPlayerContent.kt | Inline audio player with play/pause, progress bar, and duration. |
 | `AvatarPlaceholder` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/avatars/AvatarPlaceholder.kt | — |
 | `BunkerStatusBanner` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt | Floating warning shown when the active account signs through a NIP-46 bunker |
 | `ConfirmDialog` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ConfirmDialog.kt | The single confirm dialog for the native UI (Compose counterpart of the web `confirmDialog` |
 | `ConnectionStatusBanner` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ConnectionStatusBanner.kt | — |
 | `DateSeparator` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DateSeparator.kt | — |
 | `DmConversationList` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt | The DM conversation list plus its empty state, shared by [DmSidebar] (desktop column) and the |
+| `DmEventSourceDialog` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmEventSourceDialog.kt | "View source" for a DM: the decrypted kind:14 rumor as pretty JSON plus the relays |
+| `DmMessageContextMenu` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt | Context menu for a DM bubble: the group chat's [MessageContextMenu] shell (same popup, |
+| `DmRelaysDialog` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmRelaysDialog.kt | Where a peer's DMs route: their published kind:10050 relay list. Empty until the fetch lands, |
 | `DmSidebar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt | Second column on the DM section (prototype DMSidebar, obelisk-style): header with |
 | `EmojiCategoryBar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/emoji/EmojiCategoryBar.kt | — |
 | `EmojiPickerGrid` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/emoji/EmojiPickerGrid.kt | — |
@@ -44,6 +46,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `GroupCardSkeleton` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/loading/SkeletonLoader.kt | Skeleton loader for group cards on the home screen. |
 | `GroupCard` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/home/HomeCards.kt | Home page building blocks — Compose counterpart of the web's `.group-card` / |
 | `GroupGradientAvatar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/avatars/GradientAvatar.kt | Deterministic gradient fallback for group avatars (prototype gradientGroupAvatar): |
+| `GroupInviteCard` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt | DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name, |
 | `GroupSidebar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt | Second column when a group is open (prototype ChannelsSidebar group mode): the |
 | `GroupSidebar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/sidebars/GroupSidebar.kt | Channel sidebar for group screens. |
 | `GroupTypeBadges` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/GroupTypeBadges.kt | The NIP-29 access pills (kind:39000) with canonical tones, matching the web |
@@ -60,7 +63,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `MessageContextMenu` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt | Message context menu - appears on right-click (desktop) or long-press (mobile). |
 | `MessageItem` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt | Enhanced message item with grouping support. |
 | `MessageSelectionContainer` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageSelectionContainer.kt | Wraps [content] in a [SelectionContainer] only when [messagesTextSelectionEnabled]. |
-| `MessageStatusIndicator` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageStatusIndicator.kt | Optimistic-send status row shown under the author's own message. Sending: a muted "Sending..." |
+| `MessageStatusIndicator` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageStatusIndicator.kt | Failure row shown under the author's own message: the reason plus Retry / Dismiss. |
 | `MessageUploadButton` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt | Attach/upload button for the message input row. |
 | `MinimalTitleBar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/navigation/NavigationToolbar.kt | — |
 | `ModalTitleBar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ModalTitleBar.kt | Modal title bar (prototype Modal header): title + close button over a 1px |
@@ -76,6 +79,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `RelayGradientAvatar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/avatars/GradientAvatar.kt | Deterministic gradient fallback for relay avatars (prototype gradientRelayAvatar): a |
 | `ReplyPreview` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt | Compact reply preview shown above a message that is replying to another message. |
 | `RichAboutText` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/RichAboutText.kt | Renders an "about" text with clickable links and resolved nostr mentions. |
+| `SendStateIcon` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageStatusIndicator.kt | Inline send-state icon for the author's own message: a muted clock while Sending, a check |
 | `SkeletonCircle` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/loading/SkeletonLoader.kt | Generic skeleton circle for avatar placeholders. |
 | `SkeletonLine` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/loading/SkeletonLoader.kt | Generic skeleton line for text placeholders. |
 | `StepLabel` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/onboarding/OnboardingPieces.kt | Uppercase step label under the bars: "Step 1 of 2 · Welcome". |
@@ -97,21 +101,25 @@ delete the old one in the same change so the catalogue never lists a dead screen
 |---|---|---|
 | `AddAccountModal` | webMain/kotlin/org/nostr/nostrord/web/modals/AddAccountModal.kt | Add-account modal: the login page's tabbed credential picker ([LoginMethods]) inside a |
 | `AddGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/AddGroupModal.kt | Add-group chooser (prototype GroupModals 'chooser', opened by the rail "+"): pick |
-| `AddMemberModal` | webMain/kotlin/org/nostr/nostrord/web/modals/AddMemberModal.kt | Add-member modal — real port of the Compose AddMemberModal: an npub / hex pubkey field |
+| `AddMemberModal` | webMain/kotlin/org/nostr/nostrord/web/modals/AddMemberModal.kt | Add-member modal — real port of the Compose AddMemberModal: a searchable friend picker |
 | `AddRelayModal` | webMain/kotlin/org/nostr/nostrord/web/modals/AddRelayModal.kt | Add-relay modal — layout-first React port of the Compose [AddRelayModal]: a Suggested |
 | `AppLoading` | webMain/kotlin/org/nostr/nostrord/web/components/AppLoading.kt | Full-screen bootstrap / loading screen (brand spinner over a label): the React analogue of the |
 | `BunkerStatusBanner` | webMain/kotlin/org/nostr/nostrord/web/components/BunkerStatusBanner.kt | Floating banner shown when the active account signs through a NIP-46 bunker the |
+| `ChatAudio` | webMain/kotlin/org/nostr/nostrord/web/components/ChatAudio.kt | A chat inline audio clip. Renders the native <audio controls> element, which gives |
 | `ChatImage` | webMain/kotlin/org/nostr/nostrord/web/components/ChatImage.kt | A chat inline image. Opens fullscreen on click. For images that have transparency it samples |
 | `ChatMessageList` | webMain/kotlin/org/nostr/nostrord/web/components/ChatMessageList.kt | Non-virtualized chat list: renders every row as real DOM (history is bounded). |
 | `ChatVideo` | webMain/kotlin/org/nostr/nostrord/web/components/ChatVideo.kt | A chat inline video. |
 | `CreateGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt | Create-group modal — layout-first React port of the Compose [CreateGroupModal]: name, |
 | `CreateThreadModal` | webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt | Compose-a-new-thread modal (kind:11 root): an optional title plus the body, over the threads |
+| `DmEventSourceModal` | webMain/kotlin/org/nostr/nostrord/web/modals/DmEventSourceModal.kt | "View source" for a DM: the decrypted kind:14 rumor as pretty JSON plus the relays its |
+| `DmRelaysModal` | webMain/kotlin/org/nostr/nostrord/web/modals/DmRelaysModal.kt | Where a peer's DMs route: their published kind:10050 relay list. Empty until the fetch lands, |
 | `EmojiPicker` | webMain/kotlin/org/nostr/nostrord/web/components/EmojiPicker.kt | Emoji picker popover — mirrors the native EmojiPicker: search, category tabs, a recents row, |
 | `FollowAllButton` | webMain/kotlin/org/nostr/nostrord/web/components/FollowSuggestions.kt | "Follow all" action above a [FollowSuggestionCard] list. Publishes a single kind:3 |
 | `FollowSuggestionCard` | webMain/kotlin/org/nostr/nostrord/web/components/FollowSuggestions.kt | One "person to follow" row for the onboarding step and the Home "People" filter: |
 | `GeneratedKeyCard` | webMain/kotlin/org/nostr/nostrord/web/components/GeneratedKeyCard.kt | Generated private key panel shown after "Generate New Identity". Displays the |
 | `GroupAvatarUploadRow` | webMain/kotlin/org/nostr/nostrord/web/components/GroupAvatarUploadRow.kt | Group avatar preview + "Change photo" upload. Shared by Create Group and Manage > Info so the |
 | `GroupInfoModal` | webMain/kotlin/org/nostr/nostrord/web/modals/GroupInfoModal.kt | Group info modal — prototype GroupInfoModal: title bar, gradient cover with the |
+| `GroupInviteCard` | webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt | DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name, |
 | `IdentifierField` | webMain/kotlin/org/nostr/nostrord/web/components/IdentifierField.kt | [IdentifierRow] over the pubkey formats (npub / nprofile / nostrord link / |
 | `IdentifierRow` | webMain/kotlin/org/nostr/nostrord/web/components/IdentifierField.kt | Cycling identifier field (prototype IdentifierField, the .identifier-* OOCSS |
 | `ImageViewerHost` | webMain/kotlin/org/nostr/nostrord/web/components/ImageViewer.kt | Place once at the app root. Renders the fullscreen overlay whenever an image is open. |


### PR DESCRIPTION
Being added to a NIP-29 group (kind:9000) no longer auto-publishes the member's kind:10009: the add lands as a persisted pending invite, and the group screen prompts with a GROUP INVITE card - accept adopts it into the joined list, decline leaves (kind:9022 + durable marker), backdrop means decide later. Detection was rebuilt against live relay behavior (probed with nak): 0xchat-style relays reject bare-#p stored queries while their live broadcast ignores that rule, and a 39002's created_at is pinned at group creation, so the watch now pairs a [9000,39002] #p+since filter with a no-since [39002] #p membership sweep (the offline catch-up), and a #p+#h one-shot names the inviter. The courtesy DM on add gained a per-target default read from the target's public kind:10009 (already on the relay = in-app notification reaches them, DM off), and notification rows show the group's rounded-square avatar chip resolved live-first and relay-first.

The list-delivery side got the matching fixes: kind:10009 publishes set a needs-republish flag retried on every reconnect with the CURRENT list (never a stale snapshot - replaceable event), a standing own-10009 subscription converges open devices live, a consensus-gated self-heal un-poisons a freshness guard that outran reality, the join 9021 routes only to the group's own relay (a foreign OK used to mint a phantom joined+pending state), and leave/delete markers survive rejected joins. GROUP_ADD feed entries are capped at the watch's 7-day lookback so the sweep's months-old discoveries stay silent pending invites instead of fake news.

| Area | Change |
|---|---|
| Detection | dual-filter put-user watch + membership sweep; actor enrichment closed after EOSE; registration ahead of the member-list staleness guard |
| Invite lifecycle | persisted per account; re-add after leave re-opens (newer put-user clears the marker); creator echo and relay-key actors filtered; joined-by-any-path dissolves the invite; same-id replays silent |
| kind:10009 | reconnect republish retry, live cross-device sub, stale-guard self-heal (>=2 relays consensus), durable acceptance of network events |
| Join/Leave | 9021 only to the host relay, reconnecting it on demand; markers cleared only after the relay accepts |
| UI (both platforms) | GROUP INVITE card (Compose dialog + web modal in the DM card's .gic-* language); Add Member DM checkbox with smart default and "on this relay" tags; notification group chip; WebAvatar keeps the photo across seed changes; hint-less naddr renders as text, not a dead card |
| Upload | NIP-98 header propagates signer failures instead of a false "User not authenticated" |
| Tests | 660 green; jvm suite runs off the real OS keyring/prefs (dbus-java flake eliminated) |

Commits:
- 0eee61f0 feat(groups): consent-gate kind:9000 adds behind an accept/decline invite
- a8603d35 style: spotless import order in DmPageScreen and AddMemberModal
- e1786ccd fix(groups): reliable external-add detection and list delivery across relays
- b14b06e6 feat(groups): invite card prompt, smart DM default, notification group chip
- e979027a test(jvm): keep unit tests off the real OS keyring and prefs unlock state
- e4d766d4 fix(groups): live cross-device kind:10009 sync and stale-guard self-heal