### PR TITLE
Treat same-id groups on different relays as distinct groups

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -1828,6 +1828,13 @@ class NostrGroupClient(
         val createdAt: Long,
         val kind: Int,
         val tags: List<List<String>> = emptyList(),
+        /**
+         * Relay that delivered (or will receive) this event, normalized. Not part of the
+         * NIP-01 event: it scopes readers of the shared bare-id message buckets, because
+         * the same group id on two relays is two independent groups. Null when the origin
+         * is unknown (pre-tag construction sites); such messages show everywhere.
+         */
+        val relayUrl: String? = null,
     )
 
     @Immutable

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -415,9 +415,12 @@ class NostrRepository(
     // NIP-57 zap totals per zapped event id.
     override val zaps: StateFlow<Map<String, ZapManager.ZapInfo>> = zapManager.zaps
     override val groupMembers: StateFlow<Map<String, List<String>>> = groupManager.groupMembers
+    override val groupMembersByRelay: StateFlow<Map<String, Map<String, List<String>>>> = groupManager.groupMembersByRelay
     override val pendingApprovalSince: StateFlow<Map<String, Long>> = groupManager.pendingApprovalSince
     override val groupAdmins: StateFlow<Map<String, List<String>>> = groupManager.groupAdmins
+    override val groupAdminsByRelay: StateFlow<Map<String, Map<String, List<String>>>> = groupManager.groupAdminsByRelay
     override val groupRoles: StateFlow<Map<String, List<RoleDefinition>>> = groupManager.groupRoles
+    override val groupRolesByRelay: StateFlow<Map<String, Map<String, List<RoleDefinition>>>> = groupManager.groupRolesByRelay
     override val loadingMembers: StateFlow<Set<String>> = groupManager.loadingMembers
     override val restrictedGroups: StateFlow<Map<String, String>> = groupManager.restrictedGroups
     override val leftGroups: StateFlow<Set<String>> = groupManager.leftGroups
@@ -4859,13 +4862,13 @@ class NostrRepository(
                     39001 -> {
                         val groupAdmins = client.parseGroupAdmins(event) ?: return
                         val createdAt = event["created_at"]?.jsonPrimitive?.long ?: 0L
-                        groupManager.handleGroupAdmins(groupAdmins, createdAt)
+                        groupManager.handleGroupAdmins(groupAdmins, createdAt, client.getRelayUrl())
                     }
 
                     39003 -> {
                         val groupRoles = client.parseGroupRoles(event) ?: return
                         val createdAt = event["created_at"]?.jsonPrimitive?.long ?: 0L
-                        groupManager.handleGroupRoles(groupRoles, createdAt)
+                        groupManager.handleGroupRoles(groupRoles, createdAt, client.getRelayUrl())
                     }
 
                     9008 -> {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -3595,6 +3595,11 @@ class NostrRepository(
 
     override fun getMessagesForGroup(groupId: String): List<NostrGroupClient.NostrMessage> = groupManager.getMessagesForGroup(groupId)
 
+    override fun setGroupRelayHint(
+        groupId: String,
+        relayUrl: String,
+    ) = groupManager.setGroupRelayHint(groupId, relayUrl)
+
     // Unread message operations
     override fun markGroupAsRead(groupId: String) {
         unreadManager.markAsRead(groupId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -612,6 +612,16 @@ interface NostrRepositoryApi {
 
     fun getMessagesForGroup(groupId: String): List<NostrGroupClient.NostrMessage>
 
+    /**
+     * Pin [groupId]'s relay routing to [relayUrl] (the relay the open route carried).
+     * The same id can name independent groups on two relays; without the hint the
+     * repo resolves the relay by scanning and can pick the wrong one.
+     */
+    fun setGroupRelayHint(
+        groupId: String,
+        relayUrl: String,
+    )
+
     fun markGroupAsRead(groupId: String)
 
     /** Advance the last-read timestamp for partial-read tracking. See UnreadManager.markAsReadUpTo. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -112,10 +112,19 @@ interface NostrRepositoryApi {
     val zaps: StateFlow<Map<String, ZapManager.ZapInfo>>
     val groupMembers: StateFlow<Map<String, List<String>>>
 
+    /**
+     * Per-relay mirror of the member/admin/role lists (relay -> groupId -> list). The flat
+     * maps above collapse by bare id (last relay wins on a same-id collision); relay-scoped
+     * readers prefer these.
+     */
+    val groupMembersByRelay: StateFlow<Map<String, Map<String, List<String>>>>
+
     /** groupId -> epochMillis of our outstanding kind:9021 join request awaiting approval. */
     val pendingApprovalSince: StateFlow<Map<String, Long>>
     val groupAdmins: StateFlow<Map<String, List<String>>>
+    val groupAdminsByRelay: StateFlow<Map<String, Map<String, List<String>>>>
     val groupRoles: StateFlow<Map<String, List<RoleDefinition>>>
+    val groupRolesByRelay: StateFlow<Map<String, Map<String, List<RoleDefinition>>>>
     val loadingMembers: StateFlow<Set<String>>
 
     /** Groups whose subscriptions were CLOSED with "restricted" — private group, non-member. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -546,6 +546,43 @@ class GroupManager(
     private val adminEventTimestamps = mutableMapOf<String, Long>()
     private val roleEventTimestamps = mutableMapOf<String, Long>()
 
+    // Per-relay mirror of the kind:39001/2/3 lists (relay -> groupId -> list). The flat
+    // maps above stay the compat view where the last relay to publish wins on an id
+    // collision; relay-scoped readers (GroupViewModel with a host relay, home cards)
+    // prefer these so same-id groups on two relays don't overwrite each other's lists.
+    private val _groupMembersByRelay = MutableStateFlow<Map<String, Map<String, List<String>>>>(emptyMap())
+    val groupMembersByRelay: StateFlow<Map<String, Map<String, List<String>>>> = _groupMembersByRelay.asStateFlow()
+    private val _groupAdminsByRelay = MutableStateFlow<Map<String, Map<String, List<String>>>>(emptyMap())
+    val groupAdminsByRelay: StateFlow<Map<String, Map<String, List<String>>>> = _groupAdminsByRelay.asStateFlow()
+    private val _groupRolesByRelay = MutableStateFlow<Map<String, Map<String, List<RoleDefinition>>>>(emptyMap())
+    val groupRolesByRelay: StateFlow<Map<String, Map<String, List<RoleDefinition>>>> = _groupRolesByRelay.asStateFlow()
+
+    // Per-(relay, group) staleness guards for the mirrors: the flat guards are bare-id,
+    // so one relay's newer event must not get the other relay's list rejected as stale.
+    private val scopedMemberEventTimestamps = mutableMapOf<String, Long>()
+    private val scopedAdminEventTimestamps = mutableMapOf<String, Long>()
+    private val scopedRoleEventTimestamps = mutableMapOf<String, Long>()
+
+    /** Write one relay's kind:39001/2/3 list into its per-relay mirror, under its own guard. */
+    private fun <T> updateRelayScopedList(
+        flow: MutableStateFlow<Map<String, Map<String, T>>>,
+        guards: MutableMap<String, Long>,
+        relayUrl: String?,
+        groupId: String,
+        createdAt: Long,
+        value: T,
+    ) {
+        val relay = relayUrl?.normalizeRelayUrl() ?: return
+        val key = "$relay|$groupId"
+        val existing = guards[key] ?: 0L
+        if (createdAt > 0L && createdAt < existing) return
+        if (createdAt > 0L) guards[key] = createdAt
+        flow.update { byRelay ->
+            val forRelay = byRelay[relay].orEmpty()
+            if (forRelay[groupId] == value) byRelay else byRelay + (relay to (forRelay + (groupId to value)))
+        }
+    }
+
     // Groups whose subscriptions were closed with "restricted" by the relay.
     // For private groups, the relay denies access to non-members (including metadata).
     // The UI uses this to show a "Private Group" placeholder with invite code input.
@@ -3684,6 +3721,9 @@ class GroupManager(
             _loadingMembers.value = _loadingMembers.value - members.groupId
             return emptyList()
         }
+        // Before the flat guard: a same-id group on another relay may carry a newer
+        // timestamp there, which must not starve THIS relay's mirror.
+        updateRelayScopedList(_groupMembersByRelay, scopedMemberEventTimestamps, relayUrl, members.groupId, createdAt, members.members)
         val existing = memberEventTimestamps[members.groupId] ?: 0L
         if (createdAt > 0L && createdAt < existing) {
             // Stale event from a slower relay — skip state update.
@@ -4060,8 +4100,9 @@ class GroupManager(
     /**
      * Handle incoming group admins (kind 39001)
      */
-    fun handleGroupAdmins(admins: GroupAdmins, createdAt: Long = 0L) {
+    fun handleGroupAdmins(admins: GroupAdmins, createdAt: Long = 0L, relayUrl: String? = null) {
         if (isRecentlyLeft(admins.groupId)) return
+        updateRelayScopedList(_groupAdminsByRelay, scopedAdminEventTimestamps, relayUrl, admins.groupId, createdAt, admins.admins)
         val existing = adminEventTimestamps[admins.groupId] ?: 0L
         if (createdAt > 0L && createdAt < existing) {
             connStats?.onStateConflict(admins.groupId)
@@ -4104,8 +4145,9 @@ class GroupManager(
     /**
      * Handle incoming group roles (kind 39003)
      */
-    fun handleGroupRoles(roles: GroupRoles, createdAt: Long = 0L) {
+    fun handleGroupRoles(roles: GroupRoles, createdAt: Long = 0L, relayUrl: String? = null) {
         if (isRecentlyLeft(roles.groupId)) return
+        updateRelayScopedList(_groupRolesByRelay, scopedRoleEventTimestamps, relayUrl, roles.groupId, createdAt, roles.roles)
         val existing = roleEventTimestamps[roles.groupId] ?: 0L
         if (createdAt > 0L && createdAt < existing) {
             connStats?.onStateConflict(roles.groupId)
@@ -4183,6 +4225,25 @@ class GroupManager(
                 discardPendingInvite(groupId)
             }
         }
+        // Mirror the add/remove into the per-relay record under its own scoped guard,
+        // before the flat guard below (which a same-id group elsewhere can inflate).
+        if (relayUrl != null && (message.kind == 9000 || message.kind == 9001)) {
+            val relay = relayUrl.normalizeRelayUrl()
+            val scopedTs = scopedMemberEventTimestamps["$relay|$groupId"] ?: 0L
+            if (message.createdAt > scopedTs) {
+                _groupMembersByRelay.update { byRelay ->
+                    val forRelay = byRelay[relay] ?: return@update byRelay
+                    val members = forRelay[groupId] ?: return@update byRelay
+                    val updated = when {
+                        message.kind == 9000 && targetPubkey !in members -> members + targetPubkey
+                        message.kind == 9001 && targetPubkey in members -> members - targetPubkey
+                        else -> return@update byRelay
+                    }
+                    byRelay + (relay to (forRelay + (groupId to updated)))
+                }
+            }
+        }
+
         // Skip historical events older than the authoritative member list.
         val memberListTimestamp = memberEventTimestamps[groupId] ?: 0L
         if (message.createdAt <= memberListTimestamp) return
@@ -4909,6 +4970,12 @@ class GroupManager(
         memberEventTimestamps.clear()
         adminEventTimestamps.clear()
         roleEventTimestamps.clear()
+        _groupMembersByRelay.value = emptyMap()
+        _groupAdminsByRelay.value = emptyMap()
+        _groupRolesByRelay.value = emptyMap()
+        scopedMemberEventTimestamps.clear()
+        scopedAdminEventTimestamps.clear()
+        scopedRoleEventTimestamps.clear()
         _pendingApprovalSince.value = emptyMap()
         recentlyLeftAt.clear()
         // Pubkey-scoped: the next account reloads its own set from storage in loadJoinedGroupsFromStorage.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -592,6 +592,18 @@ class GroupManager(
     private val _latestMessageRelayByGroup = MutableStateFlow<Map<String, String>>(emptyMap())
     fun getLatestMessageRelayForGroup(groupId: String): String? = _latestMessageRelayByGroup.value[groupId]
 
+    // Relay the open group screen navigated to (route-carried, normalized). The same id
+    // can name two independent groups on two relays; the hint pins the opened group's
+    // reads/sends to the relay the user actually chose instead of the first relay the
+    // by-id scan finds. Last-opened wins while both are loaded (per-group stores are
+    // still keyed by bare id).
+    private val groupRelayHints = MutableStateFlow<Map<String, String>>(emptyMap())
+
+    fun setGroupRelayHint(groupId: String, relayUrl: String) {
+        val normalized = relayUrl.normalizeRelayUrl()
+        groupRelayHints.update { if (it[groupId] == normalized) it else it + (groupId to normalized) }
+    }
+
     private fun isRecentlyLeft(groupId: String): Boolean {
         val at = recentlyLeftAt[groupId] ?: return false
         if (epochMillis() - at < LEFT_GROUP_GRACE_MS) return true
@@ -804,7 +816,8 @@ class GroupManager(
      * Returns the relay URL that hosts the given group, by scanning the per-relay cache.
      * Uses an immutable snapshot of _groupsByRelay so no lock is needed.
      */
-    fun getRelayForGroup(groupId: String): String? = _groupsByRelay.value.entries.firstOrNull { (_, groups) -> groups.any { it.id == groupId } }?.key
+    fun getRelayForGroup(groupId: String): String? = groupRelayHints.value[groupId]
+        ?: _groupsByRelay.value.entries.firstOrNull { (_, groups) -> groups.any { it.id == groupId } }?.key
         // Fallback: private groups may not appear in kind 39000 listing but are
         // tracked in _joinedGroupsByRelay (from kind 10009). Without this,
         // clientForGroup() falls back to the focused client which may be wrong.
@@ -4839,6 +4852,7 @@ class GroupManager(
         groupMessageRecency.clear()
         _messageStatus.value = emptyMap()
         _latestMessageRelayByGroup.value = emptyMap()
+        groupRelayHints.value = emptyMap()
         // Joined-group sets and restricted-group markers are pubkey-scoped.
         // Leaving them in place lets isJoined() / isRestricted() report the
         // PREVIOUS account's data while the new account's flow is still

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -2905,6 +2905,9 @@ class GroupManager(
                 createdAt = event.createdAt,
                 kind = event.kind,
                 tags = event.tags,
+                // Stamp the send target so the optimistic bubble stays scoped to the
+                // group's own relay (same-id groups on other relays must not show it).
+                relayUrl = getRelayForGroup(groupId)?.normalizeRelayUrl(),
             ),
         )
         _messageStatus.update { it + (eventId to MessageStatus.Sending) }
@@ -3632,10 +3635,11 @@ class GroupManager(
      */
     private suspend fun loadOlderFromCache(groupId: String): Boolean {
         val account = currentPubkey ?: return false
+        val relay = getRelayForGroup(groupId) ?: return false
         val oldestInMemory = _messages.value[groupId]?.minOfOrNull { it.createdAt } ?: return false
         val olderPage =
             try {
-                cacheStore.loadBefore(account, groupId, oldestInMemory, PAGE_SIZE)
+                cacheStore.loadBefore(account, cacheSlot(relay, groupId), oldestInMemory, PAGE_SIZE)
             } catch (e: CancellationException) {
                 throw e
             } catch (_: Throwable) {
@@ -3646,7 +3650,7 @@ class GroupManager(
                 return false
             }
         if (olderPage.isEmpty()) return false
-        val restored = olderPage.map { it.toNostrMessage() }
+        val restored = olderPage.map { it.toNostrMessage().withOriginRelay(relay) }
         var added = false
         _messages.update { current ->
             val existing = current[groupId] ?: emptyList()
@@ -4266,7 +4270,7 @@ class GroupManager(
             if (!eventDeduplicator.tryAddSync(message.id)) return null
             val groupId = extractGroupIdFromMessage(rawMsg) ?: return null
             if (isRecentlyLeft(groupId)) return null
-            applyThreadEvent(groupId, message)
+            applyThreadEvent(groupId, message.withOriginRelay(relayUrl))
             return message.pubkey
         }
 
@@ -4318,10 +4322,27 @@ class GroupManager(
 
         // Enqueue to the ordering buffer; the buffer flushes after 300 ms of inactivity
         // for this group, applying the entire batch in one sorted StateFlow update.
-        eventOrderingBuffer.enqueue(groupId, message)
+        eventOrderingBuffer.enqueue(groupId, message.withOriginRelay(relayUrl))
 
         return message.pubkey
     }
+
+    /**
+     * Stamp the delivering relay onto a message (normalized), so readers can scope the
+     * shared bare-id buckets: the same id on two relays is two independent groups.
+     * An already-stamped or relay-less message passes through unchanged.
+     */
+    private fun NostrGroupClient.NostrMessage.withOriginRelay(relayUrl: String?): NostrGroupClient.NostrMessage = if (relayUrl == null || this.relayUrl != null) this else copy(relayUrl = relayUrl.normalizeRelayUrl())
+
+    /**
+     * Disk-cache slot for a group's history on one relay. Relay-scoped so same-id groups
+     * on two relays never mix on disk; '|' cannot appear in a relay URL or group id.
+     * A null relay falls back to the legacy bare-id slot.
+     */
+    private fun cacheSlot(
+        relayUrl: String?,
+        groupId: String,
+    ): String = relayUrl?.let { "${it.normalizeRelayUrl()}|$groupId" } ?: groupId
 
     /**
      * Apply a pre-sorted batch of messages for [groupId] to [_messages] in one atomic update.
@@ -4423,7 +4444,12 @@ class GroupManager(
         if (messages.isEmpty()) return
         scope.launch {
             try {
-                cacheStore.upsertMessages(account, groupId, messages.map { it.toCachedMsg(groupId) })
+                // One slot per origin relay: same-id groups on two relays keep separate
+                // disk histories (a mux flush batch can mix relays for one bare id).
+                messages.groupBy { it.relayUrl }.forEach { (relay, batch) ->
+                    val slot = cacheSlot(relay, groupId)
+                    cacheStore.upsertMessages(account, slot, batch.map { it.toCachedMsg(slot) })
+                }
             } catch (_: Exception) {
             }
         }
@@ -4480,14 +4506,18 @@ class GroupManager(
      */
     private suspend fun hydrateMessagesFromCache(groupId: String) {
         val account = currentPubkey ?: return
+        // The group's relay picks the slot; restored messages are stamped with it so the
+        // relay-scoped screens accept them. Pre-slot legacy rows (bare id) are skipped:
+        // they can't be attributed to a relay, and the live REQ re-fills and re-caches.
+        val relay = getRelayForGroup(groupId) ?: return
         val cached =
             try {
-                cacheStore.loadLatest(account, groupId, CACHE_HYDRATE_LIMIT)
+                cacheStore.loadLatest(account, cacheSlot(relay, groupId), CACHE_HYDRATE_LIMIT)
             } catch (_: Exception) {
                 return
             }
         if (cached.isEmpty()) return
-        val restored = cached.map { it.toNostrMessage() }
+        val restored = cached.map { it.toNostrMessage().withOriginRelay(relay) }
         _messages.update { current ->
             val existing = current[groupId] ?: emptyList()
             val index = messageIdIndex.getOrPut(groupId) { existing.mapTo(mutableSetOf()) { it.id } }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -21,6 +21,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.network.RoleDefinition
 import org.nostr.nostrord.network.UserGroupRef
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.ConnectionManager
@@ -226,9 +227,36 @@ class GroupViewModel(
                 }.toMap()
             }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.reactions.value)
-    val groupMembers = repo.groupMembers
-    val groupAdmins = repo.groupAdmins
-    val groupRoles = repo.groupRoles
+
+    /**
+     * Member/admin/role lists, host-relay scoped: entries the host relay published win
+     * over the flat compat maps (where a same-id group on another relay overwrites).
+     * The flat value stays the fallback while the per-relay mirror is still cold.
+     */
+    val groupMembers: StateFlow<Map<String, List<String>>> =
+        if (hostRelay == null) {
+            repo.groupMembers
+        } else {
+            combine(repo.groupMembers, repo.groupMembersByRelay) { flat, byRelay ->
+                byRelay.atHostRelay()?.let { flat + it } ?: flat
+            }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupMembers.value)
+        }
+    val groupAdmins: StateFlow<Map<String, List<String>>> =
+        if (hostRelay == null) {
+            repo.groupAdmins
+        } else {
+            combine(repo.groupAdmins, repo.groupAdminsByRelay) { flat, byRelay ->
+                byRelay.atHostRelay()?.let { flat + it } ?: flat
+            }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupAdmins.value)
+        }
+    val groupRoles: StateFlow<Map<String, List<RoleDefinition>>> =
+        if (hostRelay == null) {
+            repo.groupRoles
+        } else {
+            combine(repo.groupRoles, repo.groupRolesByRelay) { flat, byRelay ->
+                byRelay.atHostRelay()?.let { flat + it } ?: flat
+            }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupRoles.value)
+        }
     val loadingMembers = repo.loadingMembers
     val restrictedGroups = repo.restrictedGroups
     val isLoadingMore = repo.isLoadingMore
@@ -286,8 +314,10 @@ class GroupViewModel(
         combine(
             listOf(
                 repo.joinedGroupsByRelay,
-                repo.groupMembers,
-                repo.groupAdmins,
+                // The VM's own host-relay-scoped lists, so a same-id group on another
+                // relay can't decide membership here.
+                groupMembers,
+                groupAdmins,
                 repo.messages,
                 repo.groups,
                 AppModule.accountStore.activeId,
@@ -668,7 +698,7 @@ class GroupViewModel(
         // timeout error still on screen. The kind:9000/9001 echo updating the member or
         // admin list is the visible success signal; a change invalidates the error.
         viewModelScope.launch {
-            combine(repo.groupMembers, repo.groupAdmins) { members, admins ->
+            combine(groupMembers, groupAdmins) { members, admins ->
                 members[groupId] to admins[groupId]
             }
                 .distinctUntilChanged()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -180,10 +180,21 @@ class GroupViewModel(
      */
     val messages: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> =
         combine(repo.messages, repo.mutedPubkeys) { byGroup, muted ->
+            // Same-id groups on other relays share the bare-id buckets; with an explicit
+            // host relay keep only its events. Unstamped messages (rare pre-tag
+            // constructions) stay visible so an own send never vanishes.
+            val scoped =
+                if (hostRelay == null) {
+                    byGroup
+                } else {
+                    byGroup.mapValues { (_, list) ->
+                        list.filter { it.relayUrl == null || it.relayUrl == hostRelay }
+                    }
+                }
             if (muted.isEmpty()) {
-                byGroup
+                scoped
             } else {
-                byGroup.mapValues { (_, list) -> list.filter { it.pubkey !in muted } }
+                scoped.mapValues { (_, list) -> list.filter { it.pubkey !in muted } }
             }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.messages.value)
 
@@ -322,7 +333,9 @@ class GroupViewModel(
             // feed no longer reads as pending. (`leaveGroup` clears the feed and a re-fetch races, which
             // is why the feed alone left a left group stuck on "Request pending" until a reload.)
             val localPendingAt = pendingByGroup[groupId]
-            val ownEvents = messagesByGroup[groupId].orEmpty().asSequence().filter { it.pubkey == pubkey }
+            val ownEvents = messagesByGroup[groupId].orEmpty().asSequence()
+                .filter { it.pubkey == pubkey }
+                .filter { hostRelay == null || it.relayUrl == null || it.relayUrl == hostRelay }
             val lastJoinReq = ownEvents.filter { it.kind == 9021 }.maxOfOrNull { it.createdAt }
             val lastLeave = ownEvents.filter { it.kind == 9022 }.maxOfOrNull { it.createdAt }
             val feedRequestedAt =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -156,7 +156,23 @@ internal fun deriveMembershipStatus(
 class GroupViewModel(
     private val repo: NostrRepositoryApi,
     val groupId: String,
+    relayUrl: String? = null,
 ) : ViewModel() {
+    /**
+     * Relay the route carried (normalized), when the caller knows it. The same id can name
+     * two independent groups on two relays, so membership/metadata/orphan checks are scoped
+     * to this relay and the repo's relay routing is pinned to it. Null (legacy callers,
+     * modals riding an already-open screen) keeps the cross-relay fallbacks.
+     */
+    private val hostRelay: String? = relayUrl?.normalizeRelayUrl()
+
+    init {
+        if (hostRelay != null) repo.setGroupRelayHint(groupId, hostRelay)
+    }
+
+    /** Value under [hostRelay]'s key, tolerating maps keyed by non-normalized URLs. */
+    private fun <T> Map<String, T>.atHostRelay(): T? = hostRelay?.let { hr -> this[hr] ?: entries.firstOrNull { it.key.normalizeRelayUrl() == hr }?.value }
+
     /**
      * Chat messages with NIP-51 muted authors filtered out. The raw repo cache stays
      * untouched (membership derivation below reads it directly), so an unmute restores
@@ -266,6 +282,7 @@ class GroupViewModel(
                 AppModule.accountStore.activeId,
                 repo.pendingApprovalSince,
                 repo.leftGroups,
+                repo.groupsByRelay,
             ),
         ) { arr ->
             val joinedByRelay = arr[0] as Map<String, Set<String>>
@@ -275,15 +292,29 @@ class GroupViewModel(
             val allGroups = arr[4] as List<GroupMetadata>
             val pendingByGroup = arr[6] as Map<String, Long>
             val leftSet = arr[7] as Set<String>
+            val byRelay = arr[8] as Map<String, List<GroupMetadata>>
 
             val pubkey = repo.getPublicKey()
             val locallyLeft = groupId in leftSet
-            val joined = joinedByRelay.values.any { groupId in it }
+            // With an explicit host relay only ITS joined set counts: being in the same-id
+            // group on another relay is membership in a different group.
+            val joined =
+                if (hostRelay != null) {
+                    joinedByRelay.atHostRelay()?.contains(groupId) == true
+                } else {
+                    joinedByRelay.values.any { groupId in it }
+                }
             val members = membersByGroup[groupId].orEmpty()
             val admins = adminsByGroup[groupId].orEmpty()
             // Absent metadata defaults to open (the permissive NIP-29 default), so we don't
             // wrongly hold a group as pending before its kind:39000 arrives.
-            val isOpen = allGroups.find { it.id == groupId }?.isOpen ?: true
+            val meta =
+                if (hostRelay != null) {
+                    byRelay.atHostRelay()?.firstOrNull { it.id == groupId }
+                } else {
+                    allGroups.find { it.id == groupId }
+                }
+            val isOpen = meta?.isOpen ?: true
             // Outstanding join request: prefer the LOCAL pendingApprovalSince (set on our 9021, cleared
             // the instant we leave / are approved) — it is the reliable in-session truth. The kind:9021
             // in the message feed is the fallback that survives a restart, but it is gated on `joined`:
@@ -318,8 +349,13 @@ class GroupViewModel(
      * this for the badges and the Join-vs-Request-to-Join label.
      */
     val groupAccess: StateFlow<GroupAccess> =
-        combine(repo.groups, repo.restrictedGroups) { groups, restricted ->
-            val meta = groups.find { it.id == groupId }
+        combine(repo.groups, repo.groupsByRelay, repo.restrictedGroups) { groups, byRelay, restricted ->
+            val meta =
+                if (hostRelay != null) {
+                    byRelay.atHostRelay()?.firstOrNull { it.id == groupId }
+                } else {
+                    groups.find { it.id == groupId }
+                }
             if (meta != null) {
                 GroupAccess(isPrivate = !meta.isPublic, isOpen = meta.isOpen)
             } else {
@@ -346,14 +382,22 @@ class GroupViewModel(
     @OptIn(ExperimentalCoroutinesApi::class)
     val isOrphaned: StateFlow<Boolean> =
         combine(
-            repo.groups,
+            combine(repo.groups, repo.groupsByRelay) { g, br -> g to br },
             repo.completeGroupLoadRelays,
             repo.restrictedGroups,
             repo.currentRelayUrl,
             repo.connectionState,
-        ) { groups, doneRelays, restricted, currentRelay, connState ->
-            val hasMetadata = groups.any { it.id == groupId }
-            val relayDone = currentRelay.normalizeRelayUrl() in doneRelays
+        ) { (groups, byRelay), doneRelays, restricted, currentRelay, connState ->
+            // With an explicit host relay, only ITS listing proves existence and only ITS
+            // EOSE proves absence: same-id metadata from another relay must not mask a
+            // deleted group, nor its deletion orphan a live one.
+            val hasMetadata =
+                if (hostRelay != null) {
+                    byRelay.atHostRelay()?.any { it.id == groupId } == true
+                } else {
+                    groups.any { it.id == groupId }
+                }
+            val relayDone = (hostRelay ?: currentRelay.normalizeRelayUrl()) in doneRelays
             relayDone &&
                 !hasMetadata &&
                 groupId !in restricted &&
@@ -367,7 +411,7 @@ class GroupViewModel(
                     // Fast no-op on public relays (short challenge grace); on auth-gating relays
                     // waits out the sign budget so the post-AUTH group-list replay can deliver
                     // the withheld private 39000 before the verdict.
-                    repo.awaitRelayAuthSettled(repo.currentRelayUrl.value)
+                    repo.awaitRelayAuthSettled(hostRelay ?: repo.currentRelayUrl.value)
                     delay(4_000)
                     emit(true)
                 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -15,6 +15,7 @@ import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /** One row in the threads list: a kind:11 root plus stats derived from its kind:1111 replies. */
 data class ThreadSummary(
@@ -84,7 +85,13 @@ internal fun buildThreadSummaries(
 class ThreadsViewModel(
     private val repo: NostrRepositoryApi,
     val groupId: String,
+    relayUrl: String? = null,
 ) : ViewModel() {
+    /** Route-carried relay; scopes the bare-id thread buckets like GroupViewModel.messages. */
+    private val hostRelay: String? = relayUrl?.normalizeRelayUrl()
+
+    private fun scoped(list: List<NostrGroupClient.NostrMessage>): List<NostrGroupClient.NostrMessage> = if (hostRelay == null) list else list.filter { it.relayUrl == null || it.relayUrl == hostRelay }
+
     val userMetadata = repo.userMetadata
 
     /** Optimistic-send status per event id (Sending / Failed) - shared with chat via the repo. */
@@ -95,15 +102,15 @@ class ThreadsViewModel(
 
     val threads: StateFlow<List<ThreadSummary>> =
         combine(repo.threadRoots, repo.threadReplies) { rootsMap, repliesMap ->
-            buildThreadSummaries(rootsMap[groupId] ?: emptyList(), repliesMap[groupId] ?: emptyList())
+            buildThreadSummaries(scoped(rootsMap[groupId] ?: emptyList()), scoped(repliesMap[groupId] ?: emptyList()))
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     private val _openRootId = MutableStateFlow<String?>(null)
     val openThread: StateFlow<ThreadDetail?> =
         combine(_openRootId, repo.threadRoots, repo.threadReplies) { rootId, rootsMap, repliesMap ->
             rootId ?: return@combine null
-            val root = rootsMap[groupId]?.firstOrNull { it.id == rootId } ?: return@combine null
-            val replies = (repliesMap[groupId] ?: emptyList())
+            val root = scoped(rootsMap[groupId] ?: emptyList()).firstOrNull { it.id == rootId } ?: return@combine null
+            val replies = scoped(repliesMap[groupId] ?: emptyList())
                 .filter { it.threadRootIdTag() == rootId }
                 .sortedBy { it.createdAt }
             ThreadDetail(root, replies)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
@@ -193,6 +193,7 @@ class HomePageViewModel(
                 repo.following,
                 repo.userMetadata,
                 _membersResolved,
+                repo.groupMembersByRelay,
             ),
         ) { arr ->
             val groupsByRelay = arr[0] as Map<String, List<GroupMetadata>>
@@ -201,11 +202,15 @@ class HomePageViewModel(
             val following = arr[3] as Set<String>
             val meta = arr[4] as Map<String, UserMetadata>
             val resolved = arr[5] as Set<String>
+            val membersByRelay = arr[6] as Map<String, Map<String, List<String>>>
             joinedByRelay
                 .flatMap { (relay, ids) ->
                     val metas = groupsByRelay[relay].orEmpty().associateBy { it.id }
+                    // This relay's own member lists first: a same-id group elsewhere
+                    // must not paint this card's people row.
+                    val relayMembers = membersByRelay[relay].orEmpty()
                     ids.map { id ->
-                        val memberPks = members[id].orEmpty()
+                        val memberPks = relayMembers[id] ?: members[id].orEmpty()
                         // Small joined groups (<=5 members) include your own avatar so the
                         // row isn't near-empty; larger ones still omit it (My groups only).
                         val preview = previewPeople(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
@@ -232,7 +232,8 @@ class HomePageViewModel(
                         )
                     }
                 }
-                .distinctBy { it.meta.id }
+                // Dedup by (relay, id): the same id on two relays is two independent groups.
+                .distinctBy { it.relayUrl to it.meta.id }
             // Off Main: the previewPeople / associateBy / distinctBy transform is O(groups x members)
             // and re-runs for each of the ~50 metadata events that arrive in waves on home open;
             // running it on viewModelScope's Main dispatcher made it compete with composition. The
@@ -260,8 +261,10 @@ class HomePageViewModel(
     val railRootGroups: StateFlow<List<DiscoverGroup>> =
         railGroups
             .map { list ->
-                val joinedIds = list.mapTo(HashSet()) { it.meta.id }
-                list.filter { it.meta.parent == null || it.meta.parent !in joinedIds }
+                // Parent links only count within the same relay: a same-id parent joined
+                // on another relay is a different group and must not swallow this root.
+                val joined = list.mapTo(HashSet()) { it.relayUrl to it.meta.id }
+                list.filter { it.meta.parent == null || (it.relayUrl to it.meta.parent) !in joined }
             }
             .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
@@ -273,8 +276,9 @@ class HomePageViewModel(
     val groupParents: StateFlow<Map<String, String>> =
         railGroups
             .map { list ->
-                val joinedIds = list.mapTo(HashSet()) { it.meta.id }
-                list.mapNotNull { g -> g.meta.parent?.takeIf { it in joinedIds }?.let { g.meta.id to it } }.toMap()
+                // Same-relay scoping as railRootGroups so highlight resolution matches its filter.
+                val joined = list.mapTo(HashSet()) { it.relayUrl to it.meta.id }
+                list.mapNotNull { g -> g.meta.parent?.takeIf { (g.relayUrl to it) in joined }?.let { g.meta.id to it } }.toMap()
             }
             .stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
@@ -571,7 +571,8 @@ class HomePageViewModel(
                 // Hidden groups are not discoverable (NIP-29); never recommend them.
                 .filter { !it.meta.isHidden }
                 .filter { matchesQuery(it.meta, needle) }
-                .distinctBy { it.meta.id }
+                // (relay, id): the same id on two relays is two independent groups.
+                .distinctBy { it.relayUrl to it.meta.id }
             // Off Main: the previewPeople / associateBy / distinctBy transform is O(groups x members)
             // and re-runs for each of the ~50 metadata events that arrive in waves on home open;
             // running it on viewModelScope's Main dispatcher made it compete with composition. The

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -114,6 +114,11 @@ class FakeNostrRepository : NostrRepositoryApi {
     override suspend fun resetGroupLoadingState(groupId: String) {}
     override val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = _reactions
     override val groupMembers: StateFlow<Map<String, List<String>>> = _groupMembers
+    val _groupMembersByRelay = MutableStateFlow<Map<String, Map<String, List<String>>>>(emptyMap())
+    override val groupMembersByRelay: StateFlow<Map<String, Map<String, List<String>>>> = _groupMembersByRelay
+    val _groupAdminsByRelay = MutableStateFlow<Map<String, Map<String, List<String>>>>(emptyMap())
+    override val groupAdminsByRelay: StateFlow<Map<String, Map<String, List<String>>>> = _groupAdminsByRelay
+    override val groupRolesByRelay: StateFlow<Map<String, Map<String, List<RoleDefinition>>>> = MutableStateFlow(emptyMap())
     override val pendingApprovalSince: StateFlow<Map<String, Long>> = MutableStateFlow(emptyMap())
     override val groupAdmins: StateFlow<Map<String, List<String>>> = _groupAdmins
     override val userMetadata: StateFlow<Map<String, UserMetadata>> = _userMetadata

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -404,6 +404,15 @@ class FakeNostrRepository : NostrRepositoryApi {
 
     override fun getMessagesForGroup(groupId: String): List<NostrGroupClient.NostrMessage> = messages.value[groupId] ?: emptyList()
 
+    var relayHints = mutableMapOf<String, String>()
+
+    override fun setGroupRelayHint(
+        groupId: String,
+        relayUrl: String,
+    ) {
+        relayHints[groupId] = relayUrl
+    }
+
     override fun markGroupAsRead(groupId: String) {}
 
     override fun markGroupAsReadUpTo(groupId: String, timestamp: Long) {}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupCacheHydrationTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupCacheHydrationTest.kt
@@ -19,17 +19,21 @@ class GroupCacheHydrationTest {
     fun `opening a group renders its messages from the persistent cache`() = runTest {
         val scope = TestScope(testScheduler)
         val cache = InMemoryCacheStore()
-        // A previously-seen group's history already sits in the cache (e.g. a prior session).
+        // A previously-seen group's history already sits in the cache (e.g. a prior
+        // session), under its relay-scoped slot.
+        val slot = "wss://cache.relay|$HYDRATE_GROUP"
         cache.upsertMessages(
             HYDRATE_PUBKEY,
-            HYDRATE_GROUP,
+            slot,
             listOf(
-                CachedMsg("m1", HYDRATE_GROUP, "p", createdAt = 100, kind = 9, content = "hi", tagsJson = "[]"),
-                CachedMsg("m2", HYDRATE_GROUP, "p", createdAt = 200, kind = 9, content = "there", tagsJson = "[]"),
+                CachedMsg("m1", slot, "p", createdAt = 100, kind = 9, content = "hi", tagsJson = "[]"),
+                CachedMsg("m2", slot, "p", createdAt = 200, kind = 9, content = "there", tagsJson = "[]"),
             ),
         )
         val manager = GroupManager(connectionManager = ConnectionManager(scope), scope = scope, cacheStore = cache)
         manager.setCurrentPubkey(HYDRATE_PUBKEY)
+        // The slot is picked by the group's resolved relay.
+        manager.setGroupRelayHint(HYDRATE_GROUP, "wss://cache.relay")
 
         // Opening the group hydrates from cache with no relay round-trip.
         manager.setActiveGroupId(HYDRATE_GROUP)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupScrollbackCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupScrollbackCacheTest.kt
@@ -21,7 +21,9 @@ class GroupScrollbackCacheTest {
     @AfterTest
     fun cleanup() = SecureStorage.clearAllMessagesForAccount(SB_PUBKEY)
 
-    private fun cached(id: String, createdAt: Long) = CachedMsg(id, SB_GROUP, "p", createdAt, kind = 9, content = "c", tagsJson = "[]")
+    private val slot = "wss://cache.relay|$SB_GROUP"
+
+    private fun cached(id: String, createdAt: Long) = CachedMsg(id, slot, "p", createdAt, kind = 9, content = "c", tagsJson = "[]")
 
     @Test
     fun `scroll-back serves an older page from the cache without hitting the relay`() = runTest {
@@ -29,10 +31,11 @@ class GroupScrollbackCacheTest {
         val cache = InMemoryCacheStore()
         val manager = GroupManager(connectionManager = ConnectionManager(scope), scope = scope, cacheStore = cache)
         manager.setCurrentPubkey(SB_PUBKEY)
+        manager.setGroupRelayHint(SB_GROUP, "wss://cache.relay")
 
-        // The cache holds the full history m1..m10; memory only has the recent tail m8..m10
-        // (as if older messages were evicted or never hydrated).
-        cache.upsertMessages(SB_PUBKEY, SB_GROUP, (1L..10L).map { cached("m$it", it) })
+        // The cache holds the full history m1..m10 under the relay-scoped slot; memory only
+        // has the recent tail m8..m10 (as if older messages were evicted or never hydrated).
+        cache.upsertMessages(SB_PUBKEY, slot, (1L..10L).map { cached("m$it", it) })
         SecureStorage.saveMessagesForGroup(
             SB_PUBKEY,
             SB_GROUP,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -101,6 +101,28 @@ class GroupViewModelTest {
     }
 
     @Test
+    fun `member list prefers the host relay's mirror over the flat map`() = runTest {
+        val fake = FakeNostrRepository()
+        // Flat map holds the OTHER relay's list (last writer wins there); the per-relay
+        // mirror holds each relay's own.
+        fake._groupMembers.value = mapOf("dev" to listOf("only-b"))
+        fake._groupMembersByRelay.value =
+            mapOf(
+                "wss://a" to mapOf("dev" to listOf("alice", "bob")),
+                "wss://b" to mapOf("dev" to listOf("only-b")),
+            )
+
+        val vmA = GroupViewModel(fake, "dev", "wss://a")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("alice", "bob"), vmA.groupMembers.value["dev"])
+        // A group the host relay hasn't described yet falls back to the flat map.
+        val vmC = GroupViewModel(fake, "dev", "wss://c")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf("only-b"), vmC.groupMembers.value["dev"])
+    }
+
+    @Test
     fun `membership counts only the host relay's joined set`() = runTest {
         val fake = FakeNostrRepository()
         fake.fakePublicKey = "me"

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -79,6 +79,28 @@ class GroupViewModelTest {
     }
 
     @Test
+    fun `messages are scoped to the host relay, unstamped ones stay`() = runTest {
+        val fake = FakeNostrRepository()
+        fun msg(id: String, relay: String?) = org.nostr.nostrord.network.NostrGroupClient.NostrMessage(
+            id = id,
+            pubkey = "pk",
+            content = "hi",
+            createdAt = 1L,
+            kind = 9,
+            relayUrl = relay,
+        )
+        fake._messages.value =
+            mapOf("dev" to listOf(msg("m1", "wss://a"), msg("m2", "wss://b"), msg("m3", null)))
+
+        val vmA = GroupViewModel(fake, "dev", "wss://a")
+        val vmAll = GroupViewModel(fake, "dev")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("m1", "m3"), vmA.messages.value["dev"]?.map { it.id })
+        assertEquals(listOf("m1", "m2", "m3"), vmAll.messages.value["dev"]?.map { it.id })
+    }
+
+    @Test
     fun `membership counts only the host relay's joined set`() = runTest {
         val fake = FakeNostrRepository()
         fake.fakePublicKey = "me"

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.managers.PendingGroupInvite
+import org.nostr.nostrord.ui.screens.group.GroupAccess
 import org.nostr.nostrord.ui.screens.group.GroupMembership
 import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.deriveMembershipStatus
@@ -41,6 +43,55 @@ class GroupViewModelTest {
     }
 
     private fun vm(fake: FakeNostrRepository = FakeNostrRepository()) = GroupViewModel(fake, "test-group")
+
+    // -------------------------------------------------------------------------
+    // Host-relay scoping: the same id on two relays is two independent groups
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `explicit relay registers a relay hint so repo routing follows the route`() = runTest {
+        val fake = FakeNostrRepository()
+        GroupViewModel(fake, "dev", "wss://b")
+
+        assertEquals("wss://b", fake.relayHints["dev"])
+    }
+
+    @Test
+    fun `no relay leaves routing unhinted`() = runTest {
+        val fake = FakeNostrRepository()
+        GroupViewModel(fake, "dev")
+
+        assertNull(fake.relayHints["dev"])
+    }
+
+    @Test
+    fun `groupAccess reads the host relay's metadata, not a same-id group elsewhere`() = runTest {
+        val fake = FakeNostrRepository()
+        val closed = GroupMetadata(id = "dev", name = "Dev A", about = null, picture = null, isPublic = false, isOpen = false)
+        val open = GroupMetadata(id = "dev", name = "Dev B", about = null, picture = null, isPublic = true, isOpen = true)
+        fake._groups.value = listOf(open)
+        fake._groupsByRelay.value = mapOf("wss://a" to listOf(closed), "wss://b" to listOf(open))
+
+        val vmA = GroupViewModel(fake, "dev", "wss://a")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(GroupAccess(isPrivate = true, isOpen = false), vmA.groupAccess.value)
+    }
+
+    @Test
+    fun `membership counts only the host relay's joined set`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.fakePublicKey = "me"
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("dev"))
+
+        val vmA = GroupViewModel(fake, "dev", "wss://a")
+        val vmB = GroupViewModel(fake, "dev", "wss://b")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Joined on A (member list not arrived yet -> resolving); a stranger on B.
+        assertEquals(GroupMembership.RESOLVING, vmA.membershipState.value.status)
+        assertEquals(GroupMembership.NONE, vmB.membershipState.value.status)
+    }
 
     // -------------------------------------------------------------------------
     // State passthrough

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
@@ -65,6 +65,30 @@ class HomePageViewModelTest {
     }
 
     @Test
+    fun `same group id on two relays stays as two groups`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._groupsByRelay.value =
+            mapOf(
+                "wss://a" to listOf(meta("dev", "Dev on A")),
+                "wss://b" to listOf(meta("dev", "Dev on B")),
+            )
+        fake._joinedGroupsByRelay.value =
+            mapOf(
+                "wss://a" to setOf("dev"),
+                "wss://b" to setOf("dev"),
+            )
+        val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        // Two independent groups, each with its own relay's metadata; both on the rail.
+        assertEquals(
+            listOf("wss://a" to "Dev on A", "wss://b" to "Dev on B"),
+            vm.myGroups.value.map { it.relayUrl to it.meta.name },
+        )
+        assertEquals(2, vm.railRootGroups.value.size)
+    }
+
+    @Test
     fun `query filters by name and description`() = runTest {
         val fake = FakeNostrRepository()
         fake._groupsByRelay.value =

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -370,14 +370,19 @@ fun AppFrame() {
                 ) {
                     // An open channel highlights its root's rail chip (the chip a click
                     // would re-open); badge counts aggregate the root's whole subtree.
+                    // Matched by (relay, id): a same-id group on another relay is a
+                    // different chip and must not light up too.
                     val activeRootId = groupRoute?.groupId?.let { open -> rootGroupId(open) { groupParents[it] } }
+                    val activeRelay = groupRoute?.relayUrl?.normalizeRelayUrl()
                     railRoots.forEach { group ->
                         RailGroupButton(
                             name = group.meta.name ?: group.meta.id,
                             picture = group.meta.picture,
                             groupId = group.meta.id,
                             unread = railUnread[group.meta.id] ?: 0,
-                            active = activeRootId == group.meta.id && !showNotifications,
+                            active = activeRootId == group.meta.id &&
+                                activeRelay == group.relayUrl.normalizeRelayUrl() &&
+                                !showNotifications,
                         ) {
                             history.navigate(GroupRoute(group.relayUrl, group.meta.id))
                             closeDrawer()

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -797,6 +797,7 @@ private fun FrameContent(
                     GroupScreen(
                         groupId = route.groupId,
                         groupName = name,
+                        relayUrl = route.relayUrl,
                         onNavigateHome = onCloseGroup,
                         onNavigateToGroup = { gid, _, relay, mid ->
                             onNavigate(GroupRoute(relay ?: route.relayUrl, gid, messageId = mid))

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
@@ -101,7 +101,9 @@ fun GroupSidebar(
     onNavigateRelay: (String) -> Unit = {},
     onNavigateHome: () -> Unit = {},
 ) {
-    val vm = viewModel(key = route.groupId) { GroupViewModel(AppModule.nostrRepository, route.groupId) }
+    val vm = viewModel(key = "${route.relayUrl}|${route.groupId}") {
+        GroupViewModel(AppModule.nostrRepository, route.groupId, route.relayUrl)
+    }
     val groupsByRelay by vm.groupsByRelay.collectAsState()
     val childrenByParent by vm.childrenByParent.collectAsState()
     val groupMembers by vm.groupMembers.collectAsState()

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
@@ -310,6 +310,7 @@ fun GroupSidebar(
         MembersModal(
             groupId = rootId,
             onDismiss = { showMembers = false },
+            relayUrl = route.relayUrl,
         )
     }
     if (showManage) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -140,13 +140,19 @@ fun GroupScreen(
     val isOrphaned by vm.isOrphaned.collectAsState()
     val childrenByParent by vm.childrenByParent.collectAsState()
     // Subgroup UI is gated on the relay advertising nip29:{subgroups:true} in its NIP-11 (mirrors GroupSidebar).
+    val screenRelay = relayUrl ?: currentRelayUrl
     val supportsSubgroups =
-        (relayMetadata[currentRelayUrl] ?: relayMetadata[currentRelayUrl.normalizeRelayUrl()])?.supportsSubgroups == true
+        (relayMetadata[screenRelay] ?: relayMetadata[screenRelay.normalizeRelayUrl()])?.supportsSubgroups == true
     val currentUserPubkey = vm.getPublicKey()
 
+    // This relay's kind:39000 first: a same-id group on another relay must not paint this
+    // screen's name/about. The flat list stays the fallback while the route has no relay.
     val currentGroupMetadata =
-        remember(groups, groupId) {
-            groups.find { it.id == groupId }
+        remember(groups, allGroupsByRelay, groupId, relayUrl) {
+            relayUrl?.let { r ->
+                (allGroupsByRelay[r] ?: allGroupsByRelay.entries.firstOrNull { it.key.normalizeRelayUrl() == r.normalizeRelayUrl() }?.value)
+                    ?.firstOrNull { it.id == groupId }
+            } ?: groups.find { it.id == groupId }
         }
 
     // %group mention candidates: only joined + friends' groups (the new discovery),
@@ -486,7 +492,7 @@ fun GroupScreen(
             groupId = groupId,
             groupName = groupName,
             groupMetadata = currentGroupMetadata,
-            relayUrl = currentRelayUrl,
+            relayUrl = relayUrl ?: currentRelayUrl,
             onOpenRelay = onOpenRelay,
             isMember = isJoined,
             memberCount = groupMembers.size,
@@ -509,19 +515,19 @@ fun GroupScreen(
         ManageGroupModal(
             groupId = groupId,
             currentMetadata = currentGroupMetadata,
-            relayUrl = currentRelayUrl,
+            relayUrl = relayUrl ?: currentRelayUrl,
             onDismiss = { showEditGroupModal = false },
             onDeleted = {
                 showEditGroupModal = false
                 // Deleting a channel lands on its parent group; only a root delete goes home.
                 val parentId = currentGroupMetadata?.parent
-                if (parentId != null) onNavigateToGroup(parentId, parentGroupName, currentRelayUrl, null) else onNavigateHome()
+                if (parentId != null) onNavigateToGroup(parentId, parentGroupName, relayUrl ?: currentRelayUrl, null) else onNavigateHome()
             },
             initialTab = ManageTab.Info,
             supportsSubgroups = supportsSubgroups,
             onOpenGroup = { id ->
                 showEditGroupModal = false
-                onNavigateToGroup(id, null, currentRelayUrl, null)
+                onNavigateToGroup(id, null, relayUrl ?: currentRelayUrl, null)
             },
         )
     }
@@ -532,18 +538,18 @@ fun GroupScreen(
         ManageGroupModal(
             groupId = groupId,
             currentMetadata = currentGroupMetadata,
-            relayUrl = currentRelayUrl,
+            relayUrl = relayUrl ?: currentRelayUrl,
             onDismiss = { showMemberManagementModal = false },
             onDeleted = {
                 showMemberManagementModal = false
                 val parentId = currentGroupMetadata?.parent
-                if (parentId != null) onNavigateToGroup(parentId, parentGroupName, currentRelayUrl, null) else onNavigateHome()
+                if (parentId != null) onNavigateToGroup(parentId, parentGroupName, relayUrl ?: currentRelayUrl, null) else onNavigateHome()
             },
             initialTab = ManageTab.Members,
             supportsSubgroups = supportsSubgroups,
             onOpenGroup = { id ->
                 showMemberManagementModal = false
-                onNavigateToGroup(id, null, currentRelayUrl, null)
+                onNavigateToGroup(id, null, relayUrl ?: currentRelayUrl, null)
             },
         )
     }
@@ -561,7 +567,7 @@ fun GroupScreen(
                 createdInviteCode = null
                 if (moderationError != null) vm.clearModerationError()
             },
-            relayUrl = currentRelayUrl,
+            relayUrl = relayUrl ?: currentRelayUrl,
             groupId = groupId,
             createdCode = createdInviteCode,
             errorMessage = moderationError,
@@ -838,18 +844,18 @@ fun GroupScreen(
         ManageGroupModal(
             groupId = groupId,
             currentMetadata = currentGroupMetadata,
-            relayUrl = currentRelayUrl,
+            relayUrl = relayUrl ?: currentRelayUrl,
             onDismiss = { showJoinRequestsModal = false },
             onDeleted = {
                 showJoinRequestsModal = false
                 val parentId = currentGroupMetadata?.parent
-                if (parentId != null) onNavigateToGroup(parentId, parentGroupName, currentRelayUrl, null) else onNavigateHome()
+                if (parentId != null) onNavigateToGroup(parentId, parentGroupName, relayUrl ?: currentRelayUrl, null) else onNavigateHome()
             },
             initialTab = ManageTab.Requests,
             supportsSubgroups = supportsSubgroups,
             onOpenGroup = { id ->
                 showJoinRequestsModal = false
-                onNavigateToGroup(id, null, currentRelayUrl, null)
+                onNavigateToGroup(id, null, relayUrl ?: currentRelayUrl, null)
             },
         )
     }
@@ -896,7 +902,7 @@ fun GroupScreen(
                 GroupScreenMobile(
                     groupId = groupId,
                     groupName = groupName,
-                    relayUrl = currentRelayUrl,
+                    relayUrl = relayUrl ?: currentRelayUrl,
                     groupMetadata = currentGroupMetadata,
                     selectedChannel = selectedChannel,
                     onChannelSelect = { selectedChannel = it },
@@ -1037,7 +1043,7 @@ fun GroupScreen(
                 GroupScreenDesktop(
                     groupId = groupId,
                     groupName = groupName,
-                    relayUrl = currentRelayUrl,
+                    relayUrl = relayUrl ?: currentRelayUrl,
                     groupMetadata = currentGroupMetadata,
                     selectedChannel = selectedChannel,
                     onChannelSelect = { selectedChannel = it },

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -62,6 +62,9 @@ private fun decodeGroupMentions(encoded: Map<String, String>): Map<String, Group
 fun GroupScreen(
     groupId: String,
     groupName: String?,
+    // Relay the route carried; scopes the VM (and keys it) so same-id groups on two
+    // relays get separate screens instead of sharing one.
+    relayUrl: String? = null,
     onNavigateHome: () -> Unit = {},
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit = { _, _, _, _ -> },
     onOpenRelay: (relayUrl: String) -> Unit = {},
@@ -73,7 +76,9 @@ fun GroupScreen(
     targetMessageId: String? = null,
     onTargetMessageConsumed: () -> Unit = {},
 ) {
-    val vm = viewModel(key = groupId) { GroupViewModel(AppModule.nostrRepository, groupId) }
+    val vm = viewModel(key = relayUrl?.let { "$it|$groupId" } ?: groupId) {
+        GroupViewModel(AppModule.nostrRepository, groupId, relayUrl)
+    }
 
     var selectedChannel by remember { mutableStateOf("general") }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -77,7 +77,9 @@ fun ThreadsScreen(
     // in the same ViewModelStore, so a bare groupId key here collided with it and the two evicted +
     // recreated each other every recomposition - churning the thread sub so it never loaded
     // (blank/stuck list on the mobile layout where the sidebar VM is also composed).
-    val vm = viewModel(key = "threads:${route.groupId}") { ThreadsViewModel(AppModule.nostrRepository, route.groupId) }
+    val vm = viewModel(key = "threads:${route.relayUrl}|${route.groupId}") {
+        ThreadsViewModel(AppModule.nostrRepository, route.groupId, route.relayUrl)
+    }
     val threads by vm.threads.collectAsState()
     val isLoading by vm.isLoading.collectAsState()
     val openThread by vm.openThread.collectAsState()

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ManageGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ManageGroupModal.kt
@@ -122,7 +122,7 @@ fun ManageGroupModal(
     /** Navigate to a group/channel (Hierarchy rows); the caller closes the modal. */
     onOpenGroup: ((groupId: String) -> Unit)? = null,
 ) {
-    val vm = viewModel(key = groupId) { GroupViewModel(AppModule.nostrRepository, groupId) }
+    val vm = viewModel(key = "$relayUrl|$groupId") { GroupViewModel(AppModule.nostrRepository, groupId, relayUrl) }
     var tab by remember { mutableStateOf(initialTab) }
 
     // Hierarchy only makes sense where the relay hosts subgroups; hide that tab otherwise.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MembersModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MembersModal.kt
@@ -37,10 +37,12 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.ModalTitleBar
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
+import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.Spacing
 
@@ -53,10 +55,13 @@ import org.nostr.nostrord.ui.theme.Spacing
 fun MembersModal(
     groupId: String,
     onDismiss: () -> Unit,
+    // Relay hosting the group; scopes the roster (same-id groups elsewhere stay out).
+    relayUrl: String? = null,
 ) {
     val repo = AppModule.nostrRepository
-    val members = repo.groupMembers.collectAsState().value[groupId].orEmpty()
-    val admins = repo.groupAdmins.collectAsState().value[groupId].orEmpty().toSet()
+    val vm = viewModel(key = "members:$relayUrl|$groupId") { GroupViewModel(repo, groupId, relayUrl) }
+    val members = vm.groupMembers.collectAsState().value[groupId].orEmpty()
+    val admins = vm.groupAdmins.collectAsState().value[groupId].orEmpty().toSet()
     val userMetadata by repo.userMetadata.collectAsState()
     var selected by remember { mutableStateOf<String?>(null) }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -291,7 +291,10 @@ val AppFrame =
                         className = ClassName("rail-scroll")
                         // An open channel highlights its root's rail chip (the chip a click
                         // would re-open); badge counts aggregate the root's whole subtree.
+                        // Matched by (relay, id): a same-id group on another relay is a
+                        // different chip and must not light up too.
                         val activeRootId = groupRoute?.groupId?.let { open -> rootGroupId(open) { groupParents[it] } }
+                        val activeRelay = groupRoute?.relayUrl?.normalizeRelayUrl()
                         railRoots.forEach { group ->
                             val name = group.meta.name ?: group.meta.id
                             div {
@@ -300,7 +303,14 @@ val AppFrame =
                                 button {
                                     className =
                                         ClassName(
-                                            if (activeRootId == group.meta.id && !notificationsOpen) "rail-group-btn active" else "rail-group-btn",
+                                            if (activeRootId == group.meta.id &&
+                                                activeRelay == group.relayUrl.normalizeRelayUrl() &&
+                                                !notificationsOpen
+                                            ) {
+                                                "rail-group-btn active"
+                                            } else {
+                                                "rail-group-btn"
+                                            },
                                         )
                                     title = name
                                     onClick = { pushRoute(GroupRoute(group.relayUrl, group.meta.id)) }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -295,7 +295,7 @@ val AppFrame =
                         railRoots.forEach { group ->
                             val name = group.meta.name ?: group.meta.id
                             div {
-                                key = group.meta.id
+                                key = "${group.relayUrl}/${group.meta.id}"
                                 className = ClassName("rail-group")
                                 button {
                                     className =
@@ -677,6 +677,7 @@ val AppFrame =
                         ChatScreen {
                             key = "${r.relayUrl}/${r.groupId}"
                             group = selectedGroup
+                            relayUrl = r.relayUrl
                             onLeave = { pushHome() }
                             // Jump to + flash the message a notification (or shared link)
                             // pointed at; clear ?e= afterward so new messages or a back/

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
@@ -53,7 +53,9 @@ external interface GroupSidebarProps : Props {
 val GroupSidebar =
     FC<GroupSidebarProps> { props ->
         val route = props.route
-        val vm = useViewModel(route.groupId) { GroupViewModel(AppModule.nostrRepository, route.groupId) }
+        val vm = useViewModel("${route.relayUrl}|${route.groupId}") {
+            GroupViewModel(AppModule.nostrRepository, route.groupId, route.relayUrl)
+        }
         val groupsByRelay = useStateFlow(vm.groupsByRelay)
         val childrenByParent = useStateFlow(vm.childrenByParent)
         val groupMembers = useStateFlow(vm.groupMembers)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
@@ -347,6 +347,7 @@ val GroupSidebar =
         if (showMembers) {
             Portal {
                 MembersModal {
+                    relayUrl = route.relayUrl
                     groupId = rootId
                     onClose = { setShowMembers(false) }
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
@@ -357,6 +357,7 @@ val GroupSidebar =
                 ManageGroupModal {
                     group = rootMeta ?: placeholderMeta(rootId)
                     initialTab = manageTab
+                    relayUrl = route.relayUrl
                     onClose = { setShowManage(false) }
                 }
             }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/GroupInfoModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/GroupInfoModal.kt
@@ -5,8 +5,10 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.ui.navigation.RelayRoute
+import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.AvatarKind
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.WebAvatar
@@ -29,6 +31,9 @@ import web.cssom.ClassName
 
 external interface GroupInfoModalProps : Props {
     var group: GroupMetadata
+
+    /** Relay hosting the group; scopes the member count and the RELAY link. */
+    var relayUrl: String?
     var onLeave: () -> Unit
     var onClose: () -> Unit
 }
@@ -48,12 +53,16 @@ val GroupInfoModal =
         val defaultLevel = useStateFlow(notificationSettings.defaultLevel)
         val level = groupLevels[group.id] ?: defaultLevel
         val userMetadata = useStateFlow(AppModule.nostrRepository.userMetadata)
-        val memberCount = useStateFlow(AppModule.nostrRepository.groupMembers)[group.id]?.size ?: 0
+        // Through the relay-scoped VM: the flat map's count can belong to a same-id group
+        // on another relay.
+        val vm = useViewModel("${props.relayUrl}|${group.id}") { GroupViewModel(AppModule.nostrRepository, group.id, props.relayUrl) }
+        val memberCount = useStateFlow(vm.groupMembers)[group.id]?.size ?: 0
         // Leaving is about the user's own kind:10009 list, so it must be offered whenever the
         // group is in that list (any relay), even if the relay is dead and membership/posting
         // can't be confirmed. Gating on "can post" would hide the only exit from a broken relay.
         val isJoined = useStateFlow(AppModule.nostrRepository.joinedGroupsByRelay).values.any { group.id in it }
-        val relayUrl = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
+        val focusedRelay = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
+        val relayUrl = props.relayUrl ?: focusedRelay
         val relayMetadata = useStateFlow(AppModule.nostrRepository.relayMetadata)
         // Mention click in the description opens that user's profile on top.
         val (profilePubkey, setProfilePubkey) = useState<String?> { null }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/InviteCodesModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/InviteCodesModal.kt
@@ -2,8 +2,10 @@ package org.nostr.nostrord.web.modals
 
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.groupIdentifiers
+import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.IdentifierRow
 import org.nostr.nostrord.web.components.copyToClipboard
@@ -19,6 +21,9 @@ import web.cssom.ClassName
 
 external interface InviteCodesModalProps : Props {
     var groupId: String
+
+    /** Relay hosting the group; scopes the code list (same-id groups elsewhere stay out). */
+    var relayUrl: String?
     var onClose: () -> Unit
 }
 
@@ -30,8 +35,12 @@ external interface InviteCodesModalProps : Props {
 val InviteCodesModal =
     FC<InviteCodesModalProps> { props ->
         val repo = AppModule.nostrRepository
-        val msgs = useStateFlow(repo.messages)[props.groupId].orEmpty()
-        val relayUrl = useStateFlow(repo.currentRelayUrl)
+        // Relay-scoped VM: the raw bucket can hold a same-id group's kind:9009s from
+        // another relay.
+        val vm = useViewModel("${props.relayUrl}|${props.groupId}") { GroupViewModel(repo, props.groupId, props.relayUrl) }
+        val msgs = useStateFlow(vm.messages)[props.groupId].orEmpty()
+        val focusedRelay = useStateFlow(repo.currentRelayUrl)
+        val relayUrl = props.relayUrl ?: focusedRelay
         val (busy, setBusy) = useState { false }
 
         val revoked =

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
@@ -146,7 +146,11 @@ val ManageGroupModal =
                                     groupId = group.id
                                     this.relayUrl = relayUrl
                                 }
-                            ManageTab.Invites -> ManageInvitesSection { groupId = group.id }
+                            ManageTab.Invites ->
+                                ManageInvitesSection {
+                                    groupId = group.id
+                                    this.relayUrl = relayUrl
+                                }
                             ManageTab.Requests ->
                                 ManageRequestsSection {
                                     groupId = group.id
@@ -1058,8 +1062,12 @@ private val ManageHierarchySection =
 private val ManageInvitesSection =
     FC<ManageGroupIdProps> { props ->
         val repo = AppModule.nostrRepository
-        val msgs = useStateFlow(repo.messages)[props.groupId].orEmpty()
-        val relayUrl = useStateFlow(repo.currentRelayUrl)
+        // Relay-scoped VM, same rationale as ManageRequestsSection: the raw bucket can
+        // hold a same-id group's kind:9009s from another relay.
+        val vm = useViewModel("${props.relayUrl}|${props.groupId}") { GroupViewModel(repo, props.groupId, props.relayUrl) }
+        val msgs = useStateFlow(vm.messages)[props.groupId].orEmpty()
+        val focusedRelay = useStateFlow(repo.currentRelayUrl)
+        val relayUrl = props.relayUrl ?: focusedRelay
         val relayMetadata = useStateFlow(repo.relayMetadata)
         val (busy, setBusy) = useState { false }
         val (error, setError) = useState<String?> { null }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt
@@ -53,6 +53,13 @@ external interface ManageGroupModalProps : Props {
 
     /** Tab to open on first render (case-insensitive name, e.g. "members"). Defaults to Info. */
     var initialTab: String?
+
+    /**
+     * Relay hosting this group (route-carried). Scopes the member/request reads so a
+     * same-id group on another relay doesn't leak into this modal; null falls back to
+     * the focused relay (legacy callers).
+     */
+    var relayUrl: String?
 }
 
 private enum class ManageTab(val label: String, val ic: Ic) {
@@ -81,7 +88,8 @@ val ManageGroupModal =
 
         // The Hierarchy tab only makes sense where the relay advertises NIP-29 subgroup support
         // (nip29:{subgroups:true} in its NIP-11); hide it elsewhere.
-        val relayUrl = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
+        val focusedRelay = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
+        val relayUrl = props.relayUrl ?: focusedRelay
         val relayMetadata = useStateFlow(AppModule.nostrRepository.relayMetadata)
         val supportsSubgroups =
             (relayMetadata[relayUrl] ?: relayMetadata[relayUrl.normalizeRelayUrl()])?.supportsSubgroups == true
@@ -133,12 +141,17 @@ val ManageGroupModal =
                                     this.relayUrl = relayUrl
                                     onClose = props.onClose
                                 }
-                            ManageTab.Members -> ManageMembersSection { groupId = group.id }
+                            ManageTab.Members ->
+                                ManageMembersSection {
+                                    groupId = group.id
+                                    this.relayUrl = relayUrl
+                                }
                             ManageTab.Invites -> ManageInvitesSection { groupId = group.id }
                             ManageTab.Requests ->
                                 ManageRequestsSection {
                                     groupId = group.id
                                     isOpen = group.isOpen
+                                    this.relayUrl = relayUrl
                                 }
                             ManageTab.Hierarchy ->
                                 ManageHierarchySection {
@@ -373,6 +386,9 @@ private val ManageDangerSection =
 
 private external interface ManageGroupIdProps : Props {
     var groupId: String
+
+    /** Relay hosting the group; scopes VM reads (same-id groups on other relays stay out). */
+    var relayUrl: String?
 }
 
 private val ManageMembersSection =
@@ -380,11 +396,11 @@ private val ManageMembersSection =
         val repo = AppModule.nostrRepository
         // Same shared VM as the native manage modal: moderation actions surface relay
         // rejections/timeouts in moderationError instead of failing silently (#174).
-        val vm = useViewModel(props.groupId) { GroupViewModel(repo, props.groupId) }
+        val vm = useViewModel("${props.relayUrl}|${props.groupId}") { GroupViewModel(repo, props.groupId, props.relayUrl) }
         val moderationError = useStateFlow(vm.moderationError)
         val moderationBusy = useStateFlow(vm.moderationBusy)
-        val members = useStateFlow(repo.groupMembers)[props.groupId].orEmpty()
-        val admins = useStateFlow(repo.groupAdmins)[props.groupId].orEmpty().toSet()
+        val members = useStateFlow(vm.groupMembers)[props.groupId].orEmpty()
+        val admins = useStateFlow(vm.groupAdmins)[props.groupId].orEmpty().toSet()
         val userMetadata = useStateFlow(repo.userMetadata)
         val (tab, setTab) = useState { "All" }
         val (query, setQuery) = useState { "" }
@@ -1141,6 +1157,9 @@ private val ManageInvitesSection =
 private external interface ManageRequestsProps : Props {
     var groupId: String
     var isOpen: Boolean
+
+    /** Relay hosting the group; scopes the 9021 feed (same-id groups elsewhere stay out). */
+    var relayUrl: String?
 }
 
 private val ManageRequestsSection =
@@ -1148,8 +1167,11 @@ private val ManageRequestsSection =
         // Hooks must run unconditionally and in a stable order, so they precede the
         // open-group early return (React errors with "rendered more hooks" otherwise).
         val repo = AppModule.nostrRepository
-        val msgs = useStateFlow(repo.messages)[props.groupId].orEmpty()
-        val members = useStateFlow(repo.groupMembers)[props.groupId].orEmpty().toSet()
+        // Through the relay-scoped VM, not repo.messages: the raw bucket is keyed by bare
+        // id and would show a same-id group's join requests from another relay.
+        val vm = useViewModel("${props.relayUrl}|${props.groupId}") { GroupViewModel(repo, props.groupId, props.relayUrl) }
+        val msgs = useStateFlow(vm.messages)[props.groupId].orEmpty()
+        val members = useStateFlow(vm.groupMembers)[props.groupId].orEmpty().toSet()
         val userMetadata = useStateFlow(repo.userMetadata)
 
         val pending = pendingJoinRequests(msgs, members)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/MembersModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/MembersModal.kt
@@ -1,8 +1,10 @@
 package org.nostr.nostrord.web.modals
 
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.utils.shortNpub
 import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.icon
@@ -17,6 +19,9 @@ import web.cssom.ClassName
 
 external interface MembersModalProps : Props {
     var groupId: String
+
+    /** Relay hosting the group; scopes the roster (same-id groups elsewhere stay out). */
+    var relayUrl: String?
     var onClose: () -> Unit
 }
 
@@ -28,8 +33,9 @@ external interface MembersModalProps : Props {
 val MembersModal =
     FC<MembersModalProps> { props ->
         val repo = AppModule.nostrRepository
-        val members = useStateFlow(repo.groupMembers)[props.groupId].orEmpty()
-        val admins = useStateFlow(repo.groupAdmins)[props.groupId].orEmpty().toSet()
+        val vm = useViewModel("${props.relayUrl}|${props.groupId}") { GroupViewModel(repo, props.groupId, props.relayUrl) }
+        val members = useStateFlow(vm.groupMembers)[props.groupId].orEmpty()
+        val admins = useStateFlow(vm.groupAdmins)[props.groupId].orEmpty().toSet()
         val userMetadata = useStateFlow(repo.userMetadata)
         val (selected, setSelected) = useState<String?> { null }
         useEscClose { props.onClose() }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2473,6 +2473,7 @@ val ChatScreen =
                 "edit" ->
                     ManageGroupModal {
                         this.group = group
+                        this.relayUrl = props.relayUrl
                         onClose = { setModal(null) }
                     }
                 "share" ->
@@ -2484,6 +2485,7 @@ val ChatScreen =
                     ManageGroupModal {
                         this.group = group
                         initialTab = "members"
+                        this.relayUrl = props.relayUrl
                         onClose = { setModal(null) }
                     }
                 "addmember" ->
@@ -2506,6 +2508,7 @@ val ChatScreen =
                     ManageGroupModal {
                         this.group = group
                         initialTab = "requests"
+                        this.relayUrl = props.relayUrl
                         onClose = { setModal(null) }
                     }
             }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2438,6 +2438,7 @@ val ChatScreen =
             if (infoOpen) {
                 GroupInfoModal {
                     this.group = group
+                    this.relayUrl = props.relayUrl
                     onLeave = {
                         setInfoOpen(false)
                         // App-lifetime scope: the leave publish must survive the
@@ -2496,6 +2497,7 @@ val ChatScreen =
                 "invite" ->
                     InviteCodesModal {
                         groupId = group.id
+                        this.relayUrl = props.relayUrl
                         onClose = { setModal(null) }
                     }
                 "joincode" ->

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -103,6 +103,12 @@ import org.nostr.nostrord.ui.screens.group.pendingJoinRequests as computePending
 
 external interface ChatScreenProps : Props {
     var group: GroupMetadata
+
+    /**
+     * Relay the route carried; scopes the shared GroupViewModel so same-id groups on
+     * two relays don't share membership/metadata state.
+     */
+    var relayUrl: String?
     var onLeave: () -> Unit
 
     /** A deep-linked (&e=) message to scroll to + highlight once it's loaded, or null. */
@@ -1046,7 +1052,9 @@ val ChatScreen =
         val repo = AppModule.nostrRepository
         // Shared screen logic. Keyed by group.id so the VM (and its scope) is recreated
         // when the open group changes while this component stays mounted.
-        val vm = useViewModel(group.id) { GroupViewModel(AppModule.nostrRepository, group.id) }
+        val vm = useViewModel("${props.relayUrl}|${group.id}") {
+            GroupViewModel(AppModule.nostrRepository, group.id, props.relayUrl)
+        }
 
         val messagesByGroup = useStateFlow(vm.messages)
         val messageStatus = useStateFlow(vm.messageStatus)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
@@ -334,7 +334,7 @@ internal fun ChildrenBuilder.discoverGroupCard(
     // and flips off (skeleton stops) once the list arrives or the fetch times out.
     val peopleLoading = dg.peopleLoading
     button {
-        key = meta.id
+        key = "${dg.relayUrl}/${meta.id}"
         // Non-interactive in onboarding: the card itself does nothing (no pointer); only
         // the Join button acts, so the user can join several groups without leaving.
         className = ClassName(if (interactive) "group-card" else "group-card static")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
@@ -220,7 +220,7 @@ val ProfilePage =
                         groups.forEach { group ->
                             val groupName = group.meta.name ?: group.meta.id
                             button {
-                                key = group.meta.id
+                                key = "${group.relayUrl}/${group.meta.id}"
                                 className = ClassName("profile-group-row")
                                 onClick = { props.onOpenGroup(GroupRoute(group.relayUrl, group.meta.id)) }
                                 WebAvatar {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -74,7 +74,9 @@ external interface ThreadsScreenProps : Props {
 val ThreadsScreen =
     FC<ThreadsScreenProps> { props ->
         val route = props.route
-        val vm = useViewModel(route.groupId) { ThreadsViewModel(AppModule.nostrRepository, route.groupId) }
+        val vm = useViewModel("${route.relayUrl}|${route.groupId}") {
+            ThreadsViewModel(AppModule.nostrRepository, route.groupId, route.relayUrl)
+        }
         val threads = useStateFlow(vm.threads)
         val isLoading = useStateFlow(vm.isLoading)
         val openThread = useStateFlow(vm.openThread)


### PR DESCRIPTION
In NIP-29 a group's identity is the pair (relay, id), not the id alone; the spec explicitly allows the same id to name independent communities on different relays. Creating a group on a second relay with an id that already existed made the original vanish from My groups (the survivor depended on map iteration order), and the two groups then bled into each other everywhere: shared message history, overwritten member/admin lists, the wrong relay's join requests and invite codes, both rail chips lighting up as active. The persistence layer (kind:10009 parsing, per-relay group stores) was already correct; the consumption layer collapsed everything by bare id.

The fix keeps the bare-id stores but makes every consumer relay-aware through three mechanisms:

| Mechanism | What it covers |
|---|---|
| Route relay threaded end to end | `GroupRoute.relayUrl` now reaches every `GroupViewModel`/`ThreadsViewModel` and modal on both UIs; a per-group relay hint pins `getRelayForGroup` (sends, REQs, pagination) to the relay the user actually opened |
| Origin-relay stamp on messages | `NostrMessage.relayUrl` is set at ingestion, on optimistic sends and on cache restore; VMs filter the shared buckets by the route relay, and the disk cache stores each relay's history in its own `relay|groupId` slot |
| Per-relay member/admin/role mirrors | kind:39001/2/3 lists get a relay-scoped mirror with per-(relay, group) staleness guards, so one relay's list (or its newer timestamp) can never overwrite or starve the other's; membership, moderation gating and home-card previews read the mirror |

A final audit swept the remaining bare-id read sites (read-only MembersModal on both UIs, web GroupInfo/InviteCodes/Manage modals, native GroupScreen modals and parent/channel navigation, home and discovery dedup, web list keys, rail active chip) onto the scoped paths.

Known limits, deferred as follow-ups: unread badges, pagination state and the restricted-group set are still bare-id (cosmetic or unscopable without new mirrors); the NIP-29 migration/fork detection built on top of this lives on a separate branch. Validated with `compileKotlinJvm`, `compileKotlinJs` and `:composeApp:jvmTest` (15 new tests), plus manually on web with `nostrord` hosted on both groups.0xchat.com and chat.wisp.talk: independent histories, members, requests and rail state.

Commits:
- 9143d9c0 feat(groups): treat same-id groups on different relays as distinct
- 9b189232 fix(groups): stop same-id groups sharing message history across relays
- 604fece8 fix(groups): per-relay member/admin/role lists for same-id groups
- c68afa1f fix(groups): rail active chip matches by (relay, id)
- e60c611d fix(groups): scope Manage group modal and screen extras to the route relay
- 8c89eb96 fix(groups): sweep remaining bare-id read sites that leak across same-id groups