### PR TITLE
fix(web): jump pill keeps the mobile keyboard open

### DIFF
--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2258,6 +2258,9 @@ val ChatScreen =
                             key = "chat-jump-bottom"
                             className = ClassName("chat-jump-bottom")
                             title = if (jumpsToDivider) "Jump to new messages" else "Jump to latest message"
+                            // Keep composer focus: the tap's synthesized mousedown would blur
+                            // the input and close the mobile keyboard (native keeps it open).
+                            onMouseDown = { it.preventDefault() }
                             onClick = {
                                 if (jumpsToDivider) {
                                     // First tap: land on the "New messages" divider.


### PR DESCRIPTION
Follow-up to #199 (reopened): the earlier fix (13bb22eb) made the jump land at the bottom when the keyboard closes, but the keyboard should not close at all. The pill's tap fires a synthesized mousedown that blurs the composer; `preventDefault()` on the pill's `onMouseDown` keeps the composer focused so the keyboard stays up during the jump, matching the native apps. The click handler still runs, and the existing keyboard-close compensation stays in place for jumps started with the keyboard already down.

Same pattern already used by other focus-preserving buttons in ChatScreen/DmPage.

- dddf4985 fix(web): jump pill keeps the mobile keyboard open

Fixes #199