### PR TITLE
NIP-55 Android signer login (Amber) + login method list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,6 +246,7 @@ SecureStorage.saveRelayList(...)      // use saveRelayListFor(pubkey, ...) inste
 | secp256k1 / Schnorr signing | yes | yes | yes | yes |
 | NIP-46 bunker client | yes | yes | yes | yes |
 | NIP-07 browser extension (`Nip07.isAvailable()` true) | no | no | yes | no |
+| NIP-55 signer app (`Nip55.isAvailable()` true) | yes | no | no | no |
 | EncryptedSharedPreferences | yes | no | no | no |
 | `java.security.*` | yes | yes | no | no |
 | Keychain (iOS secure storage) | no | no | no | yes |
@@ -262,6 +263,7 @@ All NIP `expect`s have `actual` declarations on every platform (some are stubs t
 | NIP-04 / NIP-44 encryption | `nostr/Nip04.kt`, `nostr/Nip44.kt` |
 | NIP-46 bunker client | `nostr/Nip46Client.kt` |
 | NIP-07 browser extension | `nostr/Nip07.kt` (stub on Android/JVM/iOS, real on JS) |
+| NIP-55 Android signer | `nostr/Nip55.kt` (real on Android, stub on JVM/JS/iOS) |
 | Secure storage | `storage/SecureStorage.kt` |
 
 ## NIP support
@@ -278,6 +280,7 @@ All NIP `expect`s have `actual` declarations on every platform (some are stubs t
 | 42 | connection layer | AUTH for restricted groups |
 | 44 | `nostr/Nip44.kt` | Modern encryption |
 | 46 | `nostr/Nip46Client.kt` | Remote signer / bunker |
+| 55 | `nostr/Nip55.kt` | Android external signer app (Amber); real actual on Android only |
 | 65 | `network/outbox/Nip65Relay.kt` | Outbox relay metadata |
 
 Detailed NIP-29 expertise lives in `.claude/skills/nip29-expert/SKILL.md`.

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -4,6 +4,14 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- Package visibility (API 30+): lets the app detect NIP-55 signer apps (Amber). -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="nostrsigner" />
+        </intent>
+    </queries>
+
     <application
         android:name=".NostrordApplication"
         android:networkSecurityConfig="@xml/network_security_config"

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import org.nostr.nostrord.network.upload.ShareMediaQueue
+import org.nostr.nostrord.nostr.Nip55AndroidBridge
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.ui.components.media.FullscreenVideoController
@@ -39,6 +40,8 @@ class MainActivity : ComponentActivity() {
         val barStyle = SystemBarStyle.dark(Color.TRANSPARENT)
         enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
         super.onCreate(savedInstanceState)
+        // NIP-55 (Amber) requests round-trip through this activity's result launcher.
+        Nip55AndroidBridge.register(this)
         handleDeepLink(intent)
         handleShareIntent(intent)
         setContent {

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/NostrordApplication.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/NostrordApplication.kt
@@ -12,6 +12,7 @@ import coil3.memory.MemoryCache
 import coil3.svg.SvgDecoder
 import okio.Path.Companion.toOkioPath
 import org.nostr.nostrord.network.managers.AndroidNetworkMonitorInit
+import org.nostr.nostrord.nostr.Nip55AndroidBridge
 import org.nostr.nostrord.notifications.AndroidNotificationSoundInit
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.CacheStoreAndroid
@@ -40,6 +41,7 @@ class NostrordApplication :
     override fun onCreate() {
         super.onCreate()
         SecureStorage.initialize(applicationContext)
+        Nip55AndroidBridge.initialize(applicationContext)
         CacheStoreAndroid.initialize(applicationContext)
         AndroidNetworkMonitorInit.initialize(applicationContext)
         AndroidNotificationSoundInit.initialize(applicationContext)

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip55.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip55.android.kt
@@ -1,0 +1,214 @@
+package org.nostr.nostrord.nostr
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+
+/**
+ * NIP-55 Android signer client (Amber). Two channels, tried in order:
+ *
+ * 1. ContentResolver `content://<signer>.<TYPE>` — silent, works only for operations the
+ *    user pre-authorized in the signer; a null cursor means "not authorized, ask via UI".
+ * 2. `nostrsigner:` Intent — opens the signer's approval screen and returns through
+ *    [Nip55AndroidBridge]'s activity-result launcher.
+ *
+ * Background signing (NIP-42 AUTH, resubscribes) rides channel 1; channel 2 is the
+ * fallback and the only channel for `get_public_key` (login always shows the signer UI).
+ */
+actual object Nip55 {
+    actual fun isAvailable(): Boolean {
+        val pm = Nip55AndroidBridge.appContext?.packageManager ?: return false
+        val probe = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:"))
+        return pm.queryIntentActivities(probe, 0).isNotEmpty()
+    }
+
+    actual suspend fun getPublicKey(permissionsJson: String): Nip55Login {
+        val result =
+            Nip55AndroidBridge.launch(
+                signerIntent(payload = "", type = "get_public_key", signerPackage = null) {
+                    putExtra("permissions", permissionsJson)
+                },
+            )
+        val raw = result.result ?: throw Nip55Exception("Signer returned no public key")
+        return Nip55Login(pubkeyHex = normalizePubkey(raw), signerPackage = result.signerPackage)
+    }
+
+    actual suspend fun signEvent(
+        eventJson: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String {
+        queryProvider(signerPackage, "SIGN_EVENT", arrayOf(eventJson, "", currentUserHex))
+            ?.let { cols -> cols["event"]?.takeIf { it.isNotBlank() }?.let { return it } }
+        val result =
+            Nip55AndroidBridge.launch(
+                signerIntent(eventJson, "sign_event", signerPackage) {
+                    putExtra("current_user", currentUserHex)
+                },
+            )
+        return result.event?.takeIf { it.isNotBlank() }
+            ?: throw Nip55Exception("Signer returned no signed event")
+    }
+
+    actual suspend fun nip44Encrypt(
+        peerPubkeyHex: String,
+        plaintext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = cryptoOp("NIP44_ENCRYPT", "nip44_encrypt", peerPubkeyHex, plaintext, currentUserHex, signerPackage)
+
+    actual suspend fun nip44Decrypt(
+        peerPubkeyHex: String,
+        ciphertext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = cryptoOp("NIP44_DECRYPT", "nip44_decrypt", peerPubkeyHex, ciphertext, currentUserHex, signerPackage)
+
+    private suspend fun cryptoOp(
+        providerType: String,
+        intentType: String,
+        peerPubkeyHex: String,
+        payload: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String {
+        queryProvider(signerPackage, providerType, arrayOf(payload, peerPubkeyHex, currentUserHex))
+            ?.let { cols -> cols["result"]?.takeIf { it.isNotBlank() }?.let { return it } }
+        val result =
+            Nip55AndroidBridge.launch(
+                signerIntent(payload, intentType, signerPackage) {
+                    putExtra("pubkey", peerPubkeyHex)
+                    putExtra("current_user", currentUserHex)
+                },
+            )
+        return result.result?.takeIf { it.isNotBlank() }
+            ?: throw Nip55Exception("Signer returned no result for $intentType")
+    }
+
+    private fun signerIntent(
+        payload: String,
+        type: String,
+        signerPackage: String?,
+        extras: Intent.() -> Unit = {},
+    ): Intent = Intent(Intent.ACTION_VIEW, Uri.parse("nostrsigner:$payload")).apply {
+        signerPackage?.let { `package` = it }
+        putExtra("type", type)
+        extras()
+    }
+
+    /**
+     * Silent ContentResolver channel. Returns the row's columns, or null when the signer
+     * is unknown, the provider is absent, or the user hasn't pre-authorized the operation
+     * (all of which mean: fall back to the Intent flow). An explicit `rejected` column is
+     * a user decision and throws instead of re-asking.
+     */
+    private suspend fun queryProvider(
+        signerPackage: String?,
+        type: String,
+        args: Array<String>,
+    ): Map<String, String>? {
+        val pkg = signerPackage ?: return null
+        val resolver = Nip55AndroidBridge.appContext?.contentResolver ?: return null
+        return withContext(Dispatchers.IO) {
+            try {
+                resolver.query(Uri.parse("content://$pkg.$type"), args, null, null, null)?.use { cursor ->
+                    if (!cursor.moveToFirst()) return@use null
+                    if (cursor.getColumnIndex("rejected") >= 0) {
+                        throw Nip55Exception("Request rejected by the signer")
+                    }
+                    buildMap {
+                        for (i in 0 until cursor.columnCount) {
+                            put(cursor.getColumnName(i), cursor.getString(i) ?: "")
+                        }
+                    }
+                }
+            } catch (e: Nip55Exception) {
+                throw e
+            } catch (e: Exception) {
+                null // provider missing / permission error: use the Intent flow
+            }
+        }
+    }
+
+    /** Signers may return the pubkey as npub; requests need hex. */
+    private fun normalizePubkey(raw: String): String {
+        val s = raw.trim()
+        if (!s.startsWith("npub1")) return s.lowercase()
+        return (Nip19.decode(s) as? Nip19.Entity.Npub)?.pubkey
+            ?: throw Nip55Exception("Signer returned an invalid public key")
+    }
+}
+
+class Nip55Exception(
+    message: String,
+) : Exception(message)
+
+/**
+ * Bridges the `nostrsigner:` Intent round-trip into suspend land. [MainActivity]
+ * registers its launcher in onCreate (re-registering on recreation); [launch] posts one
+ * Intent at a time under a mutex — concurrent sign requests (e.g. NIP-42 AUTH on several
+ * relays) queue instead of clobbering each other's pending result.
+ */
+object Nip55AndroidBridge {
+    @Volatile var appContext: Context? = null
+        private set
+
+    private var launcher: ActivityResultLauncher<Intent>? = null
+
+    @Volatile private var pending: CompletableDeferred<Nip55IntentResult>? = null
+    private val mutex = Mutex()
+
+    fun initialize(context: Context) {
+        appContext = context.applicationContext
+    }
+
+    fun register(activity: ComponentActivity) {
+        launcher =
+            activity.registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                pending?.also { pending = null }?.complete(parse(result))
+            }
+    }
+
+    suspend fun launch(intent: Intent): Nip55IntentResult = mutex.withLock {
+        val active = launcher ?: throw Nip55Exception("App UI is not in the foreground")
+        val deferred = CompletableDeferred<Nip55IntentResult>()
+        pending = deferred
+        try {
+            withContext(Dispatchers.Main) { active.launch(intent) }
+            val result = deferred.await()
+            if (result.rejected) throw Nip55Exception("Request rejected by the signer")
+            result
+        } finally {
+            pending = null
+        }
+    }
+
+    private fun parse(result: ActivityResult): Nip55IntentResult {
+        val data = result.data
+        if (result.resultCode != android.app.Activity.RESULT_OK || data == null) {
+            return Nip55IntentResult(rejected = true)
+        }
+        return Nip55IntentResult(
+            result = data.getStringExtra("result"),
+            event = data.getStringExtra("event"),
+            signerPackage = data.getStringExtra("package"),
+            rejected = data.getStringExtra("rejected") != null,
+        )
+    }
+}
+
+data class Nip55IntentResult(
+    val result: String? = null,
+    val event: String? = null,
+    val signerPackage: String? = null,
+    val rejected: Boolean = false,
+)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/Account.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/Account.kt
@@ -26,6 +26,9 @@ enum class AuthMethod {
     LOCAL,
     BUNKER,
     NIP07,
+
+    /** NIP-55 external Android signer app (Amber). */
+    AMBER,
 }
 
 /**
@@ -48,12 +51,14 @@ fun signerLabel(account: Account): String = when (account.authMethod) {
         else -> "bunker"
     }
     AuthMethod.NIP07 -> "extension"
+    AuthMethod.AMBER -> "amber"
 }
 
 fun logoutConfirmBody(method: AuthMethod): String = when (method) {
     AuthMethod.LOCAL -> "You will need your private key to log back in."
     AuthMethod.BUNKER -> "You will need your bunker URL to log back in."
     AuthMethod.NIP07 -> "You will need to reconnect your browser extension to log back in."
+    AuthMethod.AMBER -> "You will need to reconnect your signer app to log back in."
 }
 
 /**
@@ -76,6 +81,7 @@ private fun erasedSubject(method: AuthMethod, accountLabel: String): String = wh
     AuthMethod.LOCAL -> "Credentials and local data for \"$accountLabel\""
     AuthMethod.BUNKER -> "Bunker connection and local data for \"$accountLabel\""
     AuthMethod.NIP07 -> "Local data for \"$accountLabel\""
+    AuthMethod.AMBER -> "Signer connection and local data for \"$accountLabel\""
 }
 
 /** Tail sentence for the active-without-fallback case — "how do I get back in". */
@@ -83,6 +89,7 @@ private fun signInAgainHint(method: AuthMethod): String = when (method) {
     AuthMethod.LOCAL -> "You'll need to sign in again to continue."
     AuthMethod.BUNKER -> "You'll need your bunker URL to sign in again."
     AuthMethod.NIP07 -> "Your browser extension keeps your key. Reconnect it to sign in again."
+    AuthMethod.AMBER -> "Your signer app keeps your key. Reconnect it to sign in again."
 }
 
 fun removeAccountDialogBody(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/AccountSessionFactory.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/AccountSessionFactory.kt
@@ -6,6 +6,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import org.nostr.nostrord.network.AuthManager
 import org.nostr.nostrord.nostr.Nip07
+import org.nostr.nostrord.nostr.Nip55
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.getNip55SignerPackageFor
 
 /**
  * Builds [AccountSession] instances from the credentials that
@@ -64,5 +67,11 @@ class AccountSessionFactory(
                 NostrSigner.Bunker(nip46Client = it, pubkey = account.pubkey)
             }
         AuthMethod.NIP07 -> if (Nip07.isAvailable()) NostrSigner.Nip07Extension(account.pubkey) else null
+        AuthMethod.AMBER ->
+            if (Nip55.isAvailable()) {
+                NostrSigner.Amber(account.pubkey, SecureStorage.getNip55SignerPackageFor(account.pubkey))
+            } else {
+                null
+            }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
@@ -11,6 +11,7 @@ import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip07
 import org.nostr.nostrord.nostr.Nip44
 import org.nostr.nostrord.nostr.Nip46Client
+import org.nostr.nostrord.nostr.Nip55
 import kotlin.concurrent.Volatile
 
 /**
@@ -187,6 +188,55 @@ interface NostrSigner {
                 Nip07.nip44Decrypt(peerPubkeyHex, ciphertext)
             } catch (e: Exception) {
                 throw SigningException("NIP-07 NIP-44 decryption failed: ${e.message}", e)
+            }
+        }
+
+        override fun dispose() {
+            disposed = true
+        }
+    }
+
+    /**
+     * Signs via a NIP-55 external Android signer app (Amber). The key never enters this
+     * process; pre-authorized requests go through the signer's ContentResolver silently,
+     * others open its approval UI. [signerPackage] addresses the signer chosen at login.
+     */
+    class Amber(
+        override val pubkey: String,
+        private val signerPackage: String?,
+    ) : NostrSigner {
+        override val isRemote: Boolean = true
+
+        @Volatile private var disposed = false
+
+        override suspend fun signEvent(event: Event): Event {
+            if (disposed) throw SigningException("Amber signer has been disposed")
+            return try {
+                parseSignedEventJson(Nip55.signEvent(event.toJsonString(), pubkey, signerPackage))
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                if (e is SigningException) throw e
+                throw SigningException("Amber signing failed: ${e.message}", e)
+            }
+        }
+
+        override suspend fun nip44Encrypt(peerPubkeyHex: String, plaintext: String): String {
+            if (disposed) throw SigningException("Amber signer has been disposed")
+            return try {
+                Nip55.nip44Encrypt(peerPubkeyHex, plaintext, pubkey, signerPackage)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                throw SigningException("Amber NIP-44 encryption failed: ${e.message}", e)
+            }
+        }
+
+        override suspend fun nip44Decrypt(peerPubkeyHex: String, ciphertext: String): String {
+            if (disposed) throw SigningException("Amber signer has been disposed")
+            return try {
+                Nip55.nip44Decrypt(peerPubkeyHex, ciphertext, pubkey, signerPackage)
+            } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
+                throw SigningException("Amber NIP-44 decryption failed: ${e.message}", e)
             }
         }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -26,6 +26,7 @@ import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip07
 import org.nostr.nostrord.nostr.Nip46Client
+import org.nostr.nostrord.nostr.Nip55
 import org.nostr.nostrord.platformDisplayName
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.clearAllCredentialsForAccount
@@ -34,10 +35,12 @@ import org.nostr.nostrord.storage.clearPrivateKeyFor
 import org.nostr.nostrord.storage.getBunkerClientPrivateKeyFor
 import org.nostr.nostrord.storage.getBunkerUrlFor
 import org.nostr.nostrord.storage.getEncryptedPrivateKeyFor
+import org.nostr.nostrord.storage.getNip55SignerPackageFor
 import org.nostr.nostrord.storage.getPrivateKeyFor
 import org.nostr.nostrord.storage.saveBunkerClientPrivateKeyFor
 import org.nostr.nostrord.storage.saveBunkerUrlFor
 import org.nostr.nostrord.storage.saveEncryptedPrivateKeyFor
+import org.nostr.nostrord.storage.saveNip55SignerPackageFor
 import org.nostr.nostrord.storage.savePrivateKeyFor
 import org.nostr.nostrord.utils.epochMillis
 
@@ -83,6 +86,8 @@ class AuthManager(
     private var bunkerUserPubkey: String? = null
     private var isNip07Login = false
     private var nip07UserPubkey: String? = null
+    private var isAmberLogin = false
+    private var amberUserPubkey: String? = null
 
     private val _isLoggedIn = MutableStateFlow(false)
     val isLoggedIn: StateFlow<Boolean> = _isLoggedIn.asStateFlow()
@@ -160,6 +165,7 @@ class AuthManager(
     fun getPublicKey(): String? = ActiveAccountManager.currentPubkey ?: when {
         isBunkerLogin -> bunkerUserPubkey
         isNip07Login -> nip07UserPubkey
+        isAmberLogin -> amberUserPubkey
         keyPair != null -> keyPair?.publicKeyHex
         else -> null
     }
@@ -167,7 +173,7 @@ class AuthManager(
     /**
      * Get the current user's private key (hex) - only for local login
      */
-    fun getPrivateKey(): String? = if (isBunkerLogin || isNip07Login) null else keyPair?.privateKeyHex
+    fun getPrivateKey(): String? = if (isBunkerLogin || isNip07Login || isAmberLogin) null else keyPair?.privateKeyHex
 
     fun isUsingBunker(): Boolean = isBunkerLogin
 
@@ -336,6 +342,8 @@ class AuthManager(
         nip07UserPubkey = pubkey
         isNip07Login = true
         isBunkerLogin = false
+        isAmberLogin = false
+        amberUserPubkey = null
         zeroAndClearKeyPair()
         nip46Client = null
 
@@ -345,6 +353,31 @@ class AuthManager(
         SecureStorage.clearBunkerUserPubkey()
         SecureStorage.clearBunkerClientPrivateKey()
         registerAccountAfterLogin(pubkey, AuthMethod.NIP07)
+    }
+
+    /**
+     * Login via a NIP-55 Android signer app (Amber). The public key and signer
+     * package have already been obtained through the signer's get_public_key UI.
+     */
+    fun loginWithAmber(
+        pubkey: String,
+        signerPackage: String?,
+    ) {
+        amberUserPubkey = pubkey
+        isAmberLogin = true
+        isNip07Login = false
+        nip07UserPubkey = null
+        isBunkerLogin = false
+        zeroAndClearKeyPair()
+        nip46Client = null
+
+        if (signerPackage != null) SecureStorage.saveNip55SignerPackageFor(pubkey, signerPackage)
+        SecureStorage.clearPrivateKey()
+        SecureStorage.clearBunkerUrl()
+        SecureStorage.clearBunkerUserPubkey()
+        SecureStorage.clearBunkerClientPrivateKey()
+        SecureStorage.clearNip07UserPubkey()
+        registerAccountAfterLogin(pubkey, AuthMethod.AMBER)
     }
 
     /**
@@ -364,6 +397,8 @@ class AuthManager(
         bunkerUserPubkey = null
         isNip07Login = false
         nip07UserPubkey = null
+        isAmberLogin = false
+        amberUserPubkey = null
         nip46Client = null
 
         if (ncryptsec == null) {
@@ -488,6 +523,10 @@ class AuthManager(
                     if (!Nip07.isAvailable()) return false
                     PreparedAccount.Nip07
                 }
+                AuthMethod.AMBER -> {
+                    if (!Nip55.isAvailable()) return false
+                    PreparedAccount.Amber
+                }
             }
 
         nip46Client?.disconnect()
@@ -496,6 +535,8 @@ class AuthManager(
         bunkerUserPubkey = null
         isNip07Login = false
         nip07UserPubkey = null
+        isAmberLogin = false
+        amberUserPubkey = null
         zeroAndClearKeyPair()
         stopAutoReconnect()
         _bunkerState.value = BunkerState.Inactive
@@ -511,6 +552,11 @@ class AuthManager(
             PreparedAccount.Nip07 -> {
                 isNip07Login = true
                 nip07UserPubkey = account.pubkey
+                _isLoggedIn.value = true
+            }
+            PreparedAccount.Amber -> {
+                isAmberLogin = true
+                amberUserPubkey = account.pubkey
                 _isLoggedIn.value = true
             }
         }
@@ -658,6 +704,8 @@ class AuthManager(
         ) : PreparedAccount()
 
         object Nip07 : PreparedAccount()
+
+        object Amber : PreparedAccount()
     }
 
     private suspend fun restoreBunkerSession(
@@ -946,6 +994,7 @@ class AuthManager(
         // Fallback: session not yet activated (e.g. initial login in progress).
         return when {
             isNip07Login -> signWithNip07(event)
+            isAmberLogin -> signWithAmber(event)
             isBunkerLogin -> signWithBunker(event, interactive)
             else -> signWithKeyPair(event)
         }
@@ -954,6 +1003,12 @@ class AuthManager(
     private suspend fun signWithNip07(event: Event): Event {
         val eventJson = event.toJsonString()
         val signedJson = Nip07.signEvent(eventJson)
+        return parseSignedEvent(signedJson)
+    }
+
+    private suspend fun signWithAmber(event: Event): Event {
+        val pubkey = amberUserPubkey ?: throw Exception("Amber signer not connected")
+        val signedJson = Nip55.signEvent(event.toJsonString(), pubkey, SecureStorage.getNip55SignerPackageFor(pubkey))
         return parseSignedEvent(signedJson)
     }
 
@@ -1137,6 +1192,8 @@ class AuthManager(
         bunkerUserPubkey = null
         isNip07Login = false
         nip07UserPubkey = null
+        isAmberLogin = false
+        amberUserPubkey = null
         zeroAndClearKeyPair()
 
         _isLoggedIn.value = false

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -1356,6 +1356,21 @@ class NostrRepository(
         Result.Error(AppError.Unknown(e.message ?: "Login failed", e))
     }
 
+    override suspend fun loginWithAmber(
+        pubkey: String,
+        signerPackage: String?,
+    ): Result<Unit> = try {
+        val previousPubkey = sessionManager.getPublicKey()
+        if (connectionManager.currentRelayUrl.value.isBlank()) {
+            _isDiscoveringRelays.value = true
+        }
+        sessionManager.loginWithAmber(pubkey, signerPackage)
+        finishLoginInit(previousPubkey, pubkey)
+        Result.Success(Unit)
+    } catch (e: Exception) {
+        Result.Error(AppError.Unknown(e.message ?: "Login failed", e))
+    }
+
     /**
      * Shared post-login setup. Handles two cases:
      *

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -274,6 +274,12 @@ interface NostrRepositoryApi {
 
     suspend fun loginWithNip07(pubkey: String): Result<Unit>
 
+    /** Login via a NIP-55 Android signer app (Amber); pubkey + package come from its get_public_key UI. */
+    suspend fun loginWithAmber(
+        pubkey: String,
+        signerPackage: String?,
+    ): Result<Unit>
+
     suspend fun loginWithBunker(bunkerUrl: String): Result<String>
 
     /** Default relays seeding the nostrconnect:// QR login (user-overridable). */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -128,8 +128,19 @@ class DmManager(
     }
 
     // Dedup: a gift wrap can arrive from several relays; the same rumor can arrive via the
-    // recipient wrap and the self wrap.
-    private val seenRumorIds = HashSet<String>()
+    // recipient wrap and the self wrap. Held as an immutable set swapped atomically: wraps
+    // are ingested by several coroutines at once, and a plain HashSet corrupts under that.
+    private val seenRumorIds = MutableStateFlow<Set<String>>(emptySet())
+
+    /** Test-and-set on [seenRumorIds]. True when [rumorId] was not seen before. */
+    private fun markRumorSeen(rumorId: String): Boolean {
+        var isNew = false
+        seenRumorIds.update { current ->
+            isNew = rumorId !in current
+            if (isNew) current + rumorId else current
+        }
+        return isNew
+    }
 
     /**
      * Decrypt an incoming kind:1059 with [signer] (the account) and add the message to its
@@ -157,7 +168,7 @@ class DmManager(
                 sender
             } ?: return true
 
-        if (!seenRumorIds.add(rumorId)) {
+        if (!markRumorSeen(rumorId)) {
             // Same rumor from another relay or the self-wrap echo of an optimistic send: nothing
             // new to show, but the wrap round-tripped a relay, so an own message is now Delivered,
             // and its relay still counts for "seen on".
@@ -184,7 +195,7 @@ class DmManager(
     fun addOptimistic(rumor: Event, recipientPubkey: String, myPubkey: String) {
         val rumorId = rumor.id ?: return
         setSending(rumorId)
-        if (!seenRumorIds.add(rumorId)) return
+        if (!markRumorSeen(rumorId)) return
         addMessage(
             recipientPubkey,
             DmMessage(
@@ -200,7 +211,7 @@ class DmManager(
     }
 
     private fun addMessage(peer: String, message: DmMessage) {
-        peerByRumor[message.id] = peer
+        peerByRumor.update { it + (message.id to peer) }
         _messagesByPeer.update { current ->
             val merged = (current[peer].orEmpty() + message).sortedBy { it.createdAt }
             current + (peer to merged)
@@ -211,10 +222,14 @@ class DmManager(
     // the decrypt pipeline skips (the same wrap sits on several DM relays) — so "seen on"
     // keeps growing after the first decrypt. Keyed by rumor id (stable across restarts) so
     // NostrRepository can persist it; wrapRelays buffers arrivals seen before decrypt.
-    private val wrapRelays = mutableMapOf<String, MutableSet<String>>()
-    private val rumorByWrap = mutableMapOf<String, String>()
-    private val peerByRumor = mutableMapOf<String, String>()
-    private val relaysByRumor = mutableMapOf<String, MutableSet<String>>()
+    //
+    // Immutable maps swapped atomically. Wrap arrivals write these from the relay coroutines
+    // while the debounced persist reads them from its own; a plain LinkedHashMap throws
+    // ConcurrentModificationException the moment a snapshot overlaps an arrival.
+    private val wrapRelays = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+    private val rumorByWrap = MutableStateFlow<Map<String, String>>(emptyMap())
+    private val peerByRumor = MutableStateFlow<Map<String, String>>(emptyMap())
+    private val relaysByRumor = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
 
     /** Set by NostrRepository to persist the seen-on + wrap-to-rumor maps when they grow. */
     var onSeenRelaysChanged: (() -> Unit)? = null
@@ -222,38 +237,48 @@ class DmManager(
     /** Record that [wrapId] was delivered by [relayUrl] (normalized). Safe pre-decrypt. */
     fun recordWrapRelay(wrapId: String, relayUrl: String) {
         if (relayUrl.isBlank()) return
-        wrapRelays.getOrPut(wrapId) { mutableSetOf() }.add(relayUrl)
+        wrapRelays.update { it + (wrapId to (it[wrapId].orEmpty() + relayUrl)) }
         // Known rumor (decrypted this session, or the wrap->rumor link restored from disk):
         // attach immediately. This is what lets a re-streamed but already-decrypted wrap add
         // its relay without paying the decrypt again.
-        rumorByWrap[wrapId]?.let { mergeRelays(it, listOf(relayUrl)) }
+        rumorByWrap.value[wrapId]?.let { mergeRelays(it, listOf(relayUrl)) }
     }
 
     private fun linkWrapToRumor(wrapId: String?, rumorId: String, peer: String) {
-        peerByRumor[rumorId] = peer
+        peerByRumor.update { it + (rumorId to peer) }
         if (wrapId == null) return
-        val isNew = rumorByWrap.put(wrapId, rumorId) != rumorId
+        var isNew = false
+        rumorByWrap.update { current ->
+            isNew = current[wrapId] != rumorId
+            if (isNew) current + (wrapId to rumorId) else current
+        }
         // Optimistic sends have no wrap of their own; adopt the echo's buffered relays.
-        wrapRelays[wrapId]?.let { mergeRelays(rumorId, it) }
+        wrapRelays.value[wrapId]?.let { mergeRelays(rumorId, it) }
         // Persist the new link so a later session attaches relays on the decrypt-skip path.
         if (isNew) onSeenRelaysChanged?.invoke()
     }
 
     /** Snapshot of the wrap-id to rumor-id links, for persistence. */
-    fun wrapToRumorSnapshot(): Map<String, String> = rumorByWrap.toMap()
+    fun wrapToRumorSnapshot(): Map<String, String> = rumorByWrap.value
 
     /** Merge [relays] into the rumor's seen-on set; sync the visible message + persist on change. */
     private fun mergeRelays(rumorId: String, relays: Collection<String>) {
         if (relays.isEmpty()) return
-        val set = relaysByRumor.getOrPut(rumorId) { mutableSetOf() }
-        if (!set.addAll(relays)) return
+        var changed = false
+        relaysByRumor.update { current ->
+            val existing = current[rumorId].orEmpty()
+            val merged = existing + relays
+            changed = merged.size != existing.size
+            if (changed) current + (rumorId to merged) else current
+        }
+        if (!changed) return
         syncMessageRelays(rumorId)
         onSeenRelaysChanged?.invoke()
     }
 
     private fun syncMessageRelays(rumorId: String) {
-        val peer = peerByRumor[rumorId] ?: return
-        val relays = relaysByRumor[rumorId]?.sorted() ?: return
+        val peer = peerByRumor.value[rumorId] ?: return
+        val relays = relaysByRumor.value[rumorId]?.sorted() ?: return
         _messagesByPeer.update { current ->
             val msgs = current[peer] ?: return@update current
             current + (
@@ -264,7 +289,7 @@ class DmManager(
     }
 
     /** Snapshot of seen-on relays keyed by rumor id, for persistence. */
-    fun seenRelaysSnapshot(): Map<String, List<String>> = relaysByRumor.mapValues { it.value.sorted() }
+    fun seenRelaysSnapshot(): Map<String, List<String>> = relaysByRumor.value.mapValues { it.value.sorted() }
 
     /** Mark a conversation read up to its newest message; clears its unread count. */
     fun markRead(peer: String) {
@@ -279,22 +304,20 @@ class DmManager(
         seenRelays: Map<String, List<String>> = emptyMap(),
         wrapToRumor: Map<String, String> = emptyMap(),
     ) {
-        seenRelays.forEach { (rumorId, relays) -> relaysByRumor[rumorId] = relays.toMutableSet() }
+        relaysByRumor.update { it + seenRelays.mapValues { (_, relays) -> relays.toSet() } }
         // Restore the wrap->rumor links so a re-streamed, already-processed wrap can attach its
         // relay on the decrypt-skip path (recordWrapRelay) instead of being dropped.
-        rumorByWrap.putAll(wrapToRumor)
+        rumorByWrap.update { it + wrapToRumor }
         if (messages.isNotEmpty()) {
-            messages.forEach {
-                seenRumorIds.add(it.id)
-                // Late wrap arrivals must find hydrated messages too for "seen on".
-                peerByRumor[it.id] = it.peerPubkey
-            }
+            seenRumorIds.update { it + messages.map { m -> m.id } }
+            // Late wrap arrivals must find hydrated messages too for "seen on".
+            peerByRumor.update { it + messages.associate { m -> m.id to m.peerPubkey } }
             _messagesByPeer.value =
                 messages
                     .groupBy { it.peerPubkey }
                     .mapValues { (_, msgs) ->
                         msgs.sortedBy { it.createdAt }.map { m ->
-                            relaysByRumor[m.id]?.sorted()?.let { m.copy(relays = it) } ?: m
+                            relaysByRumor.value[m.id]?.sorted()?.let { m.copy(relays = it) } ?: m
                         }
                     }
         }
@@ -318,11 +341,11 @@ class DmManager(
 
     /** Drop all state on account switch. */
     fun clear() {
-        seenRumorIds.clear()
-        wrapRelays.clear()
-        rumorByWrap.clear()
-        peerByRumor.clear()
-        relaysByRumor.clear()
+        seenRumorIds.value = emptySet()
+        wrapRelays.value = emptyMap()
+        rumorByWrap.value = emptyMap()
+        peerByRumor.value = emptyMap()
+        relaysByRumor.value = emptyMap()
         _messageStatus.value = emptyMap()
         _messagesByPeer.value = emptyMap()
         _dmRelaysByPubkey.value = emptyMap()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
@@ -76,6 +76,13 @@ class SessionManager(
         authManager.loginWithNip07(pubkey)
     }
 
+    fun loginWithAmber(
+        pubkey: String,
+        signerPackage: String?,
+    ) {
+        authManager.loginWithAmber(pubkey, signerPackage)
+    }
+
     /**
      * Set logged in state
      */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip55.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip55.kt
@@ -1,0 +1,62 @@
+package org.nostr.nostrord.nostr
+
+/** Result of a NIP-55 `get_public_key` round-trip. [signerPackage] addresses every later request. */
+data class Nip55Login(
+    val pubkeyHex: String,
+    val signerPackage: String?,
+)
+
+/**
+ * Permissions requested at login so pre-authorized operations run silently through the
+ * signer's ContentResolver instead of opening its approval UI: the kinds Nostrord signs
+ * (NIP-42 AUTH, NIP-29 chat + membership, profile / contacts / lists, reports, NIP-17
+ * seals) plus NIP-44 for direct messages. A kind missing here still works, it just falls
+ * back to the signer's approval screen.
+ */
+const val NIP55_PERMISSIONS: String =
+    """[{"type":"sign_event","kind":22242},{"type":"sign_event","kind":9},""" +
+        """{"type":"sign_event","kind":9021},{"type":"sign_event","kind":9022},""" +
+        """{"type":"sign_event","kind":0},{"type":"sign_event","kind":3},""" +
+        """{"type":"sign_event","kind":7},{"type":"sign_event","kind":13},""" +
+        """{"type":"sign_event","kind":1984},{"type":"sign_event","kind":10000},""" +
+        """{"type":"sign_event","kind":10002},{"type":"sign_event","kind":10009},""" +
+        """{"type":"nip44_encrypt"},{"type":"nip44_decrypt"}]"""
+
+/**
+ * NIP-55 Android signer application client (Amber).
+ * https://github.com/nostr-protocol/nips/blob/master/55.md
+ *
+ * Real implementation on Android only: requests go through the signer's ContentResolver
+ * when pre-authorized (silent) and fall back to an `nostrsigner:` Intent (approval UI).
+ * All other targets are documented stubs ([isAvailable] false, calls throw).
+ */
+expect object Nip55 {
+    /** True when a NIP-55 signer app is installed (an activity handles the `nostrsigner:` scheme). */
+    fun isAvailable(): Boolean
+
+    /** Opens the signer to pick/approve an account; returns its pubkey and package name. */
+    suspend fun getPublicKey(permissionsJson: String): Nip55Login
+
+    /** Signs [eventJson] as [currentUserHex]; returns the full signed event JSON. */
+    suspend fun signEvent(
+        eventJson: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String
+
+    /** NIP-44 encrypt [plaintext] for [peerPubkeyHex] with [currentUserHex]'s key. */
+    suspend fun nip44Encrypt(
+        peerPubkeyHex: String,
+        plaintext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String
+
+    /** NIP-44 decrypt [ciphertext] from [peerPubkeyHex] with [currentUserHex]'s key. */
+    suspend fun nip44Decrypt(
+        peerPubkeyHex: String,
+        ciphertext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1358,6 +1358,7 @@ fun SecureStorage.clearAllCredentialsForAccount(pubkey: String) {
     clearBunkerClientPrivateKeyFor(pubkey)
     clearPomegranateCentralFor(pubkey)
     clearPomegranateDisconnectedFor(pubkey)
+    clearNip55SignerPackageFor(pubkey)
 }
 
 private fun droppedGroupsForAccountKey(pubkey: String) = "dropped_groups_${pubkeyDigest(pubkey)}"
@@ -1388,4 +1389,27 @@ fun SecureStorage.loadDroppedGroupIds(pubkey: String): Set<String> {
     } catch (_: Exception) {
         emptySet()
     }
+}
+
+// ── NIP-55 (Amber) signer package per account ───────────────────────────────
+// Package name of the Android signer app chosen at login; addresses every later
+// Intent / ContentResolver request for this account. Android-only at runtime.
+private fun nip55SignerPackageForAccountKey(pubkey: String) = "nip55_signer_package_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.saveNip55SignerPackageFor(
+    pubkey: String,
+    packageName: String,
+) {
+    if (pubkey.isBlank() || packageName.isBlank()) return
+    saveStringPref(nip55SignerPackageForAccountKey(pubkey), packageName)
+}
+
+fun SecureStorage.getNip55SignerPackageFor(pubkey: String): String? {
+    if (pubkey.isBlank()) return null
+    return getStringPref(nip55SignerPackageForAccountKey(pubkey), "").ifBlank { null }
+}
+
+fun SecureStorage.clearNip55SignerPackageFor(pubkey: String) {
+    if (pubkey.isBlank()) return
+    saveStringPref(nip55SignerPackageForAccountKey(pubkey), "")
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethod.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethod.kt
@@ -1,0 +1,33 @@
+package org.nostr.nostrord.ui.screens.login
+
+import org.nostr.nostrord.auth.pomegranate.PomegranateService
+import org.nostr.nostrord.nostr.Nip07
+import org.nostr.nostrord.nostr.Nip55
+
+/**
+ * A credential method offered by the login screen and the add-account modal. Titles and
+ * subtitles live here so the Compose list and the web list read identically; the icon is
+ * mapped per platform (ImageVector vs the web `Ic` sprite).
+ */
+enum class LoginMethod(
+    val title: String,
+    val subtitle: String,
+) {
+    PrivateKey("Private key", "nsec, hex or ncryptsec"),
+    Bunker("Bunker", "Remote signer over NIP-46"),
+    Extension("Browser extension", "Sign with a NIP-07 extension"),
+    Amber("Amber", "Signer app on this device"),
+    Google("Google", "Managed key, nothing to back up"),
+}
+
+/**
+ * Methods usable at runtime, in the order they are offered. Extension is browser-only,
+ * Amber Android-only, Google gated on the pomegranate build config.
+ */
+fun availableLoginMethods(): List<LoginMethod> = buildList {
+    add(LoginMethod.PrivateKey)
+    add(LoginMethod.Bunker)
+    if (Nip07.isAvailable()) add(LoginMethod.Extension)
+    if (Nip55.isAvailable()) add(LoginMethod.Amber)
+    if (PomegranateService().isAvailable) add(LoginMethod.Google)
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethod.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethod.kt
@@ -16,18 +16,21 @@ enum class LoginMethod(
     PrivateKey("Private key", "nsec, hex or ncryptsec"),
     Bunker("Bunker", "Remote signer over NIP-46"),
     Extension("Browser extension", "Sign with a NIP-07 extension"),
-    Amber("Amber", "Signer app on this device"),
+
+    // Any app registering the nostrsigner: scheme qualifies, so the label names the
+    // protocol rather than Amber, which is only the most common implementation.
+    Signer("Signer app", "Sign with a NIP-55 signer app"),
     Google("Google", "Managed key, nothing to back up"),
 }
 
 /**
  * Methods usable at runtime, in the order they are offered. Extension is browser-only,
- * Amber Android-only, Google gated on the pomegranate build config.
+ * the signer app Android-only, Google gated on the pomegranate build config.
  */
 fun availableLoginMethods(): List<LoginMethod> = buildList {
     add(LoginMethod.PrivateKey)
     add(LoginMethod.Bunker)
     if (Nip07.isAvailable()) add(LoginMethod.Extension)
-    if (Nip55.isAvailable()) add(LoginMethod.Amber)
+    if (Nip55.isAvailable()) add(LoginMethod.Signer)
     if (PomegranateService().isAvailable) add(LoginMethod.Google)
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
@@ -18,10 +18,12 @@ import org.nostr.nostrord.auth.pomegranate.PomegranateStatus
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.nostr.Crypto
 import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.NIP55_PERMISSIONS
 import org.nostr.nostrord.nostr.Nip07
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip46Client
 import org.nostr.nostrord.nostr.Nip49
+import org.nostr.nostrord.nostr.Nip55
 import org.nostr.nostrord.nostr.hexToByteArray
 import org.nostr.nostrord.nostr.ncryptsecStorageApplicable
 import org.nostr.nostrord.nostr.toHexString
@@ -244,6 +246,26 @@ class LoginViewModel(
             try {
                 val pubkey = Nip07.getPublicKey() // platform call — can throw if extension unavailable
                 onResult(repo.loginWithNip07(pubkey).toKotlinResult())
+            } catch (c: CancellationException) {
+                throw c
+            } catch (e: Exception) {
+                onResult(Result.failure(e))
+            }
+        }
+    }
+
+    /** True where "Login with Amber" (NIP-55 external signer) can run: Android with a signer installed. */
+    val isAmberLoginAvailable: Boolean get() = Nip55.isAvailable()
+
+    /**
+     * Login via the NIP-55 Android signer (Amber): opens its account picker, requests
+     * the app's permission set (so later signs run silently), and registers the account.
+     */
+    fun loginWithAmber(onResult: (Result<Unit>) -> Unit) {
+        viewModelScope.launch {
+            try {
+                val login = Nip55.getPublicKey(NIP55_PERMISSIONS)
+                onResult(repo.loginWithAmber(login.pubkeyHex, login.signerPackage).toKotlinResult())
             } catch (c: CancellationException) {
                 throw c
             } catch (e: Exception) {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/auth/AccountTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/auth/AccountTest.kt
@@ -41,6 +41,7 @@ class AccountTest {
                 Account("a".repeat(64), "Local 1", AuthMethod.LOCAL, 1L),
                 Account("b".repeat(64), "Bunker 1", AuthMethod.BUNKER, 2L),
                 Account("c".repeat(64), "Extension", AuthMethod.NIP07, 3L),
+                Account("d".repeat(64), "Amber", AuthMethod.AMBER, 4L),
             )
         val encoded = json.encodeToString(list)
         val decoded = json.decodeFromString<List<Account>>(encoded)
@@ -50,7 +51,17 @@ class AccountTest {
     @Test
     fun `auth method values cover all login paths`() {
         // Guards against accidentally dropping a variant.
-        // LOCAL, BUNKER, NIP07
-        assertEquals(3, AuthMethod.entries.size)
+        // LOCAL, BUNKER, NIP07, AMBER
+        assertEquals(4, AuthMethod.entries.size)
+    }
+
+    @Test
+    fun `amber accounts get per-method copy`() {
+        val account = Account("e".repeat(64), "Amber 1", AuthMethod.AMBER, 5L)
+        assertEquals("amber", signerLabel(account))
+        assertEquals(
+            "You will need to reconnect your signer app to log back in.",
+            logoutConfirmBody(AuthMethod.AMBER),
+        )
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -61,6 +61,10 @@ class FakeNostrRepository : NostrRepositoryApi {
         _isLoggedIn.value = true
         Result.Success(Unit)
     }
+    var loginWithAmberAction: suspend (String, String?) -> Result<Unit> = { _, _ ->
+        _isLoggedIn.value = true
+        Result.Success(Unit)
+    }
     var loginWithBunkerAction: suspend (String) -> Result<String> = { Result.Success("pubkey") }
     var leaveGroupAction: suspend (String, String?) -> Result<Unit> = { _, _ -> Result.Success(Unit) }
     var sendMessageAction: suspend (String, String, String?, Map<String, String>, String?) -> Result<Unit> =
@@ -187,6 +191,14 @@ class FakeNostrRepository : NostrRepositoryApi {
     override suspend fun loginWithNip07(pubkey: String): Result<Unit> {
         calls += "loginWithNip07"
         return loginWithNip07Action(pubkey)
+    }
+
+    override suspend fun loginWithAmber(
+        pubkey: String,
+        signerPackage: String?,
+    ): Result<Unit> {
+        calls += "loginWithAmber"
+        return loginWithAmberAction(pubkey, signerPackage)
     }
 
     override suspend fun loginWithBunker(bunkerUrl: String): Result<String> {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethodTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethodTest.kt
@@ -1,0 +1,24 @@
+package org.nostr.nostrord.ui.screens.login
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LoginMethodTest {
+    @Test
+    fun everyMethodHasARowLabel() {
+        // The list renders title over subtitle; a blank one would ship an empty row.
+        LoginMethod.entries.forEach { method ->
+            assertTrue(method.title.isNotBlank(), "${method.name} has no title")
+            assertTrue(method.subtitle.isNotBlank(), "${method.name} has no subtitle")
+        }
+    }
+
+    @Test
+    fun keyAndBunkerAreOfferedOnEveryPlatform() {
+        val methods = availableLoginMethods()
+        assertEquals(LoginMethod.PrivateKey, methods.first())
+        assertTrue(methods.contains(LoginMethod.Bunker))
+        assertEquals(methods.distinct(), methods)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip55.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip55.ios.kt
@@ -1,0 +1,27 @@
+package org.nostr.nostrord.nostr
+
+actual object Nip55 {
+    actual fun isAvailable(): Boolean = false
+
+    actual suspend fun getPublicKey(permissionsJson: String): Nip55Login = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun signEvent(
+        eventJson: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun nip44Encrypt(
+        peerPubkeyHex: String,
+        plaintext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun nip44Decrypt(
+        peerPubkeyHex: String,
+        ciphertext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip55.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip55.js.kt
@@ -1,0 +1,27 @@
+package org.nostr.nostrord.nostr
+
+actual object Nip55 {
+    actual fun isAvailable(): Boolean = false
+
+    actual suspend fun getPublicKey(permissionsJson: String): Nip55Login = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun signEvent(
+        eventJson: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun nip44Encrypt(
+        peerPubkeyHex: String,
+        plaintext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun nip44Decrypt(
+        peerPubkeyHex: String,
+        ciphertext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip55.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip55.jvm.kt
@@ -1,0 +1,27 @@
+package org.nostr.nostrord.nostr
+
+actual object Nip55 {
+    actual fun isAvailable(): Boolean = false
+
+    actual suspend fun getPublicKey(permissionsJson: String): Nip55Login = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun signEvent(
+        eventJson: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun nip44Encrypt(
+        peerPubkeyHex: String,
+        plaintext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+
+    actual suspend fun nip44Decrypt(
+        peerPubkeyHex: String,
+        ciphertext: String,
+        currentUserHex: String,
+        signerPackage: String?,
+    ): String = throw UnsupportedOperationException("NIP-55 signers are only available on Android")
+}

--- a/composeApp/src/jvmTest/kotlin/org/nostr/nostrord/network/managers/DmManagerConcurrencyTest.kt
+++ b/composeApp/src/jvmTest/kotlin/org/nostr/nostrord/network/managers/DmManagerConcurrencyTest.kt
@@ -1,0 +1,53 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Wrap arrivals write the seen-on maps from the relay coroutines while the debounced
+ * persist snapshots them from its own. Both land on threads of the same pool, and while
+ * those maps were plain LinkedHashMaps the overlap threw ConcurrentModificationException
+ * out of a coroutine with no handler, killing the process. JVM-only: it needs real
+ * parallelism, which the JS Default dispatcher cannot give.
+ */
+class DmManagerConcurrencyTest {
+    @Test
+    fun `snapshots survive concurrent wrap arrivals`() = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val dm = DmManager(scope)
+
+        // Link the wraps up front so every arrival merges into relaysByRumor, which is
+        // the map seenRelaysSnapshot() iterates.
+        val wraps = (0 until 500).associate { "wrap-$it" to "rumor-$it" }
+        dm.hydrate(messages = emptyList(), lastRead = emptyMap(), wrapToRumor = wraps)
+
+        val writers =
+            (0 until 4).map { w ->
+                async(Dispatchers.Default) {
+                    wraps.keys.forEach { wrapId -> dm.recordWrapRelay(wrapId, "wss://relay$w.example") }
+                }
+            }
+        val readers =
+            (0 until 4).map {
+                async(Dispatchers.Default) {
+                    repeat(500) {
+                        dm.seenRelaysSnapshot().forEach { (_, relays) -> relays.size }
+                        dm.wrapToRumorSnapshot().forEach { (_, rumor) -> rumor.length }
+                    }
+                }
+            }
+        (writers + readers).awaitAll()
+
+        val seen = dm.seenRelaysSnapshot()
+        assertTrue(seen.size == wraps.size, "every rumor kept its seen-on entry")
+        assertTrue(seen.values.all { it.size == 4 }, "every writer's relay survived the merges")
+        scope.cancel()
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/AccountChooserDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/AccountChooserDialog.kt
@@ -260,4 +260,5 @@ private fun authMethodChooserLabel(account: Account): String = when (account.aut
     org.nostr.nostrord.auth.AuthMethod.LOCAL -> "Private key"
     org.nostr.nostrord.auth.AuthMethod.BUNKER -> "Bunker (NIP-46)"
     org.nostr.nostrord.auth.AuthMethod.NIP07 -> "Browser extension (NIP-07)"
+    org.nostr.nostrord.auth.AuthMethod.AMBER -> "Signer app (NIP-55)"
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
@@ -513,4 +513,5 @@ private fun authMethodLabel(method: AuthMethod): String = when (method) {
     AuthMethod.LOCAL -> "Private key"
     AuthMethod.BUNKER -> "Bunker (NIP-46)"
     AuthMethod.NIP07 -> "Browser extension (NIP-07)"
+    AuthMethod.AMBER -> "Signer app (NIP-55)"
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethods.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethods.kt
@@ -12,8 +12,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.nostr.nostrord.auth.pomegranate.PomegranateService
 import org.nostr.nostrord.nostr.Nip07
+import org.nostr.nostrord.nostr.Nip55
 import org.nostr.nostrord.ui.components.forms.AppSegmentedTabs
 import org.nostr.nostrord.ui.components.forms.SegmentedTab
+import org.nostr.nostrord.ui.screens.login.components.AmberLoginTab
 import org.nostr.nostrord.ui.screens.login.components.BunkerLoginTab
 import org.nostr.nostrord.ui.screens.login.components.ExtensionLoginTab
 import org.nostr.nostrord.ui.screens.login.components.GoogleLoginTab
@@ -38,6 +40,7 @@ fun LoginMethods(
                 add(LoginTab.PrivateKey)
                 add(LoginTab.Bunker)
                 if (Nip07.isAvailable()) add(LoginTab.Extension)
+                if (Nip55.isAvailable()) add(LoginTab.Amber)
                 if (googleAvailable) add(LoginTab.Google)
             }
         }
@@ -56,6 +59,7 @@ fun LoginMethods(
             LoginTab.Bunker -> BunkerLoginTab(onLoginSuccess)
             LoginTab.Extension -> ExtensionLoginTab(onLoginSuccess)
             LoginTab.Google -> GoogleLoginTab(onLoginSuccess)
+            LoginTab.Amber -> AmberLoginTab(onLoginSuccess)
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethods.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethods.kt
@@ -33,12 +33,13 @@ import androidx.compose.ui.unit.sp
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonSize
 import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
-import org.nostr.nostrord.ui.screens.login.components.AmberLoginTab
+import org.nostr.nostrord.ui.navigation.PlatformBackHandler
 import org.nostr.nostrord.ui.screens.login.components.BunkerLoginTab
 import org.nostr.nostrord.ui.screens.login.components.ExtensionLoginTab
 import org.nostr.nostrord.ui.screens.login.components.GoogleLoginTab
 import org.nostr.nostrord.ui.screens.login.components.LoginMethodList
 import org.nostr.nostrord.ui.screens.login.components.PrivateKeyLoginTab
+import org.nostr.nostrord.ui.screens.login.components.SignerLoginTab
 import org.nostr.nostrord.ui.screens.login.components.icon
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
@@ -60,6 +61,10 @@ fun LoginMethods(
     // Entered through "Generate New Key": the private key form opens on the wizard
     var generating by remember { mutableStateOf(false) }
     val methods = remember { availableLoginMethods() }
+
+    // Inside a method, system back returns to the list. Disabled on the list itself so
+    // back keeps falling through to the host (closing the add-account sheet, exiting).
+    PlatformBackHandler(enabled = selected != null) { selected = null }
 
     Column(modifier = modifier) {
         when (val method = selected) {
@@ -98,7 +103,7 @@ fun LoginMethods(
                         )
                     LoginMethod.Bunker -> BunkerLoginTab(onLoginSuccess)
                     LoginMethod.Extension -> ExtensionLoginTab(onLoginSuccess)
-                    LoginMethod.Amber -> AmberLoginTab(onLoginSuccess)
+                    LoginMethod.Signer -> SignerLoginTab(onLoginSuccess)
                     LoginMethod.Google -> GoogleLoginTab(onLoginSuccess)
                 }
             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethods.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginMethods.kt
@@ -1,65 +1,166 @@
 package org.nostr.nostrord.ui.screens.login
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import org.nostr.nostrord.auth.pomegranate.PomegranateService
-import org.nostr.nostrord.nostr.Nip07
-import org.nostr.nostrord.nostr.Nip55
-import org.nostr.nostrord.ui.components.forms.AppSegmentedTabs
-import org.nostr.nostrord.ui.components.forms.SegmentedTab
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonSize
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
 import org.nostr.nostrord.ui.screens.login.components.AmberLoginTab
 import org.nostr.nostrord.ui.screens.login.components.BunkerLoginTab
 import org.nostr.nostrord.ui.screens.login.components.ExtensionLoginTab
 import org.nostr.nostrord.ui.screens.login.components.GoogleLoginTab
+import org.nostr.nostrord.ui.screens.login.components.LoginMethodList
 import org.nostr.nostrord.ui.screens.login.components.PrivateKeyLoginTab
+import org.nostr.nostrord.ui.screens.login.components.icon
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
 
 /**
- * The tabbed credential picker shared by the login screen and the add-account modal:
- * Private Key / Bunker (NIP-46) / Extension (NIP-07, only when available). Owns the tab
- * selection and reuses the standalone login tabs, which each call [onLoginSuccess] on a
- * successful auth. Keeping this in one place is what keeps login and add-account identical.
+ * The credential picker shared by the login screen and the add-account modal: a list of
+ * the available [LoginMethod]s, then the chosen method's form behind a back header.
+ * "Generate New Key" sits at the list level because creating an identity is a separate
+ * path from presenting one. Each form calls [onLoginSuccess] on a successful auth;
+ * keeping this in one place is what keeps login and add-account identical.
  */
 @Composable
 fun LoginMethods(
     onLoginSuccess: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var selectedTab by remember { mutableStateOf<LoginTab>(LoginTab.PrivateKey) }
-    val googleAvailable = remember { PomegranateService().isAvailable }
-    val tabs =
-        remember {
-            buildList {
-                add(LoginTab.PrivateKey)
-                add(LoginTab.Bunker)
-                if (Nip07.isAvailable()) add(LoginTab.Extension)
-                if (Nip55.isAvailable()) add(LoginTab.Amber)
-                if (googleAvailable) add(LoginTab.Google)
-            }
-        }
+    // null shows the method list; a value shows that method's form
+    var selected by remember { mutableStateOf<LoginMethod?>(null) }
+    // Entered through "Generate New Key": the private key form opens on the wizard
+    var generating by remember { mutableStateOf(false) }
+    val methods = remember { availableLoginMethods() }
 
     Column(modifier = modifier) {
-        AppSegmentedTabs(
-            tabs = tabs.map { SegmentedTab(it.title, it.icon) },
-            selectedIndex = tabs.indexOf(selectedTab),
-            onSelect = { selectedTab = tabs[it] },
-        )
+        when (val method = selected) {
+            null -> {
+                LoginMethodList(
+                    methods = methods,
+                    onSelect = {
+                        generating = false
+                        selected = it
+                    },
+                )
+                OrDivider()
+                AppButton(
+                    text = "Generate New Key",
+                    onClick = {
+                        generating = true
+                        selected = LoginMethod.PrivateKey
+                    },
+                    variant = AppButtonVariant.Secondary,
+                    size = AppButtonSize.Large,
+                    fullWidth = true,
+                    icon = Icons.Default.AutoAwesome,
+                )
+            }
 
-        Spacer(modifier = Modifier.height(24.dp))
-
-        when (selectedTab) {
-            LoginTab.PrivateKey -> PrivateKeyLoginTab(onLoginSuccess)
-            LoginTab.Bunker -> BunkerLoginTab(onLoginSuccess)
-            LoginTab.Extension -> ExtensionLoginTab(onLoginSuccess)
-            LoginTab.Google -> GoogleLoginTab(onLoginSuccess)
-            LoginTab.Amber -> AmberLoginTab(onLoginSuccess)
+            else -> {
+                val back = { selected = null }
+                MethodHeader(method = method, onBack = back)
+                Spacer(modifier = Modifier.height(20.dp))
+                when (method) {
+                    LoginMethod.PrivateKey ->
+                        PrivateKeyLoginTab(
+                            onLoginSuccess = onLoginSuccess,
+                            startInWizard = generating,
+                            onBack = back,
+                        )
+                    LoginMethod.Bunker -> BunkerLoginTab(onLoginSuccess)
+                    LoginMethod.Extension -> ExtensionLoginTab(onLoginSuccess)
+                    LoginMethod.Amber -> AmberLoginTab(onLoginSuccess)
+                    LoginMethod.Google -> GoogleLoginTab(onLoginSuccess)
+                }
+            }
         }
+    }
+}
+
+/** Back arrow + method name above the chosen method's form. */
+@Composable
+private fun MethodHeader(
+    method: LoginMethod,
+    onBack: () -> Unit,
+) {
+    Row(
+        modifier =
+        Modifier
+            .clip(NostrordShapes.shapeSmall)
+            .clickable(onClick = onBack)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(vertical = 4.dp, horizontal = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+            contentDescription = "Back to login methods",
+            tint = NostrordColors.TextMuted,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Icon(
+            imageVector = method.icon,
+            contentDescription = null,
+            tint = NostrordColors.Primary,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = method.title,
+            color = NostrordColors.TextPrimary,
+            fontSize = 15.sp,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+@Composable
+private fun OrDivider() {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .padding(vertical = 20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        HorizontalDivider(modifier = Modifier.weight(1f), color = NostrordColors.Divider)
+        Text(
+            text = "or",
+            modifier = Modifier.padding(horizontal = 16.dp),
+            color = NostrordColors.TextMuted,
+            style = MaterialTheme.typography.bodySmall,
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f), color = NostrordColors.Divider)
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/NostrLoginScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/NostrLoginScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Extension
 import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -37,6 +38,8 @@ sealed class LoginTab(
     object Extension : LoginTab("Extension", Icons.Default.Extension)
 
     object Google : LoginTab("Google", Icons.Default.AccountCircle)
+
+    object Amber : LoginTab("Amber", Icons.Default.PhoneAndroid)
 }
 
 @Composable

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/NostrLoginScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/NostrLoginScreen.kt
@@ -5,51 +5,26 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.Extension
-import androidx.compose.material.icons.filled.Key
-import androidx.compose.material.icons.filled.PhoneAndroid
-import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import nostrord.composeapp.generated.resources.Res
 import nostrord.composeapp.generated.resources.nostrord_logo
 import org.jetbrains.compose.resources.painterResource
-import org.nostr.nostrord.nostr.Nip07
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
-
-sealed class LoginTab(
-    val title: String,
-    val icon: ImageVector,
-) {
-    object PrivateKey : LoginTab("Private Key", Icons.Default.Key)
-
-    object Bunker : LoginTab("Bunker", Icons.Default.Shield)
-
-    object Extension : LoginTab("Extension", Icons.Default.Extension)
-
-    object Google : LoginTab("Google", Icons.Default.AccountCircle)
-
-    object Amber : LoginTab("Amber", Icons.Default.PhoneAndroid)
-}
 
 @Composable
 fun NostrLoginScreen(
     modifier: Modifier = Modifier,
     onLoginSuccess: () -> Unit,
 ) {
-    val showExtension = remember { Nip07.isAvailable() }
-
-    Box(
+    BoxWithConstraints(
         modifier =
         modifier
             .fillMaxSize()
@@ -66,29 +41,30 @@ fun NostrLoginScreen(
                 ),
             ),
     ) {
+        // A phone never reaches the card's 448dp, so the web's 32px gutters would eat a
+        // third of the row width there; trim them to keep the card's proportions.
+        val compact = maxWidth < 600.dp
         Column(
             modifier =
             Modifier
                 .fillMaxSize()
                 .verticalScroll(rememberScrollState())
-                .padding(16.dp),
+                .padding(if (compact) 12.dp else 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             // Centers the card when it fits; the column still scrolls when taller.
             verticalArrangement = Arrangement.Center,
         ) {
-            // Main login card — wider when 3 tabs are shown to prevent label cramming
-            val cardMaxWidth = if (showExtension) 500.dp else 448.dp
             Card(
                 modifier =
                 Modifier
-                    .widthIn(max = cardMaxWidth)
+                    .widthIn(max = 448.dp)
                     .fillMaxWidth(),
                 shape = NostrordShapes.shapeXLarge,
                 colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
                 elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
             ) {
                 Column(
-                    modifier = Modifier.padding(32.dp),
+                    modifier = Modifier.padding(if (compact) 20.dp else 32.dp),
                 ) {
                     // Card header: logo on the brand tile, app name, tagline
                     Column(
@@ -118,7 +94,7 @@ fun NostrLoginScreen(
                             modifier = Modifier.padding(top = 4.dp),
                         )
                     }
-                    // Tab selector + content (shared with the add-account modal)
+                    // Method list + chosen method's form (shared with the add-account modal)
                     LoginMethods(onLoginSuccess = onLoginSuccess)
                 }
             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/AmberLoginTab.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/AmberLoginTab.kt
@@ -1,0 +1,81 @@
+package org.nostr.nostrord.ui.screens.login.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonSize
+import org.nostr.nostrord.ui.screens.login.LoginViewModel
+import org.nostr.nostrord.ui.theme.NostrordColors
+
+/** NIP-55 external signer login (Amber). Only reachable on Android with a signer installed. */
+@Composable
+fun AmberLoginTab(onLoginSuccess: () -> Unit) {
+    val vm = viewModel { LoginViewModel(AppModule.nostrRepository) }
+    var isLoading by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Default.PhoneAndroid,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = NostrordColors.Primary,
+        )
+
+        Text(
+            text = "Signer App Login",
+            style = MaterialTheme.typography.titleMedium,
+            color = NostrordColors.TextPrimary,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            text = "Connect using a NIP-55 signer app such as Amber. Your key stays in the signer.",
+            style = MaterialTheme.typography.bodySmall,
+            color = NostrordColors.TextMuted,
+            textAlign = TextAlign.Center,
+        )
+
+        if (errorMessage != null) {
+            Text(
+                text = errorMessage!!,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+            )
+        }
+
+        AppButton(
+            text = if (isLoading) "Connecting..." else "Connect Signer",
+            onClick = {
+                isLoading = true
+                errorMessage = null
+                vm.loginWithAmber { result ->
+                    isLoading = false
+                    if (result.isSuccess) {
+                        onLoginSuccess()
+                    } else {
+                        errorMessage = result.exceptionOrNull()?.message ?: "Failed to connect to the signer app"
+                    }
+                }
+            },
+            enabled = !isLoading,
+            size = AppButtonSize.Large,
+            fullWidth = true,
+            loading = isLoading,
+        )
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/BunkerLoginTab.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/BunkerLoginTab.kt
@@ -96,35 +96,17 @@ fun BunkerLoginTab(onLoginSuccess: () -> Unit) {
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        // Benefits card
-        Surface(
-            modifier = Modifier.fillMaxWidth(),
-            shape = NostrordShapes.shapeMedium,
-            color = NostrordColors.SurfaceVariant.copy(alpha = 0.5f),
-        ) {
-            Column(modifier = Modifier.padding(16.dp)) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.Lock,
-                        contentDescription = null,
-                        tint = NostrordColors.Success,
-                        modifier = Modifier.size(18.dp),
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text(
-                        "Why use a Bunker?",
-                        color = NostrordColors.TextPrimary,
-                        style = MaterialTheme.typography.titleSmall,
-                        fontWeight = FontWeight.SemiBold,
-                    )
-                }
-                Spacer(modifier = Modifier.height(12.dp))
-                BenefitItem("Your private key never leaves the signer")
-                BenefitItem("Approve each signing request")
-                BenefitItem("Works with hardware signers")
-                BenefitItem("Revoke access anytime")
-            }
-        }
+        BenefitsCard(
+            title = "Why use a Bunker?",
+            icon = Icons.Default.Lock,
+            items =
+            listOf(
+                "Your private key never leaves the signer",
+                "Approve each signing request",
+                "Works with hardware signers",
+                "Revoke access anytime",
+            ),
+        )
     }
 }
 
@@ -605,26 +587,5 @@ private fun BunkerUrlLoginContent(
                 )
             }
         }
-    }
-}
-
-@Composable
-private fun BenefitItem(text: String) {
-    Row(
-        modifier = Modifier.padding(vertical = 3.dp),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Icon(
-            imageVector = Icons.Default.CheckCircle,
-            contentDescription = null,
-            tint = NostrordColors.Success.copy(alpha = 0.7f),
-            modifier = Modifier.size(14.dp),
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = text,
-            color = NostrordColors.TextSecondary,
-            style = MaterialTheme.typography.bodySmall,
-        )
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleLoginTab.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleLoginTab.kt
@@ -1,20 +1,24 @@
 package org.nostr.nostrord.ui.screens.login.components
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -22,6 +26,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -34,6 +41,7 @@ import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonSize
 import org.nostr.nostrord.ui.screens.login.LoginViewModel
 import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
 
 /**
  * "Login with Google" (pomegranate threshold signer). Runs the whole flow in the shared
@@ -54,11 +62,10 @@ fun GoogleLoginTab(onLoginSuccess: () -> Unit) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        Icon(
-            imageVector = Icons.Default.AccountCircle,
+        Image(
+            imageVector = GoogleLogoIcon,
             contentDescription = null,
             modifier = Modifier.size(48.dp),
-            tint = NostrordColors.Primary,
         )
 
         Text(
@@ -117,49 +124,61 @@ fun GoogleLoginTab(onLoginSuccess: () -> Unit) {
             loading = busy,
         )
 
-        // How it works
-        Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        BenefitsCard(
+            title = "How it works",
+            icon = Icons.Default.Lock,
+            items =
             listOf(
                 "Your key is split into shards held by independent operators",
                 "No single server ever holds the whole key",
                 "Google only proves who you are, it never touches your key",
                 "You can export the full key (nsec) whenever you want",
-            ).forEach { line ->
-                Text(
-                    text = "- $line",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = NostrordColors.TextMuted,
-                )
-            }
-        }
+            ),
+        )
 
         // Advanced: self-hosted central server override.
-        TextButton(onClick = { advancedOpen = !advancedOpen }) {
-            Icon(
-                imageVector = if (advancedOpen) Icons.Default.KeyboardArrowDown else Icons.Default.KeyboardArrowRight,
-                contentDescription = null,
-                modifier = Modifier.size(18.dp),
-            )
-            Text("Advanced options")
-        }
-        if (advancedOpen) {
-            OutlinedTextField(
-                value = central,
-                onValueChange = { central = it },
-                label = { Text("Central server") },
-                placeholder = { Text(PomegranateConfig.CENTRAL_URL) },
-                singleLine = true,
-                enabled = !busy,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                modifier = Modifier.fillMaxWidth(),
-            )
-            Row(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier =
+                Modifier
+                    .clip(NostrordShapes.shapeSmall)
+                    .clickable { advancedOpen = !advancedOpen }
+                    .pointerHoverIcon(PointerIcon.Hand)
+                    .padding(vertical = 8.dp, horizontal = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Icon(
+                    imageVector =
+                    if (advancedOpen) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = NostrordColors.TextMuted,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "Advanced options",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = NostrordColors.TextSecondary,
+                )
+            }
+            if (advancedOpen) {
                 Text(
                     text =
-                    "Checks your Google sign-in and forwards each signing request to the key " +
-                        "operators. Change it to use a self-hosted one.",
+                    "Central server: checks your Google sign-in and forwards each signing request " +
+                        "to the key operators. Change it to use a self-hosted one.",
                     style = MaterialTheme.typography.bodySmall,
                     color = NostrordColors.TextMuted,
+                    modifier = Modifier.padding(bottom = 12.dp),
+                )
+                OutlinedTextField(
+                    value = central,
+                    onValueChange = { central = it },
+                    label = { Text("Central server") },
+                    placeholder = { Text(PomegranateConfig.CENTRAL_URL) },
+                    singleLine = true,
+                    enabled = !busy,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleLogoIcon.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleLogoIcon.kt
@@ -1,0 +1,85 @@
+package org.nostr.nostrord.ui.screens.login.components
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.addPathNodes
+import androidx.compose.ui.unit.dp
+
+/**
+ * Single-path Google "G", the same glyph the web sprite serves as `Ic.Google`. Takes the
+ * caller's tint, so it fits the brand-tinted tiles of the method list and back header
+ * where the multicolor [GoogleLogoIcon] would clash.
+ */
+val GoogleGlyph: ImageVector by lazy {
+    ImageVector
+        .Builder(
+            name = "GoogleGlyph",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f,
+        ).apply {
+            addPath(
+                pathData =
+                addPathNodes(
+                    "M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 " +
+                        "2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 " +
+                        "2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 " +
+                        "12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 " +
+                        "0-.76-.053-1.467-.173-2.053H12.48z",
+                ),
+                fill = SolidColor(Color.Black),
+            )
+        }.build()
+}
+
+/**
+ * The multicolor Google "G" mark, built from the same path data as the web [GoogleLogo]
+ * so both logins show the real brand mark. Brand colors are fixed by Google's guidelines,
+ * hence the literal hexes (exempt from the design-token rule, same as other brand marks).
+ */
+val GoogleLogoIcon: ImageVector by lazy {
+    ImageVector
+        .Builder(
+            name = "GoogleLogo",
+            defaultWidth = 48.dp,
+            defaultHeight = 48.dp,
+            viewportWidth = 48f,
+            viewportHeight = 48f,
+        ).apply {
+            addPath(
+                pathData =
+                addPathNodes(
+                    "M43.611 20.083H42V20H24v8h11.303c-1.649 4.657-6.08 8-11.303 8-6.627 0-12-5.373-12-12s5.373-12 " +
+                        "12-12c3.059 0 5.842 1.154 7.961 3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 12.955 4 4 12.955 " +
+                        "4 24s8.955 20 20 20 20-8.955 20-20c0-1.341-.138-2.65-.389-3.917z",
+                ),
+                fill = SolidColor(Color(0xFFFFC107)),
+            )
+            addPath(
+                pathData =
+                addPathNodes(
+                    "M6.306 14.691l6.571 4.819C14.655 15.108 18.961 12 24 12c3.059 0 5.842 1.154 7.961 " +
+                        "3.039l5.657-5.657C34.046 6.053 29.268 4 24 4 16.318 4 9.656 8.337 6.306 14.691z",
+                ),
+                fill = SolidColor(Color(0xFFFF3D00)),
+            )
+            addPath(
+                pathData =
+                addPathNodes(
+                    "M24 44c5.166 0 9.86-1.977 13.409-5.192l-6.19-5.238C29.211 35.091 26.715 36 24 36c-5.202 " +
+                        "0-9.619-3.317-11.283-7.946l-6.522 5.025C9.505 39.556 16.227 44 24 44z",
+                ),
+                fill = SolidColor(Color(0xFF4CAF50)),
+            )
+            addPath(
+                pathData =
+                addPathNodes(
+                    "M43.611 20.083H42V20H24v8h11.303c-.792 2.237-2.231 4.166-4.087 " +
+                        "5.571l.003-.002 6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z",
+                ),
+                fill = SolidColor(Color(0xFF1976D2)),
+            )
+        }.build()
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/LoginBenefits.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/LoginBenefits.kt
@@ -1,0 +1,85 @@
+package org.nostr.nostrord.ui.screens.login.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+
+/**
+ * The "why use this" card under a login method's action (web `.bunker-benefits`): an
+ * icon + title header over checked one-liners, on the floating card surface. Shared by
+ * the bunker and Google tabs so the two never drift.
+ */
+@Composable
+fun BenefitsCard(
+    title: String,
+    icon: ImageVector,
+    items: List<String>,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = NostrordShapes.shapeMedium,
+        color = NostrordColors.SurfaceVariant.copy(alpha = 0.5f),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = NostrordColors.Success,
+                    modifier = Modifier.size(18.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = title,
+                    color = NostrordColors.TextPrimary,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(modifier = Modifier.height(10.dp))
+            items.forEach { BenefitItem(it) }
+        }
+    }
+}
+
+/** One checked line. The check tops out with the first text line so wraps stay aligned. */
+@Composable
+private fun BenefitItem(text: String) {
+    Row(
+        modifier = Modifier.padding(vertical = 3.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Icon(
+            imageVector = Icons.Default.CheckCircle,
+            contentDescription = null,
+            tint = NostrordColors.Success.copy(alpha = 0.7f),
+            modifier = Modifier.padding(top = 2.dp).size(14.dp),
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = text,
+            color = NostrordColors.TextSecondary,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/LoginMethodList.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/LoginMethodList.kt
@@ -46,7 +46,7 @@ internal val LoginMethod.icon: ImageVector
             LoginMethod.PrivateKey -> Icons.Default.Key
             LoginMethod.Bunker -> Icons.Default.Shield
             LoginMethod.Extension -> Icons.Default.Extension
-            LoginMethod.Amber -> Icons.Default.PhoneAndroid
+            LoginMethod.Signer -> Icons.Default.PhoneAndroid
             LoginMethod.Google -> GoogleGlyph
         }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/LoginMethodList.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/LoginMethodList.kt
@@ -1,0 +1,154 @@
+package org.nostr.nostrord.ui.screens.login.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.PhoneAndroid
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.times
+import org.nostr.nostrord.ui.screens.login.LoginMethod
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+
+/** Platform icon for a shared [LoginMethod]. */
+internal val LoginMethod.icon: ImageVector
+    get() =
+        when (this) {
+            LoginMethod.PrivateKey -> Icons.Default.Key
+            LoginMethod.Bunker -> Icons.Default.Shield
+            LoginMethod.Extension -> Icons.Default.Extension
+            LoginMethod.Amber -> Icons.Default.PhoneAndroid
+            LoginMethod.Google -> GoogleGlyph
+        }
+
+/**
+ * Row metrics. The web reference row is 36px of icon in ~384px of card, so the same
+ * absolute sizes on a phone (~330dp of card) read as a zoomed-in list. [forWidth] keeps
+ * the icon-to-row ratio instead of the raw dp.
+ */
+private data class RowMetrics(
+    val icon: Dp,
+    val glyph: Dp,
+    val pad: Dp,
+    val gap: Dp,
+    val title: TextUnit,
+    val subtitle: TextUnit,
+    val chevron: Dp,
+) {
+    companion object {
+        fun forWidth(width: Dp): RowMetrics = if (width < 340.dp) {
+            RowMetrics(32.dp, 16.dp, 10.dp, 6.dp, 14.sp, 11.sp, 18.dp)
+        } else {
+            RowMetrics(36.dp, 18.dp, 12.dp, 8.dp, 15.sp, 12.sp, 20.dp)
+        }
+    }
+}
+
+/**
+ * The credential picker as full-width rows (icon, name, one-line explainer, chevron).
+ * Rows wrap their label, so the list stays readable for any number of methods, unlike
+ * the equal-weight segmented strip it replaces.
+ */
+@Composable
+fun LoginMethodList(
+    methods: List<LoginMethod>,
+    onSelect: (LoginMethod) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val metrics = RowMetrics.forWidth(maxWidth)
+        Column(verticalArrangement = Arrangement.spacedBy(metrics.gap)) {
+            methods.forEach { method ->
+                LoginMethodRow(method = method, metrics = metrics, onClick = { onSelect(method) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoginMethodRow(
+    method: LoginMethod,
+    metrics: RowMetrics,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            .clip(NostrordShapes.shapeMedium)
+            .background(NostrordColors.BackgroundFloating)
+            .border(1.dp, NostrordColors.Divider, NostrordShapes.shapeMedium)
+            .clickable(onClick = onClick)
+            .pointerHoverIcon(PointerIcon.Hand)
+            .padding(metrics.pad),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier =
+            Modifier
+                .size(metrics.icon)
+                .clip(NostrordShapes.shapeSmall)
+                .background(NostrordColors.PrimarySubtle),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = method.icon,
+                contentDescription = null,
+                tint = NostrordColors.Primary,
+                modifier = Modifier.size(metrics.glyph),
+            )
+        }
+        Spacer(modifier = Modifier.width(metrics.pad))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = method.title,
+                color = NostrordColors.TextPrimary,
+                fontSize = metrics.title,
+                lineHeight = metrics.title * 1.3f,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = method.subtitle,
+                color = NostrordColors.TextMuted,
+                fontSize = metrics.subtitle,
+                lineHeight = metrics.subtitle * 1.3f,
+            )
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = NostrordColors.TextMuted,
+            modifier = Modifier.size(metrics.chevron),
+        )
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/PrivateKeyLoginTab.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/PrivateKeyLoginTab.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Login
-import androidx.compose.material.icons.filled.AutoAwesome
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Info
@@ -51,12 +50,17 @@ import org.nostr.nostrord.utils.rememberClipboardWriter
  *  - a plain hex/nsec offers "Protect with password", which stores the key
  *    encrypted (ncryptsec) on this device — the unlock dialog asks the password
  *    at the next startup;
- *  - "Generate New Key" runs the two-step wizard: backup the npub/nsec, then an
- *    optional password with the same protected-storage semantics.
+ *  - [startInWizard] opens straight on the generate wizard (backup the npub/nsec, then
+ *    an optional password with the same protected-storage semantics), entered from the
+ *    "Generate New Key" action on the method list.
  * Key parsing, generation and encryption live in [LoginViewModel].
  */
 @Composable
-fun PrivateKeyLoginTab(onLoginSuccess: () -> Unit) {
+fun PrivateKeyLoginTab(
+    onLoginSuccess: () -> Unit,
+    startInWizard: Boolean = false,
+    onBack: () -> Unit = {},
+) {
     val vm = viewModel { LoginViewModel(AppModule.nostrRepository) }
 
     // Form state
@@ -72,8 +76,8 @@ fun PrivateKeyLoginTab(onLoginSuccess: () -> Unit) {
     var protectConfirm by remember { mutableStateOf("") }
 
     // Generate wizard: 0 = form, 1 = backup step, 2 = password step
-    var wizardStep by remember { mutableStateOf(0) }
-    var wizardKey by remember { mutableStateOf("") }
+    var wizardStep by remember { mutableStateOf(if (startInWizard) 1 else 0) }
+    var wizardKey by remember { mutableStateOf(if (startInWizard) vm.generateNewKeyHex() else "") }
     var wizardPwd by remember { mutableStateOf("") }
     var wizardConfirm by remember { mutableStateOf("") }
 
@@ -190,7 +194,9 @@ fun PrivateKeyLoginTab(onLoginSuccess: () -> Unit) {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                         AppButton(
                             text = "Back",
-                            onClick = { wizardStep = 0 },
+                            // Entered from the method list: there is no key form behind
+                            // this step, so back leaves the private-key flow entirely.
+                            onClick = { if (startInWizard) onBack() else wizardStep = 0 },
                             variant = AppButtonVariant.Ghost,
                         )
                         AppButton(
@@ -466,40 +472,6 @@ fun PrivateKeyLoginTab(onLoginSuccess: () -> Unit) {
                     fullWidth = true,
                     loading = isLoading,
                     icon = Icons.AutoMirrored.Filled.Login,
-                )
-
-                // Divider
-                Row(
-                    modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 20.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    HorizontalDivider(modifier = Modifier.weight(1f), color = NostrordColors.Divider)
-                    Text(
-                        text = "or",
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        color = NostrordColors.TextMuted,
-                        style = MaterialTheme.typography.bodySmall,
-                    )
-                    HorizontalDivider(modifier = Modifier.weight(1f), color = NostrordColors.Divider)
-                }
-
-                AppButton(
-                    text = "Generate New Key",
-                    onClick = {
-                        errorMessage = null
-                        wizardKey = vm.generateNewKeyHex()
-                        wizardPwd = ""
-                        wizardConfirm = ""
-                        wizardStep = 1
-                    },
-                    enabled = !isLoading,
-                    variant = AppButtonVariant.Secondary,
-                    size = AppButtonSize.Large,
-                    fullWidth = true,
-                    icon = Icons.Default.AutoAwesome,
                 )
             }
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/SignerLoginTab.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/SignerLoginTab.kt
@@ -16,9 +16,12 @@ import org.nostr.nostrord.ui.components.buttons.AppButtonSize
 import org.nostr.nostrord.ui.screens.login.LoginViewModel
 import org.nostr.nostrord.ui.theme.NostrordColors
 
-/** NIP-55 external signer login (Amber). Only reachable on Android with a signer installed. */
+/**
+ * NIP-55 external signer login. Works with any app registering the nostrsigner: scheme
+ * (Amber being the common one); only reachable on Android with a signer installed.
+ */
 @Composable
-fun AmberLoginTab(onLoginSuccess: () -> Unit) {
+fun SignerLoginTab(onLoginSuccess: () -> Unit) {
     val vm = viewModel { LoginViewModel(AppModule.nostrRepository) }
     var isLoading by remember { mutableStateOf(false) }
     var errorMessage by remember { mutableStateOf<String?>(null) }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/KeyLoginForm.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/KeyLoginForm.kt
@@ -5,7 +5,6 @@ import org.nostr.nostrord.ui.screens.login.LoginViewModel
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.copyToClipboard
-import org.nostr.nostrord.web.components.formDivider
 import org.nostr.nostrord.web.components.formError
 import org.nostr.nostrord.web.components.formHint
 import org.nostr.nostrord.web.components.formLabel
@@ -35,6 +34,12 @@ external interface KeyLoginFormProps : Props {
     var submitLabel: String
     var busyLabel: String
 
+    /** Open straight on the generate wizard (entered from "Generate New Key"). */
+    var startInWizard: Boolean
+
+    /** Leave the private-key flow; the wizard's first step has no form behind it. */
+    var onBack: () -> Unit
+
     /** Run the actual login: (input, ncryptsec password or null, isNewIdentity). */
     var onSubmit: (String, String?, Boolean) -> Unit
 
@@ -52,14 +57,16 @@ external interface KeyLoginFormProps : Props {
  *  - pasting an ncryptsec reveals the key-password field;
  *  - a plain hex/nsec offers "Protect with password", which stores the key encrypted
  *    (ncryptsec) on this device — the unlock dialog asks the password at startup;
- *  - "Generate New Key" runs the two-step wizard (backup npub/nsec, then optional
- *    password with the same protected-storage semantics).
+ *  - `startInWizard` opens straight on the two-step generate wizard (backup npub/nsec,
+ *    then optional password with the same protected-storage semantics), entered from the
+ *    "Generate New Key" action on the method list.
  * Mirrors the Compose PrivateKeyLoginTab; logic lives in the shared LoginViewModel.
  */
 val KeyLoginForm =
     FC<KeyLoginFormProps> { props ->
         val vm = props.vm
         val busy = props.busy
+        val startInWizard = props.startInWizard
 
         val (privateKey, setPrivateKey) = useState { "" }
         val (keyPassword, setKeyPassword) = useState { "" }
@@ -72,8 +79,8 @@ val KeyLoginForm =
         val (protectConfirm, setProtectConfirm) = useState { "" }
 
         // Generate wizard: 0 = form, 1 = backup step, 2 = password step
-        val (wizardStep, setWizardStep) = useState { 0 }
-        val (wizardKey, setWizardKey) = useState { "" }
+        val (wizardStep, setWizardStep) = useState { if (startInWizard) 1 else 0 }
+        val (wizardKey, setWizardKey) = useState { if (startInWizard) vm.generateNewKeyHex() else "" }
         val (wizardPwd, setWizardPwd) = useState { "" }
         val (wizardConfirm, setWizardConfirm) = useState { "" }
 
@@ -147,7 +154,9 @@ val KeyLoginForm =
                         className = ClassName("wizard-actions")
                         button {
                             className = ClassName("btn-ghost")
-                            onClick = { setWizardStep(0) }
+                            // Entered from the method list: there is no key form behind
+                            // this step, so back leaves the private-key flow entirely.
+                            onClick = { if (startInWizard) props.onBack() else setWizardStep(0) }
                             +"Back"
                         }
                         button {
@@ -331,20 +340,6 @@ val KeyLoginForm =
                         icon(Ic.Login)
                     }
                     +(if (busy) props.busyLabel else props.submitLabel)
-                }
-                formDivider()
-                button {
-                    className = ClassName("btn-secondary btn-lg btn-full")
-                    disabled = busy
-                    onClick = {
-                        clearError()
-                        setWizardKey(vm.generateNewKeyHex())
-                        setWizardPwd("")
-                        setWizardConfirm("")
-                        setWizardStep(1)
-                    }
-                    icon(Ic.AutoAwesome)
-                    +"Generate New Key"
                 }
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginMethods.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginMethods.kt
@@ -4,11 +4,13 @@ import org.nostr.nostrord.auth.pomegranate.PomegranateConfig
 import org.nostr.nostrord.auth.pomegranate.PomegranatePopupClosedException
 import org.nostr.nostrord.auth.pomegranate.PomegranateStatus
 import org.nostr.nostrord.di.AppModule
-import org.nostr.nostrord.nostr.Nip07
+import org.nostr.nostrord.ui.screens.login.LoginMethod
 import org.nostr.nostrord.ui.screens.login.LoginViewModel
+import org.nostr.nostrord.ui.screens.login.availableLoginMethods
 import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.GoogleLogo
 import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.formDivider
 import org.nostr.nostrord.web.components.formError
 import org.nostr.nostrord.web.components.formHint
 import org.nostr.nostrord.web.components.icon
@@ -26,9 +28,48 @@ import web.cssom.ClassName
 import web.html.InputType
 import web.html.text
 
-private enum class Tab { Key, Bunker, Extension, Google }
-
 private enum class BunkerMode { Qr, Url }
+
+/** Sprite icon for a shared [LoginMethod] (Amber never reaches the web build). */
+private val LoginMethod.ic: Ic
+    get() =
+        when (this) {
+            LoginMethod.PrivateKey -> Ic.Key
+            LoginMethod.Bunker -> Ic.Shield
+            LoginMethod.Extension -> Ic.Extension
+            LoginMethod.Amber -> Ic.Shield
+            LoginMethod.Google -> Ic.Google
+        }
+
+/** One full-width row of the method list: icon, name, one-line explainer, chevron. */
+private fun ChildrenBuilder.methodRow(
+    method: LoginMethod,
+    onClick: () -> Unit,
+) {
+    button {
+        className = ClassName("login-method")
+        this.onClick = { onClick() }
+        span {
+            className = ClassName("login-method-icon")
+            icon(method.ic)
+        }
+        span {
+            className = ClassName("login-method-text")
+            span {
+                className = ClassName("login-method-title")
+                +method.title
+            }
+            span {
+                className = ClassName("login-method-sub")
+                +method.subtitle
+            }
+        }
+        span {
+            className = ClassName("login-method-chevron")
+            icon(Ic.ChevronRight)
+        }
+    }
+}
 
 private fun ChildrenBuilder.benefit(text: String) {
     div {
@@ -57,17 +98,22 @@ external interface LoginMethodsProps : Props {
 }
 
 /**
- * The tabbed credential picker shared by the login page and the add-account modal:
- * Private Key (hex / nsec / generate), Bunker (NIP-46 QR or URL) and the NIP-07 browser
- * extension. Owns the tab + busy + error state and reuses [KeyLoginForm] / [BunkerQr] so
- * the two entry points stay identical. Login and add-account call the same LoginViewModel
- * methods; the difference is only [onSuccess].
+ * The credential picker shared by the login page and the add-account modal: a list of the
+ * available [LoginMethod]s, then the chosen method's form behind a back header. "Generate
+ * New Key" sits at the list level because creating an identity is a separate path from
+ * presenting one. Owns the method + busy + error state and reuses [KeyLoginForm] /
+ * [BunkerQr] so the two entry points stay identical. Login and add-account call the same
+ * LoginViewModel methods; the difference is only [onSuccess]. Mirrors the Compose
+ * LoginMethods.
  */
 val LoginMethods =
     FC<LoginMethodsProps> { props ->
         val vm = useViewModel { LoginViewModel(AppModule.nostrRepository) }
-        val extensionAvailable = Nip07.isAvailable()
-        val (tab, setTab) = useState { Tab.Key }
+        val methods = availableLoginMethods()
+        // null shows the method list; a value shows that method's form
+        val (method, setMethod) = useState<LoginMethod?> { null }
+        // Entered through "Generate New Key": the private key form opens on the wizard
+        val (generating, setGenerating) = useState { false }
         val (bunkerMode, setBunkerMode) = useState { BunkerMode.Qr }
         val (bunkerUrl, setBunkerUrl) = useState { "" }
         val (busy, setBusy) = useState { false }
@@ -88,26 +134,50 @@ val LoginMethods =
             }
         }
 
-        div {
-            className = ClassName("tab-strip")
-            tabItem(tab == Tab.Key, Ic.Key, "Private Key") { setTab(Tab.Key) }
-            tabItem(tab == Tab.Bunker, Ic.Shield, "Bunker") { setTab(Tab.Bunker) }
-            if (extensionAvailable) {
-                tabItem(tab == Tab.Extension, Ic.Extension, "Extension") { setTab(Tab.Extension) }
+        if (method == null) {
+            div {
+                className = ClassName("login-method-list")
+                methods.forEach { m ->
+                    methodRow(m) {
+                        setGenerating(false)
+                        setMethod(m)
+                    }
+                }
             }
-            if (vm.isGoogleLoginAvailable) {
-                tabItem(tab == Tab.Google, Ic.Google, "Google") { setTab(Tab.Google) }
+            formDivider()
+            button {
+                className = ClassName("btn-secondary btn-lg btn-full")
+                onClick = {
+                    setGenerating(true)
+                    setMethod(LoginMethod.PrivateKey)
+                }
+                icon(Ic.AutoAwesome)
+                +"Generate New Key"
             }
+            return@FC
+        }
+
+        button {
+            className = ClassName("login-back")
+            onClick = {
+                setError(null)
+                setMethod(null)
+            }
+            icon(Ic.ArrowBack)
+            icon(method.ic)
+            span { +method.title }
         }
 
         div {
             className = ClassName("login-tab-content")
             formError(error)
-            when (tab) {
-                Tab.Key -> {
+            when (method) {
+                LoginMethod.PrivateKey -> {
                     KeyLoginForm {
                         this.vm = vm
                         this.busy = busy
+                        this.startInWizard = generating
+                        onBack = { setMethod(null) }
                         submitLabel = props.submitLabel
                         busyLabel = props.busyLabel
                         onSubmit = { input, password, isNewIdentity ->
@@ -133,7 +203,7 @@ val LoginMethods =
                     }
                 }
 
-                Tab.Bunker -> {
+                LoginMethod.Bunker -> {
                     div {
                         className = ClassName("bunker-desc")
                         icon(Ic.Shield)
@@ -189,7 +259,7 @@ val LoginMethods =
                     }
                 }
 
-                Tab.Extension -> {
+                LoginMethod.Extension -> {
                     div {
                         className = ClassName("ext-content")
                         span {
@@ -218,7 +288,7 @@ val LoginMethods =
 
                 // "Login with Google" (pomegranate threshold signer), web-only.
                 // The whole flow runs in the VM; this tab only reflects its status.
-                Tab.Google -> {
+                LoginMethod.Google -> {
                     div {
                         className = ClassName("ext-content")
                         span {
@@ -317,6 +387,9 @@ val LoginMethods =
                         }
                     }
                 }
+
+                // Android-only; availableLoginMethods() never offers it on the web.
+                LoginMethod.Amber -> {}
             }
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginMethods.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginMethods.kt
@@ -30,14 +30,14 @@ import web.html.text
 
 private enum class BunkerMode { Qr, Url }
 
-/** Sprite icon for a shared [LoginMethod] (Amber never reaches the web build). */
+/** Sprite icon for a shared [LoginMethod] (the signer app never reaches the web build). */
 private val LoginMethod.ic: Ic
     get() =
         when (this) {
             LoginMethod.PrivateKey -> Ic.Key
             LoginMethod.Bunker -> Ic.Shield
             LoginMethod.Extension -> Ic.Extension
-            LoginMethod.Amber -> Ic.Shield
+            LoginMethod.Signer -> Ic.Shield
             LoginMethod.Google -> Ic.Google
         }
 
@@ -389,7 +389,7 @@ val LoginMethods =
                 }
 
                 // Android-only; availableLoginMethods() never offers it on the web.
-                LoginMethod.Amber -> {}
+                LoginMethod.Signer -> {}
             }
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginScreen.kt
@@ -1,6 +1,5 @@
 package org.nostr.nostrord.web.screens
 
-import org.nostr.nostrord.nostr.Nip07
 import react.FC
 import react.Props
 import react.dom.html.ReactHTML.div
@@ -10,21 +9,19 @@ import react.dom.html.ReactHTML.p
 import web.cssom.ClassName
 
 /**
- * Login screen — the brand header plus the shared [LoginMethods] tab picker (private key +
+ * Login screen — the brand header plus the shared [LoginMethods] picker (private key +
  * generate, NIP-46 bunker QR/URL, NIP-07 extension). A successful login flips
  * repo.isLoggedIn and the auth gate swaps to the shell, so onSuccess is a no-op here.
  */
 val LoginScreen =
     FC<Props> {
-        val extensionAvailable = Nip07.isAvailable()
-
         div {
             className = ClassName("login-page")
             div {
                 className = ClassName("login-inner")
 
                 div {
-                    className = ClassName(if (extensionAvailable) "login-card wide" else "login-card")
+                    className = ClassName("login-card")
 
                     // Header lives inside the card (prototype layout): logo on the
                     // brand tile, app name, tagline.

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -301,10 +301,6 @@ body {
     box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
 }
 
-.login-card.wide {
-    max-width: 500px;
-}
-
 .tab-strip,
 .bunker-toggle {
     display: flex;
@@ -351,7 +347,110 @@ body {
 }
 
 .login-tab-content {
-    margin-top: 24px;
+    margin-top: 20px;
+}
+
+/* Credential picker: one full-width row per login method, so the label never has to
+   compete for width the way an equal-weight tab strip does. */
+.login-method-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.login-method {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    padding: 12px;
+    border: 1px solid var(--color-divider);
+    border-radius: 10px;
+    background: var(--color-floating);
+    text-align: left;
+    cursor: pointer;
+    transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.login-method:hover {
+    background: var(--color-hover);
+    border-color: var(--color-primary);
+}
+
+.login-method-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 36px;
+    height: 36px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--color-primary) 10%, transparent);
+    color: var(--color-primary);
+}
+
+.login-method-icon svg {
+    width: 18px;
+    height: 18px;
+}
+
+.login-method-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    flex: 1;
+    min-width: 0;
+}
+
+.login-method-title {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+}
+
+.login-method-sub {
+    font-size: 12px;
+    color: var(--color-text-muted);
+}
+
+.login-method-chevron {
+    display: flex;
+    color: var(--color-text-muted);
+}
+
+.login-method-chevron svg {
+    width: 20px;
+    height: 20px;
+}
+
+/* Back to the method list, above the chosen method's form. */
+.login-back {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px;
+    border: 0;
+    border-radius: 8px;
+    background: transparent;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    cursor: pointer;
+}
+
+.login-back:hover {
+    background: var(--color-hover);
+}
+
+.login-back svg {
+    width: 18px;
+    height: 18px;
+    color: var(--color-text-muted);
+}
+
+.login-back svg:nth-of-type(2) {
+    width: 16px;
+    height: 16px;
+    color: var(--color-primary);
 }
 
 /* Prototype field label: small uppercase bold, above the input. */


### PR DESCRIPTION
Adds NIP-55 external signer login on Android and reworks the credential picker that it broke.

`AuthMethod.AMBER` rides the existing `NostrSigner` abstraction: an expect `Nip55` object (real on Android, documented stubs elsewhere) talks to the signer ContentResolver-first, so pre-authorized operations like NIP-42 AUTH sign silently, and falls back to the `nostrsigner:` Intent bridged into suspend land by an activity-result launcher serialized under a mutex. Login requests the app's kind set upfront so background signing works from the first session; the signer package is persisted per account and wiped with the account. Discovery is by scheme, not by package, so any NIP-55 signer works and the UI labels the protocol rather than naming Amber.

The signer made the login picker a fourth tab, and an equal-weight segmented control truncated every label on a phone ("Privat", "Bunke", "Ambe", "Googl"). Since the method set is dynamic, widening the card only defers the problem, so the picker is now a list of full-width rows that opens the chosen method's form behind a back header. "Generate New Key" moves up to the list level, since creating an identity is a separate path from presenting one.

Device testing the login flow also surfaced an unrelated process kill: `DmManager` kept its wrap/rumor/seen-on collections as plain `LinkedHashMap`/`HashSet`, written by the relay coroutines while the debounced persist snapshots them from its own. Both run on `Dispatchers.Default`, so the overlap threw `ConcurrentModificationException` out of a coroutine with no handler. Logins reproduce it on demand because the arrival flood is the widest window in the app. The collections are now immutable values swapped atomically.

| Area | Change |
|---|---|
| `nostr/Nip55.kt` | expect object; Android actual is ContentResolver-first with `nostrsigner:` Intent fallback |
| `auth/NostrSigner.kt` | `Amber` signer variant; package persisted per account |
| `network/AuthManager.kt` | NIP-42 AUTH signs through the signer without a UI round trip |
| `ui/screens/login/LoginMethod.kt` | shared titles, subtitles and availability, replacing two parallel enums |
| `LoginMethodList.kt` / web `.login-method` | row picker; metrics scale with the measured card width so a ~330dp phone card does not read as a zoomed-in list |
| `LoginMethods.kt` | `PlatformBackHandler` returns to the list instead of letting back exit the app |
| `LoginBenefits.kt` | `BenefitsCard` extracted from `BunkerLoginTab`, now shared with the Google tab |
| `GoogleLogoIcon.kt` | Google mark ported from the web SVG, mono glyph for rows and multicolor for the tab header |
| `network/managers/DmManager.kt` | seen-on maps and the dedup set become atomically swapped immutable values |

Web keeps parity throughout: same `LoginMethod` list, same row structure in React/DOM, `.login-card.wide` dropped along with the tab strip it existed for.

- `feat(android): NIP-55 external signer login (Amber)`
- `feat(login): replace the tab strip with a method list`
- `fix(login): name the signer by protocol and honour system back`
- `fix(dm): stop the seen-on maps crashing the process`

The DM fix has a JVM-only regression test (it needs real parallelism); it fails with a `ConcurrentModificationException` against the previous implementation. Amber login validated on device. The new picker still needs a pass on a phone and on desktop.