### PR TITLE
Accept nostr:naddr1 group links as OS deep links

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -476,7 +476,7 @@ tasks.register("fixDebPackage") {
             |Type=Application
             |Categories=Network;InstantMessaging;Chat;
             |StartupWMClass=org-nostr-nostrord-MainKt
-            |MimeType=x-scheme-handler/nostrord;
+            |MimeType=x-scheme-handler/nostrord;x-scheme-handler/nostr;
             """.trimMargin() + "\n"
         desktopFile.writeText(patchedDesktop)
 

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -25,6 +25,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- nostr:naddr1... group links (NIP-19 kind 39000 with a relay hint) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="nostr" />
+            </intent-filter>
+
             <!-- Custom scheme: nostrord://open?relay=...&group=...&code=... -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -29,6 +29,7 @@ import org.nostr.nostrord.ui.components.media.FullscreenVideoController
 import org.nostr.nostrord.ui.components.media.FullscreenVideoOverlay
 import org.nostr.nostrord.ui.components.media.LocalFullscreenVideoController
 import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.utils.parseGroupJoinInput
 import org.nostr.nostrord.utils.toRelayUrl
 import androidx.compose.ui.graphics.Color as ComposeColor
 
@@ -101,6 +102,21 @@ class MainActivity : ComponentActivity() {
 
     private fun handleDeepLink(intent: Intent?) {
         val uri = intent?.data ?: return
+        // nostr:naddr1... group link (NIP-19 kind 39000 with a relay hint). Other nostr:
+        // entities (npub, nevent, ...) decode to null and are ignored.
+        if (uri.scheme == "nostr") {
+            val target = parseGroupJoinInput(uri.toString()) ?: return
+            StartupResolver.postRuntimeLaunch(
+                ExternalLaunchContext.OpenGroup(
+                    groupId = target.groupId,
+                    groupName = null,
+                    relayUrl = target.relayUrl,
+                    inviteCode = target.inviteCode,
+                    messageId = null,
+                ),
+            )
+            return
+        }
         val relay = uri.getQueryParameter("relay")?.takeIf { it.isNotBlank() } ?: return
         val relayUrl = relay.toRelayUrl().takeIf { it.isNotBlank() } ?: return
         val groupId = uri.getQueryParameter("group")?.takeIf { it.isNotBlank() }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -135,8 +135,8 @@ class MainActivity : ComponentActivity() {
             } else {
                 ExternalLaunchContext.OpenRelay(relayUrl)
             }
-        // Also emits the runtime event so an already-running app (onNewIntent)
-        // navigates immediately; at cold start the boot resolve consumes it first.
+        // Runtime event with replay: an already-running app (onNewIntent) navigates
+        // immediately; at cold start AppFrame's collector picks it up on mount.
         StartupResolver.postRuntimeLaunch(context)
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/AppStartState.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/AppStartState.kt
@@ -9,9 +9,10 @@ import org.nostr.nostrord.ui.Screen
  * The UI layer consumes this state - it does not compute or modify it.
  *
  * Precedence (highest to lowest):
- * 1. External launch context (deep link, notification) - overrides everything
- * 2. Persisted group state - restored if valid
- * 3. Default home screen - fallback
+ * 1. Persisted group state - restored if valid
+ * 2. Default home screen - fallback
+ * Deep links are not part of this state: they navigate via
+ * StartupResolver.runtimeLaunchEvents once the app UI mounts.
  */
 sealed class AppStartState {
     /**
@@ -36,8 +37,5 @@ sealed class AppStartState {
     data class Authenticated(
         val initialScreen: Screen,
         val restoredFromPersistence: Boolean = false,
-        val deepLinkRelayUrl: String? = null,
-        val deepLinkInviteCode: String? = null,
-        val deepLinkMessageId: String? = null,
     ) : AppStartState()
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/StartupResolver.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/startup/StartupResolver.kt
@@ -42,12 +42,13 @@ object StartupResolver {
     }
 
     /**
-     * Deep link arriving while the process is already running (second desktop
-     * instance forwarding its argv, Android onNewIntent). The mounted app UI
-     * collects [runtimeLaunchEvents] and navigates immediately; the stored
-     * context covers the not-mounted case (login screen, onboarding), where
-     * [resolveInitialScreen] picks it up on the next resolve. replay = 1 so an
-     * event posted before the collector mounts is not lost.
+     * The single deep-link navigation channel: cold start (argv, intent data) and
+     * running-app arrivals (second desktop instance forwarding its argv, Android
+     * onNewIntent) both go through [postRuntimeLaunch]. The mounted AppFrame
+     * collects [runtimeLaunchEvents] and navigates; replay = 1 keeps an event
+     * posted before the collector mounts (boot, login screen, onboarding) alive
+     * until it does. The stored context only feeds [deepLinkRelayUrl] so
+     * initialize() connects the target relay before the UI asks for the group.
      */
     val runtimeLaunchEvents = MutableSharedFlow<ExternalLaunchContext>(replay = 1)
 
@@ -70,43 +71,15 @@ object StartupResolver {
             }
 
     /**
-     * Resolves the initial screen for an authenticated user.
-     *
-     * Precedence:
-     * 1. External launch context (deep link, notification)
-     * 2. Persisted last viewed group
-     * 3. Default home screen
+     * Resolves the initial screen for an authenticated user from persisted state.
+     * Deep links do NOT resolve here: they ride [runtimeLaunchEvents] and navigate
+     * once AppFrame mounts (consuming the context here would destroy the replayed
+     * event before its only collector exists).
      *
      * @param pubkey The authenticated user's public key
      */
     fun resolveInitialScreen(pubkey: String): ResolvedScreen {
-        // Priority 1: External launch context overrides everything
-        val external = externalLaunchContext
-        if (external != null) {
-            clearExternalLaunchContext() // Consume it
-            return when (external) {
-                is ExternalLaunchContext.OpenGroup ->
-                    ResolvedScreen(
-                        screen = Screen.Group(external.groupId, external.groupName),
-                        relayUrl = external.relayUrl,
-                        inviteCode = external.inviteCode,
-                        messageId = external.messageId,
-                    )
-                is ExternalLaunchContext.OpenRelay ->
-                    ResolvedScreen(
-                        screen = Screen.Home,
-                        relayUrl = external.relayUrl,
-                    )
-                is ExternalLaunchContext.OpenNotifications ->
-                    ResolvedScreen(
-                        screen = Screen.Notifications,
-                        relayUrl = external.relayUrl,
-                    )
-                is ExternalLaunchContext.OpenHome -> ResolvedScreen(screen = Screen.Home)
-            }
-        }
-
-        // Priority 2: Restore persisted group state
+        // Restore persisted group state
         try {
             val lastGroup = SecureStorage.getLastViewedGroup(pubkey)
             if (lastGroup != null) {
@@ -125,7 +98,7 @@ object StartupResolver {
             }
         }
 
-        // Priority 3: Default to home screen
+        // Default to home screen
         return ResolvedScreen(Screen.Home)
     }
 
@@ -164,22 +137,13 @@ object StartupResolver {
         return AppStartState.Authenticated(
             initialScreen = resolved.screen,
             restoredFromPersistence = resolved.restoredFromPersistence,
-            deepLinkRelayUrl = resolved.relayUrl,
-            deepLinkInviteCode = resolved.inviteCode,
-            deepLinkMessageId = resolved.messageId,
         )
     }
 }
 
-/**
- * External launch contexts that override persisted state.
- */
 data class ResolvedScreen(
     val screen: Screen,
     val restoredFromPersistence: Boolean = false,
-    val relayUrl: String? = null,
-    val inviteCode: String? = null,
-    val messageId: String? = null,
 )
 
 sealed class ExternalLaunchContext {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
@@ -42,6 +42,7 @@ import org.nostr.nostrord.ui.window.LocalAwtWindow
 import org.nostr.nostrord.ui.window.LocalDesktopWindowControls
 import org.nostr.nostrord.utils.SingleInstance
 import org.nostr.nostrord.utils.WindowsProtocolRegistrar
+import org.nostr.nostrord.utils.parseGroupJoinInput
 import org.nostr.nostrord.utils.toRelayUrl
 import java.io.File
 import java.net.URI
@@ -51,8 +52,19 @@ import javax.imageio.ImageIO
  * Parse a nostrord:// or https:// URL into an ExternalLaunchContext.
  * Supports: nostrord://open?relay=X&group=Y&code=Z
  *           https://nostrord.com/open/?relay=X&group=Y&code=Z
+ *           nostr:naddr1... / naddr1... (NIP-19 kind 39000 with a relay hint)
  */
 private fun parseDeepLinkUrl(url: String): ExternalLaunchContext? {
+    if (url.startsWith("nostr:") || url.startsWith("naddr1")) {
+        val target = parseGroupJoinInput(url) ?: return null
+        return ExternalLaunchContext.OpenGroup(
+            groupId = target.groupId,
+            groupName = null,
+            relayUrl = target.relayUrl,
+            inviteCode = target.inviteCode,
+            messageId = null,
+        )
+    }
     val uri =
         try {
             URI(url)

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/main.kt
@@ -141,9 +141,11 @@ fun main(args: Array<String> = emptyArray()) {
         }
     if (!isPrimary) return
 
-    // Parse deep link from CLI args (e.g., OS protocol handler passes URL as first arg)
+    // Parse deep link from CLI args (e.g., OS protocol handler passes URL as first arg).
+    // postRuntimeLaunch: the replayed event navigates once AppFrame mounts, and the stored
+    // context lets initialize() connect the target relay first.
     args.firstOrNull()?.let { url ->
-        parseDeepLinkUrl(url)?.let { StartupResolver.setExternalLaunchContext(it) }
+        parseDeepLinkUrl(url)?.let { StartupResolver.postRuntimeLaunch(it) }
     }
     // Configure Coil before the window opens so the first frame is already using the
     // persistent cache. Without this, Coil defaults to a temp-dir disk cache (wiped on

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/App.kt
@@ -317,13 +317,3 @@ private fun LoadingScreen(modifier: Modifier = Modifier) {
         )
     }
 }
-
-/**
- * Main authenticated app with navigation.
- *
- * CRITICAL: The initialScreen parameter is the RESOLVED startup screen.
- * It is used as the initial value for currentScreen state.
- * This ensures no navigation corrections are needed after render.
- *
- * @param initialScreen The screen to start with - computed during bootstrap
- */

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -201,13 +201,14 @@ fun AppFrame() {
     // Home -> group flash; it is a single per-account pref read. seedDeepLink keeps Home under
     // a group so back returns Home instead of leaving the app, and no-ops for plain Home.
     fun restoredStartRoute(): HashRoute? = restoredRoute(AppModule.nostrRepository.getPublicKey()?.let { SecureStorage.getLastRoute(it) })
-    val history = remember { NavigationHistory().apply { seedDeepLink(restoredStartRoute()) } }
+    val restoredSeed = remember { restoredStartRoute() }
+    val history = remember { NavigationHistory().apply { seedDeepLink(restoredSeed) } }
 
-    // Deep link arriving while the app is already open (second desktop instance
-    // forwarding nostrord://, Android onNewIntent). Cold-start deep links go through
-    // StartupResolver.resolveInitialScreen instead; this covers the running app.
-    // GroupRoute carries invite/message, so the existing groupRoute effect below does
-    // the relay switch and the group page does the auto-join, same as any navigation.
+    // Deep links, cold start and running app alike (argv / Android intent post to
+    // runtimeLaunchEvents; replay = 1 holds an event posted before this collector
+    // mounts). GroupRoute carries invite/message, so the existing groupRoute effect
+    // below does the relay switch and the group page does the auto-join, same as any
+    // navigation.
     LaunchedEffect(Unit) {
         StartupResolver.runtimeLaunchEvents.collect { ctx ->
             StartupResolver.clearExternalLaunchContext()
@@ -292,12 +293,14 @@ fun AppFrame() {
 
     // If the restored group was left on another device/session it is no longer in the rail;
     // once the group list loads, drop a now-missing restored route back to Home. Scoped to
-    // the first non-empty groups emission so it never fights normal in-session navigation.
+    // the first non-empty groups emission so it never fights normal in-session navigation,
+    // and only to the persisted seed: a deep-linked route may point at a not-yet-joined
+    // group (auto-join flow) and must survive this check.
     var validatedRestore by remember { mutableStateOf(false) }
     LaunchedEffect(groups) {
         if (!validatedRestore && groups.isNotEmpty()) {
             val r = history.current as? GroupRoute
-            if (r != null && groups.none { it.relayUrl == r.relayUrl && it.meta.id == r.groupId }) {
+            if (r != null && r == restoredSeed && groups.none { it.relayUrl == r.relayUrl && it.meta.id == r.groupId }) {
                 history.reset()
             }
             validatedRestore = true


### PR DESCRIPTION
Clicking a `nostr:naddr1...` link (kind 39000 with a relay hint) now opens the app straight in the right group on the right relay. The naddr decode already existed in `parseGroupJoinInput`; this wires it into the OS deep-link entry points, and fixes the cold-start path that was silently dead for every deep link in the new design: `resolveInitialScreen` consumed the launch context into `AppStartState.initialScreen`, which nothing reads since AppFrame seeds its history from the persisted last route. All deep links now ride `runtimeLaunchEvents` (replay = 1 survives until AppFrame's collector mounts), and the group-list restore validation only bounces the persisted seed route, so a deep link to a not-yet-joined group reaches the auto-join flow.

| Platform | Entry point |
|---|---|
| Android | `nostr` scheme intent-filter + `handleDeepLink` (other `nostr:` entities decode to null and are ignored) |
| Desktop | argv at cold start + second-instance forward; accepts `nostr:naddr1...` and bare `naddr1...` |
| Linux package | `.desktop` declares `x-scheme-handler/nostr` (no forced `xdg-mime default`, an existing handler keeps priority) |
| Web | already resolved naddr from the URL, unchanged |

Deliberately out: the Windows registrar does not claim the `nostr:` scheme (it would silently take it over system-wide), and iOS has no deep-link infra yet.

Validated on device: cold start and running app on desktop, chooser + group open on Android.

Commits:
- a02ebb62 feat(deeplink): accept nostr:naddr1 group links on Android and desktop
- b9954a83 fix(deeplink): cold-start deep links navigate again in the new design