### PR TITLE
fix(web): right-click on a hyperlink keeps the browser's native menu

### DIFF
--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2909,9 +2909,13 @@ private val MessageRow =
             // Two-stage right-click (Telegram-style): the first right-click on a
             // message opens our app menu at the cursor and suppresses the browser's
             // native menu. A second right-click escapes to the native menu. Right-click
-            // off any message keeps the browser default untouched.
+            // off any message keeps the browser default untouched. Right-click directly
+            // on a hyperlink always keeps the native menu (so "Copy link address" copies
+            // the actual URL, not our event link).
             onContextMenu = { event ->
-                if (!menuOpen) {
+                if (event.target.asDynamic().closest("a") != null) {
+                    setMenuOpen(false)
+                } else if (!menuOpen) {
                     // First right-click: open ours at the cursor and suppress native.
                     event.preventDefault()
                     setReactOpen(false)
@@ -3258,7 +3262,7 @@ private val MessageRow =
                         copyToClipboard(props.content)
                         setMenuOpen(false)
                     }
-                    ctxItem(Ic.Link, "Copy link") {
+                    ctxItem(Ic.Link, "Copy event link") {
                         copyToClipboard(props.messageLink)
                         setMenuOpen(false)
                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -361,8 +361,11 @@ val DmPage =
                                 // First right-click opens our menu at the cursor; with it open the
                                 // second lands on the overlay, which closes ours without
                                 // preventDefault so the native menu shows (Telegram-style).
+                                // Right-click directly on a hyperlink always keeps the native menu.
                                 onContextMenu = { event ->
-                                    if (menuFor == null) {
+                                    if (event.target.asDynamic().closest("a") != null) {
+                                        setMenuFor(null)
+                                    } else if (menuFor == null) {
                                         event.preventDefault()
                                         menuOpenedAt.current = 0.0
                                         setMenuAt(event.clientX.toInt() to event.clientY.toInt())


### PR DESCRIPTION
Right-clicking a link inside a message opened the app context menu, whose "Copy link" item copies the event link, so users trying to copy the URL under the cursor got an unrelated nostr link (reported by idsera). Now a right-click directly on an anchor skips the app menu entirely and the browser's native menu shows, so "Copy link address" copies the real URL. The two-stage right-click (first opens the app menu, second escapes to native) is unchanged everywhere else on the message.

| Change | Where |
|---|---|
| Right-click on `<a>` keeps the native browser menu | `ChatScreen.kt` (group chat), `DmPage.kt` (DMs) |
| App menu item renamed "Copy link" to "Copy event link" | `ChatScreen.kt` |

- 1b43516c fix(web): right-click on a hyperlink keeps the browser's native menu