### PR TITLE
feat(moderation): NIP-56 user and message reports (kind:1984) + admin inbox

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -4000,6 +4000,80 @@ class NostrRepository(
         }
     }
 
+    /**
+     * NIP-56 report (kind:1984). Settles on the FIRST relay OK (a 1984 is append-only,
+     * so one acceptance is enough — unlike the replaceable lists there is no stale-copy
+     * hazard); remaining sends finish in the background. Connects run per-relay inside
+     * the same race, so one dead outbox relay can't hold the modal's spinner.
+     */
+    override suspend fun reportUser(
+        pubkey: String,
+        type: org.nostr.nostrord.nostr.Nip56.ReportType,
+        note: String,
+        eventId: String?,
+    ): Result<Unit> {
+        val myPubkey = sessionManager.getPublicKey()
+            ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        return try {
+            val event = org.nostr.nostrord.nostr.Event(
+                pubkey = myPubkey,
+                createdAt = org.nostr.nostrord.utils.epochSeconds(),
+                kind = org.nostr.nostrord.nostr.Nip56.KIND_REPORT,
+                tags = org.nostr.nostrord.nostr.Nip56.reportTags(pubkey, eventId, type),
+                content = note.trim(),
+            )
+            val signedEvent = sessionManager.signEvent(event)
+            val signedId = signedEvent.id
+                ?: return Result.Error(AppError.Unknown("Event has no id after signing", null))
+            val message = buildJsonArray {
+                add("EVENT")
+                add(signedEvent.toJsonObject())
+            }.toString()
+
+            // Same routing as kind:3 / kind:10000: general-purpose relays only. Normalized
+            // BEFORE distinct: the kind:10002 write list and the hardcoded bootstrap list spell
+            // the same relay differently (trailing slash, case), and raw-string dedup let both
+            // through to one pooled client = the same EVENT frame twice on one socket.
+            val nip29Relays = (
+                outboxManager.kind10009Relays.value +
+                    connectionManager.currentRelayUrl.value
+                ).map { it.normalizeRelayUrl() }.toSet()
+            val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays)
+                .map { it.normalizeRelayUrl() }
+                .distinct()
+                .filter { it !in nip29Relays }
+            if (targets.isEmpty()) {
+                return Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
+            }
+            // Buffered to relay count so background stragglers never block on send
+            // after this function has already returned on the first OK.
+            val verdicts = kotlinx.coroutines.channels.Channel<PublishResult?>(capacity = targets.size)
+            targets.forEach { relayUrl ->
+                scope.launch {
+                    val client = connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }
+                        ?: connectionManager.getOrConnectRelay(relayUrl, metadataMessageHandler)?.takeIf { it.isConnected() }
+                    verdicts.send(client?.sendAndAwaitOkOrError(message, signedId))
+                }
+            }
+            val failures = mutableListOf<PublishResult>()
+            repeat(targets.size) {
+                when (val verdict = verdicts.receive()) {
+                    null -> {} // relay unreachable
+                    is PublishResult.Success -> return Result.Success(Unit)
+                    else -> failures += verdict
+                }
+            }
+            if (failures.isEmpty()) {
+                return Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
+            }
+            Result.Error(AppError.Network.PublishRejected(failures.summarizeFailures()))
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Result.Error(AppError.Unknown(e.message ?: "Failed to send report", e))
+        }
+    }
+
     private suspend fun refreshVisibleUserMetadata() {
         // Wait for resubscribeAllGroups REQs to deliver events before collecting pubkeys.
         // Without this delay, messages/members may still be empty from the previous session.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -683,6 +683,19 @@ interface NostrRepositoryApi {
     /** Remove [pubkey] from the active account's kind:10000 mute list and publish it. */
     suspend fun unmuteUser(pubkey: String): Result<Unit>
 
+    /**
+     * Publish a NIP-56 kind:1984 report flagging [pubkey], optionally pinned to their
+     * event [eventId], as [type] with an optional free-text [note]. Routed like the
+     * other non-group publishes (outbox write + bootstrap relays, never NIP-29 relays):
+     * NIP-56 reports live on the reporter's relays for clients and tools to consume.
+     */
+    suspend fun reportUser(
+        pubkey: String,
+        type: org.nostr.nostrord.nostr.Nip56.ReportType,
+        note: String = "",
+        eventId: String? = null,
+    ): Result<Unit>
+
     suspend fun updateProfileMetadata(
         displayName: String? = null,
         name: String? = null,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip56.kt
@@ -1,0 +1,30 @@
+package org.nostr.nostrord.nostr
+
+/**
+ * NIP-56 reporting. A kind:1984 flags a pubkey (and optionally one of their events);
+ * the report type rides as the third element of the `p`/`e` tag.
+ */
+object Nip56 {
+    const val KIND_REPORT = 1984
+
+    /** Wire values defined by NIP-56. */
+    enum class ReportType(val value: String) {
+        NUDITY("nudity"),
+        MALWARE("malware"),
+        PROFANITY("profanity"),
+        ILLEGAL("illegal"),
+        SPAM("spam"),
+        IMPERSONATION("impersonation"),
+        OTHER("other"),
+    }
+
+    /** Tag list for a report on [pubkey], optionally pinned to their event [eventId]. */
+    fun reportTags(
+        pubkey: String,
+        eventId: String?,
+        type: ReportType,
+    ): List<List<String>> = buildList {
+        add(listOf("p", pubkey, type.value))
+        if (!eventId.isNullOrBlank()) add(listOf("e", eventId, type.value))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/report/ReportUserViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/report/ReportUserViewModel.kt
@@ -1,0 +1,113 @@
+package org.nostr.nostrord.ui.screens.report
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.nostr.Nip56
+import org.nostr.nostrord.utils.Result
+
+/** One selectable NIP-56 reason: wire type + the UI copy shared by both UIs. */
+data class ReportReason(
+    val type: Nip56.ReportType,
+    val label: String,
+    val hint: String,
+)
+
+/** Prototype ReportModal order; labels/hints rendered identically on web and Compose. */
+val REPORT_REASONS: List<ReportReason> = listOf(
+    ReportReason(Nip56.ReportType.SPAM, "Spam", "Unwanted promotional content or repetitive posting."),
+    ReportReason(Nip56.ReportType.NUDITY, "Nudity or sexual content", "Explicit or sexual material."),
+    ReportReason(Nip56.ReportType.PROFANITY, "Harassment or abuse", "Hate speech, threats, or abusive language."),
+    ReportReason(Nip56.ReportType.ILLEGAL, "Illegal content", "Content that may violate the law."),
+    ReportReason(Nip56.ReportType.IMPERSONATION, "Impersonation", "Pretending to be someone else."),
+    ReportReason(Nip56.ReportType.MALWARE, "Malware or scam", "Phishing links, scams, or malicious software."),
+    ReportReason(Nip56.ReportType.OTHER, "Other", "Something else that doesn't fit the categories above."),
+)
+
+/**
+ * Shared logic for the report modal (NIP-56 kind:1984): reason selection, optional
+ * note, the "also mute" toggle (on by default, moot when already muted), and the
+ * send that publishes the report and optionally mutes in one go.
+ */
+class ReportUserViewModel(
+    private val repo: NostrRepositoryApi,
+    private val targetPubkey: String,
+    private val eventId: String? = null,
+) : ViewModel() {
+    enum class Phase { Editing, Sending, Sent }
+
+    private val _selected = MutableStateFlow<Nip56.ReportType?>(null)
+    val selected: StateFlow<Nip56.ReportType?> = _selected
+
+    private val _note = MutableStateFlow("")
+    val note: StateFlow<String> = _note
+
+    private val _alsoMute = MutableStateFlow(true)
+    val alsoMute: StateFlow<Boolean> = _alsoMute
+
+    private val _phase = MutableStateFlow(Phase.Editing)
+    val phase: StateFlow<Phase> = _phase
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
+
+    /** Hides the "also mute" toggle when the target is muted before the modal opens. */
+    val targetAlreadyMuted: StateFlow<Boolean> =
+        repo.mutedPubkeys
+            .map { targetPubkey in it }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, targetPubkey in repo.mutedPubkeys.value)
+
+    fun select(type: Nip56.ReportType) {
+        if (_phase.value == Phase.Editing) _selected.value = type
+    }
+
+    fun setNote(value: String) {
+        _note.value = value
+    }
+
+    fun toggleAlsoMute() {
+        _alsoMute.value = !_alsoMute.value
+    }
+
+    /** True when the send also muted the target (drives the success copy). */
+    val didMute: StateFlow<Boolean> get() = _didMute
+    private val _didMute = MutableStateFlow(false)
+
+    /** Clears the form for the next open (the Compose VM outlives the closed modal). */
+    fun reset() {
+        _selected.value = null
+        _note.value = ""
+        _alsoMute.value = true
+        _phase.value = Phase.Editing
+        _error.value = null
+        _didMute.value = false
+    }
+
+    fun send() {
+        val type = _selected.value ?: return
+        if (_phase.value != Phase.Editing) return
+        _phase.value = Phase.Sending
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.reportUser(targetPubkey, type, _note.value, eventId)) {
+                is Result.Success -> {
+                    if (_alsoMute.value && !targetAlreadyMuted.value) {
+                        // Best-effort: the report already went out even if the mute fails.
+                        _didMute.value = repo.muteUser(targetPubkey) is Result.Success
+                    }
+                    _phase.value = Phase.Sent
+                }
+                is Result.Error -> {
+                    _error.value = result.error.message.ifBlank { "Could not send the report." }
+                    _phase.value = Phase.Editing
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -486,6 +486,18 @@ class FakeNostrRepository : NostrRepositoryApi {
         return Result.Success(Unit)
     }
 
+    var reportUserResult: Result<Unit> = Result.Success(Unit)
+
+    override suspend fun reportUser(
+        pubkey: String,
+        type: org.nostr.nostrord.nostr.Nip56.ReportType,
+        note: String,
+        eventId: String?,
+    ): Result<Unit> {
+        calls += "reportUser:$pubkey:${type.value}:$note:$eventId"
+        return reportUserResult
+    }
+
     override suspend fun updateProfileMetadata(
         displayName: String?,
         name: String?,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ReportUserViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ReportUserViewModelTest.kt
@@ -1,0 +1,109 @@
+package org.nostr.nostrord.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.nostr.Nip56
+import org.nostr.nostrord.ui.screens.report.ReportUserViewModel
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ReportUserViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `send without a selected reason is a no-op`() = runTest {
+        val fake = FakeNostrRepository()
+        val vm = ReportUserViewModel(fake, targetPubkey = "target")
+
+        vm.send()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ReportUserViewModel.Phase.Editing, vm.phase.value)
+        assertTrue(fake.calls.none { it.startsWith("reportUser:") })
+    }
+
+    @Test
+    fun `send publishes the report and mutes by default`() = runTest {
+        val fake = FakeNostrRepository()
+        val vm = ReportUserViewModel(fake, targetPubkey = "target", eventId = "evt1")
+
+        vm.select(Nip56.ReportType.SPAM)
+        vm.setNote("  repeated ads  ")
+        vm.send()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ReportUserViewModel.Phase.Sent, vm.phase.value)
+        assertTrue(vm.didMute.value)
+        assertEquals("reportUser:target:spam:  repeated ads  :evt1", fake.calls.first { it.startsWith("reportUser:") })
+        assertTrue(fake.calls.contains("muteUser:target"))
+    }
+
+    @Test
+    fun `unchecking also-mute skips the mute`() = runTest {
+        val fake = FakeNostrRepository()
+        val vm = ReportUserViewModel(fake, targetPubkey = "target")
+
+        vm.select(Nip56.ReportType.OTHER)
+        vm.toggleAlsoMute()
+        vm.send()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ReportUserViewModel.Phase.Sent, vm.phase.value)
+        assertFalse(vm.didMute.value)
+        assertTrue(fake.calls.none { it.startsWith("muteUser:") })
+    }
+
+    @Test
+    fun `already-muted target is not re-muted`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._mutedPubkeys.value = setOf("target")
+        val vm = ReportUserViewModel(fake, targetPubkey = "target")
+
+        assertTrue(vm.targetAlreadyMuted.value)
+        vm.select(Nip56.ReportType.PROFANITY)
+        vm.send()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ReportUserViewModel.Phase.Sent, vm.phase.value)
+        assertTrue(fake.calls.none { it.startsWith("muteUser:") })
+    }
+
+    @Test
+    fun `publish failure surfaces the error and returns to editing`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.reportUserResult = Result.Error(AppError.Network.PublishRejected("rate-limited"))
+        val vm = ReportUserViewModel(fake, targetPubkey = "target")
+
+        vm.select(Nip56.ReportType.MALWARE)
+        vm.send()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(ReportUserViewModel.Phase.Editing, vm.phase.value)
+        assertNotNull(vm.error.value)
+        assertTrue(fake.calls.none { it.startsWith("muteUser:") })
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ReportUserModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ReportUserModal.kt
@@ -1,0 +1,360 @@
+package org.nostr.nostrord.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.components.forms.AppField
+import org.nostr.nostrord.ui.screens.report.REPORT_REASONS
+import org.nostr.nostrord.ui.screens.report.ReportUserViewModel
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * NIP-56 report modal (prototype ReportModal): reason radio cards, optional note,
+ * the "also mute" toggle and an in-modal success state. [eventId] pins the report
+ * to a specific message.
+ */
+@Composable
+fun ReportUserModal(
+    pubkey: String,
+    metadata: UserMetadata?,
+    eventId: String? = null,
+    onDismiss: () -> Unit,
+) {
+    val vm = viewModel(key = "report:$pubkey:$eventId") {
+        ReportUserViewModel(AppModule.nostrRepository, pubkey, eventId)
+    }
+    // The VM outlives the closed modal in the owner's store; clear the form on close
+    // so reopening doesn't show the previous run's Sent state.
+    DisposableEffect(Unit) { onDispose { vm.reset() } }
+    val selected by vm.selected.collectAsState()
+    val note by vm.note.collectAsState()
+    val alsoMute by vm.alsoMute.collectAsState()
+    val phase by vm.phase.collectAsState()
+    val error by vm.error.collectAsState()
+    val alreadyMuted by vm.targetAlreadyMuted.collectAsState()
+    val didMute by vm.didMute.collectAsState()
+
+    val npub = remember(pubkey) { Nip19.encodeNpub(pubkey) }
+    val displayName =
+        metadata?.displayName?.takeIf { it.isNotBlank() }
+            ?: metadata?.name?.takeIf { it.isNotBlank() }
+            ?: (npub.take(12) + "…")
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties =
+        DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
+        Box(
+            modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.7f))
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                ) { onDismiss() },
+            contentAlignment = Alignment.Center,
+        ) {
+            Card(
+                modifier =
+                Modifier
+                    .widthIn(max = 440.dp)
+                    .fillMaxWidth(0.9f)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                    ) { /* consume click */ },
+                shape = RoundedCornerShape(16.dp),
+                colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
+            ) {
+                Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                    ModalTitleBar(
+                        title = if (phase == ReportUserViewModel.Phase.Sent) "Report sent" else "Report",
+                        onClose = onDismiss,
+                    )
+
+                    Column(
+                        modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = Spacing.lg)
+                            .padding(top = Spacing.md, bottom = Spacing.lg),
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                        ) {
+                            ProfileAvatar(
+                                imageUrl = metadata?.picture,
+                                displayName = displayName,
+                                pubkey = pubkey,
+                                size = 44.dp,
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = displayName,
+                                    color = NostrordColors.TextPrimary,
+                                    fontSize = 15.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                                Spacer(modifier = Modifier.height(2.dp))
+                                Text(
+                                    text = if (eventId != null) "Report this message" else "Report user",
+                                    color = NostrordColors.TextMuted,
+                                    fontSize = 12.sp,
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(Spacing.md))
+
+                        if (phase == ReportUserViewModel.Phase.Sent) {
+                            Column(
+                                modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(12.dp))
+                                    .background(NostrordColors.BackgroundFloating)
+                                    .border(1.dp, NostrordColors.Divider, RoundedCornerShape(12.dp))
+                                    .padding(Spacing.lg),
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                            ) {
+                                Text("🛡️", fontSize = 28.sp)
+                                Spacer(modifier = Modifier.height(Spacing.sm))
+                                Text(
+                                    text = "Report submitted",
+                                    color = NostrordColors.TextPrimary,
+                                    fontSize = 15.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                )
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text =
+                                    if (didMute) {
+                                        "The report was published to your relays (kind:1984 event). $displayName was also muted."
+                                    } else {
+                                        "The report was published to your relays (kind:1984 event). Thank you."
+                                    },
+                                    color = NostrordColors.TextMuted,
+                                    fontSize = 12.sp,
+                                    textAlign = TextAlign.Center,
+                                )
+                                Spacer(modifier = Modifier.height(Spacing.md))
+                                AppButton(text = "Done", onClick = onDismiss)
+                            }
+                        } else {
+                            Text(
+                                text = "REASON",
+                                color = NostrordColors.TextMuted,
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                letterSpacing = 0.5.sp,
+                            )
+                            Spacer(modifier = Modifier.height(6.dp))
+                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                REPORT_REASONS.forEach { reason ->
+                                    val isSelected = selected == reason.type
+                                    Row(
+                                        modifier =
+                                        Modifier
+                                            .fillMaxWidth()
+                                            .clip(RoundedCornerShape(8.dp))
+                                            .border(
+                                                1.dp,
+                                                if (isSelected) NostrordColors.Primary else NostrordColors.Divider,
+                                                RoundedCornerShape(8.dp),
+                                            )
+                                            .background(
+                                                if (isSelected) NostrordColors.PrimarySubtle else NostrordColors.Background,
+                                            )
+                                            .clickable { vm.select(reason.type) }
+                                            .pointerHoverIcon(PointerIcon.Hand)
+                                            .padding(horizontal = Spacing.md, vertical = 10.dp),
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                                    ) {
+                                        Box(
+                                            modifier =
+                                            Modifier
+                                                .size(16.dp)
+                                                .clip(CircleShape)
+                                                .border(
+                                                    1.5.dp,
+                                                    if (isSelected) NostrordColors.Primary else NostrordColors.TextMuted,
+                                                    CircleShape,
+                                                )
+                                                .background(if (isSelected) NostrordColors.Primary else Color.Transparent),
+                                            contentAlignment = Alignment.Center,
+                                        ) {
+                                            if (isSelected) {
+                                                Box(
+                                                    modifier =
+                                                    Modifier
+                                                        .size(6.dp)
+                                                        .clip(CircleShape)
+                                                        .background(Color.White),
+                                                )
+                                            }
+                                        }
+                                        Column {
+                                            Text(
+                                                text = reason.label,
+                                                color = if (isSelected) NostrordColors.TextPrimary else NostrordColors.TextSecondary,
+                                                fontSize = 14.sp,
+                                            )
+                                            Text(
+                                                text = reason.hint,
+                                                color = NostrordColors.TextMuted,
+                                                fontSize = 11.sp,
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+
+                            Spacer(modifier = Modifier.height(Spacing.md))
+                            AppField(
+                                value = note,
+                                onValueChange = vm::setNote,
+                                placeholder = "Details (optional)",
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+
+                            if (!alreadyMuted) {
+                                Spacer(modifier = Modifier.height(Spacing.md))
+                                Row(
+                                    modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .clip(RoundedCornerShape(8.dp))
+                                        .background(NostrordColors.HoverBackground)
+                                        .clickable { vm.toggleAlsoMute() }
+                                        .pointerHoverIcon(PointerIcon.Hand)
+                                        .padding(horizontal = Spacing.md, vertical = 10.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                                ) {
+                                    Box(
+                                        modifier =
+                                        Modifier
+                                            .size(18.dp)
+                                            .clip(RoundedCornerShape(4.dp))
+                                            .border(
+                                                1.5.dp,
+                                                if (alsoMute) NostrordColors.Primary else NostrordColors.TextMuted,
+                                                RoundedCornerShape(4.dp),
+                                            )
+                                            .background(if (alsoMute) NostrordColors.Primary else Color.Transparent),
+                                        contentAlignment = Alignment.Center,
+                                    ) {
+                                        if (alsoMute) {
+                                            Icon(
+                                                Icons.Default.Check,
+                                                contentDescription = null,
+                                                tint = Color.White,
+                                                modifier = Modifier.size(13.dp),
+                                            )
+                                        }
+                                    }
+                                    Text(
+                                        text =
+                                        buildAnnotatedString {
+                                            append("Also mute ")
+                                            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = NostrordColors.TextPrimary)) {
+                                                append(displayName)
+                                            }
+                                            append(" (recommended)")
+                                        },
+                                        color = NostrordColors.TextSecondary,
+                                        fontSize = 13.sp,
+                                    )
+                                }
+                            }
+
+                            error?.let {
+                                Spacer(modifier = Modifier.height(Spacing.sm))
+                                Text(text = it, color = NostrordColors.Error, fontSize = 12.sp)
+                            }
+
+                            Spacer(modifier = Modifier.height(Spacing.md))
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(Spacing.sm, Alignment.End),
+                            ) {
+                                AppButton(
+                                    text = "Cancel",
+                                    onClick = onDismiss,
+                                    variant = AppButtonVariant.Ghost,
+                                )
+                                AppButton(
+                                    text = if (phase == ReportUserViewModel.Phase.Sending) "Sending…" else "Send report",
+                                    onClick = { vm.send() },
+                                    enabled = selected != null && phase == ReportUserViewModel.Phase.Editing,
+                                    variant = AppButtonVariant.Danger,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -100,6 +100,9 @@ sealed class MessageContextAction {
 
     data object PinMessage : MessageContextAction()
 
+    /** NIP-56 report on this message's author, pinned to the message. */
+    data object ReportMessage : MessageContextAction()
+
     data object DeleteMessage : MessageContextAction()
 }
 
@@ -302,7 +305,7 @@ private fun ContextMenuContent(
             )
         }
 
-        // Saved-for-later and NIP-56 reports are not implemented yet.
+        // Saved-for-later is not implemented yet.
         ContextMenuItem(
             icon = Icons.Outlined.Bookmark,
             label = "Save for later",
@@ -313,8 +316,10 @@ private fun ContextMenuContent(
             ContextMenuItem(
                 icon = Icons.Outlined.Shield,
                 label = "Report",
-                enabled = false,
-                onClick = {},
+                onClick = {
+                    onAction(MessageContextAction.ReportMessage)
+                    onDismiss()
+                },
             )
         }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -54,6 +54,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip57
+import org.nostr.nostrord.ui.components.ReportUserModal
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.zap.ZapBadge
 import org.nostr.nostrord.ui.components.zap.ZapController
@@ -123,6 +124,7 @@ fun MessageItem(
 ) {
     // Use rememberUpdatedState to avoid recomposition when callbacks change reference
     val copyToClipboard = rememberClipboardWriter()
+    var showReportModal by remember { mutableStateOf(false) }
     val currentOnUsernameClick by rememberUpdatedState(onUsernameClick)
     val currentOnReplyClick by rememberUpdatedState(onReplyClick)
     val currentOnReactionClick by rememberUpdatedState(onReactionClick)
@@ -518,12 +520,22 @@ fun MessageItem(
                         MessageContextAction.PinMessage -> currentOnPinMessage()
                         MessageContextAction.DeleteMessage -> currentOnDeleteMessage()
                         MessageContextAction.ZapMessage -> ZapController.request(message.pubkey, message.id)
+                        MessageContextAction.ReportMessage -> showReportModal = true
                     }
                 },
                 isAuthor = isAuthor,
                 isAdmin = isAdmin,
                 canZap = canZap,
             )
+
+            if (showReportModal) {
+                ReportUserModal(
+                    pubkey = message.pubkey,
+                    metadata = metadata ?: resolveMetadata(message.pubkey),
+                    eventId = message.id,
+                    onDismiss = { showReportModal = false },
+                )
+            }
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/UserProfileModal.kt
@@ -39,6 +39,7 @@ import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.ui.components.IdentifierField
 import org.nostr.nostrord.ui.components.ModalTitleBar
+import org.nostr.nostrord.ui.components.ReportUserModal
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
@@ -142,6 +143,7 @@ fun UserProfileModal(
     val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     val isFollowing = pubkey in following
     var followBusy by remember(pubkey) { mutableStateOf(false) }
+    var showReport by remember(pubkey) { mutableStateOf(false) }
     LaunchedEffect(Unit) { AppModule.nostrRepository.requestContactList() }
 
     // Zaps require signing a kind:9734 request, so only offer them when an account
@@ -371,7 +373,9 @@ fun UserProfileModal(
                                         }
                                     }
                                 }
-                                ProfileActionRow(label = "Report user", icon = Icons.Default.Shield, enabled = false) {}
+                                ProfileActionRow(label = "Report user", icon = Icons.Default.Shield) {
+                                    showReport = true
+                                }
 
                                 if (iAmAdmin && (onToggleAdminRole != null || onRemoveFromGroup != null)) {
                                     HorizontalDivider(
@@ -412,5 +416,13 @@ fun UserProfileModal(
                 }
             }
         }
+    }
+
+    if (showReport) {
+        ReportUserModal(
+            pubkey = pubkey,
+            metadata = metadata,
+            onDismiss = { showReport = false },
+        )
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/profile/ProfilePageScreen.kt
@@ -30,7 +30,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -55,6 +57,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.ui.components.GroupTypeBadges
 import org.nostr.nostrord.ui.components.IdentifierField
+import org.nostr.nostrord.ui.components.ReportUserModal
 import org.nostr.nostrord.ui.components.RichAboutText
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
@@ -215,12 +218,12 @@ fun ProfilePageScreen(
                                 IdentifierField(pubkey = pubkey, nip05 = metadata?.nip05)
 
                                 if (!vm.isSelf) {
-                                    // Zaps require a signer + a lightning address;
-                                    // NIP-56 reports aren't wired yet (disabled).
+                                    // Zaps require a signer + a lightning address.
                                     val activeSession by ActiveAccountManager.session.collectAsState()
                                     val canZap = activeSession != null &&
                                         Nip57.resolvePayEndpoint(metadata?.lud16, metadata?.lud06) != null
                                     val isMuted by vm.isMuted.collectAsState()
+                                    var showReport by remember { mutableStateOf(false) }
                                     Spacer(modifier = Modifier.height(Spacing.md))
                                     Row(horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
                                         AppButton(
@@ -240,11 +243,17 @@ fun ProfilePageScreen(
                                         )
                                         AppButton(
                                             text = "Report",
-                                            onClick = {},
-                                            enabled = false,
+                                            onClick = { showReport = true },
                                             variant = AppButtonVariant.Ghost,
                                             size = AppButtonSize.Small,
                                             icon = Icons.Default.Shield,
+                                        )
+                                    }
+                                    if (showReport) {
+                                        ReportUserModal(
+                                            pubkey = pubkey,
+                                            metadata = metadata,
+                                            onDismiss = { showReport = false },
                                         )
                                     }
                                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ReportUserModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ReportUserModal.kt
@@ -1,0 +1,208 @@
+package org.nostr.nostrord.web.modals
+
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.screens.report.REPORT_REASONS
+import org.nostr.nostrord.ui.screens.report.ReportUserViewModel
+import org.nostr.nostrord.web.bridge.launchApp
+import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
+import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.useEscClose
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.b
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.input
+import react.dom.html.ReactHTML.span
+import react.useEffect
+import web.cssom.ClassName
+
+external interface ReportUserModalProps : Props {
+    var pubkey: String
+
+    /** Pins the report to a specific message; null reports the user. */
+    var eventId: String?
+    var onClose: () -> Unit
+}
+
+/**
+ * NIP-56 report modal (prototype ReportModal): reason radio cards, optional note,
+ * the "also mute" toggle and an in-modal success state. Same shared
+ * [ReportUserViewModel] as the Compose modal.
+ */
+val ReportUserModal =
+    FC<ReportUserModalProps> { props ->
+        val vm =
+            useViewModel("report:${props.pubkey}:${props.eventId}") {
+                ReportUserViewModel(AppModule.nostrRepository, props.pubkey, props.eventId)
+            }
+        val selected = useStateFlow(vm.selected)
+        val note = useStateFlow(vm.note)
+        val alsoMute = useStateFlow(vm.alsoMute)
+        val phase = useStateFlow(vm.phase)
+        val error = useStateFlow(vm.error)
+        val alreadyMuted = useStateFlow(vm.targetAlreadyMuted)
+        val didMute = useStateFlow(vm.didMute)
+
+        val allMeta = useStateFlow(AppModule.nostrRepository.userMetadata)
+        val meta = allMeta[props.pubkey]
+        val npub = Nip19.encodeNpub(props.pubkey)
+        val name =
+            meta?.displayName?.takeIf { it.isNotBlank() }
+                ?: meta?.name?.takeIf { it.isNotBlank() }
+                ?: (npub.take(12) + "…")
+
+        useEffect(props.pubkey) {
+            launchApp { AppModule.nostrRepository.requestUserMetadata(setOf(props.pubkey)) }
+        }
+        useEscClose { props.onClose() }
+
+        div {
+            className = ClassName("modal-overlay")
+            onClick = { props.onClose() }
+            div {
+                className = ClassName("modal-card sm")
+                onClick = { it.stopPropagation() }
+
+                div {
+                    className = ClassName("modal-header")
+                    div {
+                        className = ClassName("modal-title")
+                        +(if (phase == ReportUserViewModel.Phase.Sent) "Report sent" else "Report")
+                    }
+                    button {
+                        className = ClassName("modal-close")
+                        onClick = { props.onClose() }
+                        icon(Ic.Close)
+                    }
+                }
+
+                div {
+                    className = ClassName("report-head")
+                    WebAvatar {
+                        url = meta?.picture
+                        seed = props.pubkey
+                        this.name = name
+                        cls = "report-head-avatar"
+                    }
+                    div {
+                        div {
+                            className = ClassName("report-head-name")
+                            +name
+                        }
+                        div {
+                            className = ClassName("report-head-sub")
+                            +(if (props.eventId != null) "Report this message" else "Report user")
+                        }
+                    }
+                }
+
+                if (phase == ReportUserViewModel.Phase.Sent) {
+                    div {
+                        className = ClassName("report-success")
+                        div {
+                            className = ClassName("report-success-icon")
+                            +"🛡️"
+                        }
+                        div {
+                            className = ClassName("report-success-title")
+                            +"Report submitted"
+                        }
+                        div {
+                            className = ClassName("report-success-text")
+                            +(
+                                if (didMute) {
+                                    "The report was published to your relays (kind:1984 event). $name was also muted."
+                                } else {
+                                    "The report was published to your relays (kind:1984 event). Thank you."
+                                }
+                                )
+                        }
+                        button {
+                            className = ClassName("btn-primary")
+                            onClick = { props.onClose() }
+                            +"Done"
+                        }
+                    }
+                } else {
+                    div {
+                        className = ClassName("field-label")
+                        +"Reason"
+                    }
+                    div {
+                        className = ClassName("report-reasons")
+                        REPORT_REASONS.forEach { reason ->
+                            val isSelected = selected == reason.type
+                            button {
+                                className = ClassName(if (isSelected) "report-reason selected" else "report-reason")
+                                onClick = { vm.select(reason.type) }
+                                span {
+                                    className = ClassName(if (isSelected) "report-radio on" else "report-radio")
+                                }
+                                div {
+                                    div {
+                                        className = ClassName("report-reason-label")
+                                        +reason.label
+                                    }
+                                    div {
+                                        className = ClassName("report-reason-hint")
+                                        +reason.hint
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    input {
+                        className = ClassName("modal-input")
+                        placeholder = "Details (optional)"
+                        value = note
+                        onChange = { event -> vm.setNote(event.currentTarget.value) }
+                    }
+
+                    if (!alreadyMuted) {
+                        button {
+                            className = ClassName("report-mute-row")
+                            onClick = { vm.toggleAlsoMute() }
+                            span {
+                                className = ClassName(if (alsoMute) "report-check on" else "report-check")
+                                if (alsoMute) icon(Ic.Check)
+                            }
+                            span {
+                                className = ClassName("report-mute-label")
+                                +"Also mute "
+                                b { +name }
+                                +" (recommended)"
+                            }
+                        }
+                    }
+
+                    if (error != null) {
+                        div {
+                            className = ClassName("modal-error")
+                            +error
+                        }
+                    }
+
+                    div {
+                        className = ClassName("modal-footer")
+                        button {
+                            className = ClassName("btn-text")
+                            onClick = { props.onClose() }
+                            +"Cancel"
+                        }
+                        button {
+                            className = ClassName("btn-danger")
+                            disabled = selected == null || phase != ReportUserViewModel.Phase.Editing
+                            onClick = { vm.send() }
+                            +(if (phase == ReportUserViewModel.Phase.Sending) "Sending…" else "Send report")
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt
@@ -75,6 +75,7 @@ val UserProfileModal =
         val isMuted = pubkey in mutedPubkeys
         val dmEnabled = useStateFlow(AppModule.dmSettings.dmEnabled)
         val (followBusy, setFollowBusy) = useState { false }
+        val (showReport, setShowReport) = useState { false }
 
         useEffect(pubkey) {
             launchApp { AppModule.nostrRepository.requestUserMetadata(setOf(pubkey)) }
@@ -220,7 +221,9 @@ val UserProfileModal =
                                     }
                                 }
                             }
-                            actionRow(Ic.Shield, "Report user", disabled = true) {}
+                            actionRow(Ic.Shield, "Report user") {
+                                setShowReport(true)
+                            }
 
                             val groupId = props.groupId
                             if (props.iAmAdmin && groupId != null) {
@@ -242,6 +245,14 @@ val UserProfileModal =
                         }
                     }
                 }
+            }
+        }
+
+        if (showReport) {
+            ReportUserModal {
+                this.pubkey = pubkey
+                eventId = null
+                onClose = { setShowReport(false) }
             }
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -72,6 +72,7 @@ import org.nostr.nostrord.web.modals.GroupInviteModal
 import org.nostr.nostrord.web.modals.InviteCodesModal
 import org.nostr.nostrord.web.modals.JoinWithCodeModal
 import org.nostr.nostrord.web.modals.ManageGroupModal
+import org.nostr.nostrord.web.modals.ReportUserModal
 import org.nostr.nostrord.web.modals.ShareGroupModal
 import org.nostr.nostrord.web.modals.UserProfileModal
 import org.nostr.nostrord.web.navigation.pushRoute
@@ -1212,6 +1213,7 @@ val ChatScreen =
         val (membersOpen, setMembersOpen) = useState { window.innerWidth > 1000 }
         val (infoOpen, setInfoOpen) = useState { false }
         val (profilePubkey, setProfilePubkey) = useState<String?> { null }
+        val (reportTarget, setReportTarget) = useState<ReportTargetRef?> { null }
         val (replyingToId, setReplyingToId) = useState<String?> { null }
         val (replyNonce, setReplyNonce) = useState { 0 }
         // Mention requested from the profile modal, consumed by the composer.
@@ -2259,6 +2261,7 @@ val ChatScreen =
                                                     vm.sendReaction(message.id, message.pubkey, emoji)
                                                 }
                                                 onDelete = { setMessageToDelete(message.id) }
+                                                onReport = { setReportTarget(ReportTargetRef(message.pubkey, message.id)) }
                                             }
                                         }
                                     }
@@ -2506,6 +2509,14 @@ val ChatScreen =
                         setProfilePubkey(null)
                     }
                     onClose = { setProfilePubkey(null) }
+                }
+            }
+
+            reportTarget?.let { target ->
+                ReportUserModal {
+                    pubkey = target.pubkey
+                    eventId = target.messageId
+                    onClose = { setReportTarget(null) }
                 }
             }
 
@@ -2762,6 +2773,9 @@ private fun ChildrenBuilder.reactionErrorDialog(message: String, onDismiss: () -
     }
 }
 
+/** Message the report modal is pinned to (author + event id). */
+private data class ReportTargetRef(val pubkey: String, val messageId: String)
+
 external interface MessageRowProps : Props {
     var domId: String
     var highlighted: Boolean
@@ -2787,6 +2801,9 @@ external interface MessageRowProps : Props {
 
     /** The viewer authored this message (hides Report). */
     var isMine: Boolean
+
+    /** Opens the NIP-56 report modal pinned to this message. */
+    var onReport: () -> Unit
 
     /** The viewer is a group admin (shows the moderation section). */
     var isAdmin: Boolean
@@ -3244,8 +3261,8 @@ private val MessageRow =
                         props.onReply()
                         setMenuOpen(false)
                     }
-                    // Threads / saved / reports are not implemented yet; shown disabled
-                    // so the menu shape matches the prototype.
+                    // Threads / saved are not implemented yet; shown disabled so the
+                    // menu shape matches the prototype.
                     ctxItem(Ic.Forum, "Start thread here", disabled = true) {}
                     if (props.canZap) {
                         ctxItem(Ic.Bolt, "Zap", zap = true) {
@@ -3255,7 +3272,10 @@ private val MessageRow =
                     }
                     ctxItem(Ic.Bookmark, "Save for later", disabled = true) {}
                     if (!props.isMine) {
-                        ctxItem(Ic.Shield, "Report", disabled = true) {}
+                        ctxItem(Ic.Shield, "Report") {
+                            props.onReport()
+                            setMenuOpen(false)
+                        }
                     }
                     div { className = ClassName("ctx-divider") }
                     ctxItem(Ic.ContentCopy, "Copy text") {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ProfilePage.kt
@@ -24,6 +24,7 @@ import org.nostr.nostrord.web.components.followToggleButton
 import org.nostr.nostrord.web.components.groupTypeBadges
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.renderAboutText
+import org.nostr.nostrord.web.modals.ReportUserModal
 import org.nostr.nostrord.web.navigation.pushRoute
 import react.FC
 import react.Props
@@ -34,6 +35,7 @@ import react.dom.html.ReactHTML.img
 import react.dom.html.ReactHTML.p
 import react.dom.html.ReactHTML.span
 import react.useEffect
+import react.useState
 import web.cssom.Background
 import web.cssom.ClassName
 
@@ -65,6 +67,7 @@ val ProfilePage =
         // Collected unconditionally (hooks must not run inside the isSelf branch below, or the hook
         // count changes when navigating between your own and another user's profile).
         val activeSession = useStateFlow(ActiveAccountManager.session)
+        val (showReport, setShowReport) = useState { false }
         // Resolve @names for any npub/nprofile mentioned in the bio so mentions
         // render as display names, not raw npubs.
         useEffect(metadata?.about) {
@@ -188,7 +191,6 @@ val ProfilePage =
                                         icon(Ic.Bolt)
                                         +"Zap"
                                     }
-                                    // NIP-56 reports aren't wired yet.
                                     button {
                                         className = ClassName("btn-ghost profile-btn sm")
                                         onClick = { vm.toggleMute() }
@@ -197,8 +199,7 @@ val ProfilePage =
                                     }
                                     button {
                                         className = ClassName("btn-ghost profile-btn sm")
-                                        disabled = true
-                                        title = "Coming soon"
+                                        onClick = { setShowReport(true) }
                                         icon(Ic.Shield)
                                         +"Report"
                                     }
@@ -298,6 +299,14 @@ val ProfilePage =
                         }
                     }
                 }
+            }
+        }
+
+        if (showReport) {
+            ReportUserModal {
+                pubkey = props.pubkey
+                eventId = null
+                onClose = { setShowReport(false) }
             }
         }
     }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -7952,6 +7952,176 @@ body {
     color: var(--color-text-muted);
 }
 
+/* ===== Report modal (NIP-56, prototype ReportModal) ======================= */
+
+.report-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 12px 0 16px;
+}
+
+.report-head-avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.report-head-name {
+    font-size: 15px;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--color-text-primary);
+}
+
+.report-head-sub {
+    margin-top: 2px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+}
+
+.report-reasons {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 46vh;
+    margin-bottom: 12px;
+    overflow-y: auto;
+}
+
+.report-reason {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 10px 12px;
+    text-align: left;
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    background: var(--color-background);
+    border: 1px solid var(--color-line);
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.report-reason:hover {
+    border-color: var(--color-text-muted);
+}
+
+.report-reason.selected {
+    color: var(--color-text-primary);
+    border-color: var(--color-primary);
+    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+}
+
+.report-radio {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    border: 1.5px solid var(--color-text-muted);
+    border-radius: 50%;
+}
+
+.report-radio.on {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+}
+
+.report-radio.on::after {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: #ffffff;
+}
+
+.report-reason-label {
+    font-size: 14px;
+}
+
+.report-reason-hint {
+    font-size: 11px;
+    color: var(--color-text-muted);
+}
+
+.report-mute-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    margin-top: 12px;
+    padding: 10px 12px;
+    text-align: left;
+    background: var(--color-hover);
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.report-check {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    color: #ffffff;
+    border: 1.5px solid var(--color-text-muted);
+    border-radius: 4px;
+}
+
+.report-check.on {
+    border-color: var(--color-primary);
+    background: var(--color-primary);
+}
+
+.report-check .icon {
+    font-size: 13px;
+}
+
+.report-mute-label {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+}
+
+.report-mute-label b {
+    font-weight: 600;
+    color: var(--color-text-primary);
+}
+
+.report-success {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 20px;
+    text-align: center;
+    background: var(--color-floating);
+    border: 1px solid var(--color-line);
+    border-radius: 12px;
+}
+
+.report-success-icon {
+    font-size: 28px;
+}
+
+.report-success-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+}
+
+.report-success-text {
+    max-width: 280px;
+    margin-bottom: 10px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+}
+
 .info-content {
     padding: 16px 20px 20px;
 }

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -77,6 +77,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `ReactionBadges` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReactionBadges.kt | Displays reaction badges for a message. |
 | `RelayGradientAvatar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/avatars/GradientAvatar.kt | Deterministic gradient fallback for relay avatars (prototype gradientRelayAvatar): a |
 | `ReplyPreview` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt | Compact reply preview shown above a message that is replying to another message. |
+| `ReportUserModal` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ReportUserModal.kt | NIP-56 report modal (prototype ReportModal): reason radio cards, optional note, |
 | `RichAboutText` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/RichAboutText.kt | Renders an "about" text with clickable links and resolved nostr mentions. |
 | `SendStateIcon` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageStatusIndicator.kt | Inline send-state icon for the author's own message: a muted clock while Sending, a check |
 | `SkeletonCircle` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/loading/SkeletonLoader.kt | Generic skeleton circle for avatar placeholders. |
@@ -127,10 +128,10 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `InviteCodesModal` | webMain/kotlin/org/nostr/nostrord/web/modals/InviteCodesModal.kt | Invite-codes modal — real port of the Compose InviteCodesModal (admin): active codes |
 | `JoinGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/JoinGroupModal.kt | Join-group modal — mirrors the Compose flow (App.kt onJoin): paste an invite link or a NIP-29 |
 | `JoinWithCodeModal` | webMain/kotlin/org/nostr/nostrord/web/modals/JoinWithCodeModal.kt | Join-with-invite-code modal — web port of the Compose InviteCodeJoinModal |
-| `ManageChildrenModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ManageChildrenModal.kt | Manage-children modal — layout-first React port of the Compose ManageChildrenModal |
 | `ManageGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt | Unified admin "Manage group" modal (port of the prototype GroupManage): a left tab |
 | `MembersModal` | webMain/kotlin/org/nostr/nostrord/web/modals/MembersModal.kt | Read-only member roster (port of the prototype GroupPanels "Members" panel): avatar + |
 | `Portal` | webMain/kotlin/org/nostr/nostrord/web/components/Portal.kt | Renders its children into `<body>` through a React portal, so they escape any ancestor that |
+| `ReportUserModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ReportUserModal.kt | NIP-56 report modal (prototype ReportModal): reason radio cards, optional note, |
 | `ShareGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt | Share-group modal — real port of the Compose ShareGroupModal: a single cycling identifier field |
 | `Spoiler` | webMain/kotlin/org/nostr/nostrord/web/components/Spoiler.kt | Discord-style spoiler (//text//): blurred until clicked, click toggles. Mirrors the |
 | `UnlockModal` | webMain/kotlin/org/nostr/nostrord/web/modals/UnlockModal.kt | Startup unlock for a NIP-49 password-protected account (web counterpart of the |


### PR DESCRIPTION
NIP-56 reporting: any user (or a specific message) can be flagged from the profile modals, the profile page, or the message context menu, and the offender can be muted in the same step. The report is published to the reporter's own relays for moderation tools and other clients to consume; there is no in-app moderator inbox. Both UIs share one `ReportUserViewModel`; the modal layout follows the prototype ReportModal (reason radio cards with hints, optional note, default-on "also mute" toggle, in-modal success state).

| Area | Change |
| --- | --- |
| `Nip56.kt` (commonMain) | kind:1984 constant, report types, tag builder (`p`/`e` carry the type) |
| `NostrRepository.reportUser` | Publishes to outbox write + bootstrap relays and settles on the FIRST OK (a 1984 is append-only, so one acceptance is enough); remaining sends and per-relay connects finish in the background. Targets are normalized before dedup: the kind:10002 list and the bootstrap list spelling the same relay differently used to send the same EVENT twice on one socket |
| Report modal (Compose + web) | `ReportUserModal` wired into UserProfileModal, ProfilePage/Screen and the chat context menu (pinned to the message id); sending can also mute the target via the existing kind:10000 flow |

Commits:
- bd4e079b feat(moderation): NIP-56 user and message reports (kind:1984)

Covered by new `ReportUserViewModelTest` cases; validated with `compileKotlinJvm` + `compileKotlinJs` + `:composeApp:jvmTest`.
