### PR TITLE
Keep the OS keychain working in packaged desktop builds

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -357,8 +357,11 @@ compose.desktop {
 
             // jpackage's jlink image ships only Compose's default modules; java-keyring's
             // DBus backend touches java.sql.DriverManager at startup and kills the app
-            // with NoClassDefFoundError when the module is absent (#165).
-            modules("java.sql")
+            // with NoClassDefFoundError when the module is absent (#165). jdk.unsupported
+            // provides sun.misc.Unsafe for jnr-ffi (dbus-java transport); without it
+            // Keyring.create() throws BackendNotSupportedException and the packaged app
+            // falls back to the passphrase gate even with a Secret Service running.
+            modules("java.sql", "jdk.unsupported")
 
             linux {
                 iconFile.set(project.file("src/jvmMain/resources/icon-512.png"))

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
@@ -102,7 +102,11 @@ actual object SecureStorage {
             return
         }
 
-        if (KeychainStore.isAvailable()) {
+        // Keychain available but empty: adopt it ONLY when no passphrase protects the
+        // existing data. Minting a fresh key over a passphrase verifier would orphan
+        // every slot encrypted with the passphrase-derived key; prompt one last time
+        // instead and let unlockWithPassphrase promote that key into the keychain.
+        if (KeychainStore.isAvailable() && prefs.get(PASSPHRASE_VERIFIER_PREF, null) == null) {
             val freshKey = randomKeyBytes()
             if (KeychainStore.setMasterKey(freshKey)) {
                 masterKey = SecretKeySpec(freshKey, "AES")
@@ -147,6 +151,16 @@ actual object SecureStorage {
         if (plain != PASSPHRASE_VERIFIER_PLAINTEXT) return false
         masterKey = key
         keySource = KeySource.Passphrase
+        // Keychain became available on a passphrase install: promote the derived key
+        // into the keychain so future boots unlock silently, same data, same key.
+        // Verifier and salt are removed only after the keychain write succeeds; on
+        // failure the install stays in passphrase mode untouched.
+        if (KeychainStore.isAvailable() && KeychainStore.setMasterKey(key.encoded)) {
+            keySource = KeySource.Keychain
+            prefs.remove(PASSPHRASE_VERIFIER_PREF)
+            prefs.remove(PASSPHRASE_SALT_PREF)
+            prefs.flush()
+        }
         _unlockState.value = UnlockState.Unlocked
         migrateLegacyIfNeeded()
         return true


### PR DESCRIPTION
Installed desktop builds (.deb/.rpm/.msi) silently lost the OS keychain and fell back to the passphrase gate, while `gradle :run` used the Secret Service normally. The jlink image jpackage ships lacked `jdk.unsupported`, so jnr-ffi (dbus-java transport) could not load `sun.misc.Unsafe` and `Keyring.create()` threw `BackendNotSupportedException` (same failure mode as #165, which was missing `java.sql`). Diagnosed by probing `Keyring.create()` under `--limit-modules` with the packaged runtime's module list.

The second commit heals installs damaged by that window: a keychain that appears over an existing passphrase setup used to mint a fresh master key and orphan every slot encrypted with the passphrase-derived key. Empty-keychain adoption now defers to a passphrase verifier; the user unlocks one last time and the derived key itself is promoted into the keychain (same key, no re-encryption, silent unlocks from then on). Verifier and salt are only removed after the keychain write succeeds, so a failed write leaves passphrase mode intact.

Validated on device: installed .deb boots straight into the account with the OS keychain, no prompt.

Commits:
- feefb7f9 fix(desktop): keep OS keychain working in packaged builds (jdk.unsupported)
- 0a7b7785 fix(desktop): migrate passphrase installs to the OS keychain on unlock