### PR TITLE
Google login: back up the key before the account exists, and confirm the disconnect

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.android.kt
@@ -1,0 +1,71 @@
+package org.nostr.nostrord.utils
+
+import android.content.ContentValues
+import android.content.Context
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+actual val supportsTextFileSave: Boolean = true
+
+@Composable
+actual fun rememberTextFileSaver(): suspend (content: String, fileName: String) -> Boolean {
+    val context = LocalContext.current.applicationContext
+    return { content, fileName ->
+        val target = withContext(Dispatchers.IO) { saveText(context, content, fileName) }
+        withContext(Dispatchers.Main) {
+            Toast.makeText(
+                context,
+                target?.let { "Saved to $it" } ?: "Couldn't save the file",
+                Toast.LENGTH_SHORT,
+            ).show()
+        }
+        target != null
+    }
+}
+
+/**
+ * On API 29+ inserts into MediaStore Downloads/Nostrord (no permission needed under scoped
+ * storage). Below that writes to the app-specific external Downloads dir, which is also
+ * permission-free but only reachable through a file manager that shows app storage.
+ * Returns the location shown to the user, or null when the write failed.
+ */
+private fun saveText(
+    context: Context,
+    content: String,
+    fileName: String,
+): String? = try {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val resolver = context.contentResolver
+        val values =
+            ContentValues().apply {
+                put(MediaStore.Downloads.DISPLAY_NAME, fileName)
+                put(MediaStore.Downloads.MIME_TYPE, "text/plain")
+                put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS + "/Nostrord")
+                put(MediaStore.Downloads.IS_PENDING, 1)
+            }
+        val uri = resolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+        if (uri == null) {
+            null
+        } else {
+            resolver.openOutputStream(uri)?.use { it.write(content.encodeToByteArray()) }
+            values.clear()
+            values.put(MediaStore.Downloads.IS_PENDING, 0)
+            resolver.update(uri, values, null, null)
+            "Downloads/Nostrord"
+        }
+    } else {
+        val dir = context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS) ?: return null
+        val target = File(dir, fileName)
+        target.writeText(content)
+        target.absolutePath
+    }
+} catch (_: Exception) {
+    null
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/Pomegranate.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/Pomegranate.kt
@@ -16,7 +16,11 @@ object PomegranateConfig {
     /** Central coordinator: verifies the Google sign-in and relays NIP-46 signing to the operators. */
     const val CENTRAL_URL = "https://auth.njump.me"
 
-    /** Recommended shard operators (public promenade infra, mirrors Jumble's defaults). */
+    /**
+     * Recommended shard operators (the public promenade instances). Any of them can be
+     * offline at a given moment, so the setup step probes them and registration tolerates
+     * the ones that fail.
+     */
     val OPERATOR_URLS =
         listOf(
             "https://po.jumble.social",
@@ -26,11 +30,42 @@ object PomegranateConfig {
             "https://po.nostrver.se",
         )
 
+    /** With one operator the whole key would sit on a single server, so two is the floor. */
+    const val MIN_OPERATORS = 2
+
     /**
      * ceil(n * 7/12): a little over half, so signing tolerates a few operators being
      * offline while no small subset can sign on its own.
      */
     fun defaultThreshold(operatorCount: Int): Int = (operatorCount * 7 + 11) / 12
+}
+
+/**
+ * What a new account is created with, chosen by the user in the setup step: the key they
+ * just backed up, the operators that hold its shards, and how many must sign.
+ */
+data class PomegranateAccountConfig(
+    val operators: List<String>,
+    val threshold: Int,
+    val privateKeyHex: String,
+)
+
+/** Host of an operator URL, for display (`https://po.f7z.io` -> `po.f7z.io`). */
+fun pomegranateOperatorLabel(url: String): String = url.trim().trimEnd('/').substringAfter("://")
+
+/** Normalized operator origin, or null when [raw] is not a usable URL. */
+fun pomegranateOperatorUrlOrNull(raw: String): String? {
+    val trimmed = raw.trim()
+    if (trimmed.isEmpty() || trimmed.any { it.isWhitespace() }) return null
+    val origin =
+        try {
+            normalizePomegranateOrigin(trimmed)
+        } catch (_: Exception) {
+            return null
+        }
+    val host = origin.substringAfter("://").substringBefore(':')
+    val validHost = host == "localhost" || (host.contains('.') && !host.startsWith('.') && !host.endsWith('.'))
+    return origin.takeIf { validHost }
 }
 
 /** Google auth token minted by the central server's popup; the server honors it for 24h. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateService.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateService.kt
@@ -5,6 +5,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -13,9 +14,12 @@ import io.ktor.http.contentType
 import io.ktor.http.encodeURLParameter
 import io.ktor.http.isSuccess
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
@@ -62,6 +66,13 @@ class PomegranateService {
         val central: String,
     )
 
+    /** One operator's reachability, with the transport failure when it is down. */
+    data class OperatorHealth(
+        val url: String,
+        val reachable: Boolean,
+        val detail: String?,
+    )
+
     data class Recovery(
         val token: GoogleToken,
         val account: PomegranateAccount,
@@ -69,8 +80,8 @@ class PomegranateService {
 
     /**
      * First half of the login: Google popup + account existence check. When an account
-     * exists its operators/threshold are fixed server-side; otherwise [finishLogin]
-     * creates one with the default config.
+     * exists its operators/threshold are fixed server-side; otherwise the UI runs its
+     * setup step and passes the chosen config to [finishLogin].
      */
     suspend fun startLogin(
         centralUrl: String = PomegranateConfig.CENTRAL_URL,
@@ -84,17 +95,19 @@ class PomegranateService {
     }
 
     /**
-     * Second half: creates the account when needed (key sharded across the default
-     * operators), ensures a signing profile, and returns the bunker URL to log in with
-     * plus the central origin to persist on the account. Opens no popup.
+     * Second half: creates the account when needed (key sharded across [config]'s
+     * operators, or the defaults when the caller has no setup step), ensures a signing
+     * profile, and returns the bunker URL to log in with plus the central origin to
+     * persist on the account. Opens no popup.
      */
     suspend fun finishLogin(
         started: StartedLogin,
+        config: PomegranateAccountConfig? = null,
         onStatus: (PomegranateStatus) -> Unit,
     ): LoginOutcome {
         if (!started.hasAccount) {
             onStatus(PomegranateStatus.Creating)
-            createAccount(started.central, started.token)
+            createAccount(started.central, started.token, config)
         }
         var profiles = listProfiles(started.central, started.token)
         if (profiles.isEmpty()) {
@@ -120,6 +133,43 @@ class PomegranateService {
         if (account.pubkey != expectedPubkey) throw PomegranatePubkeyMismatchException()
         return Recovery(token, account)
     }
+
+    /**
+     * Probes each operator's registration endpoint with an empty body: a live one answers
+     * (rejecting the unsigned payload), a dead host fails to connect or times out. Run
+     * before creating an account so an operator that is down is named up front instead of
+     * surfacing as a half-finished registration.
+     */
+    suspend fun checkOperators(urls: List<String>): List<OperatorHealth> = coroutineScope {
+        urls
+            .map { url ->
+                async {
+                    val origin = runCatching { normalizePomegranateOrigin(url) }.getOrNull()
+                    if (origin == null) {
+                        OperatorHealth(url, reachable = false, detail = "Invalid URL")
+                    } else {
+                        probeOperator(url, origin)
+                    }
+                }
+            }.awaitAll()
+    }
+
+    private suspend fun probeOperator(
+        url: String,
+        origin: String,
+    ): OperatorHealth = withTimeoutOrNull(OPERATOR_PROBE_TIMEOUT_MS) {
+        try {
+            http.post("$origin/po/register") {
+                contentType(ContentType.Application.Json)
+                setBody("{}")
+            }
+            OperatorHealth(url, reachable = true, detail = null)
+        } catch (c: CancellationException) {
+            throw c
+        } catch (t: Throwable) {
+            OperatorHealth(url, reachable = false, detail = t.message?.take(120) ?: "No response")
+        }
+    } ?: OperatorHealth(url, reachable = false, detail = "Timed out")
 
     /** Recovers one shard via the operator's Google recovery popup. User gesture required. */
     suspend fun recoverShard(operator: PomegranateOperator): String {
@@ -186,37 +236,46 @@ class PomegranateService {
     }
 
     /**
-     * Creates a new account: generates a key, shards it via the trusted dealer, and
-     * registers with the central server (kind 20445) and every operator (kind 20444).
-     * The key only signs these registration events and is then dropped — it never
-     * exists whole anywhere afterwards.
+     * Creates a new account: shards [config]'s key (a fresh one when absent) via the
+     * trusted dealer and registers with the central server (kind 20445) and every
+     * operator (kind 20444). The key signs only these registration events here and is
+     * then dropped — afterwards it exists whole only in the backup the user saved.
      */
     @OptIn(ExperimentalUuidApi::class)
     private suspend fun createAccount(
         central: String,
         token: GoogleToken,
+        config: PomegranateAccountConfig?,
     ) {
-        val operators = PomegranateConfig.OPERATOR_URLS.map { normalizePomegranateOrigin(it) }
-        check(operators.size >= 2) { "At least 2 operators are required" }
-        val threshold = PomegranateConfig.defaultThreshold(operators.size)
+        val operators = (config?.operators ?: PomegranateConfig.OPERATOR_URLS).map { normalizePomegranateOrigin(it) }
+        check(operators.size >= PomegranateConfig.MIN_OPERATORS) {
+            "At least ${PomegranateConfig.MIN_OPERATORS} operators are required"
+        }
+        val threshold = config?.threshold ?: PomegranateConfig.defaultThreshold(operators.size)
         check(threshold in 1..operators.size) { "Invalid signing threshold" }
         val session = Uuid.random().toString()
 
-        val keyPair = KeyPair.generate()
-        val shards = PomegranateDealer.deal(keyPair.privateKeyHex, threshold, operators.size)
-
-        val regEvent =
-            Event(
-                pubkey = keyPair.publicKeyHex,
-                createdAt = epochSeconds(),
-                kind = KIND_ACCOUNT_REGISTRATION,
-                tags =
-                buildList {
-                    add(listOf("threshold", threshold.toString()))
-                    operators.forEachIndexed { i, op -> add(listOf("operator", op, shards[i].pubShardHex)) }
-                },
-                content = "",
-            ).sign(keyPair)
+        // Key derivation, the trusted dealer and every signature are CPU-bound and none of
+        // them suspend: left on the caller's dispatcher they run on the Android main thread,
+        // which froze the app long enough for a second tap to start a second registration.
+        val (keyPair, shards, regEvent) =
+            withContext(Dispatchers.Default) {
+                val pair = config?.privateKeyHex?.let { KeyPair.fromPrivateKeyHex(it) } ?: KeyPair.generate()
+                val dealt = PomegranateDealer.deal(pair.privateKeyHex, threshold, operators.size)
+                val event =
+                    Event(
+                        pubkey = pair.publicKeyHex,
+                        createdAt = epochSeconds(),
+                        kind = KIND_ACCOUNT_REGISTRATION,
+                        tags =
+                        buildList {
+                            add(listOf("threshold", threshold.toString()))
+                            operators.forEachIndexed { i, op -> add(listOf("operator", op, dealt[i].pubShardHex)) }
+                        },
+                        content = "",
+                    ).sign(pair)
+                Triple(pair, dealt, event)
+            }
         val regRes =
             http.post("$central/register") {
                 contentType(ContentType.Application.Json)
@@ -224,41 +283,67 @@ class PomegranateService {
                 header("X-Pomegranate-Session", session)
                 setBody(regEvent.toJsonString())
             }
-        if (regRes.status.value != 200) throw Exception("Central server registration failed")
+        // Carry the server's own words: "registration failed" alone left a re-register
+        // after a disconnect undiagnosable.
+        if (regRes.status == HttpStatusCode.Conflict) {
+            throw Exception(
+                "The central server is already registering an account for this Google login. " +
+                    "Wait a few seconds and try again.",
+            )
+        }
+        if (regRes.status.value != 200) {
+            throw Exception("Central server registration failed (${regRes.status.value}): ${regRes.errorDetail()}")
+        }
 
-        // Operators in parallel; a few may fail — the account works as long as at
-        // least `threshold` of them hold their shard.
-        val registered =
+        // Operators in parallel; a few may fail — the account works as long as at least
+        // `threshold` of them hold their shard. Each attempt is time-boxed: an operator
+        // whose host hangs (no TCP reset, no response) would otherwise stall the whole
+        // registration behind awaitAll.
+        val results =
             coroutineScope {
                 operators
                     .mapIndexed { i, operator ->
                         async {
                             val event =
-                                Event(
-                                    pubkey = keyPair.publicKeyHex,
-                                    createdAt = epochSeconds(),
-                                    kind = KIND_OPERATOR_REGISTRATION,
-                                    tags = listOf(listOf("central", central), listOf("email", token.email)),
-                                    content = shards[i].shardHex,
-                                ).sign(keyPair)
-                            try {
-                                http
-                                    .post("$operator/po/register") {
-                                        contentType(ContentType.Application.Json)
-                                        header("X-Pomegranate-Operator-Token", operatorToken(session, operator))
-                                        setBody(event.toJsonString())
-                                    }.status.isSuccess()
-                            } catch (c: CancellationException) {
-                                throw c
-                            } catch (_: Throwable) {
-                                false
-                            }
+                                withContext(Dispatchers.Default) {
+                                    Event(
+                                        pubkey = keyPair.publicKeyHex,
+                                        createdAt = epochSeconds(),
+                                        kind = KIND_OPERATOR_REGISTRATION,
+                                        tags = listOf(listOf("central", central), listOf("email", token.email)),
+                                        content = shards[i].shardHex,
+                                    ).sign(keyPair)
+                                }
+                            val ok =
+                                withTimeoutOrNull(OPERATOR_REGISTER_TIMEOUT_MS) {
+                                    try {
+                                        http
+                                            .post("$operator/po/register") {
+                                                contentType(ContentType.Application.Json)
+                                                header("X-Pomegranate-Operator-Token", operatorToken(session, operator))
+                                                setBody(event.toJsonString())
+                                            }.status.isSuccess()
+                                    } catch (c: CancellationException) {
+                                        throw c
+                                    } catch (_: Throwable) {
+                                        false
+                                    }
+                                } ?: false
+                            operator to ok
                         }
                     }.awaitAll()
-                    .count { it }
             }
+        val registered = results.count { it.second }
         if (registered < threshold) {
-            throw Exception("Could not register with enough operators ($registered/$threshold). Please try again.")
+            // Roll the central registration back. Left in place it would be found by the
+            // next sign-in as an existing account whose key can never reach a signing
+            // quorum, so login would succeed and every signature then fail.
+            runCatching { http.delete("$central/account") { header("Authorization", "Token ${token.raw}") } }
+            val unreachable = results.filterNot { it.second }.joinToString { pomegranateOperatorLabel(it.first) }
+            throw Exception(
+                "Only $registered of $threshold operators accepted a shard, so the account was not created. " +
+                    "Not accepted by: $unreachable. Remove them under Advanced options and try again.",
+            )
         }
     }
 
@@ -288,7 +373,9 @@ class PomegranateService {
                 header("Authorization", "Token ${token.raw}")
                 setBody("""{"name":"$name"}""")
             }
-        if (!res.status.isSuccess()) throw Exception("Signing profile creation failed")
+        if (!res.status.isSuccess()) {
+            throw Exception("Signing profile creation failed (${res.status.value}): ${res.errorDetail()}")
+        }
         val profile =
             try {
                 json.decodeFromString<PomegranateProfile>(res.bodyAsText())
@@ -346,7 +433,20 @@ class PomegranateService {
         const val KIND_ACCOUNT_REGISTRATION = 20445
         const val KIND_OPERATOR_REGISTRATION = 20444
         const val TOKEN_MAX_AGE_MS = 24 * 60 * 60 * 1000L
+
+        /** Per-operator budget for accepting a shard; a dead host must not hold up the rest. */
+        const val OPERATOR_REGISTER_TIMEOUT_MS = 20_000L
+
+        /** Health probes run while the user reads the setup step, so they give up sooner. */
+        const val OPERATOR_PROBE_TIMEOUT_MS = 8_000L
     }
+}
+
+/** The server's error text, trimmed to something a UI line can carry. */
+private suspend fun HttpResponse.errorDetail(): String = try {
+    bodyAsText().trim().take(200).ifBlank { status.description }
+} catch (_: Exception) {
+    status.description
 }
 
 /** Normalizes a central/operator URL to its origin (scheme://host[:port], no path). */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/AuthManager.kt
@@ -199,19 +199,29 @@ class AuthManager(
     }
 
     /**
+     * The client identity to connect [signerPubkey] with: the key an account already
+     * registered with that same signer, so it stays the client the signer approved
+     * (Amber's "always allow"), or null for a fresh one.
+     *
+     * Replaying the retired global key instead is what wedged a re-login: the pomegranate
+     * handler had already dropped that client with the previous session and never answered
+     * its `connect`, leaving the UI on "Connecting..." until the request timed out.
+     */
+    private fun clientKeyForBunker(signerPubkey: String): String? = accountStore.accounts.value
+        .firstOrNull { account ->
+            SecureStorage
+                .getBunkerUrlFor(account.pubkey)
+                ?.let { runCatching { parseBunkerUrl(it).pubkey }.getOrNull() } == signerPubkey
+        }?.let { SecureStorage.getBunkerClientPrivateKeyFor(it.pubkey) }
+
+    /**
      * Login with NIP-46 bunker URL
      * Returns the user's public key on success
      */
     suspend fun loginWithBunker(bunkerUrl: String): String {
         val bunkerInfo = parseBunkerUrl(bunkerUrl)
 
-        val existingClientKey = SecureStorage.getBunkerClientPrivateKey()
-        val newNip46Client =
-            if (existingClientKey != null) {
-                Nip46Client(existingClientKey)
-            } else {
-                Nip46Client(null)
-            }
+        val newNip46Client = Nip46Client(clientKeyForBunker(bunkerInfo.pubkey))
 
         // Set up auth URL callback
         newNip46Client.onAuthUrl = { url ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/backup/BackupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/backup/BackupViewModel.kt
@@ -5,12 +5,15 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.nostr.nostrord.auth.AccountManager
+import org.nostr.nostrord.auth.AccountStore
 import org.nostr.nostrord.auth.AuthMethod
 import org.nostr.nostrord.auth.pomegranate.PomegranateOperator
 import org.nostr.nostrord.auth.pomegranate.PomegranatePopupClosedException
@@ -56,6 +59,7 @@ class BackupViewModel(
     private val cryptoDispatcher: CoroutineDispatcher = Dispatchers.Default,
     private val pomegranate: PomegranateService = PomegranateService(),
     private val accountManager: AccountManager = AppModule.accountManager,
+    private val accountStore: AccountStore = AppModule.accountStore,
 ) : ViewModel() {
     /** npub (default) / nprofile / hex. Empty when signed out. */
     val publicIds: List<Identifier> =
@@ -186,6 +190,62 @@ class BackupViewModel(
         data class Done(val convertedToLocal: Boolean) : PomegranateDisconnect
     }
 
+    /** Callout shown in the disconnect confirmation; [alert] picks the warning styling. */
+    data class DisconnectNotice(
+        val title: String,
+        val body: String,
+        val alert: Boolean,
+    )
+
+    /**
+     * Confirmation copy, keyed on whether the nsec was exported in this session. With the
+     * key in hand the account converts to a local-key login and the user stays signed in;
+     * without it the account can no longer sign, so it is signed out and only its nsec
+     * (recovered elsewhere) can bring it back.
+     */
+    fun pomDisconnectNotice(keyExported: Boolean): DisconnectNotice = if (keyExported) {
+        DisconnectNotice(
+            title = "You stay signed in",
+            body =
+            "You exported this account's private key, so disconnecting only removes the link to the " +
+                "central server: the account keeps working here and signs with that key locally. Keep " +
+                "your backup of the nsec safe, it is the only way to sign in elsewhere.",
+            alert = false,
+        )
+    } else {
+        DisconnectNotice(
+            title = "Keep your private key safe",
+            body =
+            "Disconnecting only removes the link between this account and the central server. Your " +
+                "account still exists, and you can keep using it by logging in with your private key " +
+                "(nsec). Before continuing, export and safely save your nsec using the \"Export private " +
+                "key\" option: without it here, this account is signed out and cannot sign again.",
+            alert = true,
+        )
+    }
+
+    /** Copy for the finished disconnect, mirroring the two outcomes of [pomDisconnectNotice]. */
+    fun pomDisconnectedNotice(convertedToLocal: Boolean): DisconnectNotice = if (convertedToLocal) {
+        DisconnectNotice(
+            title = "What happens next",
+            body =
+            "This account is no longer linked to the central server. It stays signed in here and " +
+                "signs with the private key you exported.",
+            alert = false,
+        )
+    } else {
+        DisconnectNotice(
+            title = "What happens next",
+            body =
+            "This account is no longer linked to the central server and is being signed out. To keep " +
+                "using it, log in again with your private key (nsec).",
+            alert = false,
+        )
+    }
+
+    /** True once the export flow has reassembled the key, which decides the disconnect outcome. */
+    val pomKeyExported: Boolean get() = _pomExport.value is PomegranateExport.Done
+
     private val _pomExport = MutableStateFlow<PomegranateExport>(PomegranateExport.Idle)
     val pomExport: StateFlow<PomegranateExport> = _pomExport.asStateFlow()
 
@@ -197,6 +257,8 @@ class BackupViewModel(
 
     // Shard hexes recovered so far; wiped on cancel and once the nsec is built.
     private val recoveredShards = mutableListOf<String>()
+
+    private var disconnectJob: Job? = null
 
     /**
      * Starts the nsec export: Google popup + account fetch, then the per-operator
@@ -251,7 +313,8 @@ class BackupViewModel(
                 val done = ops.count { it.status == ShardStatus.Recovered }
                 if (done >= cur.threshold) {
                     val pubkey = repo.getPublicKey() ?: return@launch
-                    val hex = pomegranate.aggregateKeyHex(recoveredShards.toList(), pubkey)
+                    val shardsToAggregate = recoveredShards.toList()
+                    val hex = withContext(cryptoDispatcher) { pomegranate.aggregateKeyHex(shardsToAggregate, pubkey) }
                     recoveredShards.clear()
                     _pomExport.value = PomegranateExport.Done(nsec = Nip19.encodeNsec(hex), hex = hex)
                 } else {
@@ -300,24 +363,67 @@ class BackupViewModel(
         if (_pomDisconnect.value == PomegranateDisconnect.Working) return
         _pomError.value = null
         _pomDisconnect.value = PomegranateDisconnect.Working
-        viewModelScope.launch {
-            try {
-                pomegranate.disconnectAccount(central, pubkey)
-                SecureStorage.clearPomegranateCentralFor(pubkey)
-                val exportedHex = (_pomExport.value as? PomegranateExport.Done)?.hex
-                val converted =
-                    exportedHex != null && accountManager.convertActiveToLocal(exportedHex).isSuccess
-                if (!converted) SecureStorage.markPomegranateDisconnectedFor(pubkey)
-                _pomDisconnect.value = PomegranateDisconnect.Done(convertedToLocal = converted)
-            } catch (c: CancellationException) {
-                throw c
-            } catch (t: Throwable) {
-                _pomDisconnect.value = PomegranateDisconnect.Idle
-                if (t !is PomegranatePopupClosedException) {
-                    _pomError.value = t.message ?: "Could not disconnect from the central server"
+        disconnectJob =
+            viewModelScope.launch {
+                try {
+                    pomegranate.disconnectAccount(central, pubkey)
+                    // Past the server call the account is already unlinked, so the local
+                    // swap has to finish even if the dialog closes: convertActiveToLocal
+                    // ends in reloadForActiveAccount, and cancelling that leaves the
+                    // joined-groups map empty, which reads as onboarding on an account
+                    // that is still signed in.
+                    withContext(NonCancellable) {
+                        SecureStorage.clearPomegranateCentralFor(pubkey)
+                        val exportedHex = (_pomExport.value as? PomegranateExport.Done)?.hex
+                        val converted =
+                            exportedHex != null && accountManager.convertActiveToLocal(exportedHex).isSuccess
+                        if (!converted) SecureStorage.markPomegranateDisconnectedFor(pubkey)
+                        _pomDisconnect.value = PomegranateDisconnect.Done(convertedToLocal = converted)
+                    }
+                } catch (c: CancellationException) {
+                    // Leaving Working behind would wedge the dialog: the button stays on
+                    // "Disconnecting..." and the guard above swallows every later click.
+                    _pomDisconnect.value = PomegranateDisconnect.Idle
+                    throw c
+                } catch (t: Throwable) {
+                    _pomDisconnect.value = PomegranateDisconnect.Idle
+                    _pomError.value =
+                        if (t is PomegranatePopupClosedException) {
+                            "Google sign-in was closed before it finished."
+                        } else {
+                            t.message ?: "Could not disconnect from the central server"
+                        }
                 }
             }
+    }
+
+    /** Abandons a disconnect still waiting on the Google popup (the user left the dialog). */
+    fun cancelPomegranateDisconnect() {
+        // Nothing to abandon once the server call went through; the rest is local cleanup.
+        if (_pomDisconnect.value is PomegranateDisconnect.Done) return
+        disconnectJob?.cancel()
+        disconnectJob = null
+        if (_pomDisconnect.value == PomegranateDisconnect.Working) {
+            _pomDisconnect.value = PomegranateDisconnect.Idle
         }
+        _pomError.value = null
+    }
+
+    /**
+     * Closes the disconnect flow. A converted account signs locally now, so it stays put;
+     * one that never exported its key can no longer sign, so it is removed here (falling
+     * back to another account, or to the login screen) rather than left unusable.
+     */
+    fun finishPomegranateDisconnect(onClosed: () -> Unit = {}) {
+        val done = _pomDisconnect.value as? PomegranateDisconnect.Done
+        val accountId = accountStore.activeId.value
+        if (done == null || done.convertedToLocal || accountId == null) {
+            onClosed()
+            return
+        }
+        // Removal runs on the manager's scope: it outlives this screen, which the
+        // account swap unmounts.
+        accountManager.removeAccountAsync(accountId) { onClosed() }
     }
 
     private fun setShardStatus(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/GoogleAccountSetup.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/GoogleAccountSetup.kt
@@ -1,0 +1,154 @@
+package org.nostr.nostrord.ui.screens.login
+
+import androidx.compose.runtime.Immutable
+import org.nostr.nostrord.auth.pomegranate.PomegranateAccountConfig
+import org.nostr.nostrord.auth.pomegranate.PomegranateConfig
+import org.nostr.nostrord.auth.pomegranate.pomegranateOperatorLabel
+import org.nostr.nostrord.auth.pomegranate.pomegranateOperatorUrlOrNull
+
+/**
+ * The "Create your account" step of the Google login, shown when the sign-in finds no
+ * pomegranate account for that Google identity yet: the freshly generated key the user
+ * must back up, plus the operators and signing threshold the account is registered with.
+ *
+ * Pure state with pure transforms so Compose and web share the clamping and validation
+ * instead of each screen reimplementing them.
+ */
+@Immutable
+data class GoogleAccountSetup(
+    val privateKeyHex: String,
+    val nsec: String,
+    val operators: List<String> = PomegranateConfig.OPERATOR_URLS,
+    val threshold: Int = PomegranateConfig.defaultThreshold(PomegranateConfig.OPERATOR_URLS.size),
+    /** Probe result per operator URL; missing entries have not been checked yet. */
+    val operatorStatus: Map<String, OperatorStatus> = emptyMap(),
+    /** The key was pasted by the user (an identity they already have), not generated here. */
+    val importedKey: Boolean = false,
+) {
+    /** Reachability of one operator as the setup step knows it. */
+    enum class OperatorStatus { Unknown, Checking, Reachable, Unreachable }
+
+    /** Recommended operators not currently picked, offered as one-tap chips. */
+    val recommendedOperators: List<String>
+        get() = PomegranateConfig.OPERATOR_URLS.filterNot { it in operators }
+
+    val canRemoveOperator: Boolean get() = operators.size > PomegranateConfig.MIN_OPERATORS
+    val canLowerThreshold: Boolean get() = threshold > PomegranateConfig.MIN_OPERATORS
+    val canRaiseThreshold: Boolean get() = threshold < usableOperators.size
+
+    fun statusOf(url: String): OperatorStatus = operatorStatus[url] ?: OperatorStatus.Unknown
+
+    /** Adopts a key the user pasted; [hex] is already validated by the caller. */
+    fun withImportedKey(
+        hex: String,
+        nsec: String,
+    ): GoogleAccountSetup = copy(privateKeyHex = hex, nsec = nsec, importedKey = true)
+
+    /** One-line context under the title; a pasted key changes what is about to be created. */
+    val introLine: String
+        get() = if (importedKey) {
+            "This Google account has no Nostr key yet. It will be linked to the key you pasted."
+        } else {
+            "This Google account has no Nostr key yet, so a new one was created for it."
+        }
+
+    /** Save-your-key warning shown with the key itself, so it needs no callout of its own. */
+    val keyWarning: String
+        get() = if (importedKey) {
+            "The operators only hold shards of this key. Your own backup is what recovers the account."
+        } else {
+            "Save a backup now. Google can recover this key, but the backup is what you own."
+        }
+
+    /** Operators that answered nothing; the account is created without them. */
+    val unreachableOperators: List<String>
+        get() = operators.filter { statusOf(it) == OperatorStatus.Unreachable }
+
+    /**
+     * The operators the account is actually created with: everything the probe has not ruled
+     * out. Sending a shard to a host that just failed to answer would only stall registration
+     * and leave a shard nobody holds.
+     */
+    val usableOperators: List<String>
+        get() = operators.filterNot { statusOf(it) == OperatorStatus.Unreachable }
+
+    /** True when the survivors cannot form an account at all; the screens block Create. */
+    val tooFewOperators: Boolean
+        get() = usableOperators.size < PomegranateConfig.MIN_OPERATORS
+
+    /**
+     * True until every operator has a probe verdict. Creating before that would deal
+     * shards to hosts nobody has checked, which is how a registration ends up stalling on
+     * a dead one, so the screens keep Create disabled while this holds.
+     */
+    val operatorsPending: Boolean
+        get() = operators.any { statusOf(it) == OperatorStatus.Checking || statusOf(it) == OperatorStatus.Unknown }
+
+    /** Names the operators that did not answer and what it means. Empty when all responded. */
+    val operatorWarning: String
+        get() {
+            val down = unreachableOperators
+            if (down.isEmpty()) return ""
+            val names = down.joinToString { pomegranateOperatorLabel(it) }
+            val live = usableOperators.size
+            return if (tooFewOperators) {
+                "$names did not answer, leaving $live of ${operators.size}. An account needs at least " +
+                    "${PomegranateConfig.MIN_OPERATORS} operators, so add another one or try again later."
+            } else {
+                "$names did not answer and will be skipped. Your account is created with the remaining " +
+                    "$live, $threshold of which must sign."
+            }
+        }
+
+    /** Marks every operator as being probed, dropping results for ones no longer listed. */
+    fun checking(): GoogleAccountSetup = copy(operatorStatus = operators.associateWith { OperatorStatus.Checking })
+
+    /**
+     * Folds probe results in, ignoring operators removed while the probes were in flight, and
+     * pulls the threshold down to what the survivors can actually sign.
+     */
+    fun withStatuses(results: Map<String, OperatorStatus>): GoogleAccountSetup {
+        val next = copy(operatorStatus = operators.associateWith { results[it] ?: statusOf(it) })
+        return next.copy(threshold = clampThreshold(next.threshold, next.usableOperators.size))
+    }
+
+    /** Threshold clamped into [MIN_OPERATORS, usable operator count]. */
+    fun withThreshold(value: Int): GoogleAccountSetup = copy(threshold = clampThreshold(value, usableOperators.size))
+
+    /**
+     * Adds a normalized operator origin. Fails with a user-facing message on a malformed
+     * URL or a duplicate, which the screens show under the input.
+     */
+    fun withOperatorAdded(raw: String): Result<GoogleAccountSetup> {
+        val url =
+            pomegranateOperatorUrlOrNull(raw)
+                ?: return Result.failure(IllegalArgumentException("Invalid URL"))
+        if (url in operators) return Result.failure(IllegalArgumentException("This operator is already added"))
+        return Result.success(copy(operators = operators + url))
+    }
+
+    /** Removes an operator, keeping at least [PomegranateConfig.MIN_OPERATORS] and a valid threshold. */
+    fun withOperatorRemoved(url: String): GoogleAccountSetup {
+        if (!canRemoveOperator) return this
+        val next = operators.filterNot { it == url }
+        if (next.size == operators.size) return this
+        return copy(
+            operators = next,
+            threshold = clampThreshold(threshold, next.size),
+            operatorStatus = operatorStatus - url,
+        )
+    }
+
+    fun toConfig(): PomegranateAccountConfig = PomegranateAccountConfig(
+        operators = usableOperators,
+        threshold = clampThreshold(threshold, usableOperators.size),
+        privateKeyHex = privateKeyHex,
+    )
+
+    private companion object {
+        fun clampThreshold(
+            value: Int,
+            operatorCount: Int,
+        ): Int = value.coerceIn(PomegranateConfig.MIN_OPERATORS, maxOf(PomegranateConfig.MIN_OPERATORS, operatorCount))
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/login/LoginViewModel.kt
@@ -9,9 +9,11 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.nostr.nostrord.auth.Account
+import org.nostr.nostrord.auth.pomegranate.PomegranateAccountConfig
 import org.nostr.nostrord.auth.pomegranate.PomegranateConfig
 import org.nostr.nostrord.auth.pomegranate.PomegranateService
 import org.nostr.nostrord.auth.pomegranate.PomegranateStatus
@@ -287,24 +289,42 @@ class LoginViewModel(
     val isGoogleLoginAvailable: Boolean get() = pomegranate.isAvailable
 
     /**
-     * Login with Google via the pomegranate threshold signer. The popup mints a token,
-     * a first login creates the account (key sharded across operators), and the
-     * resulting `bunker://` URL rides the normal NIP-46 login. The central URL is
-     * persisted per account so settings can offer nsec export / disconnect. Must be
-     * called from a click handler; a popup opened outside a user gesture is blocked.
+     * Non-null while the Google flow waits on the "Create your account" step: this Google
+     * identity has no account yet, so the user backs up the generated key and can review
+     * the operators before anything is registered.
+     */
+    private val _googleSetup = MutableStateFlow<GoogleAccountSetup?>(null)
+    val googleSetup: StateFlow<GoogleAccountSetup?> = _googleSetup.asStateFlow()
+
+    /** The authenticated Google token the setup step will create the account with. */
+    private var startedGoogleLogin: PomegranateService.StartedLogin? = null
+
+    private var operatorCheckJob: Job? = null
+    private var createAccountJob: Job? = null
+
+    /**
+     * Login with Google via the pomegranate threshold signer. The popup mints a token; an
+     * existing account logs straight in over the resulting `bunker://` URL, a first-time
+     * one stops at [googleSetup] and finishes in [createGoogleAccount]. Must be called
+     * from a click handler; a popup opened outside a user gesture is blocked.
      */
     fun loginWithGoogle(
         centralUrl: String = PomegranateConfig.CENTRAL_URL,
         onStatus: (PomegranateStatus) -> Unit,
+        onNewAccount: () -> Unit = {},
         onResult: (Result<Unit>) -> Unit,
     ) {
         viewModelScope.launch {
             try {
                 val started = pomegranate.startLogin(centralUrl, onStatus = onStatus)
-                val outcome = pomegranate.finishLogin(started, onStatus)
-                onStatus(PomegranateStatus.Connecting)
-                val pubkey = repo.loginWithBunker(outcome.bunkerUrl).toKotlinResult().getOrThrow()
-                SecureStorage.savePomegranateCentralFor(pubkey, outcome.central)
+                if (!started.hasAccount) {
+                    startedGoogleLogin = started
+                    _googleSetup.value = newGoogleSetup()
+                    onNewAccount()
+                    return@launch
+                }
+                // Existing account: its operators are fixed server-side, nothing to configure.
+                finishGoogleLogin(started, config = null, onStatus = onStatus)
                 onResult(Result.success(Unit))
             } catch (c: CancellationException) {
                 throw c
@@ -313,6 +333,127 @@ class LoginViewModel(
                 onResult(Result.failure(t))
             }
         }
+    }
+
+    /**
+     * Registers the new account with the key and operator config in [googleSetup], then
+     * logs in with it. Reuses the token from [loginWithGoogle], so no second Google popup.
+     */
+    fun createGoogleAccount(
+        onStatus: (PomegranateStatus) -> Unit,
+        onResult: (Result<Unit>) -> Unit,
+    ) {
+        val started = startedGoogleLogin
+        val setup = _googleSetup.value
+        if (started == null || setup == null) {
+            onResult(Result.failure(IllegalStateException("Sign in with Google again to continue")))
+            return
+        }
+        // The button disables itself, but a frozen frame can still queue a second tap, and a
+        // second /register races the first into a 409 from the central.
+        if (createAccountJob?.isActive == true) return
+        createAccountJob = viewModelScope.launch {
+            try {
+                finishGoogleLogin(started, setup.toConfig(), onStatus)
+                onResult(Result.success(Unit))
+            } catch (c: CancellationException) {
+                throw c
+            } catch (t: Throwable) {
+                onResult(Result.failure(t))
+            }
+        }
+    }
+
+    /** Leaves the setup step (Back); the next attempt signs in with Google again. */
+    fun cancelGoogleSetup() {
+        operatorCheckJob?.cancel()
+        operatorCheckJob = null
+        startedGoogleLogin = null
+        _googleSetup.value = null
+    }
+
+    /** Replaces the offered key with a fresh one; the shown nsec is what gets registered. */
+    fun regenerateGoogleKey() {
+        _googleSetup.update { current ->
+            current?.let { newGoogleSetup(it.operators, it.threshold).copy(operatorStatus = it.operatorStatus) }
+        }
+    }
+
+    /**
+     * Shards an identity the user already has instead of the generated one: they paste its
+     * nsec or hex and the account is created for that pubkey. Returns the error message
+     * when the input is not a usable key. An ncryptsec is rejected here — it needs its
+     * password, which the private-key login handles.
+     */
+    fun importGoogleKey(input: String): String? {
+        if (_googleSetup.value == null) return null
+        val hex = parsePrivateKeyHex(input) ?: return "Enter a valid nsec or 64-character hex key"
+        _googleSetup.update { it?.withImportedKey(hex, Nip19.encodeNsec(hex)) }
+        return null
+    }
+
+    /** Adds an operator to the new account; returns the error message when it can't be added. */
+    fun addGoogleOperator(raw: String): String? {
+        val setup = _googleSetup.value ?: return null
+        val next = setup.withOperatorAdded(raw)
+        next.getOrNull()?.let {
+            _googleSetup.value = it
+            checkGoogleOperators()
+        }
+        return next.exceptionOrNull()?.message
+    }
+
+    /**
+     * Probes the listed operators so a host that is down is named in the setup step rather
+     * than surfacing as a failed registration. The screens run it when the step opens and
+     * after an operator is added; it is also the Retry action on the warning.
+     */
+    fun checkGoogleOperators() {
+        val setup = _googleSetup.value ?: return
+        operatorCheckJob?.cancel()
+        _googleSetup.value = setup.checking()
+        operatorCheckJob =
+            viewModelScope.launch {
+                val results =
+                    pomegranate.checkOperators(setup.operators).associate { health ->
+                        health.url to
+                            if (health.reachable) {
+                                GoogleAccountSetup.OperatorStatus.Reachable
+                            } else {
+                                GoogleAccountSetup.OperatorStatus.Unreachable
+                            }
+                    }
+                _googleSetup.update { it?.withStatuses(results) }
+            }
+    }
+
+    fun removeGoogleOperator(url: String) {
+        _googleSetup.update { it?.withOperatorRemoved(url) }
+    }
+
+    fun setGoogleThreshold(value: Int) {
+        _googleSetup.update { it?.withThreshold(value) }
+    }
+
+    private fun newGoogleSetup(
+        operators: List<String> = PomegranateConfig.OPERATOR_URLS,
+        threshold: Int = PomegranateConfig.defaultThreshold(operators.size),
+    ): GoogleAccountSetup {
+        val hex = generateNewKeyHex()
+        return GoogleAccountSetup(hex, Nip19.encodeNsec(hex), operators, threshold)
+    }
+
+    /** Creates the account when needed, logs in over its bunker URL, and clears the setup step. */
+    private suspend fun finishGoogleLogin(
+        started: PomegranateService.StartedLogin,
+        config: PomegranateAccountConfig?,
+        onStatus: (PomegranateStatus) -> Unit,
+    ) {
+        val outcome = pomegranate.finishLogin(started, config, onStatus)
+        onStatus(PomegranateStatus.Connecting)
+        val pubkey = repo.loginWithBunker(outcome.bunkerUrl).toKotlinResult().getOrThrow()
+        SecureStorage.savePomegranateCentralFor(pubkey, outcome.central)
+        cancelGoogleSetup()
     }
 
     fun startQrSession(

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/login/GoogleAccountSetupTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/login/GoogleAccountSetupTest.kt
@@ -1,0 +1,143 @@
+package org.nostr.nostrord.ui.screens.login
+
+import org.nostr.nostrord.auth.pomegranate.PomegranateConfig
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GoogleAccountSetupTest {
+    private fun setup() = GoogleAccountSetup(privateKeyHex = "ab".repeat(32), nsec = "nsec1test")
+
+    @Test
+    fun `defaults to the recommended operators and threshold`() {
+        val s = setup()
+        assertEquals(PomegranateConfig.OPERATOR_URLS, s.operators)
+        assertEquals(PomegranateConfig.defaultThreshold(s.operators.size), s.threshold)
+        assertTrue(s.recommendedOperators.isEmpty())
+    }
+
+    @Test
+    fun `added operator is normalized to its origin`() {
+        val s = setup().withOperatorAdded(" po.example.com/po/ ").getOrThrow()
+        assertEquals("https://po.example.com", s.operators.last())
+    }
+
+    @Test
+    fun `duplicate and malformed operators are rejected with a message`() {
+        val s = setup()
+        assertEquals(
+            "This operator is already added",
+            s.withOperatorAdded("https://po.f7z.io").exceptionOrNull()?.message,
+        )
+        assertEquals("Invalid URL", s.withOperatorAdded("not a url").exceptionOrNull()?.message)
+        assertEquals("Invalid URL", s.withOperatorAdded("").exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `removing operators stops at the minimum and lowers the threshold with them`() {
+        var s = setup().withThreshold(5)
+        PomegranateConfig.OPERATOR_URLS.forEach { s = s.withOperatorRemoved(it) }
+        assertEquals(PomegranateConfig.MIN_OPERATORS, s.operators.size)
+        assertEquals(PomegranateConfig.MIN_OPERATORS, s.threshold)
+        assertFalse(s.canRemoveOperator)
+        assertEquals(PomegranateConfig.OPERATOR_URLS.size - 2, s.recommendedOperators.size)
+    }
+
+    @Test
+    fun `threshold is clamped to the operator count and the minimum`() {
+        val s = setup()
+        assertEquals(s.operators.size, s.withThreshold(99).threshold)
+        assertEquals(PomegranateConfig.MIN_OPERATORS, s.withThreshold(0).threshold)
+        assertFalse(s.withThreshold(0).canLowerThreshold)
+        assertFalse(s.withThreshold(99).canRaiseThreshold)
+    }
+
+    @Test
+    fun `config carries the shown key, operators and threshold`() {
+        val s = setup().withThreshold(4)
+        val config = s.toConfig()
+        assertEquals("ab".repeat(32), config.privateKeyHex)
+        assertEquals(s.operators, config.operators)
+        assertEquals(4, config.threshold)
+    }
+
+    @Test
+    fun `probe results only stick to operators still listed`() {
+        val s = setup()
+        val down = s.operators.first()
+        val checked =
+            s.withStatuses(
+                mapOf(
+                    down to GoogleAccountSetup.OperatorStatus.Unreachable,
+                    "https://po.gone.example" to GoogleAccountSetup.OperatorStatus.Reachable,
+                ),
+            )
+        assertEquals(listOf(down), checked.unreachableOperators)
+        assertEquals(GoogleAccountSetup.OperatorStatus.Unknown, checked.statusOf("https://po.gone.example"))
+        assertEquals(GoogleAccountSetup.OperatorStatus.Unknown, checked.withOperatorRemoved(down).statusOf(down))
+    }
+
+    @Test
+    fun `an unreachable operator is dropped from the account and the threshold follows`() {
+        val s = setup()
+        val down = s.operators[0]
+        val downOne = s.withStatuses(mapOf(down to GoogleAccountSetup.OperatorStatus.Unreachable))
+        assertFalse(downOne.tooFewOperators)
+        assertTrue(downOne.operatorWarning.contains("will be skipped"))
+        // The dead operator stays listed (so the row can say why) but never gets a shard.
+        assertEquals(s.operators.size, downOne.operators.size)
+        assertEquals(s.operators - down, downOne.toConfig().operators)
+        assertEquals(3, downOne.toConfig().threshold)
+
+        val downMost =
+            s.withStatuses(s.operators.take(4).associateWith { GoogleAccountSetup.OperatorStatus.Unreachable })
+        assertTrue(downMost.tooFewOperators)
+        assertTrue(downMost.operatorWarning.contains("at least ${PomegranateConfig.MIN_OPERATORS} operators"))
+    }
+
+    @Test
+    fun `a pasted key replaces the generated one and is what gets sharded`() {
+        val mine = "cd".repeat(32)
+        val s = setup().withImportedKey(mine, "nsec1mine")
+        assertEquals(mine, s.toConfig().privateKeyHex)
+        assertEquals("nsec1mine", s.nsec)
+        assertTrue(s.importedKey)
+        assertTrue(s.introLine.contains("the key you pasted"))
+        assertTrue(s.keyWarning.contains("only hold shards"))
+        assertFalse(setup().introLine.contains("the key you pasted"))
+    }
+
+    @Test
+    fun `creation waits for every operator verdict`() {
+        val s = setup()
+        assertTrue(s.operatorsPending, "an unprobed operator set is not ready to create")
+        assertTrue(s.checking().operatorsPending, "still pending while the probes run")
+
+        val partial = s.withStatuses(mapOf(s.operators[0] to GoogleAccountSetup.OperatorStatus.Reachable))
+        assertTrue(partial.operatorsPending, "one verdict is not all of them")
+
+        val all = s.withStatuses(s.operators.associateWith { GoogleAccountSetup.OperatorStatus.Reachable })
+        assertFalse(all.operatorsPending)
+        // A newly added operator re-opens the wait: it has no verdict yet.
+        assertTrue(all.withOperatorAdded("https://po.example.com").getOrThrow().operatorsPending)
+    }
+
+    @Test
+    fun `probe results pull an unreachable-heavy threshold down`() {
+        val s = setup().withThreshold(5)
+        val down = s.withStatuses(s.operators.take(2).associateWith { GoogleAccountSetup.OperatorStatus.Unreachable })
+        assertEquals(3, down.threshold)
+        assertEquals(3, down.usableOperators.size)
+        assertFalse(down.canRaiseThreshold)
+    }
+
+    @Test
+    fun `localhost operators are accepted, bare hostnames are not`() {
+        val s = setup()
+        assertNotNull(s.withOperatorAdded("http://localhost:3334").getOrNull())
+        assertNull(s.withOperatorAdded("operator").getOrNull())
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.ios.kt
@@ -1,0 +1,11 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+
+// Exporting a file on iOS goes through a share sheet (UIActivityViewController), which is the
+// same plumbing ShareUtils.ios.kt still lacks. Until that lands the save button is hidden here
+// rather than writing into a sandbox the user cannot reach; copying the key still works.
+actual val supportsTextFileSave: Boolean = false
+
+@Composable
+actual fun rememberTextFileSaver(): suspend (content: String, fileName: String) -> Boolean = { _, _ -> false }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/ImageDownloader.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/ImageDownloader.jvm.kt
@@ -25,7 +25,7 @@ actual fun rememberImageDownloader(): suspend (bytes: ByteArray, fileName: Strin
 }
 
 /** Avoids clobbering an existing file by appending " (1)", " (2)", ... before the extension. */
-private fun uniqueFile(
+internal fun uniqueFile(
     dir: File,
     name: String,
 ): File {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.jvm.kt
@@ -1,0 +1,25 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.nostr.nostrord.di.AppModule
+import java.io.File
+
+actual val supportsTextFileSave: Boolean = true
+
+@Composable
+actual fun rememberTextFileSaver(): suspend (content: String, fileName: String) -> Boolean = { content, fileName ->
+    withContext(Dispatchers.IO) {
+        try {
+            val downloads = File(System.getProperty("user.home"), "Downloads").apply { if (!exists()) mkdirs() }
+            val target = uniqueFile(downloads, fileName)
+            target.writeText(content)
+            AppModule.postSystemMessage("Saved to ${target.absolutePath}")
+            true
+        } catch (_: Exception) {
+            AppModule.postSystemMessage("Couldn't save the file")
+            false
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/IdentifierField.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/IdentifierField.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.ui.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -26,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -69,6 +71,9 @@ fun IdentifierRow(
     ids: List<Identifier>,
     modifier: Modifier = Modifier,
     showQr: Boolean = false,
+    // Same reason as AppField's: on a panel painted the default colour the row would vanish.
+    containerColor: Color = NostrordColors.BackgroundFloating,
+    trailing: @Composable RowScope.() -> Unit = {},
 ) {
     if (ids.isEmpty()) return
     var index by remember(ids) { mutableStateOf(0) }
@@ -85,7 +90,7 @@ fun IdentifierRow(
     }
 
     Column(modifier = modifier) {
-        Surface(shape = NostrordShapes.shapeMedium, color = NostrordColors.BackgroundFloating) {
+        Surface(shape = NostrordShapes.shapeMedium, color = containerColor) {
             // Compact icon buttons + tight spacing to match the web .identifier-field (22px
             // buttons, 6px gap), instead of Material's 48dp touch targets.
             Row(
@@ -95,7 +100,7 @@ fun IdentifierRow(
             ) {
                 Text(
                     id.value,
-                    color = NostrordColors.TextMuted,
+                    color = NostrordColors.TextSecondary,
                     fontSize = 12.sp,
                     fontFamily = FontFamily.Monospace,
                     maxLines = 1,
@@ -136,6 +141,7 @@ fun IdentifierRow(
                         modifier = Modifier.size(16.dp),
                     )
                 }
+                trailing()
             }
         }
         if (showQr && qrOpen) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt
@@ -87,14 +87,14 @@ fun appFieldTextStyle() = LocalTextStyle.current.copy(fontSize = 14.sp)
  * this, so the input background never drifts per screen.
  */
 @Composable
-fun appFieldColors() = OutlinedTextFieldDefaults.colors(
+fun appFieldColors(container: Color = NostrordColors.BackgroundFloating) = OutlinedTextFieldDefaults.colors(
     focusedTextColor = NostrordColors.TextContent,
     unfocusedTextColor = NostrordColors.TextContent,
     focusedBorderColor = NostrordColors.Primary,
     unfocusedBorderColor = NostrordColors.Divider,
     cursorColor = NostrordColors.Primary,
-    focusedContainerColor = NostrordColors.BackgroundFloating,
-    unfocusedContainerColor = NostrordColors.BackgroundFloating,
+    focusedContainerColor = container,
+    unfocusedContainerColor = container,
     focusedPlaceholderColor = NostrordColors.TextMuted,
     unfocusedPlaceholderColor = NostrordColors.TextMuted,
 )
@@ -135,6 +135,9 @@ fun AppField(
     onImeAction: (() -> Unit)? = null,
     leadingIcon: (@Composable () -> Unit)? = null,
     trailingIcon: (@Composable () -> Unit)? = null,
+    // Fields on a raised surface need one of their own: the default matches the page, so on a
+    // panel painted the same colour the value would read as loose text in a hairline box.
+    containerColor: Color = NostrordColors.BackgroundFloating,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     // Drop the inherited lineHeight (bodyLarge = 24sp): a standalone placeholder Text honors it,
@@ -147,7 +150,7 @@ fun AppField(
             lineHeight = TextUnit.Unspecified,
         )
     val visual = if (masked) PasswordVisualTransformation() else VisualTransformation.None
-    val colors = appFieldColors()
+    val colors = appFieldColors(containerColor)
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
@@ -274,6 +277,7 @@ fun AppTextField(
     keyboardType: KeyboardType = KeyboardType.Text,
     maxLines: Int = 1,
     enabled: Boolean = true,
+    containerColor: Color = NostrordColors.BackgroundFloating,
     onDone: (() -> Unit)? = null,
     // Opt-in: when set, Escape clears focus and invokes this (filters clear with it).
     onEscape: (() -> Unit)? = null,
@@ -330,6 +334,7 @@ fun AppTextField(
             imeAction = if (onDone != null) ImeAction.Done else ImeAction.Default,
             onImeAction = onDone,
             enabled = enabled,
+            containerColor = containerColor,
         )
         hint?.let { FormHint(it) }
     }
@@ -359,6 +364,7 @@ fun AppSearchField(
     icon: ImageVector? = Icons.Default.Search,
     trailing: (@Composable () -> Unit)? = null,
     autoFocus: Boolean = false,
+    containerColor: Color = NostrordColors.BackgroundFloating,
     onEscape: (() -> Unit)? = null,
     onDone: (() -> Unit)? = null,
 ) {
@@ -385,7 +391,7 @@ fun AppSearchField(
         modifier
             .height(inputHeight)
             .clip(shape)
-            .background(NostrordColors.BackgroundFloating)
+            .background(containerColor)
             .border(1.dp, borderColor, shape)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/backup/BackupKeysSections.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/backup/BackupKeysSections.kt
@@ -118,7 +118,7 @@ private fun PomegranateBackupSection(vm: BackupViewModel) {
     val export by vm.pomExport.collectAsState()
     val disconnect by vm.pomDisconnect.collectAsState()
     val pomError by vm.pomError.collectAsState()
-    var disconnectArmed by remember { mutableStateOf(false) }
+    var confirmingDisconnect by remember { mutableStateOf(false) }
 
     BackupCard {
         FieldLabel("Private key")
@@ -214,7 +214,7 @@ private fun PomegranateBackupSection(vm: BackupViewModel) {
         )
         Spacer(Modifier.height(Spacing.md))
         val done = disconnect as? BackupViewModel.PomegranateDisconnect.Done
-        if (done != null) {
+        if (done != null && !confirmingDisconnect) {
             Text(
                 if (done.convertedToLocal) {
                     "Disconnected from Google. This account now signs with the exported key on this device."
@@ -226,19 +226,16 @@ private fun PomegranateBackupSection(vm: BackupViewModel) {
             )
         } else {
             Button(
-                onClick = { if (!disconnectArmed) disconnectArmed = true else vm.disconnectPomegranate() },
-                enabled = disconnect != BackupViewModel.PomegranateDisconnect.Working,
+                onClick = { confirmingDisconnect = true },
                 colors = ButtonDefaults.buttonColors(containerColor = NostrordColors.Error),
             ) {
-                Text(
-                    when {
-                        disconnect == BackupViewModel.PomegranateDisconnect.Working -> "Disconnecting…"
-                        disconnectArmed -> "Click again to confirm"
-                        else -> "Disconnect from central server"
-                    },
-                )
+                Text("Disconnect from central server")
             }
         }
+    }
+
+    if (confirmingDisconnect) {
+        PomegranateDisconnectDialog(vm) { confirmingDisconnect = false }
     }
 }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/backup/PomegranateDisconnectDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/backup/PomegranateDisconnectDialog.kt
@@ -1,0 +1,142 @@
+package org.nostr.nostrord.ui.screens.backup
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.unit.dp
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.components.cards.InfoCard
+import org.nostr.nostrord.ui.components.forms.FormError
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.ui.theme.NostrordTypography
+
+/**
+ * Confirmation for unlinking a Login-with-Google account from its central server. The
+ * outcome depends on whether the nsec was exported first: with it the account converts to
+ * a local-key login and stays signed in, without it it can no longer sign and is signed
+ * out. Mirrors the web PomegranateDisconnectModal.
+ */
+@Composable
+fun PomegranateDisconnectDialog(
+    vm: BackupViewModel,
+    onClose: () -> Unit,
+) {
+    val disconnect by vm.pomDisconnect.collectAsState()
+    val pomError by vm.pomError.collectAsState()
+    var acknowledged by remember { mutableStateOf(false) }
+
+    val keyExported = vm.pomKeyExported
+    val working = disconnect == BackupViewModel.PomegranateDisconnect.Working
+    val done = disconnect as? BackupViewModel.PomegranateDisconnect.Done
+    val notice = if (done != null) vm.pomDisconnectedNotice(done.convertedToLocal) else vm.pomDisconnectNotice(keyExported)
+
+    // Closing while the Google popup is still open abandons the attempt, so the next one
+    // starts clean instead of finding the flow stuck on "Disconnecting...".
+    val close = {
+        if (done == null) {
+            vm.cancelPomegranateDisconnect()
+            onClose()
+        } else {
+            // Dismissing after the disconnect finished still has to settle the account: an
+            // unlinked bunker account left in place can no longer sign.
+            vm.finishPomegranateDisconnect(onClose)
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = { close() },
+        containerColor = NostrordColors.Surface,
+        titleContentColor = NostrordColors.TextPrimary,
+        textContentColor = NostrordColors.TextSecondary,
+        title = {
+            Text(if (done != null) "Disconnected from central server" else "Disconnect from central server")
+        },
+        text = {
+            Column {
+                InfoCard(
+                    title = notice.title,
+                    titleColor = if (notice.alert) NostrordColors.WarningOrange else NostrordColors.Primary,
+                    content = notice.body,
+                    icon = if (notice.alert) Icons.Default.Warning else Icons.Default.Info,
+                    isCompact = true,
+                )
+                if (done == null) {
+                    pomError?.let {
+                        Spacer(Modifier.height(12.dp))
+                        FormError(it)
+                    }
+                    // The ack only guards the lossy path: with the key exported the app
+                    // keeps signing locally, so there is nothing to lose by continuing.
+                    if (!keyExported) {
+                        Spacer(Modifier.height(12.dp))
+                        Row(
+                            modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clip(NostrordShapes.shapeSmall)
+                                .clickable(enabled = !working) { acknowledged = !acknowledged }
+                                .pointerHoverIcon(PointerIcon.Hand),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Checkbox(
+                                checked = acknowledged,
+                                onCheckedChange = { acknowledged = it },
+                                enabled = !working,
+                                colors = CheckboxDefaults.colors(checkedColor = NostrordColors.Primary),
+                            )
+                            Text(
+                                "I have safely backed up my private key",
+                                color = NostrordColors.TextContent,
+                                style = NostrordTypography.Caption,
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            if (done != null) {
+                AppButton(text = "Done", onClick = { vm.finishPomegranateDisconnect(onClose) })
+            } else {
+                AppButton(
+                    text = if (working) "Disconnecting..." else "Disconnect from central server",
+                    onClick = { vm.disconnectPomegranate() },
+                    enabled = !working && (keyExported || acknowledged),
+                    variant = AppButtonVariant.Danger,
+                    loading = working,
+                )
+            }
+        },
+        dismissButton = {
+            if (done == null) {
+                TextButton(onClick = close) {
+                    Text("Cancel", color = NostrordColors.TextSecondary)
+                }
+            }
+        },
+    )
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleAccountSetupSection.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleAccountSetupSection.kt
@@ -1,0 +1,557 @@
+package org.nostr.nostrord.ui.screens.login.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.Key
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Remove
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.auth.pomegranate.pomegranateOperatorLabel
+import org.nostr.nostrord.ui.Identifier
+import org.nostr.nostrord.ui.components.IdentifierRow
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonSize
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.components.cards.InfoCard
+import org.nostr.nostrord.ui.components.forms.AppSearchField
+import org.nostr.nostrord.ui.components.forms.InputSize
+import org.nostr.nostrord.ui.screens.login.GoogleAccountSetup
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.utils.rememberTextFileSaver
+import org.nostr.nostrord.utils.rememberTextSharer
+import org.nostr.nostrord.utils.supportsNativeShare
+import org.nostr.nostrord.utils.supportsTextFileSave
+
+/**
+ * "Create your account": the step the Google login stops at when that Google identity has
+ * no pomegranate account yet. The key is generated client-side and shown here because the
+ * shards are dealt from it — this is the only moment the whole key exists for the user to
+ * back up. Operators and threshold stay behind Advanced options; the defaults are fine.
+ */
+@Composable
+fun GoogleAccountSetupSection(
+    setup: GoogleAccountSetup,
+    busy: Boolean,
+    createLabel: String,
+    errorMessage: String?,
+    onRegenerateKey: () -> Unit,
+    onImportKey: (String) -> String?,
+    onAddOperator: (String) -> String?,
+    onRemoveOperator: (String) -> Unit,
+    onThresholdChange: (Int) -> Unit,
+    onCheckOperators: () -> Unit,
+    onCreate: () -> Unit,
+) {
+    var acknowledged by remember { mutableStateOf(false) }
+    var advancedOpen by remember { mutableStateOf(false) }
+
+    // Probe on entry so a dead operator is visible before the user hits Create.
+    LaunchedEffect(Unit) { onCheckOperators() }
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = "Create your account",
+            style = MaterialTheme.typography.titleMedium,
+            color = NostrordColors.TextPrimary,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Text(
+            text = setup.introLine,
+            style = MaterialTheme.typography.bodySmall,
+            color = NostrordColors.TextMuted,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        KeyPanel(
+            setup = setup,
+            enabled = !busy,
+            onRegenerate = onRegenerateKey,
+            onImportKey = onImportKey,
+        )
+
+        Row(
+            modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(NostrordShapes.shapeSmall)
+                .clickable(enabled = !busy) { acknowledged = !acknowledged }
+                .pointerHoverIcon(PointerIcon.Hand),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Checkbox(
+                checked = acknowledged,
+                onCheckedChange = { acknowledged = it },
+                enabled = !busy,
+                colors = CheckboxDefaults.colors(checkedColor = NostrordColors.Primary),
+            )
+            Text(
+                text = "I have safely backed up my private key",
+                style = MaterialTheme.typography.bodyMedium,
+                color = NostrordColors.TextContent,
+            )
+        }
+
+        AdvancedDisclosure(
+            open = advancedOpen,
+            onToggle = { advancedOpen = !advancedOpen },
+        ) {
+            OperatorConfig(
+                setup = setup,
+                enabled = !busy,
+                onAddOperator = onAddOperator,
+                onRemoveOperator = onRemoveOperator,
+                onThresholdChange = onThresholdChange,
+            )
+        }
+
+        // Operator trouble is reported outside Advanced options, which is collapsed by
+        // default: a quiet line while the account can still be created, a callout when it
+        // cannot.
+        if (setup.unreachableOperators.isNotEmpty()) {
+            if (setup.tooFewOperators) {
+                InfoCard(
+                    title = "Not enough operators are responding",
+                    titleColor = NostrordColors.Error,
+                    content = setup.operatorWarning,
+                    icon = Icons.Default.Warning,
+                    isCompact = true,
+                )
+            } else {
+                Text(
+                    text = setup.operatorWarning,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NostrordColors.TextMuted,
+                )
+            }
+            AppButton(
+                text = "Check operators again",
+                onClick = onCheckOperators,
+                enabled = !busy,
+                variant = AppButtonVariant.Ghost,
+                size = AppButtonSize.Small,
+                icon = Icons.Default.Refresh,
+            )
+        }
+
+        if (errorMessage != null) {
+            Text(
+                text = errorMessage,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+
+        // Create waits for the probe: the operator set is decided by its verdicts.
+        AppButton(
+            text = if (!busy && setup.operatorsPending) "Checking operators..." else createLabel,
+            onClick = onCreate,
+            enabled = !busy && acknowledged && !setup.tooFewOperators && !setup.operatorsPending,
+            size = AppButtonSize.Large,
+            fullWidth = true,
+            loading = busy || setup.operatorsPending,
+        )
+    }
+}
+
+@Composable
+private fun ImportKeyField(
+    enabled: Boolean,
+    onImportKey: (String) -> String?,
+) {
+    var open by remember { mutableStateOf(false) }
+    var draft by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    if (!open) {
+        AppButton(
+            text = "Use a key I already have",
+            onClick = { open = true },
+            enabled = enabled,
+            variant = AppButtonVariant.Ghost,
+            size = AppButtonSize.Small,
+            icon = Icons.Default.Key,
+        )
+        return
+    }
+
+    val submit = {
+        if (draft.isNotBlank()) {
+            error = onImportKey(draft)
+            if (error == null) {
+                draft = ""
+                open = false
+            }
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        // Compact input-group with the action inside it, the same shape the web uses here.
+        AppSearchField(
+            value = draft,
+            onValueChange = {
+                draft = it
+                error = null
+            },
+            placeholder = "nsec1... or 64-character hex",
+            size = InputSize.Compact,
+            icon = null,
+            containerColor = NostrordColors.InputBackground,
+            onDone = submit,
+            trailing = {
+                AppButton(
+                    text = "Use key",
+                    onClick = submit,
+                    enabled = enabled && draft.isNotBlank(),
+                    variant = AppButtonVariant.Secondary,
+                    size = AppButtonSize.Small,
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        error?.let {
+            Text(text = it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+        }
+    }
+}
+
+/** Same name the web download uses, so a user with both ends up with matching files. */
+private const val BACKUP_FILE_NAME = "nostr-private-key.txt"
+
+/**
+ * Everything about the key in one bordered block: the value, why it matters, and the two
+ * ways to keep it. The rest of the step stays loose so this reads as the part that needs
+ * attention.
+ */
+@Composable
+private fun KeyPanel(
+    setup: GoogleAccountSetup,
+    enabled: Boolean,
+    onRegenerate: () -> Unit,
+    onImportKey: (String) -> String?,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = NostrordShapes.shapeMedium,
+        color = NostrordColors.BackgroundFloating,
+        border = BorderStroke(1.dp, NostrordColors.Divider),
+    ) {
+        Column(modifier = Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            SectionLabel("YOUR PRIVATE KEY", color = NostrordColors.TextSecondary)
+            IdentifierRow(
+                ids = listOf(Identifier("nsec", setup.nsec)),
+                containerColor = NostrordColors.InputBackground,
+                trailing = {
+                    IconButton(onClick = onRegenerate, enabled = enabled, modifier = Modifier.size(28.dp)) {
+                        Icon(
+                            imageVector = Icons.Default.Refresh,
+                            contentDescription = "Generate new key",
+                            tint = NostrordColors.TextMuted,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+                },
+            )
+            Row(verticalAlignment = Alignment.Top, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                Icon(
+                    imageVector = Icons.Default.Warning,
+                    contentDescription = null,
+                    tint = NostrordColors.WarningOrange,
+                    modifier = Modifier.size(14.dp),
+                )
+                Text(
+                    text = setup.keyWarning,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NostrordColors.TextMuted,
+                )
+            }
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                if (supportsTextFileSave) {
+                    val scope = rememberCoroutineScope()
+                    val saveFile = rememberTextFileSaver()
+                    AppButton(
+                        text = "Download backup",
+                        onClick = { scope.launch { saveFile(setup.nsec, BACKUP_FILE_NAME) } },
+                        enabled = enabled,
+                        variant = AppButtonVariant.Secondary,
+                        size = AppButtonSize.Small,
+                        icon = Icons.Default.Download,
+                    )
+                }
+                if (supportsNativeShare) {
+                    val shareText = rememberTextSharer()
+                    AppButton(
+                        text = "Share backup",
+                        onClick = { shareText(setup.nsec) },
+                        enabled = enabled,
+                        variant = AppButtonVariant.Secondary,
+                        size = AppButtonSize.Small,
+                        icon = Icons.Default.Share,
+                    )
+                }
+                ImportKeyField(enabled = enabled, onImportKey = onImportKey)
+            }
+        }
+    }
+}
+
+/** Operators holding the key shards, plus how many of them must sign. */
+@Composable
+private fun OperatorConfig(
+    setup: GoogleAccountSetup,
+    enabled: Boolean,
+    onAddOperator: (String) -> String?,
+    onRemoveOperator: (String) -> Unit,
+    onThresholdChange: (Int) -> Unit,
+) {
+    var draft by remember { mutableStateOf("") }
+    var addError by remember { mutableStateOf<String?>(null) }
+
+    val submitDraft = {
+        if (draft.isNotBlank()) {
+            addError = onAddOperator(draft)
+            if (addError == null) draft = ""
+        }
+    }
+
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        SectionLabel("OPERATORS")
+        Text(
+            text =
+            "Independent servers that each hold a shard of your private key, so no single " +
+                "operator can sign on its own.",
+            style = MaterialTheme.typography.bodySmall,
+            color = NostrordColors.TextMuted,
+        )
+        setup.operators.forEach { url ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = pomegranateOperatorLabel(url),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = NostrordColors.TextContent,
+                    modifier = Modifier.weight(1f),
+                )
+                when (setup.statusOf(url)) {
+                    GoogleAccountSetup.OperatorStatus.Checking -> {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(14.dp),
+                            strokeWidth = 2.dp,
+                            color = NostrordColors.TextMuted,
+                        )
+                    }
+
+                    GoogleAccountSetup.OperatorStatus.Reachable -> {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = "Responding",
+                            tint = NostrordColors.Success,
+                            modifier = Modifier.size(16.dp),
+                        )
+                    }
+
+                    GoogleAccountSetup.OperatorStatus.Unreachable -> {
+                        Text(
+                            text = "not responding",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = NostrordColors.Error,
+                        )
+                    }
+
+                    GoogleAccountSetup.OperatorStatus.Unknown -> {}
+                }
+                IconButton(
+                    onClick = { onRemoveOperator(url) },
+                    enabled = enabled && setup.canRemoveOperator,
+                    modifier = Modifier.size(32.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Cancel,
+                        contentDescription = "Remove ${pomegranateOperatorLabel(url)}",
+                        tint = NostrordColors.TextMuted,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+            }
+        }
+
+        AppSearchField(
+            value = draft,
+            onValueChange = {
+                draft = it
+                addError = null
+            },
+            placeholder = "Add operator URL",
+            size = InputSize.Compact,
+            icon = null,
+            containerColor = NostrordColors.InputBackground,
+            onDone = submitDraft,
+            trailing = {
+                AppButton(
+                    text = "Add",
+                    onClick = submitDraft,
+                    enabled = enabled && draft.isNotBlank(),
+                    variant = AppButtonVariant.Secondary,
+                    size = AppButtonSize.Small,
+                )
+            },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        addError?.let {
+            Text(text = it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+        }
+
+        if (setup.recommendedOperators.isNotEmpty()) {
+            Text(
+                text = "Recommended",
+                style = MaterialTheme.typography.bodySmall,
+                color = NostrordColors.TextMuted,
+            )
+            setup.recommendedOperators.forEach { url ->
+                AppButton(
+                    text = pomegranateOperatorLabel(url),
+                    onClick = { addError = onAddOperator(url) },
+                    enabled = enabled,
+                    variant = AppButtonVariant.Ghost,
+                    size = AppButtonSize.Small,
+                    icon = Icons.Default.Add,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(4.dp))
+        SectionLabel("SIGNING THRESHOLD")
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            IconButton(
+                onClick = { onThresholdChange(setup.threshold - 1) },
+                enabled = enabled && setup.canLowerThreshold,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(Icons.Default.Remove, contentDescription = "Lower threshold", tint = NostrordColors.TextContent)
+            }
+            Text(
+                text = setup.threshold.toString(),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = NostrordColors.TextPrimary,
+            )
+            IconButton(
+                onClick = { onThresholdChange(setup.threshold + 1) },
+                enabled = enabled && setup.canRaiseThreshold,
+                modifier = Modifier.size(32.dp),
+            ) {
+                Icon(Icons.Default.Add, contentDescription = "Raise threshold", tint = NostrordColors.TextContent)
+            }
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = "of ${setup.usableOperators.size} operators are enough to sign",
+                style = MaterialTheme.typography.bodySmall,
+                color = NostrordColors.TextMuted,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(
+    text: String,
+    color: Color = NostrordColors.TextMuted,
+) {
+    Text(
+        text = text,
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = color,
+    )
+}
+
+/** Collapsed-by-default disclosure, matching the central-server one in [GoogleLoginTab]. */
+@Composable
+internal fun AdvancedDisclosure(
+    open: Boolean,
+    onToggle: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier =
+            Modifier
+                .clip(NostrordShapes.shapeSmall)
+                .clickable { onToggle() }
+                .pointerHoverIcon(PointerIcon.Hand)
+                .padding(vertical = 8.dp, horizontal = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector =
+                if (open) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = NostrordColors.TextMuted,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = "Advanced options",
+                style = MaterialTheme.typography.bodyMedium,
+                color = NostrordColors.TextSecondary,
+            )
+        }
+        if (open) content()
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleLoginTab.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/login/components/GoogleLoginTab.kt
@@ -1,34 +1,25 @@
 package org.nostr.nostrord.ui.screens.login.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.pointer.PointerIcon
-import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -41,21 +32,56 @@ import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonSize
 import org.nostr.nostrord.ui.screens.login.LoginViewModel
 import org.nostr.nostrord.ui.theme.NostrordColors
-import org.nostr.nostrord.ui.theme.NostrordShapes
 
 /**
  * "Login with Google" (pomegranate threshold signer). Runs the whole flow in the shared
  * [LoginViewModel]; this tab only reflects its status and offers the central-server override.
- * First sign-in creates a sharded account; the resulting bunker session logs in like any other.
+ * A Google identity with no account yet stops at [GoogleAccountSetupSection] to back up its
+ * key; the resulting bunker session then logs in like any other.
  */
 @Composable
 fun GoogleLoginTab(onLoginSuccess: () -> Unit) {
     val vm = viewModel { LoginViewModel(AppModule.nostrRepository) }
+    val setup by vm.googleSetup.collectAsState()
     var status by remember { mutableStateOf<PomegranateStatus?>(null) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
     var central by remember { mutableStateOf(PomegranateConfig.CENTRAL_URL) }
     var advancedOpen by remember { mutableStateOf(false) }
     val busy = status != null
+
+    // Shared by both phases: success closes the login, a dismissed popup is a silent cancel.
+    val handleResult = { result: Result<Unit> ->
+        status = null
+        val err = result.exceptionOrNull()
+        when {
+            err == null -> onLoginSuccess()
+            err is PomegranatePopupClosedException -> {}
+            else -> errorMessage = err.message ?: "Google login failed"
+        }
+    }
+
+    setup?.let { current ->
+        GoogleAccountSetupSection(
+            setup = current,
+            busy = busy,
+            createLabel = if (busy) statusLabel(status) else "Create account",
+            errorMessage = errorMessage,
+            onRegenerateKey = vm::regenerateGoogleKey,
+            onImportKey = vm::importGoogleKey,
+            onAddOperator = vm::addGoogleOperator,
+            onRemoveOperator = vm::removeGoogleOperator,
+            onThresholdChange = vm::setGoogleThreshold,
+            onCheckOperators = vm::checkGoogleOperators,
+            onCreate = {
+                if (!busy) {
+                    errorMessage = null
+                    status = PomegranateStatus.Creating
+                    vm.createGoogleAccount(onStatus = { status = it }, onResult = handleResult)
+                }
+            },
+        )
+        return
+    }
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -94,28 +120,18 @@ fun GoogleLoginTab(onLoginSuccess: () -> Unit) {
         }
 
         AppButton(
-            text =
-            when (status) {
-                PomegranateStatus.WaitingForGoogle -> "Waiting for Google sign-in..."
-                PomegranateStatus.Checking -> "Checking your account..."
-                PomegranateStatus.Creating -> "Setting up your secure account..."
-                PomegranateStatus.Connecting -> "Connecting..."
-                null -> "Continue with Google"
-            },
+            text = statusLabel(status),
             onClick = {
                 if (!busy && central.isNotBlank()) {
                     errorMessage = null
                     status = PomegranateStatus.WaitingForGoogle
-                    vm.loginWithGoogle(centralUrl = central, onStatus = { status = it }) { result ->
-                        status = null
-                        val err = result.exceptionOrNull()
-                        when {
-                            err == null -> onLoginSuccess()
-                            // User dismissed the WebView: a cancel, not an error.
-                            err is PomegranatePopupClosedException -> {}
-                            else -> errorMessage = err.message ?: "Google login failed"
-                        }
-                    }
+                    vm.loginWithGoogle(
+                        centralUrl = central,
+                        onStatus = { status = it },
+                        // New account: the setup step takes over, so drop the busy state.
+                        onNewAccount = { status = null },
+                        onResult = handleResult,
+                    )
                 }
             },
             enabled = !busy && central.isNotBlank(),
@@ -137,31 +153,8 @@ fun GoogleLoginTab(onLoginSuccess: () -> Unit) {
         )
 
         // Advanced: self-hosted central server override.
-        Column(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                modifier =
-                Modifier
-                    .clip(NostrordShapes.shapeSmall)
-                    .clickable { advancedOpen = !advancedOpen }
-                    .pointerHoverIcon(PointerIcon.Hand)
-                    .padding(vertical = 8.dp, horizontal = 4.dp),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    imageVector =
-                    if (advancedOpen) Icons.Default.KeyboardArrowDown else Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = null,
-                    tint = NostrordColors.TextMuted,
-                    modifier = Modifier.size(18.dp),
-                )
-                Spacer(modifier = Modifier.width(6.dp))
-                Text(
-                    text = "Advanced options",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = NostrordColors.TextSecondary,
-                )
-            }
-            if (advancedOpen) {
+        AdvancedDisclosure(open = advancedOpen, onToggle = { advancedOpen = !advancedOpen }) {
+            Column(modifier = Modifier.fillMaxWidth()) {
                 Text(
                     text =
                     "Central server: checks your Google sign-in and forwards each signing request " +
@@ -183,4 +176,12 @@ fun GoogleLoginTab(onLoginSuccess: () -> Unit) {
             }
         }
     }
+}
+
+private fun statusLabel(status: PomegranateStatus?): String = when (status) {
+    PomegranateStatus.WaitingForGoogle -> "Waiting for Google sign-in..."
+    PomegranateStatus.Checking -> "Checking your account..."
+    PomegranateStatus.Creating -> "Setting up your secure account..."
+    PomegranateStatus.Connecting -> "Connecting..."
+    null -> "Continue with Google"
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/utils/TextFileSaver.kt
@@ -1,0 +1,14 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+
+/** True on platforms that can write a text file to the user's downloads. */
+expect val supportsTextFileSave: Boolean
+
+/**
+ * Returns a suspend callback that saves [content] as [fileName] in the platform's downloads
+ * location and reports whether it succeeded. The call suspends for the duration of the write
+ * and surfaces its own user feedback (Toast / system message) per platform.
+ */
+@Composable
+expect fun rememberTextFileSaver(): suspend (content: String, fileName: String) -> Boolean

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/Icon.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/Icon.kt
@@ -212,6 +212,7 @@ enum class Ic(val d: String) {
         "M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z",
     ),
     Download("M5 20h14v-2H5v2zM19 9h-4V3H9v6H5l7 7 7-7z"),
+    Remove("M19 13H5v-2h14v2z"),
 }
 
 /** Render a Material icon as inline SVG (24×24 viewBox); colour/size come from CSS (`fill: currentColor`). */

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/NoticeCard.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/NoticeCard.kt
@@ -1,0 +1,31 @@
+package org.nostr.nostrord.web.components
+
+import react.ChildrenBuilder
+import react.dom.html.ReactHTML.div
+import web.cssom.ClassName
+
+/**
+ * Tinted callout with an icon, title and body: brand by default, warning when [alert].
+ * The web counterpart of the Compose `InfoCard`.
+ */
+fun ChildrenBuilder.noticeCard(
+    title: String,
+    body: String,
+    alert: Boolean = false,
+    ic: Ic = if (alert) Ic.Warning else Ic.Info,
+) {
+    div {
+        className = ClassName(if (alert) "protect-info alert" else "protect-info")
+        icon(ic)
+        div {
+            div {
+                className = ClassName("protect-info-title")
+                +title
+            }
+            div {
+                className = ClassName("protect-info-desc")
+                +body
+            }
+        }
+    }
+}

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/PomegranateDisconnectModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/PomegranateDisconnectModal.kt
@@ -1,0 +1,127 @@
+package org.nostr.nostrord.web.modals
+
+import org.nostr.nostrord.ui.screens.backup.BackupViewModel
+import org.nostr.nostrord.ui.screens.backup.BackupViewModel.DisconnectNotice
+import org.nostr.nostrord.ui.screens.backup.BackupViewModel.PomegranateDisconnect
+import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.components.formError
+import org.nostr.nostrord.web.components.noticeCard
+import org.nostr.nostrord.web.components.useEscClose
+import react.ChildrenBuilder
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.input
+import react.dom.html.ReactHTML.span
+import react.useState
+import web.cssom.ClassName
+import web.html.InputType
+import web.html.checkbox
+
+external interface PomegranateDisconnectModalProps : Props {
+    var vm: BackupViewModel
+
+    /** Closes the modal; the account may already be gone when the disconnect signed it out. */
+    var onClose: () -> Unit
+}
+
+/**
+ * Confirmation for unlinking a Login-with-Google account from its central server. The
+ * outcome depends on whether the nsec was exported first: with it the account converts to
+ * a local-key login and stays signed in, without it it can no longer sign and is signed
+ * out. Mirrors the Compose PomegranateDisconnectDialog.
+ */
+val PomegranateDisconnectModal =
+    FC<PomegranateDisconnectModalProps> { props ->
+        val vm = props.vm
+        val disconnect = useStateFlow(vm.pomDisconnect)
+        val pomError = useStateFlow(vm.pomError)
+        val (acknowledged, setAcknowledged) = useState { false }
+        val keyExported = vm.pomKeyExported
+        val working = disconnect == PomegranateDisconnect.Working
+        val done = disconnect as? PomegranateDisconnect.Done
+
+        // Closing while the Google popup is still open abandons the attempt, so the next
+        // one starts clean instead of finding the flow stuck on "Disconnecting...".
+        val close = {
+            if (done == null) {
+                vm.cancelPomegranateDisconnect()
+                props.onClose()
+            } else {
+                // Esc / overlay / Cancel after the disconnect finished still has to settle
+                // the account: an unlinked bunker account left in place can no longer sign.
+                vm.finishPomegranateDisconnect { props.onClose() }
+            }
+        }
+        useEscClose { close() }
+
+        div {
+            // over-settings: this modal is only ever opened from the settings overlay.
+            className = ClassName("modal-overlay over-settings")
+            onClick = { close() }
+            div {
+                className = ClassName("modal-card sm")
+                onClick = { it.stopPropagation() }
+                div {
+                    className = ClassName("modal-title")
+                    +(if (done != null) "Disconnected from central server" else "Disconnect from central server")
+                }
+
+                if (done != null) {
+                    notice(vm.pomDisconnectedNotice(done.convertedToLocal))
+                    div {
+                        className = ClassName("modal-footer")
+                        button {
+                            className = ClassName("btn-primary")
+                            onClick = { vm.finishPomegranateDisconnect { props.onClose() } }
+                            +"Done"
+                        }
+                    }
+                    return@div
+                }
+
+                notice(vm.pomDisconnectNotice(keyExported))
+                formError(pomError)
+
+                // The ack only guards the lossy path: with the key exported the app keeps
+                // signing locally, so there is nothing to lose by continuing.
+                if (!keyExported) {
+                    div {
+                        className = ClassName("protect-card")
+                        onClick = { if (!working) setAcknowledged(!acknowledged) }
+                        input {
+                            type = InputType.checkbox
+                            checked = acknowledged
+                            disabled = working
+                            onChange = { event -> setAcknowledged(event.currentTarget.checked) }
+                        }
+                        div {
+                            className = ClassName("protect-card-title")
+                            +"I have safely backed up my private key"
+                        }
+                    }
+                }
+
+                div {
+                    className = ClassName("modal-footer")
+                    button {
+                        className = ClassName("btn-text")
+                        onClick = { close() }
+                        +"Cancel"
+                    }
+                    button {
+                        className = ClassName("btn-danger")
+                        disabled = working || (!keyExported && !acknowledged)
+                        onClick = { vm.disconnectPomegranate() }
+                        if (working) {
+                            span { className = ClassName("btn-spinner") }
+                        }
+                        +(if (working) "Disconnecting…" else "Disconnect from central server")
+                    }
+                }
+            }
+        }
+    }
+
+private fun ChildrenBuilder.notice(notice: DisconnectNotice) = noticeCard(title = notice.title, body = notice.body, alert = notice.alert)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/GoogleAccountSetupPanel.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/GoogleAccountSetupPanel.kt
@@ -1,0 +1,399 @@
+package org.nostr.nostrord.web.screens
+
+import kotlinx.browser.document
+import kotlinx.browser.window
+import kotlinx.coroutines.delay
+import org.nostr.nostrord.auth.pomegranate.pomegranateOperatorLabel
+import org.nostr.nostrord.ui.screens.login.GoogleAccountSetup
+import org.nostr.nostrord.ui.screens.login.LoginViewModel
+import org.nostr.nostrord.web.bridge.launchApp
+import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.copyToClipboard
+import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.noticeCard
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.code
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.input
+import react.dom.html.ReactHTML.label
+import react.dom.html.ReactHTML.p
+import react.dom.html.ReactHTML.span
+import react.useEffect
+import react.useState
+import web.cssom.ClassName
+import web.html.InputType
+import web.html.checkbox
+
+external interface GoogleAccountSetupPanelProps : Props {
+    var vm: LoginViewModel
+
+    /** Account creation in flight: everything is read-only until it finishes. */
+    var busy: Boolean
+
+    /** Primary button label (progress text while [busy]). */
+    var createLabel: String
+
+    var onCreate: () -> Unit
+}
+
+/**
+ * "Create your account": the step the Google login stops at when that Google identity has
+ * no pomegranate account yet. The key is generated client-side and shown here because the
+ * shards are dealt from it — this is the only moment the whole key exists for the user to
+ * back up. Operators and threshold sit behind Advanced options; the defaults are fine.
+ * Mirrors the Compose GoogleAccountSetupSection.
+ */
+val GoogleAccountSetupPanel =
+    FC<GoogleAccountSetupPanelProps> { props ->
+        val vm = props.vm
+        val setup = useStateFlow(vm.googleSetup)
+        val (acknowledged, setAcknowledged) = useState { false }
+        val (advanced, setAdvanced) = useState { false }
+        val (copied, setCopied) = useState { false }
+        val (draft, setDraft) = useState { "" }
+        val (addError, setAddError) = useState<String?> { null }
+        val (importing, setImporting) = useState { false }
+        val (keyDraft, setKeyDraft) = useState { "" }
+        val (keyError, setKeyError) = useState<String?> { null }
+        // Probe on entry so a dead operator is visible before the user hits Create.
+        useEffect(Unit) { vm.checkGoogleOperators() }
+        if (setup == null) return@FC
+        val busy = props.busy
+
+        val useKey = {
+            val error = vm.importGoogleKey(keyDraft)
+            setKeyError(error)
+            if (error == null) {
+                setKeyDraft("")
+                setImporting(false)
+            }
+        }
+
+        val addOperator = { raw: String ->
+            val error = vm.addGoogleOperator(raw)
+            setAddError(error)
+            if (error == null) setDraft("")
+        }
+
+        div {
+            className = ClassName("wizard-title")
+            +"Create your account"
+        }
+
+        p {
+            className = ClassName("wizard-sub")
+            +setup.introLine
+        }
+
+        // Everything about the key lives in one panel: the value, why it matters, and the
+        // two ways to keep it. The rest of the step stays loose so this reads as the block
+        // that needs attention.
+        div {
+            className = ClassName("key-panel")
+            div {
+                className = ClassName("key-panel-label")
+                +"YOUR PRIVATE KEY"
+            }
+            div {
+                className = ClassName("input-group sm")
+                code {
+                    className = ClassName("keyline-value")
+                    +setup.nsec
+                }
+                button {
+                    className = ClassName("keyline-copy")
+                    title = if (copied) "Copied" else "Copy private key"
+                    disabled = busy
+                    onClick = {
+                        copyToClipboard(setup.nsec)
+                        setCopied(true)
+                        launchApp {
+                            delay(2_000)
+                            setCopied(false)
+                        }
+                    }
+                    if (copied) icon(Ic.Check) else icon(Ic.ContentCopy)
+                }
+                button {
+                    className = ClassName("keyline-copy")
+                    title = "Generate new key"
+                    disabled = busy
+                    onClick = { vm.regenerateGoogleKey() }
+                    icon(Ic.Refresh)
+                }
+            }
+            div {
+                className = ClassName("key-warning")
+                icon(Ic.Warning)
+                span { +setup.keyWarning }
+            }
+            div {
+                className = ClassName("key-actions")
+                button {
+                    className = ClassName("btn-secondary btn-sm")
+                    disabled = busy
+                    onClick = { downloadTextFile("nostr-private-key.txt", setup.nsec) }
+                    icon(Ic.Download)
+                    +"Download backup"
+                }
+                if (!importing) {
+                    button {
+                        className = ClassName("link-inline")
+                        disabled = busy
+                        onClick = { setImporting(true) }
+                        icon(Ic.Key)
+                        +"Use a key I already have"
+                    }
+                }
+            }
+
+            // Bringing an identity you already have: the shards are dealt from the pasted
+            // key instead of the generated one, so the account keeps your pubkey.
+            if (importing) {
+                div {
+                    className = ClassName("input-group sm key-import")
+                    input {
+                        className = ClassName("input")
+                        placeholder = "nsec1... or 64-character hex"
+                        value = keyDraft
+                        disabled = busy
+                        autoFocus = true
+                        onChange = { event ->
+                            setKeyDraft(event.currentTarget.value)
+                            setKeyError(null)
+                        }
+                        onKeyDown = { event ->
+                            if (event.key == "Enter") {
+                                event.preventDefault()
+                                useKey()
+                            }
+                        }
+                    }
+                    button {
+                        className = ClassName("btn-secondary btn-sm")
+                        disabled = busy || keyDraft.isBlank()
+                        onClick = { useKey() }
+                        +"Use key"
+                    }
+                }
+                keyError?.let {
+                    div {
+                        className = ClassName("po-add-error")
+                        +it
+                    }
+                }
+            }
+        }
+
+        label {
+            className = ClassName("ack-row")
+            input {
+                type = InputType.checkbox
+                checked = acknowledged
+                disabled = busy
+                onChange = { event -> setAcknowledged(event.currentTarget.checked) }
+            }
+            span { +"I have safely backed up my private key" }
+        }
+
+        div {
+            className = ClassName("advanced-section")
+            div {
+                className = ClassName("advanced-header")
+                onClick = { setAdvanced(!advanced) }
+                span {
+                    className = ClassName(if (advanced) "advanced-chevron" else "advanced-chevron collapsed")
+                    icon(Ic.ExpandMore)
+                }
+                span {
+                    className = ClassName("advanced-title")
+                    +"Advanced options"
+                }
+            }
+            if (advanced) {
+                div {
+                    className = ClassName("po-section-label")
+                    +"OPERATORS"
+                }
+                p {
+                    className = ClassName("advanced-desc")
+                    +"Independent servers that each hold a shard of your private key, so no single operator can sign on its own."
+                }
+                setup.operators.forEach { url ->
+                    div {
+                        key = url
+                        className = ClassName("advanced-relay-row")
+                        span {
+                            className = ClassName("advanced-relay-url")
+                            +pomegranateOperatorLabel(url)
+                        }
+                        when (setup.statusOf(url)) {
+                            GoogleAccountSetup.OperatorStatus.Checking -> span { className = ClassName("btn-spinner") }
+                            GoogleAccountSetup.OperatorStatus.Reachable -> {
+                                span {
+                                    className = ClassName("benefit-check")
+                                    icon(Ic.Check)
+                                }
+                            }
+
+                            GoogleAccountSetup.OperatorStatus.Unreachable -> {
+                                span {
+                                    className = ClassName("po-operator-down")
+                                    +"not responding"
+                                }
+                            }
+
+                            GoogleAccountSetup.OperatorStatus.Unknown -> {}
+                        }
+                        button {
+                            className = ClassName("advanced-relay-remove")
+                            title = "Remove operator"
+                            disabled = busy || !setup.canRemoveOperator
+                            onClick = { vm.removeGoogleOperator(url) }
+                            icon(Ic.Close)
+                        }
+                    }
+                }
+                div {
+                    className = ClassName("input-group sm advanced-add")
+                    input {
+                        className = ClassName("input")
+                        placeholder = "Add operator URL"
+                        value = draft
+                        disabled = busy
+                        onChange = { event ->
+                            setDraft(event.currentTarget.value)
+                            setAddError(null)
+                        }
+                        onKeyDown = { event ->
+                            if (event.key == "Enter") {
+                                event.preventDefault()
+                                addOperator(draft)
+                            }
+                        }
+                    }
+                    button {
+                        className = ClassName("btn-secondary btn-sm")
+                        disabled = busy || draft.isBlank()
+                        onClick = { addOperator(draft) }
+                        +"Add"
+                    }
+                }
+                addError?.let {
+                    div {
+                        className = ClassName("po-add-error")
+                        +it
+                    }
+                }
+                if (setup.recommendedOperators.isNotEmpty()) {
+                    div {
+                        className = ClassName("advanced-desc")
+                        +"Recommended"
+                    }
+                    div {
+                        className = ClassName("po-chips")
+                        setup.recommendedOperators.forEach { url ->
+                            button {
+                                key = url
+                                className = ClassName("btn-secondary btn-sm")
+                                disabled = busy
+                                onClick = { addOperator(url) }
+                                icon(Ic.Add)
+                                +pomegranateOperatorLabel(url)
+                            }
+                        }
+                    }
+                }
+
+                div {
+                    className = ClassName("po-section-label")
+                    +"SIGNING THRESHOLD"
+                }
+                div {
+                    className = ClassName("po-threshold")
+                    button {
+                        className = ClassName("btn-secondary po-step")
+                        disabled = busy || !setup.canLowerThreshold
+                        title = "Lower threshold"
+                        onClick = { vm.setGoogleThreshold(setup.threshold - 1) }
+                        icon(Ic.Remove)
+                    }
+                    span {
+                        className = ClassName("po-threshold-value")
+                        +setup.threshold.toString()
+                    }
+                    button {
+                        className = ClassName("btn-secondary po-step")
+                        disabled = busy || !setup.canRaiseThreshold
+                        title = "Raise threshold"
+                        onClick = { vm.setGoogleThreshold(setup.threshold + 1) }
+                        icon(Ic.Add)
+                    }
+                    span {
+                        className = ClassName("po-threshold-desc")
+                        +"of ${setup.usableOperators.size} operators are enough to sign"
+                    }
+                }
+            }
+        }
+
+        // Operator trouble is reported outside Advanced options, which is collapsed by
+        // default: a quiet line while the account can still be created, a callout when it
+        // cannot.
+        if (setup.unreachableOperators.isNotEmpty()) {
+            if (setup.tooFewOperators) {
+                noticeCard(title = "Not enough operators are responding", body = setup.operatorWarning, alert = true)
+            } else {
+                div {
+                    className = ClassName("po-operator-note")
+                    +setup.operatorWarning
+                    // Inline with the sentence it answers: on its own line it read as a
+                    // stray action with no object.
+                    button {
+                        className = ClassName("link-inline")
+                        disabled = busy
+                        onClick = { vm.checkGoogleOperators() }
+                        icon(Ic.Refresh)
+                        +"Check operators again"
+                    }
+                }
+            }
+            if (setup.tooFewOperators) {
+                button {
+                    className = ClassName("link-inline")
+                    disabled = busy
+                    onClick = { vm.checkGoogleOperators() }
+                    icon(Ic.Refresh)
+                    +"Check operators again"
+                }
+            }
+        }
+
+        button {
+            className = ClassName("btn-primary btn-lg btn-full login-submit")
+            // Create waits for the probe: the operator set is decided by its verdicts.
+            disabled = busy || !acknowledged || setup.tooFewOperators || setup.operatorsPending
+            onClick = { props.onCreate() }
+            if (busy || setup.operatorsPending) {
+                span { className = ClassName("btn-spinner") }
+            }
+            +(if (!busy && setup.operatorsPending) "Checking operators…" else props.createLabel)
+        }
+    }
+
+/** Saves [content] as a downloaded text file (data URL: the nsec is small and ASCII). */
+private fun downloadTextFile(
+    name: String,
+    content: String,
+) {
+    val anchor = document.createElement("a")
+    val a = anchor.asDynamic()
+    a.href = "data:text/plain;charset=utf-8," + window.asDynamic().encodeURIComponent(content)
+    a.download = name
+    document.body?.appendChild(anchor)
+    a.click()
+    anchor.remove()
+}

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginMethods.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/LoginMethods.kt
@@ -7,6 +7,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.screens.login.LoginMethod
 import org.nostr.nostrord.ui.screens.login.LoginViewModel
 import org.nostr.nostrord.ui.screens.login.availableLoginMethods
+import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.GoogleLogo
 import org.nostr.nostrord.web.components.Ic
@@ -71,6 +72,14 @@ private fun ChildrenBuilder.methodRow(
     }
 }
 
+private fun googleStatusLabel(status: PomegranateStatus?): String = when (status) {
+    PomegranateStatus.WaitingForGoogle -> "Waiting for Google sign-in…"
+    PomegranateStatus.Checking -> "Checking your account…"
+    PomegranateStatus.Creating -> "Setting up your secure account…"
+    PomegranateStatus.Connecting -> "Connecting…"
+    null -> "Continue with Google"
+}
+
 private fun ChildrenBuilder.benefit(text: String) {
     div {
         className = ClassName("benefit")
@@ -121,6 +130,22 @@ val LoginMethods =
         val (googleStatus, setGoogleStatus) = useState<PomegranateStatus?> { null }
         val (googleCentral, setGoogleCentral) = useState { PomegranateConfig.CENTRAL_URL }
         val (googleAdvanced, setGoogleAdvanced) = useState { false }
+
+        // Non-null once a Google sign-in finds no account: the setup panel replaces the tab.
+        val googleSetup = useStateFlow(vm.googleSetup)
+
+        // Terminal callback of both Google phases (direct login and account creation).
+        fun finishGoogleLogin(result: Result<Unit>) {
+            setBusy(false)
+            setGoogleStatus(null)
+            val err = result.exceptionOrNull()
+            when {
+                err == null -> props.onSuccess()
+                // User dismissed the popup: a cancel, not an error.
+                err is PomegranatePopupClosedException -> {}
+                else -> setError(err.message ?: "Google login failed")
+            }
+        }
 
         // Run a VM auth action. The VM launches on its own scope, so we just react to the
         // callback: success calls onSuccess, failure surfaces the error string.
@@ -287,8 +312,26 @@ val LoginMethods =
                 }
 
                 // "Login with Google" (pomegranate threshold signer), web-only.
-                // The whole flow runs in the VM; this tab only reflects its status.
-                LoginMethod.Google -> {
+                // The whole flow runs in the VM; this tab only reflects its status. A Google
+                // identity with no account yet stops at the setup panel to back up its key.
+                LoginMethod.Google -> if (googleSetup != null) {
+                    GoogleAccountSetupPanel {
+                        this.vm = vm
+                        this.busy = busy
+                        this.createLabel = if (busy) googleStatusLabel(googleStatus) else "Create account"
+                        onCreate = {
+                            if (!busy) {
+                                setError(null)
+                                setBusy(true)
+                                setGoogleStatus(PomegranateStatus.Creating)
+                                vm.createGoogleAccount(
+                                    onStatus = { setGoogleStatus(it) },
+                                    onResult = { result -> finishGoogleLogin(result) },
+                                )
+                            }
+                        }
+                    }
+                } else {
                     div {
                         className = ClassName("ext-content")
                         span {
@@ -313,29 +356,19 @@ val LoginMethods =
                                     vm.loginWithGoogle(
                                         centralUrl = googleCentral,
                                         onStatus = { setGoogleStatus(it) },
-                                    ) { result ->
-                                        setBusy(false)
-                                        setGoogleStatus(null)
-                                        val err = result.exceptionOrNull()
-                                        when {
-                                            err == null -> props.onSuccess()
-                                            // User dismissed the popup: a cancel, not an error.
-                                            err is PomegranatePopupClosedException -> {}
-                                            else -> setError(err.message ?: "Google login failed")
-                                        }
-                                    }
+                                        // New account: the setup panel takes over, so drop the busy state.
+                                        onNewAccount = {
+                                            setBusy(false)
+                                            setGoogleStatus(null)
+                                        },
+                                        onResult = { result -> finishGoogleLogin(result) },
+                                    )
                                 }
                             }
                             if (googleStatus != null) {
                                 span { className = ClassName("btn-spinner") }
                             }
-                            +when (googleStatus) {
-                                PomegranateStatus.WaitingForGoogle -> "Waiting for Google sign-in…"
-                                PomegranateStatus.Checking -> "Checking your account…"
-                                PomegranateStatus.Creating -> "Setting up your secure account…"
-                                PomegranateStatus.Connecting -> "Connecting…"
-                                null -> "Continue with Google"
-                            }
+                            +googleStatusLabel(googleStatus)
                         }
 
                         div {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/PomegranateKeySection.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/PomegranateKeySection.kt
@@ -7,8 +7,10 @@ import org.nostr.nostrord.ui.screens.backup.BackupViewModel.ShardStatus
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.IdentifierRow
+import org.nostr.nostrord.web.components.Portal
 import org.nostr.nostrord.web.components.formError
 import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.modals.PomegranateDisconnectModal
 import react.FC
 import react.Props
 import react.dom.html.ReactHTML.button
@@ -33,7 +35,7 @@ val PomegranateKeySection =
         val export = useStateFlow(vm.pomExport)
         val disconnect = useStateFlow(vm.pomDisconnect)
         val pomError = useStateFlow(vm.pomError)
-        val (disconnectArmed, setDisconnectArmed) = useState { false }
+        val (confirming, setConfirming) = useState { false }
 
         div {
             className = ClassName("settings-card")
@@ -156,7 +158,7 @@ val PomegranateKeySection =
                         "signs with that key locally. Without it the account can no longer sign anything."
                     )
             }
-            if (disconnect is PomegranateDisconnect.Done) {
+            if (disconnect is PomegranateDisconnect.Done && !confirming) {
                 div {
                     className = ClassName("settings-tip")
                     +(
@@ -172,19 +174,20 @@ val PomegranateKeySection =
                     className = ClassName("pom-actions")
                     button {
                         className = ClassName("btn-danger")
-                        disabled = disconnect == PomegranateDisconnect.Working
-                        onClick = {
-                            if (!disconnectArmed) setDisconnectArmed(true) else vm.disconnectPomegranate()
-                        }
-                        if (disconnect == PomegranateDisconnect.Working) {
-                            span { className = ClassName("btn-spinner") }
-                        }
-                        +when {
-                            disconnect == PomegranateDisconnect.Working -> "Disconnecting…"
-                            disconnectArmed -> "Click again to confirm"
-                            else -> "Disconnect from central server"
-                        }
+                        onClick = { setConfirming(true) }
+                        +"Disconnect from central server"
                     }
+                }
+            }
+        }
+
+        // Portaled to <body>: the settings panel this section renders inside establishes a
+        // containing block, which would pin the overlay to the panel instead of the viewport.
+        if (confirming) {
+            Portal {
+                PomegranateDisconnectModal {
+                    this.vm = vm
+                    onClose = { setConfirming(false) }
                 }
             }
         }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -7329,6 +7329,12 @@ body {
     background: var(--color-background);
 }
 
+/* A modal opened from inside settings portals to <body>, landing as a sibling of
+   .settings-overlay: without this it paints under that opaque full-screen layer. */
+.modal-overlay.over-settings {
+    z-index: 300;
+}
+
 .settings-fill {
     flex: 1 1 0;
     min-width: 0;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -826,7 +826,8 @@ body {
     color: var(--color-text-secondary);
 }
 
-/* Wizard password recommendation card (brand tint; brand is theme-invariant) */
+/* Callout card: brand tint by default, `.alert` for the save-your-key warning
+   (brand and warning are both theme-invariant) */
 .protect-info {
     display: flex;
     align-items: flex-start;
@@ -856,6 +857,16 @@ body {
     margin-top: 2px;
     font-size: 12px;
     color: var(--color-text-secondary);
+}
+
+.protect-info.alert {
+    border-color: rgba(255, 165, 0, 0.4);
+    background: rgba(255, 165, 0, 0.1);
+}
+
+.protect-info.alert .ico,
+.protect-info.alert .protect-info-title {
+    color: var(--color-warning-orange);
 }
 
 .form-divider {
@@ -1189,6 +1200,146 @@ body {
 
 .advanced-apply {
     margin-top: 12px;
+}
+
+/* Google new-account setup: key backup, acknowledgement and operator notes */
+.key-panel {
+    margin-top: 16px;
+    padding: 14px;
+    background: var(--color-floating);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-md);
+}
+
+.key-panel-label {
+    margin-bottom: 8px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-secondary);
+}
+
+/* The panel already sits on --color-floating, so its fields need a lighter surface of
+   their own or they read as flat text on the panel. */
+.key-panel .input-group {
+    background: var(--color-input);
+    border-color: var(--color-divider);
+}
+
+.key-panel .input-group:focus-within {
+    border-color: var(--color-primary);
+}
+
+.key-import {
+    margin-top: 10px;
+}
+
+.key-warning {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--color-text-muted);
+}
+
+.key-warning .ico {
+    width: 14px;
+    height: 14px;
+    flex-shrink: 0;
+    margin-top: 1px;
+    color: var(--color-warning-orange);
+}
+
+.key-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 10px;
+}
+
+.ack-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 16px;
+    font-size: 13px;
+    color: var(--color-text-content);
+    cursor: pointer;
+}
+
+.ack-row input[type="checkbox"] {
+    accent-color: var(--color-primary);
+}
+
+.po-operator-note {
+    margin-top: 4px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--color-text-muted);
+}
+
+.po-operator-note .link-inline {
+    margin-left: 6px;
+    vertical-align: baseline;
+}
+
+/* Google new-account setup: operator list + signing threshold */
+.po-section-label {
+    margin-top: 12px;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-text-muted);
+}
+
+.po-operator-down {
+    flex-shrink: 0;
+    font-size: 12px;
+    color: var(--color-error);
+}
+
+.po-add-error {
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--color-error);
+}
+
+.po-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.po-threshold {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.po-step {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.po-threshold-value {
+    min-width: 24px;
+    text-align: center;
+    font-size: 15px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-primary);
+}
+
+.po-threshold-desc {
+    font-size: 13px;
+    color: var(--color-text-muted);
 }
 
 .benefits-title {
@@ -4932,6 +5083,17 @@ body {
 }
 
 /* Size and width modifiers */
+
+.btn-sm {
+    gap: 6px;
+    padding: 6px 12px;
+    font-size: 13px;
+}
+
+.btn-sm .ico {
+    width: 14px;
+    height: 14px;
+}
 
 .btn-lg {
     height: 48px;

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -130,6 +130,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `JoinWithCodeModal` | webMain/kotlin/org/nostr/nostrord/web/modals/JoinWithCodeModal.kt | Join-with-invite-code modal — web port of the Compose InviteCodeJoinModal |
 | `ManageGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt | Unified admin "Manage group" modal (port of the prototype GroupManage): a left tab |
 | `MembersModal` | webMain/kotlin/org/nostr/nostrord/web/modals/MembersModal.kt | Read-only member roster (port of the prototype GroupPanels "Members" panel): avatar + |
+| `PomegranateDisconnectModal` | webMain/kotlin/org/nostr/nostrord/web/modals/PomegranateDisconnectModal.kt | Confirmation for unlinking a Login-with-Google account from its central server. The |
 | `Portal` | webMain/kotlin/org/nostr/nostrord/web/components/Portal.kt | Renders its children into `<body>` through a React portal, so they escape any ancestor that |
 | `ReportUserModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ReportUserModal.kt | NIP-56 report modal (prototype ReportModal): reason radio cards, optional note, |
 | `ShareGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt | Share-group modal — real port of the Compose ShareGroupModal: a single cycling identifier field |


### PR DESCRIPTION
A first Google sign-in used to register a sharded account silently: the key was generated, dealt to the operators and dropped, so the user never saw the one copy that exists whole. It now stops at a setup step that shows the nsec for backup and only deals the shards once the user confirms it, or after pasting a key they already have so the Google login adopts that identity instead. The operators are probed on entry, so a host that is down is named there rather than surfacing as a stalled registration, and creation waits for every verdict before choosing who gets a shard.

Disconnecting from the central server gets the same treatment: a confirmation that says what actually happens, which differs depending on whether the nsec was exported first.

Two bugs found while testing this fall out of the same area and ride along: a bunker login replayed a retired client key, and a cancelled disconnect left the app looking logged out without being logged out.

| Behavior | Before | After |
|---|---|---|
| First Google sign-in | account registered silently, key never shown | setup step: nsec for backup, acknowledgement gate, then shards |
| Existing identity | not possible, always a new key | paste an nsec or hex and the account is created for that pubkey |
| Operator down | 20s stall per host, shard registered to nobody | probed up front, named in the step, skipped at registration |
| Registration below threshold | account left half-registered on the central | rolled back, error carries the server's status and message |
| Disconnect | inline click-again button, no explanation | dialog stating whether the account stays signed in or is signed out |
| Disconnect cancelled mid-flight | joined groups left empty, app on onboarding while signed in | server-side work finishes NonCancellable |
| Bunker re-login after logout | replayed the global client key, sat on Connecting for 120s | client key of an account still registered with that signer, fresh otherwise |
| Saving the backup as a file | web only | desktop writes to Downloads, Android to MediaStore Downloads; iOS still hidden pending a share sheet |

Operators and signing threshold stay behind Advanced options with the recommended defaults, so the common path is one button. Shared state and copy live in `GoogleAccountSetup` and `BackupViewModel` (commonMain), with the Compose section and the React panel as layout over them.

Validated with `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid` and `:composeApp:jvmTest` (12 new tests on the setup state); each commit builds on its own. iOS is unbuilt here (no macOS), but nothing new is platform-specific. The Google popup flow itself still needs a browser pass against live operators.

- 81e27bf9 feat(pomegranate): create the Google account from a setup step that backs up the key
- ac4705d6 feat(pomegranate): confirm the central-server disconnect in a dialog
- eec079f0 fix(nip46): connect a bunker with a client key the signer still knows
- 1cd48702 feat(pomegranate): save the key backup to a file on the native targets too
