### PR TITLE
feat(web): redirect naddr group links to the group hash route

### DIFF
--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/main.kt
@@ -6,6 +6,7 @@ import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.toHash
+import org.nostr.nostrord.utils.parseGroupJoinInput
 import org.nostr.nostrord.utils.toRelayUrl
 import org.nostr.nostrord.web.WebApp
 import org.nostr.nostrord.web.bridge.launchApp
@@ -16,6 +17,39 @@ import react.create
 import react.dom.client.createRoot
 import web.dom.ElementId
 import web.dom.document
+
+/**
+ * People share groups as https://web.nostrord.com/<naddr1...> (or the hash variant
+ * /#/naddr1...). The hosting layer keeps the path form alive (sw.js serves index.html on
+ * 404; 404.html's ?/ redirect covers the first, uncontrolled visit; historyApiFallback on
+ * the dev server), so the app boots with the naddr as the last path segment or in the
+ * hash. Decode it (kind 39000 + relay hint, via parseGroupJoinInput) and rewrite to the
+ * canonical #/g/<relay>/<id>[?invite=Z] hash route before render. Undecodable naddrs
+ * fall through.
+ */
+private fun redirectNaddrPath() {
+    val path = window.location.pathname.trimEnd('/')
+    val pathSegment = path.substringAfterLast('/')
+    val hashSegment = window.location.hash.trimStart('#', '/').substringBefore('?')
+    val segment =
+        when {
+            pathSegment.startsWith("naddr1") -> pathSegment
+            hashSegment.startsWith("naddr1") -> hashSegment
+            else -> return
+        }
+    val target = parseGroupJoinInput(segment) ?: return
+    // ?invite=Z rides either the real query (/naddr1...?invite=Z) or the hash's own
+    // query (#/naddr1...?invite=Z).
+    val query = window.location.search.removePrefix("?").ifBlank { window.location.hash.substringAfter('?', "") }
+    val invite =
+        query.split("&")
+            .firstOrNull { it.startsWith("invite=") }
+            ?.substringAfter('=')?.takeIf { it.isNotBlank() }
+    val route = GroupRoute(relayUrl = target.relayUrl, groupId = target.groupId, inviteCode = invite)
+    // Hash form leaves the path untouched; path form strips the naddr segment.
+    val base = path.removeSuffix(segment).ifEmpty { "/" }
+    window.history.replaceState(null, "", base + route.toHash())
+}
 
 /**
  * Parse URL query parameters for deep linking.
@@ -101,6 +135,7 @@ fun main() {
     // theme preference so a light-theme user doesn't get a dark first paint.
     applyTheme(AppModule.appearanceSettings.theme.value)
     applyDimenTokens()
+    redirectNaddrPath()
     parseDeepLinkFromUrl()
     val container =
         document.getElementById(ElementId("composeApplication"))

--- a/composeApp/src/webMain/resources/404.html
+++ b/composeApp/src/webMain/resources/404.html
@@ -8,7 +8,9 @@
         // Preserves the path so the SPA can handle routing
         // Based on: https://github.com/rafgraph/spa-github-pages
 
-        const pathSegmentsToKeep = 1; // Keep repo name in path (e.g., /repo-name/)
+        // 0: site is served at the domain root (web.nostrord.com). A value of 1 (repo-name
+        // subpath hosting) keeps the unknown segment in the path and redirect-loops on 404.
+        const pathSegmentsToKeep = 0;
 
         const l = window.location;
         const path = l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +

--- a/composeApp/webpack.config.d/spa-fallback.js
+++ b/composeApp/webpack.config.d/spa-fallback.js
@@ -1,0 +1,6 @@
+// Dev-server SPA fallback: deep-link paths like /naddr1... must serve index.html so the
+// app boots and rewrites them to the #/g/ hash route. Production equivalent: sw.js serves
+// index.html on 404 + 404.html's ?/ redirect for the first, uncontrolled visit.
+if (config.devServer) {
+    config.devServer.historyApiFallback = true
+}


### PR DESCRIPTION
People share groups as `https://web.nostrord.com/<naddr1...>`, which today dead-ends (redirect loop in production, "Cannot GET" on the dev server). This makes both the path form (`/naddr1...`) and the hash form (`#/naddr1...`) resolve to the canonical `#/g/<relay>/<id>` route before render, reusing `parseGroupJoinInput` (kind 39000 + relay hint required; anything else falls through to a normal boot). An `?invite=Z` suffix is carried into the route on either form.

| File | Change |
|---|---|
| `webMain/main.kt` | Boot-time redirect: naddr in path or hash rewritten to `#/g/<relay>/<id>[?invite=Z]` |
| `404.html` | `pathSegmentsToKeep` 1 -> 0: on the root-served custom domain the old value redirect-looped instead of reaching `index.html` |
| `webpack.config.d/spa-fallback.js` | Dev server `historyApiFallback` so deep-link paths serve `index.html` locally |

With a service worker installed the 404.html hop is skipped entirely (sw.js already serves `index.html` on 404 with the URL preserved).

Commits:
- 0d8a1cbf feat(web): redirect naddr group links to the group hash route

Verified with `compileKotlinJs` + `compileKotlinJvm`; tested locally against `naddr1qqxxkam0x...` (chat.wisp.talk / kwo1rv4arl8t).