### PR TITLE
feat(security): protect a plain-key account with a password after login

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SecurityViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SecurityViewModel.kt
@@ -11,17 +11,28 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.nostr.Nip49
+import org.nostr.nostrord.nostr.hexToByteArray
+import org.nostr.nostrord.nostr.ncryptsecStorageApplicable
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.clearPrivateKeyFor
 import org.nostr.nostrord.storage.getEncryptedPrivateKeyFor
+import org.nostr.nostrord.storage.getPrivateKeyFor
 import org.nostr.nostrord.storage.saveEncryptedPrivateKeyFor
 
 /**
- * Change the password of a password-protected (ncryptsec) account, shared by the web and native
- * Security settings so the two stay identical. An account logged in with an ncryptsec keeps only
- * that ncryptsec on disk and is unlocked per session; this rotates the password by decrypting the
- * stored ncryptsec with the current one (which also verifies it) and re-encrypting under the new
- * one (NIP-49). The underlying key never changes, so the running session is unaffected; the new
- * password applies at the next unlock.
+ * Password protection of the active account's key, shared by the web and native Security
+ * settings so the two stay identical.
+ *
+ * Two modes over the same fields:
+ *  - [changePassword] rotates the password of an already-protected (ncryptsec) account by
+ *    decrypting the stored ncryptsec with the current password (which also verifies it) and
+ *    re-encrypting under the new one (NIP-49). The underlying key never changes, so the
+ *    running session is unaffected; the new password applies at the next unlock.
+ *  - [protectWithPassword] opts a plain-key account into protection after the fact, where
+ *    [canProtect]: the stored key is wrapped as an ncryptsec and the plaintext slot is
+ *    dropped, exactly what the login-time "protect with a password" option does. Only
+ *    offered where plaintext at rest is the alternative ([ncryptsecStorageApplicable],
+ *    i.e. the web); platforms with secure storage don't need it.
  *
  * This is distinct from the desktop-only app-store passphrase ([org.nostr.nostrord.storage.PassphraseSettings]).
  *
@@ -31,10 +42,19 @@ class SecurityViewModel(
     private val pubkey: String? = AppModule.nostrRepository.getPublicKey(),
     private val readNcryptsec: (String) -> String? = { SecureStorage.getEncryptedPrivateKeyFor(it) },
     private val writeNcryptsec: (String, String) -> Unit = { pk, nc -> SecureStorage.saveEncryptedPrivateKeyFor(pk, nc) },
+    private val readPlainKey: (String) -> String? = { SecureStorage.getPrivateKeyFor(it) },
+    private val clearPlainKey: (String) -> Unit = { SecureStorage.clearPrivateKeyFor(it) },
+    private val protectApplicable: Boolean = ncryptsecStorageApplicable,
     private val cryptoDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
-    /** True when the active account stores its key as a password-protected ncryptsec. */
-    val isPasswordProtected: Boolean = pubkey?.let { readNcryptsec(it) != null } ?: false
+    private val _isPasswordProtected = MutableStateFlow(pubkey?.let { readNcryptsec(it) != null } ?: false)
+
+    /** True when the active account stores its key as a password-protected ncryptsec. Flips after [protectWithPassword]. */
+    val isPasswordProtected: StateFlow<Boolean> = _isPasswordProtected.asStateFlow()
+
+    /** True when the active account keeps a plain key at rest here and can opt into protection. */
+    val canProtect: Boolean
+        get() = pubkey != null && protectApplicable && !_isPasswordProtected.value && readPlainKey(pubkey) != null
 
     private val _current = MutableStateFlow("")
     val current: StateFlow<String> = _current.asStateFlow()
@@ -54,6 +74,11 @@ class SecurityViewModel(
     private val _success = MutableStateFlow(false)
     val success: StateFlow<Boolean> = _success.asStateFlow()
 
+    private val _successMessage = MutableStateFlow<String?>(null)
+
+    /** Feedback line for the last successful action; rendered below whichever form is showing. */
+    val successMessage: StateFlow<String?> = _successMessage.asStateFlow()
+
     fun setCurrent(value: String) = edit { _current.value = value }
 
     fun setNew(value: String) = edit { _new.value = value }
@@ -64,6 +89,7 @@ class SecurityViewModel(
         block()
         _error.value = null
         _success.value = false
+        _successMessage.value = null
     }
 
     fun changePassword() {
@@ -106,9 +132,58 @@ class SecurityViewModel(
                         _new.value = ""
                         _confirm.value = ""
                         _success.value = true
+                        _successMessage.value = "Password changed."
                     }
                 },
                 onFailure = { _error.value = "Could not change the password." },
+            )
+        }
+    }
+
+    /**
+     * Protect the active plain-key account with a password: wraps the stored key as an
+     * ncryptsec (NIP-49) under [new] and drops the plaintext slot. The running session
+     * keeps its in-memory key; the password is required from the next session restore on.
+     */
+    fun protectWithPassword() {
+        if (_busy.value) return
+        val pk = pubkey
+        val hex = pk?.let { readPlainKey(it) }
+        if (pk == null || hex == null || _isPasswordProtected.value) {
+            _error.value = "There is no plain key to protect on this device."
+            return
+        }
+        val nw = _new.value
+        if (nw.length < MIN_PASSPHRASE) {
+            _error.value = "Use at least $MIN_PASSPHRASE characters."
+            return
+        }
+        if (nw != _confirm.value) {
+            _error.value = "The passwords do not match."
+            return
+        }
+        _error.value = null
+        _success.value = false
+        _busy.value = true
+        viewModelScope.launch {
+            val result =
+                withContext(cryptoDispatcher) {
+                    runCatching { Nip49.encrypt(hex.hexToByteArray(), nw) }
+                }
+            _busy.value = false
+            result.fold(
+                onSuccess = { ncryptsec ->
+                    // Encrypted slot first, plaintext drop second: a crash in between
+                    // leaves both readable rather than neither.
+                    writeNcryptsec(pk, ncryptsec)
+                    clearPlainKey(pk)
+                    _new.value = ""
+                    _confirm.value = ""
+                    _isPasswordProtected.value = true
+                    _success.value = true
+                    _successMessage.value = "Password set. It will be asked for the next time the app starts."
+                },
+                onFailure = { _error.value = "Could not protect the key." },
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SecurityViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/SecurityViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip49
 import org.nostr.nostrord.nostr.hexToByteArray
 import org.nostr.nostrord.nostr.ncryptsecStorageApplicable
@@ -44,6 +45,8 @@ class SecurityViewModel(
     private val writeNcryptsec: (String, String) -> Unit = { pk, nc -> SecureStorage.saveEncryptedPrivateKeyFor(pk, nc) },
     private val readPlainKey: (String) -> String? = { SecureStorage.getPrivateKeyFor(it) },
     private val clearPlainKey: (String) -> Unit = { SecureStorage.clearPrivateKeyFor(it) },
+    private val readLegacyPlainKey: () -> String? = { SecureStorage.getPrivateKey() },
+    private val clearLegacyPlainKey: () -> Unit = { SecureStorage.clearPrivateKey() },
     private val protectApplicable: Boolean = ncryptsecStorageApplicable,
     private val cryptoDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ViewModel() {
@@ -54,7 +57,20 @@ class SecurityViewModel(
 
     /** True when the active account keeps a plain key at rest here and can opt into protection. */
     val canProtect: Boolean
-        get() = pubkey != null && protectApplicable && !_isPasswordProtected.value && readPlainKey(pubkey) != null
+        get() =
+            pubkey != null &&
+                protectApplicable &&
+                !_isPasswordProtected.value &&
+                (readPlainKey(pubkey) != null || legacyPlainKeyFor(pubkey) != null)
+
+    /**
+     * The legacy single-slot plain key, only when it derives [pubkey]. Session restore falls
+     * back to this slot (AuthManager.useAccount), so protection must wrap and clear it too or
+     * the account keeps restoring without a password.
+     */
+    private fun legacyPlainKeyFor(pubkey: String): String? = readLegacyPlainKey()?.takeIf {
+        runCatching { KeyPair.fromPrivateKeyHex(it).publicKeyHex }.getOrNull() == pubkey
+    }
 
     private val _current = MutableStateFlow("")
     val current: StateFlow<String> = _current.asStateFlow()
@@ -148,7 +164,7 @@ class SecurityViewModel(
     fun protectWithPassword() {
         if (_busy.value) return
         val pk = pubkey
-        val hex = pk?.let { readPlainKey(it) }
+        val hex = pk?.let { readPlainKey(it) ?: legacyPlainKeyFor(it) }
         if (pk == null || hex == null || _isPasswordProtected.value) {
             _error.value = "There is no plain key to protect on this device."
             return
@@ -177,6 +193,7 @@ class SecurityViewModel(
                     // leaves both readable rather than neither.
                     writeNcryptsec(pk, ncryptsec)
                     clearPlainKey(pk)
+                    if (legacyPlainKeyFor(pk) != null) clearLegacyPlainKey()
                     _new.value = ""
                     _confirm.value = ""
                     _isPasswordProtected.value = true

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/SecurityViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/SecurityViewModelTest.kt
@@ -34,19 +34,25 @@ class SecurityViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private class Store(var ncryptsec: String?)
+    private class Store(var ncryptsec: String?, var plainKey: String? = null)
 
-    private fun vm(store: Store): SecurityViewModel = SecurityViewModel(
+    private fun vm(
+        store: Store,
+        protectApplicable: Boolean = true,
+    ): SecurityViewModel = SecurityViewModel(
         pubkey = pubHex,
         readNcryptsec = { store.ncryptsec },
         writeNcryptsec = { _, nc -> store.ncryptsec = nc },
+        readPlainKey = { store.plainKey },
+        clearPlainKey = { store.plainKey = null },
+        protectApplicable = protectApplicable,
         cryptoDispatcher = testDispatcher,
     )
 
     @Test
     fun `isPasswordProtected reflects whether an ncryptsec is stored`() {
-        assertTrue(vm(Store(Nip49.encrypt(privBytes, oldPassword))).isPasswordProtected)
-        assertFalse(vm(Store(null)).isPasswordProtected)
+        assertTrue(vm(Store(Nip49.encrypt(privBytes, oldPassword))).isPasswordProtected.value)
+        assertFalse(vm(Store(null)).isPasswordProtected.value)
     }
 
     @Test
@@ -100,5 +106,55 @@ class SecurityViewModelTest {
         model.setConfirm("short")
         model.changePassword()
         assertTrue(model.error.value != null)
+    }
+
+    @Test
+    fun `canProtect only for a plain key on an applicable platform`() {
+        val plainHex = privBytes.toHexString()
+        assertTrue(vm(Store(ncryptsec = null, plainKey = plainHex)).canProtect)
+        assertFalse(vm(Store(ncryptsec = null, plainKey = plainHex), protectApplicable = false).canProtect)
+        assertFalse(vm(Store(ncryptsec = null, plainKey = null)).canProtect)
+        assertFalse(vm(Store(ncryptsec = Nip49.encrypt(privBytes, oldPassword), plainKey = plainHex)).canProtect)
+    }
+
+    @Test
+    fun `protect encrypts the plain key, drops the plaintext slot and flips protected`() = runTest {
+        val store = Store(ncryptsec = null, plainKey = privBytes.toHexString())
+        val model = vm(store)
+        model.setNew("a brand new password")
+        model.setConfirm("a brand new password")
+        model.protectWithPassword()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(model.success.value)
+        assertNull(model.error.value)
+        assertTrue(model.isPasswordProtected.value)
+        assertFalse(model.canProtect)
+        assertNull(store.plainKey)
+        assertTrue(Nip49.decrypt(store.ncryptsec!!, "a brand new password").contentEquals(privBytes))
+    }
+
+    @Test
+    fun `protect rejects a mismatched confirmation and keeps the plain key`() {
+        val store = Store(ncryptsec = null, plainKey = privBytes.toHexString())
+        val model = vm(store)
+        model.setNew("a brand new password")
+        model.setConfirm("different")
+        model.protectWithPassword()
+        assertEquals("The passwords do not match.", model.error.value)
+        assertNull(store.ncryptsec)
+        assertTrue(store.plainKey != null)
+    }
+
+    @Test
+    fun `protect is refused when already protected`() {
+        val original = Nip49.encrypt(privBytes, oldPassword)
+        val store = Store(ncryptsec = original, plainKey = null)
+        val model = vm(store)
+        model.setNew("a brand new password")
+        model.setConfirm("a brand new password")
+        model.protectWithPassword()
+        assertTrue(model.error.value != null)
+        assertEquals(original, store.ncryptsec)
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/SecurityViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/SecurityViewModelTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip49
 import org.nostr.nostrord.ui.screens.settings.SecurityViewModel
 import kotlin.test.AfterTest
@@ -19,8 +20,11 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
 class SecurityViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
-    private val pubHex = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
-    private val privBytes = "67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa".hexToByteArray()
+    private val privHex = "67dea2ed018072d675f5415ecfaed7d2597555e202d85b3d65ea4e58d2d92ffa"
+    private val privBytes = privHex.hexToByteArray()
+
+    // Derived, not hardcoded: the legacy-slot guard only clears a key that derives this pubkey.
+    private val pubHex = KeyPair.fromPrivateKeyHex(privHex).publicKeyHex
     private val oldPassword = "old password"
 
     @BeforeTest
@@ -34,7 +38,11 @@ class SecurityViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private class Store(var ncryptsec: String?, var plainKey: String? = null)
+    private class Store(
+        var ncryptsec: String?,
+        var plainKey: String? = null,
+        var legacyKey: String? = null,
+    )
 
     private fun vm(
         store: Store,
@@ -45,6 +53,8 @@ class SecurityViewModelTest {
         writeNcryptsec = { _, nc -> store.ncryptsec = nc },
         readPlainKey = { store.plainKey },
         clearPlainKey = { store.plainKey = null },
+        readLegacyPlainKey = { store.legacyKey },
+        clearLegacyPlainKey = { store.legacyKey = null },
         protectApplicable = protectApplicable,
         cryptoDispatcher = testDispatcher,
     )
@@ -132,6 +142,48 @@ class SecurityViewModelTest {
         assertFalse(model.canProtect)
         assertNull(store.plainKey)
         assertTrue(Nip49.decrypt(store.ncryptsec!!, "a brand new password").contentEquals(privBytes))
+    }
+
+    @Test
+    fun `protect also clears the legacy global slot so restore cannot bypass the password`() = runTest {
+        val plainHex = privBytes.toHexString()
+        val store = Store(ncryptsec = null, plainKey = plainHex, legacyKey = plainHex)
+        val model = vm(store)
+        model.setNew("a brand new password")
+        model.setConfirm("a brand new password")
+        model.protectWithPassword()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(model.success.value)
+        assertNull(store.plainKey)
+        assertNull(store.legacyKey)
+        assertTrue(Nip49.decrypt(store.ncryptsec!!, "a brand new password").contentEquals(privBytes))
+    }
+
+    @Test
+    fun `protect covers a key present only in the legacy slot and spares another account's`() = runTest {
+        // Another account's key in the legacy slot must survive untouched.
+        val otherKey = "0000000000000000000000000000000000000000000000000000000000000001"
+        val storeOther = Store(ncryptsec = null, plainKey = privBytes.toHexString(), legacyKey = otherKey)
+        val modelOther = vm(storeOther)
+        modelOther.setNew("a brand new password")
+        modelOther.setConfirm("a brand new password")
+        modelOther.protectWithPassword()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(modelOther.success.value)
+        assertEquals(otherKey, storeOther.legacyKey)
+
+        // Legacy-only residue (per-account slot empty) is still protectable.
+        val storeLegacyOnly = Store(ncryptsec = null, plainKey = null, legacyKey = privBytes.toHexString())
+        val model = vm(storeLegacyOnly)
+        assertTrue(model.canProtect)
+        model.setNew("a brand new password")
+        model.setConfirm("a brand new password")
+        model.protectWithPassword()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(model.success.value)
+        assertNull(storeLegacyOnly.legacyKey)
+        assertTrue(Nip49.decrypt(storeLegacyOnly.ncryptsec!!, "a brand new password").contentEquals(privBytes))
     }
 
     @Test

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -1354,9 +1354,13 @@ private fun SecurityPanelContent() {
         verticalArrangement = Arrangement.spacedBy(Spacing.lg),
     ) {
         // ncryptsec accounts are unlocked per session and own a rotatable password, independent
-        // of the desktop app-store passphrase handled below.
-        if (accountSecurity.isPasswordProtected) {
+        // of the desktop app-store passphrase handled below. Plain-key accounts on platforms
+        // without secure storage can opt into that protection here (web-only in practice).
+        val isProtected by accountSecurity.isPasswordProtected.collectAsState()
+        if (isProtected) {
             ChangeAccountPasswordForm(accountSecurity)
+        } else if (accountSecurity.canProtect) {
+            ProtectAccountPasswordForm(accountSecurity)
         }
         AppPassphraseContent()
     }
@@ -1411,7 +1415,7 @@ private fun ChangeAccountPasswordForm(vm: SecurityViewModel) {
     val confirm by vm.confirm.collectAsState()
     val busy by vm.busy.collectAsState()
     val error by vm.error.collectAsState()
-    val success by vm.success.collectAsState()
+    val successMessage by vm.successMessage.collectAsState()
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -1465,21 +1469,84 @@ private fun ChangeAccountPasswordForm(vm: SecurityViewModel) {
             }
         }
 
-        if (success) {
-            Card(
-                colors = CardDefaults.cardColors(containerColor = NostrordColors.Success),
-                shape = RoundedCornerShape(8.dp),
-                modifier = Modifier.fillMaxWidth(),
+        successMessage?.let { SecuritySuccessCard(it) }
+    }
+}
+
+@Composable
+private fun SecuritySuccessCard(text: String) {
+    Card(
+        colors = CardDefaults.cardColors(containerColor = NostrordColors.Success),
+        shape = RoundedCornerShape(8.dp),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                Icons.Default.Check,
+                contentDescription = null,
+                tint = Color.White,
+                modifier = Modifier.size(16.dp),
+            )
+            Spacer(Modifier.width(8.dp))
+            Text(text, color = Color.White, fontWeight = FontWeight.Bold)
+        }
+    }
+}
+
+@Composable
+private fun ProtectAccountPasswordForm(vm: SecurityViewModel) {
+    val new by vm.new.collectAsState()
+    val confirm by vm.confirm.collectAsState()
+    val busy by vm.busy.collectAsState()
+    val error by vm.error.collectAsState()
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.lg),
+    ) {
+        InfoCard(
+            title = "Protect your key",
+            titleColor = NostrordColors.Warning,
+            icon = Icons.Default.Key,
+            content = "Your private key is stored unencrypted on this device. Set a password to keep it " +
+                "encrypted at rest (NIP-49); you will be asked for it when the app starts. It cannot be " +
+                "recovered if you forget it.",
+            isCompact = false,
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = NostrordShapes.cardShape,
+            colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(Spacing.xl),
+                verticalArrangement = Arrangement.spacedBy(Spacing.lg),
             ) {
-                Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        Icons.Default.Check,
-                        contentDescription = null,
-                        tint = Color.White,
-                        modifier = Modifier.size(16.dp),
-                    )
-                    Spacer(Modifier.width(8.dp))
-                    Text("Password changed", color = Color.White, fontWeight = FontWeight.Bold)
+                PassphraseField("Password", new) { vm.setNew(it) }
+                PassphraseField("Confirm password", confirm) { vm.setConfirm(it) }
+
+                Text(
+                    text = "At least 6 characters. Must match.",
+                    style = NostrordTypography.Caption,
+                    color = NostrordColors.TextSecondary,
+                )
+
+                error?.let {
+                    Text(text = it, style = NostrordTypography.MessageBody, color = NostrordColors.Error)
+                }
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(
+                        onClick = { vm.protectWithPassword() },
+                        enabled = !busy && new.isNotEmpty() && confirm.isNotEmpty(),
+                    ) {
+                        Text(
+                            if (busy) "Encrypting…" else "Set password",
+                            color = NostrordColors.Primary,
+                            style = NostrordTypography.Button,
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -986,9 +986,10 @@ private val SecurityPanel =
         val confirm = useStateFlow(vm.confirm)
         val busy = useStateFlow(vm.busy)
         val error = useStateFlow(vm.error)
-        val success = useStateFlow(vm.success)
+        val successMessage = useStateFlow(vm.successMessage)
+        val isProtected = useStateFlow(vm.isPasswordProtected)
 
-        if (vm.isPasswordProtected) {
+        if (isProtected) {
             // The active account is unlocked per session from a stored ncryptsec; let the user
             // rotate that password (the key itself is unchanged).
             div {
@@ -1010,10 +1011,10 @@ private val SecurityPanel =
                         +it
                     }
                 }
-                if (success) {
+                successMessage?.let {
                     div {
                         className = ClassName("settings-success")
-                        +"Password changed."
+                        +it
                     }
                 }
                 button {
@@ -1021,6 +1022,38 @@ private val SecurityPanel =
                     disabled = busy || current.isEmpty() || newPassword.isEmpty() || confirm.isEmpty()
                     onClick = { vm.changePassword() }
                     +(if (busy) "Saving…" else "Change password")
+                }
+            }
+        } else if (vm.canProtect) {
+            // Plain key at rest (the web default): offer the same protect-with-password
+            // option the login screen has, after the fact.
+            div {
+                className = ClassName("settings-card")
+                div {
+                    className = ClassName("settings-section-head")
+                    +"PROTECT YOUR KEY"
+                }
+                div {
+                    className = ClassName("settings-tip")
+                    +(
+                        "Your private key is stored unencrypted in this browser. Set a password to keep it " +
+                            "encrypted at rest (NIP-49); you will be asked for it when the app starts. " +
+                            "It cannot be recovered if you forget it."
+                        )
+                }
+                passwordField("Password", newPassword) { vm.setNew(it) }
+                passwordField("Confirm password", confirm) { vm.setConfirm(it) }
+                error?.let {
+                    div {
+                        className = ClassName("settings-error")
+                        +it
+                    }
+                }
+                button {
+                    className = ClassName("settings-outline-btn")
+                    disabled = busy || newPassword.isEmpty() || confirm.isEmpty()
+                    onClick = { vm.protectWithPassword() }
+                    +(if (busy) "Encrypting…" else "Set password")
                 }
             }
         } else {


### PR DESCRIPTION
Settings > Security only offered password rotation for accounts already protected at login; an account logged in with a plain nsec kept the key unencrypted in browser storage forever, with no way to opt in later. SecurityViewModel gains a protect mode (offered where ncryptsec at rest applies, i.e. the web): the stored key is wrapped as a NIP-49 ncryptsec, every plaintext slot is dropped, and the password is required from the next session restore on. Both UIs render the form over the same shared ViewModel.

The follow-up fix covers the legacy global key slot: plain-key login writes the key to the per-account slot AND the legacy single slot, and session restore falls back to the latter, so dropping only the per-account slot let a reload restore the session without asking the password (and left the plaintext key behind). Protect now reads/clears the legacy slot too, guarded by pubkey derivation so another account's legacy key is untouched.

| Area | Change |
| --- | --- |
| `SecurityViewModel` (commonMain) | `canProtect` + `protectWithPassword()`; legacy-slot fallback with pubkey-derivation guard; unified `successMessage` |
| Settings > Security (Compose + web) | "Protect with a password" form for plain-key accounts |
| Tests | protect happy path, guards, legacy-slot clearing, other-account legacy key spared, legacy-only residue |

Commits:
- 1f39e75c feat(security): protect a plain-key account with a password after login
- 88726ea3 fix(security): clear the legacy global key slot when protecting with a password