### PR TITLE
fix(nip46): pace bunker publishes and back off on relay rate limits

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -11,6 +11,13 @@ import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
+// Per-relay WebSocket connect timeout for the NIP-46 signer relays. Longer than
+// NostrGroupClient's 7s default: the QR/bunker flow runs while the account's own
+// relay sockets are (re)connecting, and a cold handshake can exceed 7s under that
+// load. A dropped signer relay here silently loses the signer's connect response
+// ("Waiting for signer..." forever) - mirrors the web's 20s timeout.
+private const val SIGNER_RELAY_CONNECT_TIMEOUT_MS = 20_000L
+
 actual class Nip46Client actual constructor(
     existingPrivateKey: String?,
 ) {
@@ -72,7 +79,7 @@ actual class Nip46Client actual constructor(
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
-                        if (!client.waitForConnection()) {
+                        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
                             // WS never opened (timeout) — drop it so callers don't
                             // treat a dead socket as a live relay connection.
                             client.disconnect()
@@ -110,7 +117,7 @@ actual class Nip46Client actual constructor(
                     val cleanUrl = relayUrl.trimEnd('/')
                     val client = NostrGroupClient(cleanUrl)
                     client.connect { msg -> handleMessage(msg, client) }
-                    if (!client.waitForConnection()) {
+                    if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
                         // WS never opened — drop it (mirrors connectRelaysParallel)
                         // instead of adding a dead socket and completing firstReady.
                         // Otherwise the QR displays while no listening sub is live,
@@ -382,7 +389,15 @@ actual class Nip46Client actual constructor(
                     }
                     attempt++
                 }
-                responseDeferred.await()
+                try {
+                    val response = responseDeferred.await()
+                    if (background) publishPacer.noteResponseArrived()
+                    response
+                } catch (e: CancellationException) {
+                    // Died unanswered (timeout/cancel): the signer or its relay path is behind.
+                    if (background) publishPacer.noteResponseLost()
+                    throw e
+                }
             } finally {
                 pendingRequests.remove(requestId)
             }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -368,10 +368,11 @@ actual class Nip46Client actual constructor(
             try {
                 // Publish in parallel via sendAndAwaitOk so a relay-side rejection
                 // surfaces immediately. The response sub opened on connect routes
-                // the signer's reply back into responseDeferred. publishPacer spaces
-                // the publishes and, when the relay rate-limits, holds a shared
-                // cooldown and retries; it is never held across the response await.
-                var attempt = 1
+                // the signer's reply back into responseDeferred. A rate-limited
+                // publish retries under the pacer's escalating cooldown until this
+                // request's own deadline: failing hard reads as "signer unreachable"
+                // upstream and tears the session down, when the relay only asked us
+                // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
@@ -384,11 +385,10 @@ actual class Nip46Client actual constructor(
                     val rateLimited = publishResults.any {
                         it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
                     }
-                    if (rateLimited) publishPacer.noteRateLimited()
-                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    if (!rateLimited) {
                         throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
                     }
-                    attempt++
+                    publishPacer.noteRateLimited()
                 }
                 try {
                     val response = responseDeferred.await()

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -343,6 +343,7 @@ actual class Nip46Client actual constructor(
         // see). created_at is stamped after the slot wait so a long pause cannot expire the
         // event.
         publishPacer.withRequestSlot(background) {
+            val requestStartMs = epochMillis()
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -391,7 +392,7 @@ actual class Nip46Client actual constructor(
                 }
                 try {
                     val response = responseDeferred.await()
-                    if (background) publishPacer.noteResponseArrived()
+                    if (background) publishPacer.noteResponseArrived(latencyMs = epochMillis() - requestStartMs)
                     response
                 } catch (e: CancellationException) {
                     // Died unanswered (timeout/cancel): the signer or its relay path is behind.

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -327,55 +327,60 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        val event =
-            Event(
-                pubkey = clientKeyPair.publicKeyHex,
-                createdAt = epochMillis() / 1000,
-                kind = 24133,
-                tags = listOf(listOf("p", signerPubkey)),
-                content = encryptedContent,
-            )
+        // In-flight window: pauses new requests when the signer stops answering (its own
+        // response publishes got rate-limited, which our OK-based backoff cannot see).
+        // created_at is stamped after the slot wait so a long pause cannot expire the event.
+        publishPacer.withRequestSlot {
+            val event =
+                Event(
+                    pubkey = clientKeyPair.publicKeyHex,
+                    createdAt = epochMillis() / 1000,
+                    kind = 24133,
+                    tags = listOf(listOf("p", signerPubkey)),
+                    content = encryptedContent,
+                )
 
-        val signedEvent = event.sign(clientKeyPair)
-        val eventId = signedEvent.id
-            ?: throw Exception("Failed to sign NIP-46 request event")
-        val responseDeferred = CompletableDeferred<String>()
-        pendingRequests[requestId] = responseDeferred
+            val signedEvent = event.sign(clientKeyPair)
+            val eventId = signedEvent.id
+                ?: throw Exception("Failed to sign NIP-46 request event")
+            val responseDeferred = CompletableDeferred<String>()
+            pendingRequests[requestId] = responseDeferred
 
-        val eventMessage =
-            buildJsonArray {
-                add("EVENT")
-                add(signedEvent.toJsonObject())
-            }.toString()
+            val eventMessage =
+                buildJsonArray {
+                    add("EVENT")
+                    add(signedEvent.toJsonObject())
+                }.toString()
 
-        try {
-            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
-            // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred. publishPacer spaces
-            // the publishes and, when the relay rate-limits, holds a shared
-            // cooldown and retries; it is never held across the response await.
-            var attempt = 1
-            while (true) {
-                publishPacer.awaitTurn()
-                val publishResults = relayClients.map { client ->
-                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-                }.awaitAll()
-                if (publishResults.any { it is PublishResult.Success }) {
-                    publishPacer.noteAccepted()
-                    break
+            try {
+                // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+                // surfaces immediately. The response sub opened on connect routes
+                // the signer's reply back into responseDeferred. publishPacer spaces
+                // the publishes and, when the relay rate-limits, holds a shared
+                // cooldown and retries; it is never held across the response await.
+                var attempt = 1
+                while (true) {
+                    publishPacer.awaitTurn()
+                    val publishResults = relayClients.map { client ->
+                        async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                    }.awaitAll()
+                    if (publishResults.any { it is PublishResult.Success }) {
+                        publishPacer.noteAccepted()
+                        break
+                    }
+                    val rateLimited = publishResults.any {
+                        it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                    }
+                    if (rateLimited) publishPacer.noteRateLimited()
+                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                        throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                    }
+                    attempt++
                 }
-                val rateLimited = publishResults.any {
-                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
-                }
-                if (rateLimited) publishPacer.noteRateLimited()
-                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
-                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
-                }
-                attempt++
+                responseDeferred.await()
+            } finally {
+                pendingRequests.remove(requestId)
             }
-            responseDeferred.await()
-        } finally {
-            pendingRequests.remove(requestId)
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -306,6 +306,21 @@ actual class Nip46Client actual constructor(
 
     actual suspend fun nip44Decrypt(peerPubkey: String, ciphertext: String): String = sendRequest(generateRequestId(), "nip44_decrypt", listOf(peerPubkey, ciphertext))
 
+    actual suspend fun nip44DecryptBatch(items: List<Pair<String, String>>): List<String?> {
+        val payload = buildJsonArray {
+            items.forEach { (peer, ciphertext) ->
+                addJsonArray {
+                    add(peer)
+                    add(ciphertext)
+                }
+            }
+        }.toString()
+        val raw = sendRequest(generateRequestId(), "nip44_decrypt_batch", listOf(payload))
+        return nip46Json.parseToJsonElement(raw).jsonArray.map { el ->
+            if (el is JsonNull) null else el.jsonPrimitive.content
+        }
+    }
+
     private suspend fun sendRequest(
         requestId: String,
         method: String,
@@ -337,7 +352,7 @@ actual class Nip46Client actual constructor(
         // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
         // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
         // user-action signs/encrypts) publish immediately so they never queue behind it.
-        val background = method == "nip44_decrypt"
+        val background = method.startsWith("nip44_decrypt")
         // In-flight window: pauses new background requests when the signer stops answering
         // (its own response publishes got rate-limited, which our OK-based backoff cannot
         // see). created_at is stamped after the slot wait so a long pause cannot expire the

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -327,10 +327,15 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        // In-flight window: pauses new requests when the signer stops answering (its own
-        // response publishes got rate-limited, which our OK-based backoff cannot see).
-        // created_at is stamped after the slot wait so a long pause cannot expire the event.
-        publishPacer.withRequestSlot {
+        // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
+        // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
+        // user-action signs/encrypts) publish immediately so they never queue behind it.
+        val background = method == "nip44_decrypt"
+        // In-flight window: pauses new background requests when the signer stops answering
+        // (its own response publishes got rate-limited, which our OK-based backoff cannot
+        // see). created_at is stamped after the slot wait so a long pause cannot expire the
+        // event.
+        publishPacer.withRequestSlot(background) {
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -360,7 +365,7 @@ actual class Nip46Client actual constructor(
                 // cooldown and retries; it is never held across the response await.
                 var attempt = 1
                 while (true) {
-                    publishPacer.awaitTurn()
+                    publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -32,6 +32,9 @@ actual class Nip46Client actual constructor(
     private val relayConnectMutex = Mutex()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests: MutableMap<String, CompletableDeferred<String>> = java.util.concurrent.ConcurrentHashMap()
+
+    // Shared pacing + rate-limit backoff for every request publish (see Nip46PublishPacer).
+    private val publishPacer = Nip46PublishPacer()
     private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
@@ -348,12 +351,27 @@ actual class Nip46Client actual constructor(
         try {
             // Publish in parallel via sendAndAwaitOk so a relay-side rejection
             // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred.
-            val publishResults = relayClients.map { client ->
-                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-            }.awaitAll()
-            if (publishResults.none { it is PublishResult.Success }) {
-                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+            // the signer's reply back into responseDeferred. publishPacer spaces
+            // the publishes and, when the relay rate-limits, holds a shared
+            // cooldown and retries; it is never held across the response await.
+            var attempt = 1
+            while (true) {
+                publishPacer.awaitTurn()
+                val publishResults = relayClients.map { client ->
+                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                }.awaitAll()
+                if (publishResults.any { it is PublishResult.Success }) {
+                    publishPacer.noteAccepted()
+                    break
+                }
+                val rateLimited = publishResults.any {
+                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                }
+                if (rateLimited) publishPacer.noteRateLimited()
+                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                }
+                attempt++
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
@@ -136,8 +136,36 @@ interface NostrSigner {
             }
         }
 
+        /** How this signer session answers the custom `nip44_decrypt_batch` method. */
+        enum class BatchDecryptMode { Untried, Supported, Unsupported }
+
+        @Volatile
+        var batchDecryptMode: BatchDecryptMode = BatchDecryptMode.Untried
+            private set
+
+        private val decryptBatcher = org.nostr.nostrord.nostr.Nip46DecryptBatcher(
+            send = { items -> nip46Client.nip44DecryptBatch(items) },
+        )
+
         override suspend fun nip44Decrypt(peerPubkeyHex: String, ciphertext: String): String {
             if (disposed) throw SigningException("Bunker signer has been disposed")
+            // Batch lane first: concurrent decrypts (the DM backlog) coalesce into one
+            // request/response event pair, the only real cure for the bunker relay's
+            // rate limit. Falls back to per-item for signers without the method.
+            if (batchDecryptMode != BatchDecryptMode.Unsupported) {
+                try {
+                    val plaintext = decryptBatcher.decrypt(peerPubkeyHex, ciphertext)
+                    batchDecryptMode = BatchDecryptMode.Supported
+                    return plaintext
+                        ?: throw SigningException("Bunker NIP-44 decryption failed: signer could not decrypt")
+                } catch (e: org.nostr.nostrord.nostr.Nip46DecryptBatcher.BatchUnsupported) {
+                    batchDecryptMode = BatchDecryptMode.Unsupported
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    if (e is SigningException) throw e
+                    throw SigningException("Bunker NIP-44 decryption failed: ${e.message}", e)
+                }
+            }
             return try {
                 nip46Client.nip44Decrypt(peerPubkeyHex, ciphertext)
             } catch (e: Exception) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -987,7 +987,7 @@ class AuthManager(
                     handlePermissionDenied()
                     throw Exception("Signing permission denied. Please login again.")
                 }
-                if (sessionSigner is NostrSigner.Bunker) noteBunkerSignFailure(interactive)
+                if (sessionSigner is NostrSigner.Bunker) noteBunkerSignFailure(interactive && !isRateLimitThrottle(e))
                 throw e
             }
         }
@@ -1045,10 +1045,17 @@ class AuthManager(
                 markSignerUnreachable(BunkerUnreachableReason.PermissionDenied)
                 throw Exception("Your signer refused to sign. Check its permissions.")
             }
-            noteBunkerSignFailure(interactive)
+            noteBunkerSignFailure(interactive && !isRateLimitThrottle(e))
             throw e
         }
     }
+
+    // A rate-limited bunker publish is the relay asking us to slow down, not evidence the
+    // signer is gone. An interactive teardown here starts a reconnect loop whose fresh
+    // client re-bursts and gets rate-limited again (devices stuck cycling "can't reach
+    // signer" while the first one works), so a throttle only counts toward the
+    // background failure streak.
+    private fun isRateLimitThrottle(e: Exception): Boolean = org.nostr.nostrord.nostr.Nip46PublishPacer.isRateLimitReason(e.message ?: "")
 
     private fun signWithKeyPair(event: Event): Event {
         val kp = keyPair ?: throw Exception("Not logged in")

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -240,6 +240,19 @@ class NostrRepository(
     @kotlin.concurrent.Volatile
     private var dmBacklogHoldUntilMs = 0L
 
+    // Newest-first cap on a fresh device's backlog decrypt. Relays stream the REQ newest-first,
+    // so the first N wraps admitted are (approximately, gift-wrap created_at is randomized) the
+    // most recent conversation: they decrypt at the normal paced rate and fill the visible inbox
+    // fast. Everything older takes a spaced trickle slot and parks OUTSIDE the admission gate,
+    // so live wraps (arriving after every DM relay EOSEd) and the eager batch never queue behind
+    // the deep history. 2 signer round trips per wrap times N devices is the load that trips the
+    // bunker relay's rate limit; the cap bounds what a fresh login costs.
+    private val DM_EAGER_DECRYPT_CAP = 50
+    private val DM_TRICKLE_INTERVAL_MS = 5_000L
+    private val dmTrickleMutex = Mutex()
+    private var dmEagerDecryptCount = 0
+    private var dmTrickleNextSlotMs = 0L
+
     // Durable per-wrap dedup so a re-streamed backlog skips wraps already decrypted (no repeat
     // bunker round-trip). Loaded per account in startDmInbox; grows as wraps are handled.
     // Copy-on-write + @Volatile: the relay pipeline thread reads it while the (serialized) decrypt
@@ -1779,6 +1792,10 @@ class NostrRepository(
         resumeDmSendQueue(myPub)
 
         dmBacklogHoldUntilMs = org.nostr.nostrord.utils.epochMillis() + DM_BACKLOG_BOOT_HOLD_MS
+        dmTrickleMutex.withLock {
+            dmEagerDecryptCount = 0
+            dmTrickleNextSlotMs = 0L
+        }
 
         // Resume per-wrap decrypt progress, and reset the this-session sync bookkeeping.
         dmProcessedWrapIds = SecureStorage.loadDmProcessedWrapIds(myPub)
@@ -4564,6 +4581,10 @@ class NostrRepository(
                     dmInFlightWrapIds = dmInFlightWrapIds + wrapId
                 }
                 scope.launch {
+                    // Captured at arrival: wraps streaming in before every DM relay EOSEd are
+                    // backlog; anything after is a live incoming DM.
+                    val liveWrap = dmInboxSubscribedRelays.isNotEmpty() &&
+                        dmInboxEosedRelays.containsAll(dmInboxSubscribedRelays)
                     try {
                         // A bunker signer pays a remote round-trip per NIP-44 decrypt, and a gift
                         // wrap needs two (wrap then seal). A cold start with a large DM backlog
@@ -4598,6 +4619,27 @@ class NostrRepository(
                                 // signer's burst.
                                 val bootHold = dmBacklogHoldUntilMs - org.nostr.nostrord.utils.epochMillis()
                                 if (bootHold > 0) delay(bootHold)
+                                // Live wraps and the newest DM_EAGER_DECRYPT_CAP go straight to the
+                                // gate; deeper history parks on a trickle slot (assigned FIFO, so
+                                // approximately newest-first) outside it.
+                                val trickleSlot = dmTrickleMutex.withLock {
+                                    when {
+                                        liveWrap -> null
+                                        dmEagerDecryptCount < DM_EAGER_DECRYPT_CAP -> {
+                                            dmEagerDecryptCount++
+                                            null
+                                        }
+                                        else -> {
+                                            dmTrickleNextSlotMs =
+                                                maxOf(org.nostr.nostrord.utils.epochMillis(), dmTrickleNextSlotMs) + DM_TRICKLE_INTERVAL_MS
+                                            dmTrickleNextSlotMs
+                                        }
+                                    }
+                                }
+                                if (trickleSlot != null) {
+                                    val trickleWait = trickleSlot - org.nostr.nostrord.utils.epochMillis()
+                                    if (trickleWait > 0) delay(trickleWait)
+                                }
                                 bunkerPublishGate.withLock { delay(BUNKER_WRAP_ADMIT_INTERVAL_MS) }
                                 decrypt()
                             } else {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -196,16 +196,18 @@ class NostrRepository(
     // decrypt in-process and don't care about it.
     private val dmDecryptSemaphore = Semaphore(6)
 
-    // A bunker decrypt PUBLISHES a kind:24133 request to the bunker relay. A full DM backlog (two
-    // publishes per gift wrap) bursts hundreds of events at once and trips the relay's publish rate
-    // limit ("you are noting too much"), which REJECTS them before the signer ever sees them. So the
-    // request publishes are spaced out by this gate. Crucially the gate is released BEFORE the await,
-    // not held across it: the signer answers nip44_decrypt in bursts, so we keep many requests
-    // in-flight for one burst to satisfy at once (serializing the await instead collapses throughput
-    // and every wrap hits the 90s timeout). Local / NIP-07 decrypt in-process (no publish), skip the
-    // gate, and keep the full semaphore concurrency above.
+    // A bunker decrypt PUBLISHES two kind:24133 requests to the bunker relay (wrap then seal), and
+    // every publish is paced + rate-limit-backed-off inside Nip46Client (Nip46PublishPacer). This
+    // gate only ADMITS backlog wraps slowly enough (two publishes' worth of client pacing per wrap)
+    // that the client-side publish queue stays shallow: the admission wait happens BEFORE the 90s
+    // decrypt timeout starts counting, and interactive signs (reactions, uploads, NIP-42 AUTH) find
+    // a near-empty queue. Crucially the gate is released BEFORE the await, not held across it: the
+    // signer answers nip44_decrypt in bursts, so we keep many requests in-flight for one burst to
+    // satisfy at once (serializing the await instead collapses throughput and every wrap hits the
+    // 90s timeout). Local / NIP-07 decrypt in-process (no publish), skip the gate, and keep the
+    // full semaphore concurrency above.
     private val bunkerPublishGate = Mutex()
-    private val BUNKER_PUBLISH_INTERVAL_MS = 400L
+    private val BUNKER_WRAP_ADMIT_INTERVAL_MS = 2 * org.nostr.nostrord.nostr.Nip46PublishPacer.MIN_INTERVAL_MS
 
     // Cap one wrap's decryption. The signer RPC's own timeout is 120s; an intermittently
     // unresponsive bunker would otherwise pin a decrypt permit for that long per stuck wrap. But too
@@ -4579,9 +4581,9 @@ class NostrRepository(
                         }
                         val handled =
                             if (signer is NostrSigner.Bunker) {
-                                // Space out the publish, then release the gate before awaiting so many
-                                // requests stay in-flight for the signer's next response burst.
-                                bunkerPublishGate.withLock { delay(BUNKER_PUBLISH_INTERVAL_MS) }
+                                // Admit one wrap per two client-pacer slots, releasing the gate before
+                                // the decrypt so many requests stay in-flight for the signer's burst.
+                                bunkerPublishGate.withLock { delay(BUNKER_WRAP_ADMIT_INTERVAL_MS) }
                                 decrypt()
                             } else {
                                 dmDecryptSemaphore.withPermit { decrypt() }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -249,6 +249,11 @@ class NostrRepository(
     // bunker relay's rate limit; the cap bounds what a fresh login costs.
     private val DM_EAGER_DECRYPT_CAP = 50
     private val DM_TRICKLE_INTERVAL_MS = 5_000L
+
+    // With nip44_decrypt_batch confirmed (Amber extension), decrypts coalesce into one
+    // request/response event pair per ~16 items, so the per-wrap admission can run hot
+    // and the trickle is unnecessary - the batcher is what shields the relay.
+    private val BUNKER_WRAP_ADMIT_INTERVAL_BATCHED_MS = 100L
     private val dmTrickleMutex = Mutex()
     private var dmEagerDecryptCount = 0
     private var dmTrickleNextSlotMs = 0L
@@ -4622,9 +4627,12 @@ class NostrRepository(
                                 // Live wraps and the newest DM_EAGER_DECRYPT_CAP go straight to the
                                 // gate; deeper history parks on a trickle slot (assigned FIFO, so
                                 // approximately newest-first) outside it.
+                                val batchedDecrypt =
+                                    (signer as? NostrSigner.Bunker)?.batchDecryptMode ==
+                                        NostrSigner.Bunker.BatchDecryptMode.Supported
                                 val trickleSlot = dmTrickleMutex.withLock {
                                     when {
-                                        liveWrap -> null
+                                        liveWrap || batchedDecrypt -> null
                                         dmEagerDecryptCount < DM_EAGER_DECRYPT_CAP -> {
                                             dmEagerDecryptCount++
                                             null
@@ -4640,7 +4648,9 @@ class NostrRepository(
                                     val trickleWait = trickleSlot - org.nostr.nostrord.utils.epochMillis()
                                     if (trickleWait > 0) delay(trickleWait)
                                 }
-                                bunkerPublishGate.withLock { delay(BUNKER_WRAP_ADMIT_INTERVAL_MS) }
+                                bunkerPublishGate.withLock {
+                                    delay(if (batchedDecrypt) BUNKER_WRAP_ADMIT_INTERVAL_BATCHED_MS else BUNKER_WRAP_ADMIT_INTERVAL_MS)
+                                }
                                 decrypt()
                             } else {
                                 dmDecryptSemaphore.withPermit { decrypt() }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -226,9 +226,19 @@ class NostrRepository(
     private val DM_SEND_RETRY_BASE_MS = 4_000L
     private val DM_SEND_RETRY_MAX_MS = 30_000L
 
-    // Give up on a wrap after this many failed decrypt attempts (this session). Stops the retry
-    // loop from hammering wraps the signer never answers, or genuinely malformed ones.
-    private val DM_MAX_DECRYPT_ATTEMPTS = 4
+    // Give up on a wrap after this many failed decrypt attempts (this session). High enough that
+    // congestion cycles (the relay dropping the signer's responses -> 90s timeouts) don't park the
+    // inbox for the whole session; still stops the retry loop from hammering wraps the signer
+    // never answers, or genuinely malformed ones.
+    private val DM_MAX_DECRYPT_ATTEMPTS = 10
+
+    // Keeps the decrypt backlog off the signer for the first seconds of a session so
+    // login-critical signs (NIP-42 AUTH, handshake acks - including another device's login
+    // against the same signer) find its queue empty. Set in startDmInbox.
+    private val DM_BACKLOG_BOOT_HOLD_MS = 10_000L
+
+    @kotlin.concurrent.Volatile
+    private var dmBacklogHoldUntilMs = 0L
 
     // Durable per-wrap dedup so a re-streamed backlog skips wraps already decrypted (no repeat
     // bunker round-trip). Loaded per account in startDmInbox; grows as wraps are handled.
@@ -1767,6 +1777,8 @@ class NostrRepository(
         wireDmPersistence(myPub)
         // Resume any wraps that never reached a relay before the app last closed.
         resumeDmSendQueue(myPub)
+
+        dmBacklogHoldUntilMs = org.nostr.nostrord.utils.epochMillis() + DM_BACKLOG_BOOT_HOLD_MS
 
         // Resume per-wrap decrypt progress, and reset the this-session sync bookkeeping.
         dmProcessedWrapIds = SecureStorage.loadDmProcessedWrapIds(myPub)
@@ -4581,8 +4593,11 @@ class NostrRepository(
                         }
                         val handled =
                             if (signer is NostrSigner.Bunker) {
-                                // Admit one wrap per two client-pacer slots, releasing the gate before
-                                // the decrypt so many requests stay in-flight for the signer's burst.
+                                // Boot hold, then admit one wrap per two client-pacer slots, releasing
+                                // the gate before the decrypt so many requests stay in-flight for the
+                                // signer's burst.
+                                val bootHold = dmBacklogHoldUntilMs - org.nostr.nostrord.utils.epochMillis()
+                                if (bootHold > 0) delay(bootHold)
                                 bunkerPublishGate.withLock { delay(BUNKER_WRAP_ADMIT_INTERVAL_MS) }
                                 decrypt()
                             } else {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.kt
@@ -76,5 +76,13 @@ expect class Nip46Client(
     /** NIP-46 nip44_decrypt RPC: decrypt [ciphertext] from [peerPubkey] with the remote signer's key. */
     suspend fun nip44Decrypt(peerPubkey: String, ciphertext: String): String
 
+    /**
+     * Batch variant of [nip44Decrypt] (custom method `nip44_decrypt_batch`: one
+     * request/response event pair for many ciphertexts - see Nip46DecryptBatcher).
+     * Result aligns with [items]; null = that item could not be decrypted. Throws
+     * when the signer does not support the method; callers fall back to per-item.
+     */
+    suspend fun nip44DecryptBatch(items: List<Pair<String, String>>): List<String?>
+
     fun disconnect()
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46DecryptBatcher.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46DecryptBatcher.kt
@@ -1,0 +1,101 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Coalesces concurrent NIP-44 decrypt calls into `nip44_decrypt_batch` requests
+ * (one request/response event pair for many ciphertexts). No background job:
+ * the first caller to grab the drain lock services the queue for everyone and
+ * keeps draining until it is empty; items that pile up while a batch is in
+ * flight ride the next one, so batches fatten under load by backpressure alone.
+ *
+ * A signer without the custom method (or one that requires user approval for
+ * it) fails the whole batch with [BatchUnsupported]; the owner then falls back
+ * to per-item decrypts for the rest of the session.
+ */
+class Nip46DecryptBatcher(
+    private val maxBatch: Int = MAX_BATCH,
+    private val send: suspend (List<Pair<String, String>>) -> List<String?>,
+) {
+    /** The signer cannot serve batches (unknown method / approval required). */
+    class BatchUnsupported(cause: Throwable) : Exception("Signer does not support nip44_decrypt_batch: ${cause.message}", cause)
+
+    private class Item(val peer: String, val ciphertext: String) {
+        val result = CompletableDeferred<String?>()
+    }
+
+    private val queueLock = Mutex()
+    private val queue = ArrayDeque<Item>()
+    private val drainLock = Mutex()
+
+    /** Returns the plaintext, or null when the signer could not decrypt this item. */
+    suspend fun decrypt(peerPubkey: String, ciphertext: String): String? {
+        val item = Item(peerPubkey, ciphertext)
+        queueLock.withLock { queue.addLast(item) }
+        // The active drainer will take this item; anyone else just awaits. If the
+        // drainer was cancelled mid-flight the item stays queued until the next
+        // caller drains - the owner's own decrypt timeout bounds that wait.
+        while (!item.result.isCompleted) {
+            if (drainLock.tryLock()) {
+                try {
+                    drainAll()
+                } finally {
+                    drainLock.unlock()
+                }
+            } else {
+                break
+            }
+        }
+        return item.result.await()
+    }
+
+    private suspend fun drainAll() {
+        while (true) {
+            val batch = queueLock.withLock {
+                if (queue.isEmpty()) return
+                List(minOf(maxBatch, queue.size)) { queue.removeFirst() }
+            }
+            try {
+                val results = send(batch.map { it.peer to it.ciphertext })
+                batch.forEachIndexed { i, item -> item.result.complete(results.getOrNull(i)) }
+            } catch (e: CancellationException) {
+                // The drainer's caller died (its decrypt timeout / scope teardown);
+                // fail this batch so its awaiters retry rather than hang.
+                batch.forEach { it.result.completeExceptionally(Exception("Batch decrypt aborted", e)) }
+                throw e
+            } catch (e: Throwable) {
+                val wrapped = if (isUnsupportedBatchError(e)) BatchUnsupported(e) else e
+                batch.forEach { it.result.completeExceptionally(wrapped) }
+                if (wrapped is BatchUnsupported) {
+                    // Everything still queued would fail the same way; flush it so
+                    // every caller falls back to per-item at once.
+                    queueLock.withLock {
+                        while (queue.isNotEmpty()) queue.removeFirst().result.completeExceptionally(BatchUnsupported(e))
+                    }
+                    return
+                }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Bounded by relay event-size caps: the response carries every plaintext
+         * (seal events, ~1-2KB each) NIP-44-encrypted inside one kind:24133.
+         */
+        const val MAX_BATCH = 16
+
+        /** Errors that mean "this signer can't serve batches", not "this batch failed". */
+        fun isUnsupportedBatchError(e: Throwable): Boolean {
+            val msg = e.message?.lowercase() ?: return false
+            return msg.contains("unrecognized method") ||
+                msg.contains("unknown method") ||
+                msg.contains("not supported") ||
+                msg.contains("approval required") ||
+                msg.contains("invalid batch params")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -12,33 +12,32 @@ import org.nostr.nostrord.utils.epochMillis
 /**
  * Flow control for kind:24133 publishes to the bunker relay.
  *
- * The one traffic source that floods the relay is the DM gift-wrap decrypt
- * backlog (two nip44_decrypt per wrap, per device). That background lane is
- * paced ([awaitTurn]), bounded by an adaptive in-flight window
- * ([withRequestSlot]) and backed off on explicit rate-limit rejections.
- * Interactive requests (login handshake, NIP-42 AUTH, user-action
- * signs/encrypts - a handful per session) publish immediately and honor only
- * an explicit relay cooldown: queuing them behind the backlog made bunker
- * login visibly slow.
+ * Every request costs the relay twice: our publish and the signer's response
+ * publish, and the relay rate-limits both sides. The signer's side is
+ * invisible to OK-based backoff here - it shows up only as responses arriving
+ * slow (current Amber retries each response up to 5x re-signed) or not at all.
  *
- * The relay also rate-limits the SIGNER's response publishes, which is
- * invisible to OK-based backoff here - it shows up only as responses not
- * coming back. The adaptive window (TCP-style AIMD: grow by one per answered
- * request, halve on a lost one) converges each device onto the response rate
- * the relay actually delivers, so N devices sharing one signer shrink
- * automatically instead of stacking requests into its queue - which is also
- * what keeps the signer's own queue short enough that another device's login
- * gets answered promptly, and stops the signer retrying stale responses that
- * the relay then rejects as "ephemeral event expired".
+ * Background lane (the DM gift-wrap decrypt backlog, the one bulk source):
+ * paced by an adaptive interval, bounded by an adaptive in-flight window
+ * (TCP-style AIMD), cooled down on explicit rate-limit rejections. Interactive
+ * lane (login handshake, NIP-42 AUTH, user-action signs/encrypts): never
+ * queues behind the backlog, but pays a token bucket - a fresh session AUTHs
+ * every relay in the pool at once, and that burst alone (x2 with a second
+ * device logging in) can blow the relay's budget with no DM involved. The
+ * bucket lets a login's handful through instantly and spaces the rest.
  */
 class Nip46PublishPacer(
-    private val minIntervalMs: Long = MIN_INTERVAL_MS,
+    private val baseIntervalMs: Long = MIN_INTERVAL_MS,
     private val now: () -> Long = { epochMillis() },
 ) {
     private val gate = Mutex()
+    private val interactiveGate = Mutex()
 
     // Raced by the note* callbacks; the races are benign (worst case one extra
     // paced slot or cooldown step).
+    @kotlin.concurrent.Volatile
+    private var currentIntervalMs = baseIntervalMs
+
     @kotlin.concurrent.Volatile
     private var nextSlotAtMs = 0L
 
@@ -47,6 +46,10 @@ class Nip46PublishPacer(
 
     @kotlin.concurrent.Volatile
     private var cooldownUntilMs = 0L
+
+    // Interactive token bucket, strictly under [interactiveGate].
+    private var interactiveTokens = INTERACTIVE_BURST.toDouble()
+    private var interactiveRefillAtMs = 0L
 
     // Adaptive window state. [inFlight] and the waiter queue are strictly under
     // [windowLock]; [windowSize] is volatile so shrink paths can write it from
@@ -59,29 +62,54 @@ class Nip46PublishPacer(
     private var windowSize = INITIAL_WINDOW
 
     internal val windowSizeNow: Int get() = windowSize
+    internal val intervalNowMs: Long get() = currentIntervalMs
 
     /**
-     * Wait for this publish's slot. Background requests pay the pacing interval
-     * plus any active rate-limit cooldown; interactive ones only the cooldown.
+     * Wait for this publish's slot. Background requests pay the adaptive pacing
+     * interval plus any active rate-limit cooldown; interactive ones pay the
+     * cooldown and the token bucket (burst of [INTERACTIVE_BURST], then one
+     * token per interval).
      */
     suspend fun awaitTurn(background: Boolean = true) {
+        val cooldownWait = cooldownUntilMs - now()
+        if (cooldownWait > 0) delay(cooldownWait)
         if (!background) {
-            val wait = cooldownUntilMs - now()
-            if (wait > 0) delay(wait)
+            interactiveGate.withLock {
+                refillInteractiveLocked()
+                if (interactiveTokens < 1.0) {
+                    delay(((1.0 - interactiveTokens) * currentIntervalMs).toLong())
+                    refillInteractiveLocked()
+                }
+                interactiveTokens = maxOf(0.0, interactiveTokens - 1.0)
+            }
             return
         }
         gate.withLock {
             val wait = nextSlotAtMs - now()
             if (wait > 0) delay(wait)
-            nextSlotAtMs = maxOf(now(), nextSlotAtMs) + minIntervalMs
+            nextSlotAtMs = maxOf(now(), nextSlotAtMs) + currentIntervalMs
         }
+    }
+
+    private fun refillInteractiveLocked() {
+        val t = now()
+        if (interactiveRefillAtMs != 0L) {
+            val elapsed = t - interactiveRefillAtMs
+            if (elapsed > 0) {
+                interactiveTokens = minOf(
+                    INTERACTIVE_BURST.toDouble(),
+                    interactiveTokens + elapsed.toDouble() / currentIntervalMs,
+                )
+            }
+        }
+        interactiveRefillAtMs = t
     }
 
     /**
      * Runs [block] (the whole publish + response await) inside the adaptive
      * in-flight window when [background]; interactive requests bypass it for
-     * the same reason they skip pacing - they must not wait behind a backlog
-     * slot held across a full signer round trip.
+     * the same reason they skip the backlog queue - they must not wait behind
+     * a slot held across a full signer round trip.
      */
     suspend fun <T> withRequestSlot(background: Boolean = true, block: suspend () -> T): T {
         if (!background) return block()
@@ -94,28 +122,36 @@ class Nip46PublishPacer(
     }
 
     /**
-     * A background request's response arrived. Fast answer: the signer keeps up, widen the
-     * window. Slow answer (over [SLOW_RESPONSE_MS]): it arrived but the signer is drowning -
-     * its relay keeps rejecting response publishes, so each response burns seconds of the
-     * signer's own retry backoff (Amber: 5 re-signed attempts, 200ms-3.2s). Shrink gently so
-     * the combined multi-device queue at the signer stays short and an interactive sign
-     * (another device's login ack) is answered promptly.
+     * A background request's response arrived. Fast answer: the signer keeps up,
+     * widen the window and relax the interval. Slow answer (over
+     * [SLOW_RESPONSE_MS]): it arrived but the signer is drowning - its relay
+     * keeps rejecting response publishes, so each response burns seconds of the
+     * signer's own retry backoff. Shrink the window and stretch the interval so
+     * the combined multi-device rate drops under what the relay delivers and an
+     * interactive sign (another device's login ack) is answered promptly.
      */
     suspend fun noteResponseArrived(latencyMs: Long = 0L) {
         windowLock.withLock {
             if (latencyMs > SLOW_RESPONSE_MS) {
                 windowSize = maxOf(MIN_WINDOW, windowSize - maxOf(1, windowSize / 4))
-            } else if (windowSize < MAX_WINDOW) {
-                windowSize++
-                wakeSlotWaitersLocked()
+                stretchInterval()
+            } else {
+                relaxInterval()
+                if (windowSize < MAX_WINDOW) {
+                    windowSize++
+                    wakeSlotWaitersLocked()
+                }
             }
         }
     }
 
-    /** A background request died unanswered (timeout/cancel): halve the window. */
+    /** A background request died unanswered (timeout/cancel): halve the window, stretch the interval. */
     suspend fun noteResponseLost() {
         withContext(NonCancellable) {
-            windowLock.withLock { windowSize = maxOf(MIN_WINDOW, windowSize / 2) }
+            windowLock.withLock {
+                windowSize = maxOf(MIN_WINDOW, windowSize / 2)
+                stretchInterval()
+            }
         }
     }
 
@@ -131,6 +167,15 @@ class Nip46PublishPacer(
         cooldownUntilMs = maxOf(cooldownUntilMs, now() + cooldownMs)
         nextSlotAtMs = maxOf(nextSlotAtMs, cooldownUntilMs)
         windowSize = maxOf(MIN_WINDOW, windowSize / 2)
+        stretchInterval()
+    }
+
+    private fun stretchInterval() {
+        currentIntervalMs = minOf(currentIntervalMs * 2, MAX_INTERVAL_MS)
+    }
+
+    private fun relaxInterval() {
+        currentIntervalMs = maxOf(baseIntervalMs, currentIntervalMs * 3 / 4)
     }
 
     private suspend fun acquireSlot() {
@@ -175,11 +220,22 @@ class Nip46PublishPacer(
 
     companion object {
         const val MIN_INTERVAL_MS = 400L
+
+        /** Congestion cap for the adaptive pacing interval (stretch doubles up to here). */
+        const val MAX_INTERVAL_MS = 3_200L
+
         const val INITIAL_COOLDOWN_MS = 2_000L
         const val MAX_COOLDOWN_MS = 30_000L
 
         /** Publish attempts per request before the failure propagates to the caller. */
         const val MAX_PUBLISH_ATTEMPTS = 3
+
+        /**
+         * Interactive burst allowance. A login handshake needs 2-3 requests
+         * instantly; a fresh session's NIP-42 AUTH storm (one sign per pool
+         * relay) gets the rest spaced at the current interval.
+         */
+        const val INTERACTIVE_BURST = 6
 
         /**
          * Adaptive window bounds. Start modest so a fresh boot leaves the signer's

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -91,8 +91,15 @@ class Nip46PublishPacer(
         /** Publish attempts per request before the failure propagates to the caller. */
         const val MAX_PUBLISH_ATTEMPTS = 3
 
-        /** Unanswered requests allowed in flight per client (see [withRequestSlot]). */
-        const val MAX_IN_FLIGHT_REQUESTS = 8
+        /**
+         * Unanswered background requests allowed in flight per client (see [withRequestSlot]).
+         * Sized for the signer's burst cycle: it answers batches with quiet gaps, and each
+         * cycle can satisfy at most this many requests, so a small window collapses backlog
+         * throughput (decrypts pile into the 90s timeout and burn their retry attempts).
+         * The publish RATE is already bounded by [MIN_INTERVAL_MS]; this bound only has to
+         * stop the feed when responses stop coming back entirely.
+         */
+        const val MAX_IN_FLIGHT_REQUESTS = 24
 
         /** OK-false reasons that mean "slow down" (NIP-01 rate-limited: prefix + common free text). */
         fun isRateLimitReason(reason: String): Boolean {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -227,9 +227,6 @@ class Nip46PublishPacer(
         const val INITIAL_COOLDOWN_MS = 2_000L
         const val MAX_COOLDOWN_MS = 30_000L
 
-        /** Publish attempts per request before the failure propagates to the caller. */
-        const val MAX_PUBLISH_ATTEMPTS = 3
-
         /**
          * Interactive burst allowance. A login handshake needs 2-3 requests
          * instantly; a fresh session's NIP-42 AUTH storm (one sign per pool

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -2,7 +2,9 @@ package org.nostr.nostrord.nostr
 
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
 import org.nostr.nostrord.utils.epochMillis
 
 /**
@@ -22,6 +24,7 @@ class Nip46PublishPacer(
     private val now: () -> Long = { epochMillis() },
 ) {
     private val gate = Mutex()
+    private val requestWindow = Semaphore(MAX_IN_FLIGHT_REQUESTS)
 
     // Written under [gate] in awaitTurn and raced by the note* callbacks; both
     // races are benign (worst case one extra paced slot or cooldown step).
@@ -39,6 +42,17 @@ class Nip46PublishPacer(
             nextSlotAtMs = maxOf(now(), nextSlotAtMs) + minIntervalMs
         }
     }
+
+    /**
+     * Caps unanswered requests in flight (the whole publish + response await runs inside
+     * [block]). The relay rate-limits the SIGNER's response publishes too, and that side is
+     * invisible to the OK-based backoff here: it shows up only as responses not coming back.
+     * A full window pauses new publishes until answers return, draining the signer's queue
+     * instead of growing it (a grown queue also makes the signer retry stale responses that
+     * the relay then rejects as "ephemeral event expired"). Window > 1 because the signer
+     * answers in bursts with quiet gaps; serializing the awaits collapses throughput.
+     */
+    suspend fun <T> withRequestSlot(block: suspend () -> T): T = requestWindow.withPermit { block() }
 
     /** A relay accepted a publish: the rate limit (if any) has lifted. */
     fun noteAccepted() {
@@ -59,11 +73,16 @@ class Nip46PublishPacer(
         /** Publish attempts per request before the failure propagates to the caller. */
         const val MAX_PUBLISH_ATTEMPTS = 3
 
+        /** Unanswered requests allowed in flight per client (see [withRequestSlot]). */
+        const val MAX_IN_FLIGHT_REQUESTS = 8
+
         /** OK-false reasons that mean "slow down" (NIP-01 rate-limited: prefix + common free text). */
         fun isRateLimitReason(reason: String): Boolean {
             val r = reason.lowercase()
-            return r.contains("rate-limit") || r.contains("rate limit") ||
-                r.contains("slow down") || r.contains("noting too much")
+            return r.contains("rate-limit") ||
+                r.contains("rate limit") ||
+                r.contains("slow down") ||
+                r.contains("noting too much")
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -1,33 +1,44 @@
 package org.nostr.nostrord.nostr
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withContext
 import org.nostr.nostrord.utils.epochMillis
 
 /**
- * Paces kind:24133 publishes to the bunker relay and backs off when it
- * rate-limits ("rate-limited: you are noting too much"). Every NIP-46 request
- * type (sign_event, nip44 encrypt/decrypt, get_public_key) takes a slot via
- * [awaitTurn] before publishing. The slot lock is held only for the wait,
- * never across the response await: the signer answers in bursts, so many
- * requests must stay in-flight for one burst to satisfy at once.
+ * Flow control for kind:24133 publishes to the bunker relay.
  *
- * Pacing also throttles the signer's own kind:24133 responses (one per
- * request, on the same relay), which is what the relay was rate-limiting on
- * the signer's side ("Error sending bunker response" in Amber).
+ * The one traffic source that floods the relay is the DM gift-wrap decrypt
+ * backlog (two nip44_decrypt per wrap, per device). That background lane is
+ * paced ([awaitTurn]), bounded by an adaptive in-flight window
+ * ([withRequestSlot]) and backed off on explicit rate-limit rejections.
+ * Interactive requests (login handshake, NIP-42 AUTH, user-action
+ * signs/encrypts - a handful per session) publish immediately and honor only
+ * an explicit relay cooldown: queuing them behind the backlog made bunker
+ * login visibly slow.
+ *
+ * The relay also rate-limits the SIGNER's response publishes, which is
+ * invisible to OK-based backoff here - it shows up only as responses not
+ * coming back. The adaptive window (TCP-style AIMD: grow by one per answered
+ * request, halve on a lost one) converges each device onto the response rate
+ * the relay actually delivers, so N devices sharing one signer shrink
+ * automatically instead of stacking requests into its queue - which is also
+ * what keeps the signer's own queue short enough that another device's login
+ * gets answered promptly, and stops the signer retrying stale responses that
+ * the relay then rejects as "ephemeral event expired".
  */
 class Nip46PublishPacer(
     private val minIntervalMs: Long = MIN_INTERVAL_MS,
     private val now: () -> Long = { epochMillis() },
 ) {
     private val gate = Mutex()
-    private val requestWindow = Semaphore(MAX_IN_FLIGHT_REQUESTS)
 
-    // Written under [gate] in awaitTurn and raced by the note* callbacks; both
-    // races are benign (worst case one extra paced slot or cooldown step).
+    // Raced by the note* callbacks; the races are benign (worst case one extra
+    // paced slot or cooldown step).
     @kotlin.concurrent.Volatile
     private var nextSlotAtMs = 0L
 
@@ -37,12 +48,21 @@ class Nip46PublishPacer(
     @kotlin.concurrent.Volatile
     private var cooldownUntilMs = 0L
 
+    // Adaptive window state. [inFlight] and the waiter queue are strictly under
+    // [windowLock]; [windowSize] is volatile so shrink paths can write it from
+    // non-suspend contexts (growth takes the lock because it must wake waiters).
+    private val windowLock = Mutex()
+    private var inFlight = 0
+    private val slotWaiters = ArrayDeque<CompletableDeferred<Unit>>()
+
+    @kotlin.concurrent.Volatile
+    private var windowSize = INITIAL_WINDOW
+
+    internal val windowSizeNow: Int get() = windowSize
+
     /**
-     * Wait for this publish's slot. The background lane (the DM gift-wrap decrypt backlog,
-     * the one source that floods the relay) pays the pacing interval plus any active
-     * rate-limit cooldown. The interactive lane (login handshake, NIP-42 AUTH, user-action
-     * signs and encrypts - a handful per session) publishes immediately and honors only an
-     * explicit relay cooldown: queuing it behind the backlog made bunker login visibly slow.
+     * Wait for this publish's slot. Background requests pay the pacing interval
+     * plus any active rate-limit cooldown; interactive ones only the cooldown.
      */
     suspend fun awaitTurn(background: Boolean = true) {
         if (!background) {
@@ -58,17 +78,37 @@ class Nip46PublishPacer(
     }
 
     /**
-     * Caps unanswered background requests in flight (the whole publish + response await runs
-     * inside [block]). The relay rate-limits the SIGNER's response publishes too, and that
-     * side is invisible to the OK-based backoff here: it shows up only as responses not
-     * coming back. A full window pauses new publishes until answers return, draining the
-     * signer's queue instead of growing it (a grown queue also makes the signer retry stale
-     * responses that the relay then rejects as "ephemeral event expired"). Window > 1 because
-     * the signer answers in bursts with quiet gaps; serializing the awaits collapses
-     * throughput. Interactive requests bypass the window for the same reason they skip
-     * pacing: they must not wait behind a backlog slot held across a signer round trip.
+     * Runs [block] (the whole publish + response await) inside the adaptive
+     * in-flight window when [background]; interactive requests bypass it for
+     * the same reason they skip pacing - they must not wait behind a backlog
+     * slot held across a full signer round trip.
      */
-    suspend fun <T> withRequestSlot(background: Boolean = true, block: suspend () -> T): T = if (background) requestWindow.withPermit { block() } else block()
+    suspend fun <T> withRequestSlot(background: Boolean = true, block: suspend () -> T): T {
+        if (!background) return block()
+        acquireSlot()
+        try {
+            return block()
+        } finally {
+            withContext(NonCancellable) { releaseSlot() }
+        }
+    }
+
+    /** A background request's response arrived: the signer keeps up, widen the window. */
+    suspend fun noteResponseArrived() {
+        windowLock.withLock {
+            if (windowSize < MAX_WINDOW) {
+                windowSize++
+                wakeSlotWaitersLocked()
+            }
+        }
+    }
+
+    /** A background request died unanswered (timeout/cancel): halve the window. */
+    suspend fun noteResponseLost() {
+        withContext(NonCancellable) {
+            windowLock.withLock { windowSize = maxOf(MIN_WINDOW, windowSize / 2) }
+        }
+    }
 
     /** A relay accepted a publish: the rate limit (if any) has lifted. */
     fun noteAccepted() {
@@ -81,6 +121,47 @@ class Nip46PublishPacer(
         cooldownMs = if (cooldownMs == 0L) INITIAL_COOLDOWN_MS else minOf(cooldownMs * 4, MAX_COOLDOWN_MS)
         cooldownUntilMs = maxOf(cooldownUntilMs, now() + cooldownMs)
         nextSlotAtMs = maxOf(nextSlotAtMs, cooldownUntilMs)
+        windowSize = maxOf(MIN_WINDOW, windowSize / 2)
+    }
+
+    private suspend fun acquireSlot() {
+        val waiter = windowLock.withLock {
+            if (inFlight < windowSize) {
+                inFlight++
+                null
+            } else {
+                CompletableDeferred<Unit>().also { slotWaiters.addLast(it) }
+            }
+        } ?: return
+        try {
+            waiter.await()
+        } catch (e: CancellationException) {
+            withContext(NonCancellable) {
+                windowLock.withLock {
+                    // Completed concurrently with the cancel: the slot handed to this
+                    // waiter would leak, so pass it on.
+                    if (!slotWaiters.remove(waiter) && waiter.isCompleted) releaseSlotLocked()
+                }
+            }
+            throw e
+        }
+    }
+
+    private suspend fun releaseSlot() {
+        windowLock.withLock { releaseSlotLocked() }
+    }
+
+    private fun releaseSlotLocked() {
+        inFlight--
+        wakeSlotWaitersLocked()
+    }
+
+    // Waking transfers the slot: inFlight is incremented on the waiter's behalf.
+    private fun wakeSlotWaitersLocked() {
+        while (slotWaiters.isNotEmpty() && inFlight < windowSize) {
+            slotWaiters.removeFirst().complete(Unit)
+            inFlight++
+        }
     }
 
     companion object {
@@ -92,14 +173,15 @@ class Nip46PublishPacer(
         const val MAX_PUBLISH_ATTEMPTS = 3
 
         /**
-         * Unanswered background requests allowed in flight per client (see [withRequestSlot]).
-         * Sized for the signer's burst cycle: it answers batches with quiet gaps, and each
-         * cycle can satisfy at most this many requests, so a small window collapses backlog
-         * throughput (decrypts pile into the 90s timeout and burn their retry attempts).
-         * The publish RATE is already bounded by [MIN_INTERVAL_MS]; this bound only has to
-         * stop the feed when responses stop coming back entirely.
+         * Adaptive window bounds. Start modest so a fresh boot leaves the signer's
+         * queue short for login-critical signs; grow toward [MAX_WINDOW] while the
+         * signer answers (it replies in bursts - a near-serial window collapses
+         * backlog throughput into the 90s decrypt timeout); never below
+         * [MIN_WINDOW] so probing continues and recovery is detected.
          */
-        const val MAX_IN_FLIGHT_REQUESTS = 24
+        const val MIN_WINDOW = 2
+        const val INITIAL_WINDOW = 6
+        const val MAX_WINDOW = 24
 
         /** OK-false reasons that mean "slow down" (NIP-01 rate-limited: prefix + common free text). */
         fun isRateLimitReason(reason: String): Boolean {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -34,8 +34,22 @@ class Nip46PublishPacer(
     @kotlin.concurrent.Volatile
     private var cooldownMs = 0L
 
-    /** Wait for this publish's slot: the pacing interval plus any active rate-limit cooldown. */
-    suspend fun awaitTurn() {
+    @kotlin.concurrent.Volatile
+    private var cooldownUntilMs = 0L
+
+    /**
+     * Wait for this publish's slot. The background lane (the DM gift-wrap decrypt backlog,
+     * the one source that floods the relay) pays the pacing interval plus any active
+     * rate-limit cooldown. The interactive lane (login handshake, NIP-42 AUTH, user-action
+     * signs and encrypts - a handful per session) publishes immediately and honors only an
+     * explicit relay cooldown: queuing it behind the backlog made bunker login visibly slow.
+     */
+    suspend fun awaitTurn(background: Boolean = true) {
+        if (!background) {
+            val wait = cooldownUntilMs - now()
+            if (wait > 0) delay(wait)
+            return
+        }
         gate.withLock {
             val wait = nextSlotAtMs - now()
             if (wait > 0) delay(wait)
@@ -44,25 +58,29 @@ class Nip46PublishPacer(
     }
 
     /**
-     * Caps unanswered requests in flight (the whole publish + response await runs inside
-     * [block]). The relay rate-limits the SIGNER's response publishes too, and that side is
-     * invisible to the OK-based backoff here: it shows up only as responses not coming back.
-     * A full window pauses new publishes until answers return, draining the signer's queue
-     * instead of growing it (a grown queue also makes the signer retry stale responses that
-     * the relay then rejects as "ephemeral event expired"). Window > 1 because the signer
-     * answers in bursts with quiet gaps; serializing the awaits collapses throughput.
+     * Caps unanswered background requests in flight (the whole publish + response await runs
+     * inside [block]). The relay rate-limits the SIGNER's response publishes too, and that
+     * side is invisible to the OK-based backoff here: it shows up only as responses not
+     * coming back. A full window pauses new publishes until answers return, draining the
+     * signer's queue instead of growing it (a grown queue also makes the signer retry stale
+     * responses that the relay then rejects as "ephemeral event expired"). Window > 1 because
+     * the signer answers in bursts with quiet gaps; serializing the awaits collapses
+     * throughput. Interactive requests bypass the window for the same reason they skip
+     * pacing: they must not wait behind a backlog slot held across a signer round trip.
      */
-    suspend fun <T> withRequestSlot(block: suspend () -> T): T = requestWindow.withPermit { block() }
+    suspend fun <T> withRequestSlot(background: Boolean = true, block: suspend () -> T): T = if (background) requestWindow.withPermit { block() } else block()
 
     /** A relay accepted a publish: the rate limit (if any) has lifted. */
     fun noteAccepted() {
         cooldownMs = 0L
+        cooldownUntilMs = 0L
     }
 
     /** Every relay rejected the publish as rate-limited: push all upcoming slots out, escalating. */
     fun noteRateLimited() {
         cooldownMs = if (cooldownMs == 0L) INITIAL_COOLDOWN_MS else minOf(cooldownMs * 4, MAX_COOLDOWN_MS)
-        nextSlotAtMs = maxOf(nextSlotAtMs, now() + cooldownMs)
+        cooldownUntilMs = maxOf(cooldownUntilMs, now() + cooldownMs)
+        nextSlotAtMs = maxOf(nextSlotAtMs, cooldownUntilMs)
     }
 
     companion object {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -1,0 +1,69 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.nostr.nostrord.utils.epochMillis
+
+/**
+ * Paces kind:24133 publishes to the bunker relay and backs off when it
+ * rate-limits ("rate-limited: you are noting too much"). Every NIP-46 request
+ * type (sign_event, nip44 encrypt/decrypt, get_public_key) takes a slot via
+ * [awaitTurn] before publishing. The slot lock is held only for the wait,
+ * never across the response await: the signer answers in bursts, so many
+ * requests must stay in-flight for one burst to satisfy at once.
+ *
+ * Pacing also throttles the signer's own kind:24133 responses (one per
+ * request, on the same relay), which is what the relay was rate-limiting on
+ * the signer's side ("Error sending bunker response" in Amber).
+ */
+class Nip46PublishPacer(
+    private val minIntervalMs: Long = MIN_INTERVAL_MS,
+    private val now: () -> Long = { epochMillis() },
+) {
+    private val gate = Mutex()
+
+    // Written under [gate] in awaitTurn and raced by the note* callbacks; both
+    // races are benign (worst case one extra paced slot or cooldown step).
+    @kotlin.concurrent.Volatile
+    private var nextSlotAtMs = 0L
+
+    @kotlin.concurrent.Volatile
+    private var cooldownMs = 0L
+
+    /** Wait for this publish's slot: the pacing interval plus any active rate-limit cooldown. */
+    suspend fun awaitTurn() {
+        gate.withLock {
+            val wait = nextSlotAtMs - now()
+            if (wait > 0) delay(wait)
+            nextSlotAtMs = maxOf(now(), nextSlotAtMs) + minIntervalMs
+        }
+    }
+
+    /** A relay accepted a publish: the rate limit (if any) has lifted. */
+    fun noteAccepted() {
+        cooldownMs = 0L
+    }
+
+    /** Every relay rejected the publish as rate-limited: push all upcoming slots out, escalating. */
+    fun noteRateLimited() {
+        cooldownMs = if (cooldownMs == 0L) INITIAL_COOLDOWN_MS else minOf(cooldownMs * 4, MAX_COOLDOWN_MS)
+        nextSlotAtMs = maxOf(nextSlotAtMs, now() + cooldownMs)
+    }
+
+    companion object {
+        const val MIN_INTERVAL_MS = 400L
+        const val INITIAL_COOLDOWN_MS = 2_000L
+        const val MAX_COOLDOWN_MS = 30_000L
+
+        /** Publish attempts per request before the failure propagates to the caller. */
+        const val MAX_PUBLISH_ATTEMPTS = 3
+
+        /** OK-false reasons that mean "slow down" (NIP-01 rate-limited: prefix + common free text). */
+        fun isRateLimitReason(reason: String): Boolean {
+            val r = reason.lowercase()
+            return r.contains("rate-limit") || r.contains("rate limit") ||
+                r.contains("slow down") || r.contains("noting too much")
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacer.kt
@@ -93,10 +93,19 @@ class Nip46PublishPacer(
         }
     }
 
-    /** A background request's response arrived: the signer keeps up, widen the window. */
-    suspend fun noteResponseArrived() {
+    /**
+     * A background request's response arrived. Fast answer: the signer keeps up, widen the
+     * window. Slow answer (over [SLOW_RESPONSE_MS]): it arrived but the signer is drowning -
+     * its relay keeps rejecting response publishes, so each response burns seconds of the
+     * signer's own retry backoff (Amber: 5 re-signed attempts, 200ms-3.2s). Shrink gently so
+     * the combined multi-device queue at the signer stays short and an interactive sign
+     * (another device's login ack) is answered promptly.
+     */
+    suspend fun noteResponseArrived(latencyMs: Long = 0L) {
         windowLock.withLock {
-            if (windowSize < MAX_WINDOW) {
+            if (latencyMs > SLOW_RESPONSE_MS) {
+                windowSize = maxOf(MIN_WINDOW, windowSize - maxOf(1, windowSize / 4))
+            } else if (windowSize < MAX_WINDOW) {
                 windowSize++
                 wakeSlotWaitersLocked()
             }
@@ -182,6 +191,9 @@ class Nip46PublishPacer(
         const val MIN_WINDOW = 2
         const val INITIAL_WINDOW = 6
         const val MAX_WINDOW = 24
+
+        /** Response latency above this means the signer's queue is backed up (see noteResponseArrived). */
+        const val SLOW_RESPONSE_MS = 10_000L
 
         /** OK-false reasons that mean "slow down" (NIP-01 rate-limited: prefix + common free text). */
         fun isRateLimitReason(reason: String): Boolean {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -908,3 +908,16 @@ class GroupViewModel(
         viewModelScope.launch { repo.fetchGroupPreview(previewGroupId, relayUrl) }
     }
 }
+
+/** How a failed reaction should be presented: the relay wants a join first, the signer could not sign the kind:7, or the relay rejected it. */
+enum class ReactionErrorKind { JoinRequired, SignerFailure, RelayRejected }
+
+/** Shared by the Compose and web reaction-error dialogs so both classify identically. */
+fun classifyReactionError(message: String): ReactionErrorKind = when {
+    message.contains("unknown member", ignoreCase = true) -> ReactionErrorKind.JoinRequired
+    // "Bunker signing failed: ..." / "Your signer refused to sign ..." - the reaction never
+    // reached the group relay, so a relay-rejection message would be false.
+    message.contains("signing failed", ignoreCase = true) ||
+        message.contains("signer", ignoreCase = true) -> ReactionErrorKind.SignerFailure
+    else -> ReactionErrorKind.RelayRejected
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46DecryptBatcherTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46DecryptBatcherTest.kt
@@ -1,0 +1,59 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class Nip46DecryptBatcherTest {
+    @Test
+    fun coalescesConcurrentDecryptsIntoFewBatches() = runTest {
+        val batchSizes = mutableListOf<Int>()
+        val batcher = Nip46DecryptBatcher { items ->
+            batchSizes += items.size
+            delay(100)
+            items.map { (peer, ciphertext) -> "$peer:$ciphertext" }
+        }
+        val results = (1..20).map { i ->
+            async { batcher.decrypt("p$i", "c$i") }
+        }.awaitAll()
+        assertEquals((1..20).map { "p$it:c$it" }, results)
+        assertEquals(20, batchSizes.sum())
+        // The first caller drains a batch of one; everyone who queued while it was
+        // in flight rides the next batches (fattening by backpressure).
+        assertTrue(batchSizes.size <= 3)
+        assertTrue(batchSizes.all { it <= Nip46DecryptBatcher.MAX_BATCH })
+    }
+
+    @Test
+    fun nullResultMeansItemNotDecryptable() = runTest {
+        val batcher = Nip46DecryptBatcher { items -> items.map { null } }
+        assertNull(batcher.decrypt("p", "c"))
+    }
+
+    @Test
+    fun unsupportedSignerFailsTheWholeQueueWithBatchUnsupported() = runTest {
+        val batcher = Nip46DecryptBatcher { throw Exception("Unrecognized method: nip44_decrypt_batch") }
+        val a = async { runCatching { batcher.decrypt("p1", "c1") } }
+        val b = async { runCatching { batcher.decrypt("p2", "c2") } }
+        assertTrue(a.await().exceptionOrNull() is Nip46DecryptBatcher.BatchUnsupported)
+        assertTrue(b.await().exceptionOrNull() is Nip46DecryptBatcher.BatchUnsupported)
+    }
+
+    @Test
+    fun otherSendFailuresPropagateWithoutDisablingBatches() = runTest {
+        var calls = 0
+        val batcher = Nip46DecryptBatcher { items ->
+            calls++
+            if (calls == 1) throw Exception("rate-limited: you are noting too much")
+            items.map { "ok" }
+        }
+        val first = runCatching { batcher.decrypt("p", "c") }.exceptionOrNull()
+        assertTrue(first != null && first !is Nip46DecryptBatcher.BatchUnsupported)
+        assertEquals("ok", batcher.decrypt("p", "c"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
@@ -1,10 +1,14 @@
 package org.nostr.nostrord.nostr
 
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
 class Nip46PublishPacerTest {
     @Test
     fun spacesConsecutivePublishesByTheMinInterval() = runTest {
@@ -56,6 +60,33 @@ class Nip46PublishPacerTest {
         val before = testScheduler.currentTime
         pacer.awaitTurn()
         assertEquals(Nip46PublishPacer.MIN_INTERVAL_MS, testScheduler.currentTime - before)
+    }
+
+    @Test
+    fun requestWindowCapsUnansweredRequestsInFlight() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        val release = CompletableDeferred<Unit>()
+        var active = 0
+        var maxActive = 0
+        var completed = 0
+        repeat(20) {
+            launch {
+                pacer.withRequestSlot {
+                    active++
+                    maxActive = maxOf(maxActive, active)
+                    release.await()
+                    active--
+                    completed++
+                }
+            }
+        }
+        runCurrent()
+        // All 20 requests are unanswered: only a window's worth may be in flight.
+        assertEquals(Nip46PublishPacer.MAX_IN_FLIGHT_REQUESTS, maxActive)
+        release.complete(Unit)
+        runCurrent()
+        // Answers release the slots and the remaining requests flow through.
+        assertEquals(20, completed)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
@@ -57,9 +57,10 @@ class Nip46PublishPacerTest {
         pacer.noteAccepted()
 
         // Back to plain pacing: the next slot is one interval away, not a cooldown.
+        // The rate limit stretched the interval (400 -> 800); only fast responses relax it.
         val before = testScheduler.currentTime
         pacer.awaitTurn()
-        assertEquals(Nip46PublishPacer.MIN_INTERVAL_MS, testScheduler.currentTime - before)
+        assertEquals(2 * Nip46PublishPacer.MIN_INTERVAL_MS, testScheduler.currentTime - before)
     }
 
     @Test
@@ -112,6 +113,42 @@ class Nip46PublishPacerTest {
         // An explicit rate-limit rejection also halves the window.
         pacer.noteRateLimited()
         assertEquals(Nip46PublishPacer.MAX_WINDOW / 2, pacer.windowSizeNow)
+    }
+
+    @Test
+    fun interactiveBurstIsCappedThenPaced() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        repeat(Nip46PublishPacer.INTERACTIVE_BURST) { pacer.awaitTurn(background = false) }
+        // The whole burst allowance goes through instantly (a login needs 2-3).
+        assertEquals(0L, testScheduler.currentTime)
+
+        // Beyond the burst (an AUTH storm), each request pays one interval.
+        pacer.awaitTurn(background = false)
+        assertEquals(Nip46PublishPacer.MIN_INTERVAL_MS, testScheduler.currentTime)
+        pacer.awaitTurn(background = false)
+        assertEquals(2 * Nip46PublishPacer.MIN_INTERVAL_MS, testScheduler.currentTime)
+    }
+
+    @Test
+    fun congestionStretchesTheIntervalAndRecoveryRelaxesIt() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        assertEquals(Nip46PublishPacer.MIN_INTERVAL_MS, pacer.intervalNowMs)
+
+        // Losses and slow answers double the interval, capped.
+        pacer.noteResponseLost()
+        assertEquals(2 * Nip46PublishPacer.MIN_INTERVAL_MS, pacer.intervalNowMs)
+        repeat(5) { pacer.noteResponseLost() }
+        assertEquals(Nip46PublishPacer.MAX_INTERVAL_MS, pacer.intervalNowMs)
+
+        // Background pacing pays the stretched interval.
+        pacer.awaitTurn()
+        val before = testScheduler.currentTime
+        pacer.awaitTurn()
+        assertEquals(Nip46PublishPacer.MAX_INTERVAL_MS, testScheduler.currentTime - before)
+
+        // Fast answers relax it back to the floor.
+        repeat(12) { pacer.noteResponseArrived() }
+        assertEquals(Nip46PublishPacer.MIN_INTERVAL_MS, pacer.intervalNowMs)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
@@ -115,6 +115,22 @@ class Nip46PublishPacerTest {
     }
 
     @Test
+    fun slowResponsesShrinkTheWindow() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        // Arrived but slow: the signer's queue is backed up, shrink gently.
+        pacer.noteResponseArrived(latencyMs = Nip46PublishPacer.SLOW_RESPONSE_MS + 1)
+        assertTrue(pacer.windowSizeNow < Nip46PublishPacer.INITIAL_WINDOW)
+
+        // Repeated slow answers floor at MIN_WINDOW.
+        repeat(10) { pacer.noteResponseArrived(latencyMs = Nip46PublishPacer.SLOW_RESPONSE_MS + 1) }
+        assertEquals(Nip46PublishPacer.MIN_WINDOW, pacer.windowSizeNow)
+
+        // Fast answers grow it back.
+        pacer.noteResponseArrived()
+        assertEquals(Nip46PublishPacer.MIN_WINDOW + 1, pacer.windowSizeNow)
+    }
+
+    @Test
     fun windowGrowthWakesQueuedRequests() = runTest {
         val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
         val release = CompletableDeferred<Unit>()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
@@ -1,0 +1,69 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class Nip46PublishPacerTest {
+    @Test
+    fun spacesConsecutivePublishesByTheMinInterval() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        val slots = mutableListOf<Long>()
+        repeat(3) {
+            pacer.awaitTurn()
+            slots += testScheduler.currentTime
+        }
+        assertEquals(0L, slots[0])
+        assertEquals(Nip46PublishPacer.MIN_INTERVAL_MS, slots[1])
+        assertEquals(2 * Nip46PublishPacer.MIN_INTERVAL_MS, slots[2])
+    }
+
+    @Test
+    fun rateLimitCooldownDelaysTheNextSlotAndEscalates() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        pacer.awaitTurn()
+
+        pacer.noteRateLimited()
+        val beforeFirstRetry = testScheduler.currentTime
+        pacer.awaitTurn()
+        assertTrue(testScheduler.currentTime - beforeFirstRetry >= Nip46PublishPacer.INITIAL_COOLDOWN_MS)
+
+        pacer.noteRateLimited()
+        val beforeSecondRetry = testScheduler.currentTime
+        pacer.awaitTurn()
+        assertTrue(testScheduler.currentTime - beforeSecondRetry >= 4 * Nip46PublishPacer.INITIAL_COOLDOWN_MS)
+    }
+
+    @Test
+    fun cooldownEscalationIsCapped() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        repeat(10) { pacer.noteRateLimited() }
+        val before = testScheduler.currentTime
+        pacer.awaitTurn()
+        val waited = testScheduler.currentTime - before
+        assertTrue(waited <= Nip46PublishPacer.MAX_COOLDOWN_MS)
+    }
+
+    @Test
+    fun acceptedPublishResetsTheCooldown() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        pacer.noteRateLimited()
+        pacer.awaitTurn()
+        pacer.noteAccepted()
+
+        // Back to plain pacing: the next slot is one interval away, not a cooldown.
+        val before = testScheduler.currentTime
+        pacer.awaitTurn()
+        assertEquals(Nip46PublishPacer.MIN_INTERVAL_MS, testScheduler.currentTime - before)
+    }
+
+    @Test
+    fun recognizesRateLimitReasons() {
+        assertTrue(Nip46PublishPacer.isRateLimitReason("rate-limited: you are noting too much"))
+        assertTrue(Nip46PublishPacer.isRateLimitReason("Rate limit exceeded"))
+        assertTrue(Nip46PublishPacer.isRateLimitReason("slow down there"))
+        assertTrue(!Nip46PublishPacer.isRateLimitReason("blocked: unknown member"))
+        assertTrue(!Nip46PublishPacer.isRateLimitReason("auth-required: please auth"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
@@ -66,7 +66,7 @@ class Nip46PublishPacerTest {
     fun requestWindowCapsUnansweredRequestsInFlight() = runTest {
         val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
         val release = CompletableDeferred<Unit>()
-        val total = Nip46PublishPacer.MAX_IN_FLIGHT_REQUESTS + 12
+        val total = Nip46PublishPacer.INITIAL_WINDOW + 10
         var active = 0
         var maxActive = 0
         var completed = 0
@@ -82,8 +82,8 @@ class Nip46PublishPacerTest {
             }
         }
         runCurrent()
-        // All requests are unanswered: only a window's worth may be in flight.
-        assertEquals(Nip46PublishPacer.MAX_IN_FLIGHT_REQUESTS, maxActive)
+        // All requests are unanswered: only the initial window's worth may be in flight.
+        assertEquals(Nip46PublishPacer.INITIAL_WINDOW, maxActive)
         release.complete(Unit)
         runCurrent()
         // Answers release the slots and the remaining requests flow through.
@@ -91,11 +91,60 @@ class Nip46PublishPacerTest {
     }
 
     @Test
+    fun windowGrowsOnAnswersAndShrinksOnLosses() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        assertEquals(Nip46PublishPacer.INITIAL_WINDOW, pacer.windowSizeNow)
+
+        repeat(4) { pacer.noteResponseArrived() }
+        assertEquals(Nip46PublishPacer.INITIAL_WINDOW + 4, pacer.windowSizeNow)
+
+        pacer.noteResponseLost()
+        assertEquals((Nip46PublishPacer.INITIAL_WINDOW + 4) / 2, pacer.windowSizeNow)
+
+        // Repeated losses floor at MIN_WINDOW so probing continues.
+        repeat(6) { pacer.noteResponseLost() }
+        assertEquals(Nip46PublishPacer.MIN_WINDOW, pacer.windowSizeNow)
+
+        // Growth is capped at MAX_WINDOW.
+        repeat(100) { pacer.noteResponseArrived() }
+        assertEquals(Nip46PublishPacer.MAX_WINDOW, pacer.windowSizeNow)
+
+        // An explicit rate-limit rejection also halves the window.
+        pacer.noteRateLimited()
+        assertEquals(Nip46PublishPacer.MAX_WINDOW / 2, pacer.windowSizeNow)
+    }
+
+    @Test
+    fun windowGrowthWakesQueuedRequests() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        val release = CompletableDeferred<Unit>()
+        var active = 0
+        repeat(Nip46PublishPacer.INITIAL_WINDOW + 2) {
+            launch {
+                pacer.withRequestSlot {
+                    active++
+                    release.await()
+                }
+            }
+        }
+        runCurrent()
+        assertEquals(Nip46PublishPacer.INITIAL_WINDOW, active)
+
+        // Widening the window admits the queued requests without any release.
+        pacer.noteResponseArrived()
+        pacer.noteResponseArrived()
+        runCurrent()
+        assertEquals(Nip46PublishPacer.INITIAL_WINDOW + 2, active)
+        release.complete(Unit)
+        runCurrent()
+    }
+
+    @Test
     fun interactiveLaneSkipsPacingAndTheWindow() = runTest {
         val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
         // Fill the background window with requests the signer never answers.
         val stuck = CompletableDeferred<Unit>()
-        repeat(Nip46PublishPacer.MAX_IN_FLIGHT_REQUESTS) {
+        repeat(Nip46PublishPacer.INITIAL_WINDOW) {
             launch { pacer.withRequestSlot { stuck.await() } }
         }
         runCurrent()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
@@ -66,10 +66,11 @@ class Nip46PublishPacerTest {
     fun requestWindowCapsUnansweredRequestsInFlight() = runTest {
         val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
         val release = CompletableDeferred<Unit>()
+        val total = Nip46PublishPacer.MAX_IN_FLIGHT_REQUESTS + 12
         var active = 0
         var maxActive = 0
         var completed = 0
-        repeat(20) {
+        repeat(total) {
             launch {
                 pacer.withRequestSlot {
                     active++
@@ -81,12 +82,12 @@ class Nip46PublishPacerTest {
             }
         }
         runCurrent()
-        // All 20 requests are unanswered: only a window's worth may be in flight.
+        // All requests are unanswered: only a window's worth may be in flight.
         assertEquals(Nip46PublishPacer.MAX_IN_FLIGHT_REQUESTS, maxActive)
         release.complete(Unit)
         runCurrent()
         // Answers release the slots and the remaining requests flow through.
-        assertEquals(20, completed)
+        assertEquals(total, completed)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip46PublishPacerTest.kt
@@ -90,6 +90,46 @@ class Nip46PublishPacerTest {
     }
 
     @Test
+    fun interactiveLaneSkipsPacingAndTheWindow() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        // Fill the background window with requests the signer never answers.
+        val stuck = CompletableDeferred<Unit>()
+        repeat(Nip46PublishPacer.MAX_IN_FLIGHT_REQUESTS) {
+            launch { pacer.withRequestSlot { stuck.await() } }
+        }
+        runCurrent()
+
+        // Interactive requests neither pace nor wait for a window slot.
+        var done = 0
+        launch {
+            repeat(3) {
+                pacer.awaitTurn(background = false)
+                pacer.withRequestSlot(background = false) { done++ }
+            }
+        }
+        runCurrent()
+        assertEquals(3, done)
+        assertEquals(0L, testScheduler.currentTime)
+        stuck.complete(Unit)
+    }
+
+    @Test
+    fun interactiveLaneHonorsTheRateLimitCooldown() = runTest {
+        val pacer = Nip46PublishPacer(now = { testScheduler.currentTime })
+        pacer.noteRateLimited()
+        val before = testScheduler.currentTime
+        pacer.awaitTurn(background = false)
+        assertTrue(testScheduler.currentTime - before >= Nip46PublishPacer.INITIAL_COOLDOWN_MS)
+
+        // An accepted publish lifts the cooldown for the interactive lane too.
+        pacer.noteRateLimited()
+        pacer.noteAccepted()
+        val after = testScheduler.currentTime
+        pacer.awaitTurn(background = false)
+        assertEquals(after, testScheduler.currentTime)
+    }
+
+    @Test
     fun recognizesRateLimitReasons() {
         assertTrue(Nip46PublishPacer.isRateLimitReason("rate-limited: you are noting too much"))
         assertTrue(Nip46PublishPacer.isRateLimitReason("Rate limit exceeded"))

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -54,6 +54,9 @@ actual class Nip46Client actual constructor(
     private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests = ConcurrentMap<String, CompletableDeferred<String>>()
+
+    // Shared pacing + rate-limit backoff for every request publish (see Nip46PublishPacer).
+    private val publishPacer = Nip46PublishPacer()
     private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
@@ -371,12 +374,27 @@ actual class Nip46Client actual constructor(
         try {
             // Publish in parallel via sendAndAwaitOk so a relay-side rejection
             // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred.
-            val publishResults = relayClients.map { client ->
-                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-            }.awaitAll()
-            if (publishResults.none { it is PublishResult.Success }) {
-                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+            // the signer's reply back into responseDeferred. publishPacer spaces
+            // the publishes and, when the relay rate-limits, holds a shared
+            // cooldown and retries; it is never held across the response await.
+            var attempt = 1
+            while (true) {
+                publishPacer.awaitTurn()
+                val publishResults = relayClients.map { client ->
+                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                }.awaitAll()
+                if (publishResults.any { it is PublishResult.Success }) {
+                    publishPacer.noteAccepted()
+                    break
+                }
+                val rateLimited = publishResults.any {
+                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                }
+                if (rateLimited) publishPacer.noteRateLimited()
+                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                }
+                attempt++
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -350,10 +350,15 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        // In-flight window: pauses new requests when the signer stops answering (its own
-        // response publishes got rate-limited, which our OK-based backoff cannot see).
-        // created_at is stamped after the slot wait so a long pause cannot expire the event.
-        publishPacer.withRequestSlot {
+        // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
+        // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
+        // user-action signs/encrypts) publish immediately so they never queue behind it.
+        val background = method == "nip44_decrypt"
+        // In-flight window: pauses new background requests when the signer stops answering
+        // (its own response publishes got rate-limited, which our OK-based backoff cannot
+        // see). created_at is stamped after the slot wait so a long pause cannot expire the
+        // event.
+        publishPacer.withRequestSlot(background) {
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -383,7 +388,7 @@ actual class Nip46Client actual constructor(
                 // cooldown and retries; it is never held across the response await.
                 var attempt = 1
                 while (true) {
-                    publishPacer.awaitTurn()
+                    publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -39,6 +39,13 @@ private class ConcurrentMap<K, V> : SynchronizedObject() {
     fun clear() = synchronized(this) { map.clear() }
 }
 
+// Per-relay WebSocket connect timeout for the NIP-46 signer relays. Longer than
+// NostrGroupClient's 7s default: the QR/bunker flow runs while the account's own
+// relay sockets are (re)connecting, and a cold handshake can exceed 7s under that
+// load. A dropped signer relay here silently loses the signer's connect response
+// ("Waiting for signer..." forever) - mirrors the web's 20s timeout.
+private const val SIGNER_RELAY_CONNECT_TIMEOUT_MS = 20_000L
+
 actual class Nip46Client actual constructor(
     existingPrivateKey: String?,
 ) {
@@ -87,7 +94,7 @@ actual class Nip46Client actual constructor(
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
-                        if (!client.waitForConnection()) {
+                        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
                             // WS never opened (timeout) — drop it so callers don't
                             // treat a dead socket as a live relay connection.
                             client.disconnect()
@@ -124,7 +131,7 @@ actual class Nip46Client actual constructor(
                     val cleanUrl = relayUrl.trimEnd('/')
                     val client = NostrGroupClient(cleanUrl)
                     client.connect { msg -> handleMessage(msg, client) }
-                    if (!client.waitForConnection()) {
+                    if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
                         // WS never opened — drop it (mirrors connectRelaysParallel)
                         // instead of adding a dead socket and completing firstReady.
                         // Otherwise the QR displays while no listening sub is live,
@@ -405,7 +412,15 @@ actual class Nip46Client actual constructor(
                     }
                     attempt++
                 }
-                responseDeferred.await()
+                try {
+                    val response = responseDeferred.await()
+                    if (background) publishPacer.noteResponseArrived()
+                    response
+                } catch (e: CancellationException) {
+                    // Died unanswered (timeout/cancel): the signer or its relay path is behind.
+                    if (background) publishPacer.noteResponseLost()
+                    throw e
+                }
             } finally {
                 pendingRequests.remove(requestId)
             }

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -350,55 +350,60 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        val event =
-            Event(
-                pubkey = clientKeyPair.publicKeyHex,
-                createdAt = epochMillis() / 1000,
-                kind = 24133,
-                tags = listOf(listOf("p", signerPubkey)),
-                content = encryptedContent,
-            )
+        // In-flight window: pauses new requests when the signer stops answering (its own
+        // response publishes got rate-limited, which our OK-based backoff cannot see).
+        // created_at is stamped after the slot wait so a long pause cannot expire the event.
+        publishPacer.withRequestSlot {
+            val event =
+                Event(
+                    pubkey = clientKeyPair.publicKeyHex,
+                    createdAt = epochMillis() / 1000,
+                    kind = 24133,
+                    tags = listOf(listOf("p", signerPubkey)),
+                    content = encryptedContent,
+                )
 
-        val signedEvent = event.sign(clientKeyPair)
-        val eventId = signedEvent.id
-            ?: throw Exception("Failed to sign NIP-46 request event")
-        val responseDeferred = CompletableDeferred<String>()
-        pendingRequests[requestId] = responseDeferred
+            val signedEvent = event.sign(clientKeyPair)
+            val eventId = signedEvent.id
+                ?: throw Exception("Failed to sign NIP-46 request event")
+            val responseDeferred = CompletableDeferred<String>()
+            pendingRequests[requestId] = responseDeferred
 
-        val eventMessage =
-            buildJsonArray {
-                add("EVENT")
-                add(signedEvent.toJsonObject())
-            }.toString()
+            val eventMessage =
+                buildJsonArray {
+                    add("EVENT")
+                    add(signedEvent.toJsonObject())
+                }.toString()
 
-        try {
-            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
-            // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred. publishPacer spaces
-            // the publishes and, when the relay rate-limits, holds a shared
-            // cooldown and retries; it is never held across the response await.
-            var attempt = 1
-            while (true) {
-                publishPacer.awaitTurn()
-                val publishResults = relayClients.map { client ->
-                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-                }.awaitAll()
-                if (publishResults.any { it is PublishResult.Success }) {
-                    publishPacer.noteAccepted()
-                    break
+            try {
+                // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+                // surfaces immediately. The response sub opened on connect routes
+                // the signer's reply back into responseDeferred. publishPacer spaces
+                // the publishes and, when the relay rate-limits, holds a shared
+                // cooldown and retries; it is never held across the response await.
+                var attempt = 1
+                while (true) {
+                    publishPacer.awaitTurn()
+                    val publishResults = relayClients.map { client ->
+                        async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                    }.awaitAll()
+                    if (publishResults.any { it is PublishResult.Success }) {
+                        publishPacer.noteAccepted()
+                        break
+                    }
+                    val rateLimited = publishResults.any {
+                        it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                    }
+                    if (rateLimited) publishPacer.noteRateLimited()
+                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                        throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                    }
+                    attempt++
                 }
-                val rateLimited = publishResults.any {
-                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
-                }
-                if (rateLimited) publishPacer.noteRateLimited()
-                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
-                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
-                }
-                attempt++
+                responseDeferred.await()
+            } finally {
+                pendingRequests.remove(requestId)
             }
-            responseDeferred.await()
-        } finally {
-            pendingRequests.remove(requestId)
         }
     }
 

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -391,10 +391,11 @@ actual class Nip46Client actual constructor(
             try {
                 // Publish in parallel via sendAndAwaitOk so a relay-side rejection
                 // surfaces immediately. The response sub opened on connect routes
-                // the signer's reply back into responseDeferred. publishPacer spaces
-                // the publishes and, when the relay rate-limits, holds a shared
-                // cooldown and retries; it is never held across the response await.
-                var attempt = 1
+                // the signer's reply back into responseDeferred. A rate-limited
+                // publish retries under the pacer's escalating cooldown until this
+                // request's own deadline: failing hard reads as "signer unreachable"
+                // upstream and tears the session down, when the relay only asked us
+                // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
@@ -407,11 +408,10 @@ actual class Nip46Client actual constructor(
                     val rateLimited = publishResults.any {
                         it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
                     }
-                    if (rateLimited) publishPacer.noteRateLimited()
-                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    if (!rateLimited) {
                         throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
                     }
-                    attempt++
+                    publishPacer.noteRateLimited()
                 }
                 try {
                     val response = responseDeferred.await()

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -328,6 +328,21 @@ actual class Nip46Client actual constructor(
 
     actual suspend fun nip44Decrypt(peerPubkey: String, ciphertext: String): String = sendRequest(generateRequestId(), "nip44_decrypt", listOf(peerPubkey, ciphertext))
 
+    actual suspend fun nip44DecryptBatch(items: List<Pair<String, String>>): List<String?> {
+        val payload = buildJsonArray {
+            items.forEach { (peer, ciphertext) ->
+                addJsonArray {
+                    add(peer)
+                    add(ciphertext)
+                }
+            }
+        }.toString()
+        val raw = sendRequest(generateRequestId(), "nip44_decrypt_batch", listOf(payload))
+        return nip46Json.parseToJsonElement(raw).jsonArray.map { el ->
+            if (el is JsonNull) null else el.jsonPrimitive.content
+        }
+    }
+
     private suspend fun sendRequest(
         requestId: String,
         method: String,
@@ -360,7 +375,7 @@ actual class Nip46Client actual constructor(
         // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
         // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
         // user-action signs/encrypts) publish immediately so they never queue behind it.
-        val background = method == "nip44_decrypt"
+        val background = method.startsWith("nip44_decrypt")
         // In-flight window: pauses new background requests when the signer stops answering
         // (its own response publishes got rate-limited, which our OK-based backoff cannot
         // see). created_at is stamped after the slot wait so a long pause cannot expire the

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -366,6 +366,7 @@ actual class Nip46Client actual constructor(
         // see). created_at is stamped after the slot wait so a long pause cannot expire the
         // event.
         publishPacer.withRequestSlot(background) {
+            val requestStartMs = epochMillis()
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -414,7 +415,7 @@ actual class Nip46Client actual constructor(
                 }
                 try {
                     val response = responseDeferred.await()
-                    if (background) publishPacer.noteResponseArrived()
+                    if (background) publishPacer.noteResponseArrived(latencyMs = epochMillis() - requestStartMs)
                     response
                 } catch (e: CancellationException) {
                     // Died unanswered (timeout/cancel): the signer or its relay path is behind.

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -367,10 +367,11 @@ actual class Nip46Client actual constructor(
             try {
                 // Publish in parallel via sendAndAwaitOk so a relay-side rejection
                 // surfaces immediately. The response sub opened on connect routes
-                // the signer's reply back into responseDeferred. publishPacer spaces
-                // the publishes and, when the relay rate-limits, holds a shared
-                // cooldown and retries; it is never held across the response await.
-                var attempt = 1
+                // the signer's reply back into responseDeferred. A rate-limited
+                // publish retries under the pacer's escalating cooldown until this
+                // request's own deadline: failing hard reads as "signer unreachable"
+                // upstream and tears the session down, when the relay only asked us
+                // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
@@ -383,11 +384,10 @@ actual class Nip46Client actual constructor(
                     val rateLimited = publishResults.any {
                         it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
                     }
-                    if (rateLimited) publishPacer.noteRateLimited()
-                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    if (!rateLimited) {
                         throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
                     }
-                    attempt++
+                    publishPacer.noteRateLimited()
                 }
                 try {
                     val response = responseDeferred.await()

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -342,6 +342,7 @@ actual class Nip46Client actual constructor(
         // see). created_at is stamped after the slot wait so a long pause cannot expire the
         // event.
         publishPacer.withRequestSlot(background) {
+            val requestStartMs = epochMillis()
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -390,7 +391,7 @@ actual class Nip46Client actual constructor(
                 }
                 try {
                     val response = responseDeferred.await()
-                    if (background) publishPacer.noteResponseArrived()
+                    if (background) publishPacer.noteResponseArrived(latencyMs = epochMillis() - requestStartMs)
                     response
                 } catch (e: CancellationException) {
                     // Died unanswered (timeout/cancel): the signer or its relay path is behind.

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -41,6 +41,9 @@ actual class Nip46Client actual constructor(
     private val relayConnectMutex = Mutex()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests: MutableMap<String, CompletableDeferred<String>> = mutableMapOf()
+
+    // Shared pacing + rate-limit backoff for every request publish (see Nip46PublishPacer).
+    private val publishPacer = Nip46PublishPacer()
     private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
@@ -354,12 +357,27 @@ actual class Nip46Client actual constructor(
         try {
             // Publish in parallel via sendAndAwaitOk so a relay-side rejection
             // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred.
-            val publishResults = relayClients.map { client ->
-                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-            }.awaitAll()
-            if (publishResults.none { it is PublishResult.Success }) {
-                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+            // the signer's reply back into responseDeferred. publishPacer spaces
+            // the publishes and, when the relay rate-limits, holds a shared
+            // cooldown and retries; it is never held across the response await.
+            var attempt = 1
+            while (true) {
+                publishPacer.awaitTurn()
+                val publishResults = relayClients.map { client ->
+                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                }.awaitAll()
+                if (publishResults.any { it is PublishResult.Success }) {
+                    publishPacer.noteAccepted()
+                    break
+                }
+                val rateLimited = publishResults.any {
+                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                }
+                if (rateLimited) publishPacer.noteRateLimited()
+                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                }
+                attempt++
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -388,7 +388,15 @@ actual class Nip46Client actual constructor(
                     }
                     attempt++
                 }
-                responseDeferred.await()
+                try {
+                    val response = responseDeferred.await()
+                    if (background) publishPacer.noteResponseArrived()
+                    response
+                } catch (e: CancellationException) {
+                    // Died unanswered (timeout/cancel): the signer or its relay path is behind.
+                    if (background) publishPacer.noteResponseLost()
+                    throw e
+                }
             } finally {
                 pendingRequests.remove(requestId)
             }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -333,55 +333,60 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        val event =
-            Event(
-                pubkey = clientKeyPair.publicKeyHex,
-                createdAt = epochMillis() / 1000,
-                kind = 24133,
-                tags = listOf(listOf("p", signerPubkey)),
-                content = encryptedContent,
-            )
+        // In-flight window: pauses new requests when the signer stops answering (its own
+        // response publishes got rate-limited, which our OK-based backoff cannot see).
+        // created_at is stamped after the slot wait so a long pause cannot expire the event.
+        publishPacer.withRequestSlot {
+            val event =
+                Event(
+                    pubkey = clientKeyPair.publicKeyHex,
+                    createdAt = epochMillis() / 1000,
+                    kind = 24133,
+                    tags = listOf(listOf("p", signerPubkey)),
+                    content = encryptedContent,
+                )
 
-        val signedEvent = event.sign(clientKeyPair)
-        val eventId = signedEvent.id
-            ?: throw Exception("Failed to sign NIP-46 request event")
-        val responseDeferred = CompletableDeferred<String>()
-        pendingRequests[requestId] = responseDeferred
+            val signedEvent = event.sign(clientKeyPair)
+            val eventId = signedEvent.id
+                ?: throw Exception("Failed to sign NIP-46 request event")
+            val responseDeferred = CompletableDeferred<String>()
+            pendingRequests[requestId] = responseDeferred
 
-        val eventMessage =
-            buildJsonArray {
-                add("EVENT")
-                add(signedEvent.toJsonObject())
-            }.toString()
+            val eventMessage =
+                buildJsonArray {
+                    add("EVENT")
+                    add(signedEvent.toJsonObject())
+                }.toString()
 
-        try {
-            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
-            // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred. publishPacer spaces
-            // the publishes and, when the relay rate-limits, holds a shared
-            // cooldown and retries; it is never held across the response await.
-            var attempt = 1
-            while (true) {
-                publishPacer.awaitTurn()
-                val publishResults = relayClients.map { client ->
-                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-                }.awaitAll()
-                if (publishResults.any { it is PublishResult.Success }) {
-                    publishPacer.noteAccepted()
-                    break
+            try {
+                // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+                // surfaces immediately. The response sub opened on connect routes
+                // the signer's reply back into responseDeferred. publishPacer spaces
+                // the publishes and, when the relay rate-limits, holds a shared
+                // cooldown and retries; it is never held across the response await.
+                var attempt = 1
+                while (true) {
+                    publishPacer.awaitTurn()
+                    val publishResults = relayClients.map { client ->
+                        async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                    }.awaitAll()
+                    if (publishResults.any { it is PublishResult.Success }) {
+                        publishPacer.noteAccepted()
+                        break
+                    }
+                    val rateLimited = publishResults.any {
+                        it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                    }
+                    if (rateLimited) publishPacer.noteRateLimited()
+                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                        throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                    }
+                    attempt++
                 }
-                val rateLimited = publishResults.any {
-                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
-                }
-                if (rateLimited) publishPacer.noteRateLimited()
-                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
-                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
-                }
-                attempt++
+                responseDeferred.await()
+            } finally {
+                pendingRequests.remove(requestId)
             }
-            responseDeferred.await()
-        } finally {
-            pendingRequests.remove(requestId)
         }
     }
 

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -333,10 +333,15 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        // In-flight window: pauses new requests when the signer stops answering (its own
-        // response publishes got rate-limited, which our OK-based backoff cannot see).
-        // created_at is stamped after the slot wait so a long pause cannot expire the event.
-        publishPacer.withRequestSlot {
+        // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
+        // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
+        // user-action signs/encrypts) publish immediately so they never queue behind it.
+        val background = method == "nip44_decrypt"
+        // In-flight window: pauses new background requests when the signer stops answering
+        // (its own response publishes got rate-limited, which our OK-based backoff cannot
+        // see). created_at is stamped after the slot wait so a long pause cannot expire the
+        // event.
+        publishPacer.withRequestSlot(background) {
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -366,7 +371,7 @@ actual class Nip46Client actual constructor(
                 // cooldown and retries; it is never held across the response await.
                 var attempt = 1
                 while (true) {
-                    publishPacer.awaitTurn()
+                    publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -306,6 +306,21 @@ actual class Nip46Client actual constructor(
 
     actual suspend fun nip44Decrypt(peerPubkey: String, ciphertext: String): String = sendRequest(generateRequestId(), "nip44_decrypt", listOf(peerPubkey, ciphertext))
 
+    actual suspend fun nip44DecryptBatch(items: List<Pair<String, String>>): List<String?> {
+        val payload = buildJsonArray {
+            items.forEach { (peer, ciphertext) ->
+                addJsonArray {
+                    add(peer)
+                    add(ciphertext)
+                }
+            }
+        }.toString()
+        val raw = sendRequest(generateRequestId(), "nip44_decrypt_batch", listOf(payload))
+        return nip46Json.parseToJsonElement(raw).jsonArray.map { el ->
+            if (el is JsonNull) null else el.jsonPrimitive.content
+        }
+    }
+
     private suspend fun sendRequest(
         requestId: String,
         method: String,
@@ -336,7 +351,7 @@ actual class Nip46Client actual constructor(
         // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
         // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
         // user-action signs/encrypts) publish immediately so they never queue behind it.
-        val background = method == "nip44_decrypt"
+        val background = method.startsWith("nip44_decrypt")
         // In-flight window: pauses new background requests when the signer stops answering
         // (its own response publishes got rate-limited, which our OK-based backoff cannot
         // see). created_at is stamped after the slot wait so a long pause cannot expire the

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -316,6 +316,21 @@ actual class Nip46Client actual constructor(
 
     actual suspend fun nip44Decrypt(peerPubkey: String, ciphertext: String): String = sendRequest(generateRequestId(), "nip44_decrypt", listOf(peerPubkey, ciphertext))
 
+    actual suspend fun nip44DecryptBatch(items: List<Pair<String, String>>): List<String?> {
+        val payload = buildJsonArray {
+            items.forEach { (peer, ciphertext) ->
+                addJsonArray {
+                    add(peer)
+                    add(ciphertext)
+                }
+            }
+        }.toString()
+        val raw = sendRequest(generateRequestId(), "nip44_decrypt_batch", listOf(payload))
+        return nip46Json.parseToJsonElement(raw).jsonArray.map { el ->
+            if (el is JsonNull) null else el.jsonPrimitive.content
+        }
+    }
+
     private suspend fun sendRequest(
         requestId: String,
         method: String,
@@ -348,7 +363,7 @@ actual class Nip46Client actual constructor(
         // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
         // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
         // user-action signs/encrypts) publish immediately so they never queue behind it.
-        val background = method == "nip44_decrypt"
+        val background = method.startsWith("nip44_decrypt")
         // In-flight window: pauses new background requests when the signer stops answering
         // (its own response publishes got rate-limited, which our OK-based backoff cannot
         // see). created_at is stamped after the slot wait so a long pause cannot expire the

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -11,6 +11,13 @@ import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
 import kotlin.random.Random
 
+// Per-relay WebSocket connect timeout for the NIP-46 signer relays. Longer than
+// NostrGroupClient's 7s default: the QR/bunker flow runs while the account's own
+// relay sockets are (re)connecting, and a cold handshake can exceed 7s under that
+// load. A dropped signer relay here silently loses the signer's connect response
+// ("Waiting for signer..." forever) - mirrors the web's 20s timeout.
+private const val SIGNER_RELAY_CONNECT_TIMEOUT_MS = 20_000L
+
 actual class Nip46Client actual constructor(
     existingPrivateKey: String?,
 ) {
@@ -72,7 +79,7 @@ actual class Nip46Client actual constructor(
                         val cleanUrl = relayUrl.trimEnd('/')
                         val client = NostrGroupClient(cleanUrl)
                         client.connect { msg -> handleMessage(msg, client) }
-                        if (!client.waitForConnection()) {
+                        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
                             // WS never opened (timeout) — drop it so callers don't
                             // treat a dead socket as a live relay connection.
                             client.disconnect()
@@ -110,7 +117,7 @@ actual class Nip46Client actual constructor(
                     val cleanUrl = relayUrl.trimEnd('/')
                     val client = NostrGroupClient(cleanUrl)
                     client.connect { msg -> handleMessage(msg, client) }
-                    if (!client.waitForConnection()) {
+                    if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
                         // WS never opened — drop it (mirrors connectRelaysParallel)
                         // instead of adding a dead socket and completing firstReady.
                         // Otherwise the QR displays while no listening sub is live,
@@ -393,7 +400,15 @@ actual class Nip46Client actual constructor(
                     }
                     attempt++
                 }
-                responseDeferred.await()
+                try {
+                    val response = responseDeferred.await()
+                    if (background) publishPacer.noteResponseArrived()
+                    response
+                } catch (e: CancellationException) {
+                    // Died unanswered (timeout/cancel): the signer or its relay path is behind.
+                    if (background) publishPacer.noteResponseLost()
+                    throw e
+                }
             } finally {
                 pendingRequests.remove(requestId)
             }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -354,6 +354,7 @@ actual class Nip46Client actual constructor(
         // see). created_at is stamped after the slot wait so a long pause cannot expire the
         // event.
         publishPacer.withRequestSlot(background) {
+            val requestStartMs = epochMillis()
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -402,7 +403,7 @@ actual class Nip46Client actual constructor(
                 }
                 try {
                     val response = responseDeferred.await()
-                    if (background) publishPacer.noteResponseArrived()
+                    if (background) publishPacer.noteResponseArrived(latencyMs = epochMillis() - requestStartMs)
                     response
                 } catch (e: CancellationException) {
                     // Died unanswered (timeout/cancel): the signer or its relay path is behind.

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -338,55 +338,60 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        val event =
-            Event(
-                pubkey = clientKeyPair.publicKeyHex,
-                createdAt = epochMillis() / 1000,
-                kind = 24133,
-                tags = listOf(listOf("p", signerPubkey)),
-                content = encryptedContent,
-            )
+        // In-flight window: pauses new requests when the signer stops answering (its own
+        // response publishes got rate-limited, which our OK-based backoff cannot see).
+        // created_at is stamped after the slot wait so a long pause cannot expire the event.
+        publishPacer.withRequestSlot {
+            val event =
+                Event(
+                    pubkey = clientKeyPair.publicKeyHex,
+                    createdAt = epochMillis() / 1000,
+                    kind = 24133,
+                    tags = listOf(listOf("p", signerPubkey)),
+                    content = encryptedContent,
+                )
 
-        val signedEvent = event.sign(clientKeyPair)
-        val eventId = signedEvent.id
-            ?: throw Exception("Failed to sign NIP-46 request event")
-        val responseDeferred = CompletableDeferred<String>()
-        pendingRequests[requestId] = responseDeferred
+            val signedEvent = event.sign(clientKeyPair)
+            val eventId = signedEvent.id
+                ?: throw Exception("Failed to sign NIP-46 request event")
+            val responseDeferred = CompletableDeferred<String>()
+            pendingRequests[requestId] = responseDeferred
 
-        val eventMessage =
-            buildJsonArray {
-                add("EVENT")
-                add(signedEvent.toJsonObject())
-            }.toString()
+            val eventMessage =
+                buildJsonArray {
+                    add("EVENT")
+                    add(signedEvent.toJsonObject())
+                }.toString()
 
-        try {
-            // Publish in parallel via sendAndAwaitOk so a relay-side rejection
-            // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred. publishPacer spaces
-            // the publishes and, when the relay rate-limits, holds a shared
-            // cooldown and retries; it is never held across the response await.
-            var attempt = 1
-            while (true) {
-                publishPacer.awaitTurn()
-                val publishResults = relayClients.map { client ->
-                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-                }.awaitAll()
-                if (publishResults.any { it is PublishResult.Success }) {
-                    publishPacer.noteAccepted()
-                    break
+            try {
+                // Publish in parallel via sendAndAwaitOk so a relay-side rejection
+                // surfaces immediately. The response sub opened on connect routes
+                // the signer's reply back into responseDeferred. publishPacer spaces
+                // the publishes and, when the relay rate-limits, holds a shared
+                // cooldown and retries; it is never held across the response await.
+                var attempt = 1
+                while (true) {
+                    publishPacer.awaitTurn()
+                    val publishResults = relayClients.map { client ->
+                        async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                    }.awaitAll()
+                    if (publishResults.any { it is PublishResult.Success }) {
+                        publishPacer.noteAccepted()
+                        break
+                    }
+                    val rateLimited = publishResults.any {
+                        it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                    }
+                    if (rateLimited) publishPacer.noteRateLimited()
+                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                        throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                    }
+                    attempt++
                 }
-                val rateLimited = publishResults.any {
-                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
-                }
-                if (rateLimited) publishPacer.noteRateLimited()
-                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
-                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
-                }
-                attempt++
+                responseDeferred.await()
+            } finally {
+                pendingRequests.remove(requestId)
             }
-            responseDeferred.await()
-        } finally {
-            pendingRequests.remove(requestId)
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -338,10 +338,15 @@ actual class Nip46Client actual constructor(
                 pubKeyHex = signerPubkey,
             )
 
-        // In-flight window: pauses new requests when the signer stops answering (its own
-        // response publishes got rate-limited, which our OK-based backoff cannot see).
-        // created_at is stamped after the slot wait so a long pause cannot expire the event.
-        publishPacer.withRequestSlot {
+        // Background lane = the DM gift-wrap decrypt backlog, the one flood source. It is
+        // paced, windowed and cooled down; interactive requests (login handshake, AUTH,
+        // user-action signs/encrypts) publish immediately so they never queue behind it.
+        val background = method == "nip44_decrypt"
+        // In-flight window: pauses new background requests when the signer stops answering
+        // (its own response publishes got rate-limited, which our OK-based backoff cannot
+        // see). created_at is stamped after the slot wait so a long pause cannot expire the
+        // event.
+        publishPacer.withRequestSlot(background) {
             val event =
                 Event(
                     pubkey = clientKeyPair.publicKeyHex,
@@ -371,7 +376,7 @@ actual class Nip46Client actual constructor(
                 // cooldown and retries; it is never held across the response await.
                 var attempt = 1
                 while (true) {
-                    publishPacer.awaitTurn()
+                    publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -32,6 +32,9 @@ actual class Nip46Client actual constructor(
     private val relayConnectMutex = Mutex()
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests: MutableMap<String, CompletableDeferred<String>> = java.util.concurrent.ConcurrentHashMap()
+
+    // Shared pacing + rate-limit backoff for every request publish (see Nip46PublishPacer).
+    private val publishPacer = Nip46PublishPacer()
     private var responseSubscriptionId: String? = null
     private var nostrConnectSecret: String? = null
 
@@ -359,12 +362,27 @@ actual class Nip46Client actual constructor(
         try {
             // Publish in parallel via sendAndAwaitOk so a relay-side rejection
             // surfaces immediately. The response sub opened on connect routes
-            // the signer's reply back into responseDeferred.
-            val publishResults = relayClients.map { client ->
-                async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
-            }.awaitAll()
-            if (publishResults.none { it is PublishResult.Success }) {
-                throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+            // the signer's reply back into responseDeferred. publishPacer spaces
+            // the publishes and, when the relay rate-limits, holds a shared
+            // cooldown and retries; it is never held across the response await.
+            var attempt = 1
+            while (true) {
+                publishPacer.awaitTurn()
+                val publishResults = relayClients.map { client ->
+                    async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
+                }.awaitAll()
+                if (publishResults.any { it is PublishResult.Success }) {
+                    publishPacer.noteAccepted()
+                    break
+                }
+                val rateLimited = publishResults.any {
+                    it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
+                }
+                if (rateLimited) publishPacer.noteRateLimited()
+                if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
+                }
+                attempt++
             }
             responseDeferred.await()
         } finally {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -379,10 +379,11 @@ actual class Nip46Client actual constructor(
             try {
                 // Publish in parallel via sendAndAwaitOk so a relay-side rejection
                 // surfaces immediately. The response sub opened on connect routes
-                // the signer's reply back into responseDeferred. publishPacer spaces
-                // the publishes and, when the relay rate-limits, holds a shared
-                // cooldown and retries; it is never held across the response await.
-                var attempt = 1
+                // the signer's reply back into responseDeferred. A rate-limited
+                // publish retries under the pacer's escalating cooldown until this
+                // request's own deadline: failing hard reads as "signer unreachable"
+                // upstream and tears the session down, when the relay only asked us
+                // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
                     val publishResults = relayClients.map { client ->
@@ -395,11 +396,10 @@ actual class Nip46Client actual constructor(
                     val rateLimited = publishResults.any {
                         it is PublishResult.Rejected && Nip46PublishPacer.isRateLimitReason(it.reason)
                     }
-                    if (rateLimited) publishPacer.noteRateLimited()
-                    if (!rateLimited || attempt >= Nip46PublishPacer.MAX_PUBLISH_ATTEMPTS) {
+                    if (!rateLimited) {
                         throw Exception("Failed to publish NIP-46 request: ${publishResults.summarizeFailures()}")
                     }
-                    attempt++
+                    publishPacer.noteRateLimited()
                 }
                 try {
                     val response = responseDeferred.await()

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -679,14 +679,15 @@ fun GroupScreen(
 
     // Reaction error dialog (relay rejected kind 7)
     reactionError?.let { error ->
-        val isUnknownMember = error.contains("unknown member", ignoreCase = true)
+        val errorKind = classifyReactionError(error)
+        val isUnknownMember = errorKind == ReactionErrorKind.JoinRequired
         ConfirmDialog(
             title = if (isUnknownMember) "Join Required" else "Cannot React",
             message =
-            if (isUnknownMember) {
-                "You need to join this group before you can react to messages."
-            } else {
-                "This relay does not support reactions.\n\n$error"
+            when (errorKind) {
+                ReactionErrorKind.JoinRequired -> "You need to join this group before you can react to messages."
+                ReactionErrorKind.SignerFailure -> "Your signer could not sign the reaction. Please try again.\n\n$error"
+                ReactionErrorKind.RelayRejected -> "This relay does not support reactions.\n\n$error"
             },
             confirmLabel = if (isUnknownMember) "Join Group" else "OK",
             cancelLabel = if (isUnknownMember) "Cancel" else null,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -27,6 +27,8 @@ import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.screens.group.GroupMembership
 import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.MentionableGroup
+import org.nostr.nostrord.ui.screens.group.ReactionErrorKind
+import org.nostr.nostrord.ui.screens.group.classifyReactionError
 import org.nostr.nostrord.ui.screens.group.pluralizeSystemAction
 import org.nostr.nostrord.ui.scroll.ChatScrollPolicy
 import org.nostr.nostrord.ui.scroll.JumpPillTarget
@@ -2721,11 +2723,13 @@ private fun ChildrenBuilder.uploadErrorDialog(message: String, onDismiss: () -> 
     }
 }
 
-/** Dialog shown when the relay rejects a kind:7 reaction. Mirrors the native
- *  AlertDialog at GroupScreen.kt:620-665: a "Join Required" variant (offers Join)
- *  when the relay says we're an unknown member, otherwise "Cannot React" + OK. */
+/** Dialog shown when a kind:7 reaction fails. Mirrors the native ConfirmDialog in
+ *  GroupScreen: a "Join Required" variant (offers Join) when the relay says we're an
+ *  unknown member, a signer-failure variant when the signer could not sign, otherwise
+ *  "Cannot React" + OK. Classification is shared via classifyReactionError. */
 private fun ChildrenBuilder.reactionErrorDialog(message: String, onDismiss: () -> Unit, onJoin: () -> Unit) {
-    val isUnknownMember = message.contains("unknown member", ignoreCase = true)
+    val errorKind = classifyReactionError(message)
+    val isUnknownMember = errorKind == ReactionErrorKind.JoinRequired
     div {
         className = ClassName("modal-overlay")
         onClick = { onDismiss() }
@@ -2741,7 +2745,15 @@ private fun ChildrenBuilder.reactionErrorDialog(message: String, onDismiss: () -
                 if (isUnknownMember) {
                     +"You need to join this group before you can react to messages."
                 } else {
-                    div { +"This relay does not support reactions." }
+                    div {
+                        +(
+                            if (errorKind == ReactionErrorKind.SignerFailure) {
+                                "Your signer could not sign the reaction. Please try again."
+                            } else {
+                                "This relay does not support reactions."
+                            }
+                            )
+                    }
                     div {
                         className = ClassName("modal-reason")
                         +message


### PR DESCRIPTION
Fixes #182. All three reported errors are one incident seen from three angles: the bunker relay rate-limits kind:24133 traffic ("rate-limited: you are noting too much"). Opening the app burst NIP-46 requests (mainly the DM gift-wrap backlog, two decrypts per wrap), the relay rejected our publishes AND the signer's responses (the Amber toast), and a single rejection failed the whole action with a misleading dialog.

Every NIP-46 request publish now goes through a shared `Nip46PublishPacer`: 400ms spacing plus an escalating cooldown (2s to 30s) with up to 3 retries when all relays reject as rate-limited. The pacer is never held across the response await, so many requests stay in-flight for the signer's burst replies. The DM backlog gate now admits one wrap per two pacer slots, keeping the client-side queue shallow so interactive signs (reactions, uploads, NIP-42 AUTH) are not stuck behind it and the admission wait lands before the 90s decrypt timeout starts. Reaction errors are classified in the shared ViewModel (join required / signer failure / relay rejection) so both UIs stop blaming the relay for a signing failure.

| Symptom | Cause | Fix |
|---|---|---|
| Amber toast "Error sending bunker response: rate-limited" on app open | Our request burst forces one signer response per request on the same relay | Global 400ms pacing caps the combined publish rate |
| Reaction fails: "This relay does not support reactions" + rejected=1 rate-limited | Publish rejected once = hard failure, and any error mapped to a relay-rejection message | Cooldown + retry in `sendRequest`; signer failures get their own dialog copy (Compose + web) |
| "Upload Failed: User not authenticated" | NIP-98 auth sign died on the same rejected publish | Same retry path; the upload signs after the cooldown |

Deliberate non-changes: `dmGivenUpWrapIds` stays session-only (persisting it risks parking DMs forever), and request timeouts do not trigger the cooldown (timeout also means signer offline or waiting on manual approval, where slowing down would delay recovery). Pacing is per app instance; several devices each back off independently on their own rejections.

A multi-device test (3 clients booting together) surfaced the blind side of OK-based backoff: the relay also rate-limits the SIGNER's response publishes, which we only see as responses not coming back while every client keeps feeding its queue (whose stale retries then bounce as "ephemeral event expired"). `sendRequest` now also runs inside an in-flight window of 8 unanswered requests per client: when answers stop, publishing pauses until they return, draining the signer's queue instead of growing it. `created_at` is stamped after the slot wait so a long pause cannot expire our own ephemeral request event.

Applying pacing and the window to every request made bunker login visibly slow (each handshake step paid 400ms, then queued FIFO behind backlog slots held across signer round trips). The flood the relay limits comes from one source only, the DM gift-wrap `nip44_decrypt` backlog, so that is now the only throttled lane: interactive requests (connect, get_public_key, AUTH, user-action signs/encrypts) publish immediately and honor just an explicit rate-limit cooldown. Login is back to its original speed.

Commits:
- bcce3a61 fix(nip46): pace bunker publishes and back off on relay rate limits (#182)
- b4e4ec09 fix(nip46): cap unanswered requests in flight per client
- 1797190c fix(nip46): interactive requests skip the backlog lane

Validated with `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid`, `:composeApp:jvmTest` (new `Nip46PublishPacerTest`). Device validation with a live Amber backlog still pending.

