### PR TITLE
fix(nip29): scope group membership to the relay, not the bare group id

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -460,6 +460,10 @@ class NostrRepository(
         groupManager.acceptPendingInvite(groupId)
     }
 
+    override suspend fun addGroupToMyList(groupId: String, relayUrl: String?) {
+        groupManager.addRelaySideMembershipToList(groupId, relayUrl)
+    }
+
     // Expose auth state
     override val isLoggedIn: StateFlow<Boolean> = sessionManager.isLoggedIn
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -143,6 +143,13 @@ interface NostrRepositoryApi {
     /** Adopt a pending external add into the joined set and republish kind:10009. */
     suspend fun acceptGroupInvite(groupId: String)
 
+    /**
+     * Put a group [relayUrl] already lists us in into our own kind:10009, with no invite card
+     * involved. Relay-side membership and the list are separate states; this is the manual way
+     * to reconcile them for a group we can read and post in but that no list knows about.
+     */
+    suspend fun addGroupToMyList(groupId: String, relayUrl: String?)
+
     // --- Metadata state ---
     val userMetadata: StateFlow<Map<String, UserMetadata>>
     val cachedEvents: StateFlow<Map<String, CachedEvent>>

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -65,6 +65,7 @@ import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochMillis
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -3743,6 +3744,9 @@ class GroupManager(
         val self = currentPubkey
         val selfNowMember = self != null && self in members.members
         val selfWasAbsent = currentMembers?.contains(self) != true
+        // Relay this listing belongs to: every membership decision below is scoped to it,
+        // because group ids repeat across relays.
+        val hostRelay = (relayUrl ?: getRelayForGroup(members.groupId) ?: currentRelayUrl)?.normalizeRelayUrl()
 
         // The relay listing us in 39002 is the ground-truth approval signal. If we were gated
         // (locally pending OR persisted/CLOSED as restricted) and have just transitioned into the
@@ -3770,15 +3774,14 @@ class GroupManager(
         if (self != null &&
             self in members.members &&
             members.groupId in _leftGroups.value &&
-            _joinedGroupsByRelay.value.values.any { members.groupId in it }
+            hostRelay != null &&
+            isJoinedOn(hostRelay, members.groupId)
         ) {
             _leftGroups.update { it - members.groupId }
-            getRelayForGroup(members.groupId)?.let { relay ->
-                currentPubkey?.let { pk ->
-                    try {
-                        SecureStorage.removeLeftGroupForRelay(pk, relay.normalizeRelayUrl(), members.groupId)
-                    } catch (_: Exception) {}
-                }
+            currentPubkey?.let { pk ->
+                try {
+                    SecureStorage.removeLeftGroupForRelay(pk, hostRelay, members.groupId)
+                } catch (_: Exception) {}
             }
         }
 
@@ -3790,7 +3793,8 @@ class GroupManager(
             registerExternalAdd(members.groupId, relayUrl, createdAtSeconds = createdAt)
         } else if (self != null && !selfNowMember) {
             // No longer listed (admin removed us before we decided): the invite is moot.
-            discardPendingInvite(members.groupId)
+            // Only this relay's invite: a same-id invite from another relay is a different group.
+            if (_pendingGroupInvites.value[members.groupId]?.relayUrl == hostRelay) discardPendingInvite(members.groupId)
         }
 
         return members.members
@@ -3849,13 +3853,22 @@ class GroupManager(
         // registered an "invite" here; without this the creator is prompted to accept
         // their own group.
         scope.launch {
-            _joinedGroupsByRelay.collect { byRelay ->
+            _joinedGroupsByRelay.collect {
                 if (_pendingGroupInvites.value.isEmpty()) return@collect
-                val joined = byRelay.values.flatten().toSet()
-                _pendingGroupInvites.value.keys.filter { it in joined }.forEach { discardPendingInvite(it) }
+                // Settled only on the invite's OWN relay: the same id joined elsewhere is a
+                // different group, and treating it as settled discarded the invite unanswered.
+                _pendingGroupInvites.value.values
+                    .filter { isJoinedOn(it.relayUrl, it.groupId) }
+                    .forEach { discardPendingInvite(it.groupId) }
             }
         }
     }
+
+    /** True when [groupId] is in the joined set of [relayUrl] specifically (ids repeat across relays). */
+    private fun isJoinedOn(
+        relayUrl: String,
+        groupId: String,
+    ): Boolean = _joinedGroupsByRelay.value.isJoinedOn(relayUrl, groupId)
 
     private fun persistPendingInvites() {
         val pk = currentPubkey ?: return
@@ -3872,9 +3885,8 @@ class GroupManager(
             emptyList()
         }
         if (stored.isEmpty()) return
-        val joined = _joinedGroupsByRelay.value.values.flatten().toSet()
         val valid = stored.filter {
-            it.groupId !in joined && it.groupId !in _leftGroups.value && it.groupId !in deletedGroupIds
+            !isJoinedOn(it.relayUrl, it.groupId) && it.groupId !in _leftGroups.value && it.groupId !in deletedGroupIds
         }
         if (valid.isEmpty()) return
         // Keep in-memory entries: a live registration this session is fresher than the slot.
@@ -3899,11 +3911,14 @@ class GroupManager(
         // are the actor when we add ourselves) is not an external add.
         if (actorPubkey != null && actorPubkey == currentPubkey) return
         if (isRecentlyLeft(groupId) || groupId in deletedGroupIds) return
-        if (_joinedGroupsByRelay.value.values.any { groupId in it }) return
+        val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
+        // Per relay: the same id joined elsewhere is a different group. Matching across all
+        // relays swallowed the invite, so a group we are a relay-side member of never got a
+        // prompt, never entered the joined set, and never reached kind:10009 (no rail entry).
+        if (isJoinedOn(relay, groupId)) return
         // A create/join we initiated is still in flight (id pre-claimed before the send):
         // the relay's put-user echo for it is our own doing, not an external add.
         if (isRecentlyJoined(groupId)) return
-        val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
         val leftAt = _leftGroups.value[groupId]
         if (leftAt != null) {
             // Only an actual put-user event dated after the leave re-opens; 39002 listings
@@ -3916,7 +3931,9 @@ class GroupManager(
                 } catch (_: Exception) {}
             }
         }
-        val existing = _pendingGroupInvites.value[groupId]
+        // Scoped to this relay: an entry held for the same id on another relay is a different
+        // group's invite and must be replaced by this one, not refreshed in place.
+        val existing = _pendingGroupInvites.value[groupId]?.takeIf { it.relayUrl == relay }
         if (existing != null) {
             if (actorPubkey == null) return
             // The same put-user replayed by the inclusive since-cursor: nothing new.
@@ -3978,7 +3995,9 @@ class GroupManager(
     fun acceptPendingInvite(groupId: String) {
         val self = currentPubkey ?: return
         val invite = _pendingGroupInvites.value[groupId] ?: return
-        discardPendingInvite(groupId)
+        // The entry is dropped by the adoption itself, once the membership is really in the
+        // joined set. Discarding first spent the user's consent on a no-op whenever a guard
+        // then blocked the adoption: the card was gone and the group never reached kind:10009.
         adoptExternalMembership(
             groupId = groupId,
             pubkey = self,
@@ -3989,6 +4008,17 @@ class GroupManager(
         )
     }
 
+    /**
+     * Put a group the relay already lists us in (kind:39002) into our own kind:10009, without
+     * an invite card. The relay side and the list are separate states, and any missed prompt
+     * (or one answered while a guard blocked the adoption) leaves a group we can read and post
+     * in but that no list, and therefore no rail, knows about. This is the manual way in.
+     */
+    fun addRelaySideMembershipToList(groupId: String, relayUrl: String?) {
+        val self = currentPubkey ?: return
+        adoptExternalMembership(groupId = groupId, pubkey = self, relayUrl = relayUrl)
+    }
+
     /** Drop a pending invite without adopting (decline path, or the add became moot). */
     fun discardPendingInvite(groupId: String) {
         if (groupId !in _pendingGroupInvites.value) return
@@ -3997,10 +4027,12 @@ class GroupManager(
     }
 
     /**
-     * Adopt a membership created by an admin's kind:9000 (put-user) instead of our own
-     * join request — the [acceptPendingInvite] path. The durable left marker wins: a relay
-     * that keeps listing us after our kind:9022 must not resurrect the group (B2), and a
-     * rejoin has to be the user's call.
+     * Adopt a membership the relay already grants us into the joined set: the
+     * [acceptPendingInvite] and [addRelaySideMembershipToList] paths. Both are a deliberate
+     * user action, so a durable left marker (B2: the relay keeps listing us after our
+     * kind:9022) is CLEARED here rather than obeyed — obeying it turned an explicit rejoin
+     * into a silent no-op. Unattended adoption still can't happen: nothing calls this
+     * without the user asking for it.
      */
     private fun adoptExternalMembership(
         groupId: String,
@@ -4010,14 +4042,28 @@ class GroupManager(
         eventId: String? = null,
         createdAtSeconds: Long = 0L,
     ) {
-        if (groupId in _leftGroups.value) return
-        if (isRecentlyLeft(groupId) || groupId in deletedGroupIds) return
-        if (_joinedGroupsByRelay.value.values.any { groupId in it }) return
         val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
+        // Already-joined check is per relay: group ids are relay-scoped, so a short one
+        // ("nostrord") commonly exists on several. Matching across all of them silently
+        // dropped the accept for every relay after the first.
+        if (isJoinedOn(relay, groupId)) {
+            discardPendingInvite(groupId)
+            return
+        }
         scope.launch {
             // Re-check inside the launch: two 39002s (or a 39002 + a live 9000) can both pass
             // the synchronous guard and only the first may adopt.
-            if (_joinedGroupsByRelay.value.values.any { groupId in it }) return@launch
+            if (isJoinedOn(relay, groupId)) {
+                discardPendingInvite(groupId)
+                return@launch
+            }
+            deletedGroupIds.remove(groupId)
+            persistDroppedGroups(pubkey)
+            recentlyLeftAt.remove(groupId)
+            _leftGroups.update { it - groupId }
+            try {
+                SecureStorage.removeLeftGroupForRelay(pubkey, relay, groupId)
+            } catch (_: Exception) {}
             // Merge with the persisted slot like joinGroup: the in-memory map can be partial
             // early in a session and a memory-only write would clobber the slot.
             val stored = try {
@@ -4030,6 +4076,8 @@ class GroupManager(
                 SecureStorage.saveJoinedGroupsForRelay(pubkey, relay, updated)
             } catch (_: Exception) {}
             _joinedGroupsByRelay.update { it + (relay to updated) }
+            // Consent is spent only now that the membership is really in the joined set.
+            discardPendingInvite(groupId)
             // Grace against the orphan auto-forget while this group's kind:39000 is in flight.
             markRecentlyJoined(groupId)
             clearGroupRestricted(groupId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -30,6 +30,7 @@ import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.shortNpub
 
@@ -175,6 +176,22 @@ class GroupViewModel(
     private fun <T> Map<String, T>.atHostRelay(): T? = hostRelay?.let { hr -> this[hr] ?: entries.firstOrNull { it.key.normalizeRelayUrl() == hr }?.value }
 
     /**
+     * The host relay's own mirror of a per-relay map, laid over the flat (bare-id) one.
+     *
+     * The flat map is last-writer-wins across relays, so for [groupId] it is trustworthy only
+     * while no OTHER relay has served that id: once one has, inheriting it reports another
+     * group's members and admins as ours — which handed out the admin UI, and its join-request
+     * list, on a group we do not administer. In that case the entry reads absent until this
+     * relay answers. Other groups' entries pass through untouched.
+     */
+    private fun <T> Map<String, Map<String, T>>.scopedOverFlat(flat: Map<String, T>): Map<String, T> {
+        val mine = atHostRelay().orEmpty()
+        if (groupId in mine) return flat + mine
+        val servedElsewhere = entries.any { it.key.normalizeRelayUrl() != hostRelay && groupId in it.value }
+        return if (servedElsewhere) (flat - groupId) + mine else flat + mine
+    }
+
+    /**
      * Chat messages with NIP-51 muted authors filtered out. The raw repo cache stays
      * untouched (membership derivation below reads it directly), so an unmute restores
      * the author's messages instantly without a re-fetch.
@@ -204,6 +221,23 @@ class GroupViewModel(
     val connectionState = repo.connectionState
     val joinedGroups = repo.joinedGroups
     val joinedGroupsByRelay = repo.joinedGroupsByRelay
+
+    /**
+     * Is this group in the user's own list ON THIS RELAY. The flat id view answers "some group
+     * with this id is joined somewhere", which for a repeated id ("nostrord") offered Leave for
+     * a group that was never joined here and hid the way in. Routes with no relay (legacy deep
+     * links) keep the flat answer, as there is no relay to scope to.
+     */
+    val isJoinedHere: StateFlow<Boolean> =
+        repo.joinedGroupsByRelay
+            .map { byRelay ->
+                if (hostRelay == null) {
+                    byRelay.values.any { groupId in it }
+                } else {
+                    byRelay.isJoinedOn(hostRelay, groupId)
+                }
+            }.distinctUntilChanged()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
     val groups = repo.groups
     val groupsByRelay = repo.groupsByRelay
     val userMetadata = repo.userMetadata
@@ -238,7 +272,7 @@ class GroupViewModel(
             repo.groupMembers
         } else {
             combine(repo.groupMembers, repo.groupMembersByRelay) { flat, byRelay ->
-                byRelay.atHostRelay()?.let { flat + it } ?: flat
+                byRelay.scopedOverFlat(flat)
             }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupMembers.value)
         }
     val groupAdmins: StateFlow<Map<String, List<String>>> =
@@ -246,7 +280,7 @@ class GroupViewModel(
             repo.groupAdmins
         } else {
             combine(repo.groupAdmins, repo.groupAdminsByRelay) { flat, byRelay ->
-                byRelay.atHostRelay()?.let { flat + it } ?: flat
+                byRelay.scopedOverFlat(flat)
             }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupAdmins.value)
         }
     val groupRoles: StateFlow<Map<String, List<RoleDefinition>>> =
@@ -254,7 +288,7 @@ class GroupViewModel(
             repo.groupRoles
         } else {
             combine(repo.groupRoles, repo.groupRolesByRelay) { flat, byRelay ->
-                byRelay.atHostRelay()?.let { flat + it } ?: flat
+                byRelay.scopedOverFlat(flat)
             }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupRoles.value)
         }
     val loadingMembers = repo.loadingMembers
@@ -564,10 +598,13 @@ class GroupViewModel(
      * if any. Both UIs prompt on it: [acceptInvite] adopts the group into the joined set
      * + kind:10009; declining routes through [leaveGroup] (kind:9022 + durable left marker).
      */
+    /** This relay's invite only: an invite for the same id on another relay belongs to another group. */
+    private fun Map<String, PendingGroupInvite>.inviteHere(): PendingGroupInvite? = this[groupId]?.takeIf { hostRelay == null || it.relayUrl.normalizeRelayUrl() == hostRelay }
+
     val pendingInvite: StateFlow<PendingGroupInvite?> =
         repo.pendingGroupInvites
-            .map { it[groupId] }
-            .stateIn(viewModelScope, SharingStarted.Eagerly, repo.pendingGroupInvites.value[groupId])
+            .map { it.inviteHere() }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, repo.pendingGroupInvites.value.inviteHere())
 
     /**
      * Who invited us, for the pending-invite prompt: display name, short-npub fallback,
@@ -598,6 +635,23 @@ class GroupViewModel(
 
     fun acceptInvite() {
         viewModelScope.launch { repo.acceptGroupInvite(groupId) }
+    }
+
+    /**
+     * True when the relay already grants us membership but our own kind:10009 has no entry for
+     * this (relay, group): readable and postable, yet absent from every list and from the rail.
+     * Drives the "Add to my groups" action, the way back in when no invite card is pending.
+     */
+    val canAddToMyList: StateFlow<Boolean> =
+        combine(membershipState, isJoinedHere, pendingInvite) { membership, joinedHere, invite ->
+            invite == null &&
+                !joinedHere &&
+                (membership.status == GroupMembership.MEMBER || membership.status == GroupMembership.ADMIN)
+        }.distinctUntilChanged()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    fun addToMyList() {
+        viewModelScope.launch { repo.addGroupToMyList(groupId, hostRelay) }
     }
 
     /** Fetch [pubkey]'s public kind:10009 so the add-member "on this relay" hint has data. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupMembership.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupMembership.kt
@@ -1,0 +1,18 @@
+package org.nostr.nostrord.utils
+
+/**
+ * Membership test scoped to (relay, group id) over the `joinedGroupsByRelay` map.
+ *
+ * NIP-29 group ids are relay-scoped and short ones ("nostrord", "lotus") exist on several
+ * relays, so a flat id match reports a group as joined because a DIFFERENT group with the
+ * same id is in the list. Every "am I in this group" check the UI makes must go through here.
+ */
+fun Map<String, Set<String>>.isJoinedOn(
+    relayUrl: String?,
+    groupId: String,
+): Boolean {
+    if (relayUrl == null) return false
+    val normalized = relayUrl.normalizeRelayUrl()
+    return this[normalized]?.contains(groupId) == true ||
+        entries.any { it.key.normalizeRelayUrl() == normalized && groupId in it.value }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -607,6 +607,14 @@ class FakeNostrRepository : NostrRepositoryApi {
         pendingGroupInvitesFlow.update { it - groupId }
     }
 
+    val addedToList = mutableListOf<Pair<String, String?>>()
+
+    override suspend fun addGroupToMyList(groupId: String, relayUrl: String?) {
+        addedToList += groupId to relayUrl
+        val relay = relayUrl ?: return
+        _joinedGroupsByRelay.update { it + (relay to (it[relay].orEmpty() + groupId)) }
+    }
+
     override suspend fun sendReaction(
         groupId: String,
         targetEventId: String,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
@@ -73,6 +73,74 @@ class GroupExternalMembershipAdoptionTest {
     }
 
     @Test
+    fun `the same group id joined on another relay does not block the invite`() = runTest {
+        val scope = TestScope(testScheduler)
+        val otherRelay = "wss://other.relay"
+        SecureStorage.saveJoinedGroupsForRelay(pubkey, otherRelay, setOf(group))
+        try {
+            val gm = makeManager(scope)
+            gm.setCurrentPubkey(pubkey)
+            // In memory too, not only in storage: every membership guard reads the live map.
+            gm.loadJoinedGroupsFromStorage(pubkey, otherRelay)
+            testScheduler.advanceUntilIdle()
+            assertTrue(group in gm.joinedGroupsByRelay.value[otherRelay].orEmpty())
+
+            gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+            testScheduler.advanceUntilIdle()
+            assertEquals(relay, gm.pendingGroupInvites.value[group]?.relayUrl, "invite survives the id clash")
+
+            gm.acceptPendingInvite(group)
+            testScheduler.advanceUntilIdle()
+
+            assertTrue(group in gm.getGroupIdsForMux(relay), "short ids repeat across relays; each is its own group")
+            assertTrue(group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay))
+            assertTrue(group in SecureStorage.getJoinedGroupsForRelay(pubkey, otherRelay), "the other relay is untouched")
+        } finally {
+            SecureStorage.saveJoinedGroupsForRelay(pubkey, otherRelay, emptySet())
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a relay-side membership can be added to the list with no invite pending`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.addRelaySideMembershipToList(group, relay)
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(group in gm.getGroupIdsForMux(relay))
+        assertTrue(group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay))
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `the invite is spent by the adoption itself, not before it`() = runTest {
+        val scope = TestScope(testScheduler)
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        testScheduler.advanceUntilIdle()
+
+        gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
+        testScheduler.advanceUntilIdle()
+        assertTrue(group in gm.pendingGroupInvites.value)
+
+        // Accept, but do not let the adoption coroutine run yet: discarding here would spend
+        // the user's consent on work that has not happened (and may still be blocked).
+        gm.acceptPendingInvite(group)
+        assertTrue(group in gm.pendingGroupInvites.value, "card survives until the membership lands")
+
+        testScheduler.advanceUntilIdle()
+        assertFalse(group in gm.pendingGroupInvites.value)
+        assertTrue(group in SecureStorage.getJoinedGroupsForRelay(pubkey, relay))
+
+        scope.cancel()
+    }
+
+    @Test
     fun `accepting a pending invite adopts the membership into the joined set and storage`() = runTest {
         val scope = TestScope(testScheduler)
         val gm = makeManager(scope)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -79,6 +79,47 @@ class GroupViewModelTest {
     }
 
     @Test
+    fun `isJoinedHere ignores the same id joined on another relay`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("dev"))
+
+        val onB = GroupViewModel(fake, "dev", "wss://b")
+        val onA = GroupViewModel(fake, "dev", "wss://a")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(false, onB.isJoinedHere.value, "joined on another relay is a different group")
+        assertEquals(true, onA.isJoinedHere.value)
+    }
+
+    @Test
+    fun `canAddToMyList offers the way in for a relay-side member absent from the list`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.fakePublicKey = "me"
+        fake._groupMembersByRelay.value = mapOf("wss://b" to mapOf("dev" to listOf("me")))
+
+        val vm = GroupViewModel(fake, "dev", "wss://b")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(true, vm.canAddToMyList.value)
+
+        vm.addToMyList()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf<Pair<String, String?>>("dev" to "wss://b"), fake.addedToList.toList())
+        assertEquals(false, vm.canAddToMyList.value, "once listed there is nothing to add")
+    }
+
+    @Test
+    fun `pendingInvite ignores an invite held for the same id on another relay`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.pendingGroupInvitesFlow.value = mapOf("dev" to invite("dev"))
+
+        val vm = GroupViewModel(fake, "dev", "wss://elsewhere")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(vm.pendingInvite.value)
+    }
+
+    @Test
     fun `messages are scoped to the host relay, unstamped ones stay`() = runTest {
         val fake = FakeNostrRepository()
         fun msg(id: String, relay: String?) = org.nostr.nostrord.network.NostrGroupClient.NostrMessage(
@@ -116,10 +157,38 @@ class GroupViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(listOf("alice", "bob"), vmA.groupMembers.value["dev"])
-        // A group the host relay hasn't described yet falls back to the flat map.
+        // Other relays already served this id, so the flat map is one of THEIR lists: a relay
+        // that hasn't answered yet reads absent rather than inheriting it.
         val vmC = GroupViewModel(fake, "dev", "wss://c")
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(listOf("only-b"), vmC.groupMembers.value["dev"])
+        assertNull(vmC.groupMembers.value["dev"])
+    }
+
+    @Test
+    fun `admins are not inherited from a same-id group on another relay`() = runTest {
+        val fake = FakeNostrRepository()
+        // Flat map holds A's admins (last writer wins); B has not served its 39001 yet.
+        fake._groupAdmins.value = mapOf("dev" to listOf("me"))
+        fake._groupAdminsByRelay.value = mapOf("wss://a" to mapOf("dev" to listOf("me")))
+
+        val vmB = GroupViewModel(fake, "dev", "wss://b")
+        val vmA = GroupViewModel(fake, "dev", "wss://a")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertNull(vmB.groupAdmins.value["dev"], "admin on another relay is not admin here")
+        assertEquals(listOf("me"), vmA.groupAdmins.value["dev"])
+    }
+
+    @Test
+    fun `an unclaimed id still falls back to the flat map`() = runTest {
+        val fake = FakeNostrRepository()
+        // Nothing per-relay yet: the flat value is the only data and is unambiguous.
+        fake._groupAdmins.value = mapOf("dev" to listOf("me"))
+
+        val vm = GroupViewModel(fake, "dev", "wss://b")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("me"), vm.groupAdmins.value["dev"])
     }
 
     @Test

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -230,10 +230,6 @@ fun GroupScreen(
     var inputOverlayOpen by remember { mutableStateOf(false) }
     var createdInviteCode by remember { mutableStateOf<String?>(null) }
     var resolvedRequestPubkeys by remember(groupId) { mutableStateOf(emptySet<String>()) }
-    val isJoined =
-        remember(joinedGroups, groupId) {
-            joinedGroups.contains(groupId)
-        }
 
     val initialInviteCode = remember { pendingInviteCode }
     val isConnected = connectionState is ConnectionManager.ConnectionState.Connected
@@ -303,6 +299,17 @@ fun GroupScreen(
     val membership by vm.membershipState.collectAsState()
     val isPendingApproval = membership.status == GroupMembership.PENDING
     val pendingRequestedAtSeconds = membership.requestedAtSeconds
+    // Our own kind:10009 entry for THIS relay (the flat view answers for a same-id group
+    // elsewhere): gates Leave and the "Add to my groups" way back in.
+    val isJoinedHere by vm.isJoinedHere.collectAsState()
+    val canAddToMyList by vm.canAddToMyList.collectAsState()
+    // Participation gate (composer + header Join), same rule as the web canPost: the relay's
+    // member list decides. A member missing from our own list keeps writing while the header
+    // offers to add it.
+    val isJoined =
+        isJoinedHere ||
+            membership.status == GroupMembership.MEMBER ||
+            membership.status == GroupMembership.ADMIN
 
     // Switching accounts while a group is open leaves groupId unchanged, so the
     // per-session REQ effects must also key on the active account; otherwise the new
@@ -497,7 +504,9 @@ fun GroupScreen(
             groupMetadata = currentGroupMetadata,
             relayUrl = relayUrl ?: currentRelayUrl,
             onOpenRelay = onOpenRelay,
-            isMember = isJoined,
+            // Leave acts on our own kind:10009 entry, so the list decides, not the relay's
+            // member list.
+            isMember = isJoinedHere,
             memberCount = groupMembers.size,
             userMetadata = userMetadata,
             onUserClick = { pubkey ->
@@ -916,6 +925,8 @@ fun GroupScreen(
                     connectionStatus = connectionStatus,
                     connectionState = connectionState,
                     isJoined = isJoined,
+                    canAddToList = canAddToMyList,
+                    onAddToList = { vm.addToMyList() },
                     isAdmin = isAdmin,
                     userMetadata = userMetadata,
                     reactions = allReactions,
@@ -1060,6 +1071,8 @@ fun GroupScreen(
                     connectionStatus = connectionStatus,
                     connectionState = connectionState,
                     isJoined = isJoined,
+                    canAddToList = canAddToMyList,
+                    onAddToList = { vm.addToMyList() },
                     isAdmin = isAdmin,
                     userMetadata = userMetadata,
                     reactions = allReactions,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -55,6 +55,9 @@ fun GroupScreenDesktop(
     connectionStatus: String,
     connectionState: ConnectionManager.ConnectionState,
     isJoined: Boolean,
+    /** Relay-side member with no entry in our own kind:10009: offer to add it. */
+    canAddToList: Boolean = false,
+    onAddToList: () -> Unit = {},
     isAdmin: Boolean = false,
     userMetadata: Map<String, UserMetadata>,
     reactions: Map<String, Map<String, GroupManager.ReactionInfo>> = emptyMap(),
@@ -155,6 +158,8 @@ fun GroupScreenDesktop(
                     relayUrl = relayUrl,
                     groupId = groupId,
                     isJoined = isJoined,
+                    canAddToList = canAddToList,
+                    onAddToListClick = onAddToList,
                     isAdmin = isAdmin,
                     onJoinClick = onJoinGroup,
                     onLeaveClick = onLeaveGroup,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -62,6 +62,9 @@ fun GroupScreenMobile(
     connectionStatus: String,
     connectionState: ConnectionManager.ConnectionState,
     isJoined: Boolean,
+    /** Relay-side member with no entry in our own kind:10009: offer to add it. */
+    canAddToList: Boolean = false,
+    onAddToList: () -> Unit = {},
     isAdmin: Boolean = false,
     userMetadata: Map<String, UserMetadata>,
     reactions: Map<String, Map<String, GroupManager.ReactionInfo>> = emptyMap(),
@@ -159,6 +162,8 @@ fun GroupScreenMobile(
                         relayUrl = relayUrl,
                         groupId = groupId,
                         isJoined = isJoined,
+                        canAddToList = canAddToList,
+                        onAddToListClick = onAddToList,
                         isAdmin = isAdmin,
                         onJoinClick = onJoinGroup,
                         onLeaveClick = onLeaveGroup,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupHeader.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupHeader.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Search
@@ -56,6 +57,9 @@ fun GroupHeader(
     relayUrl: String = "",
     groupId: String = "",
     isJoined: Boolean,
+    /** Relay-side member with no entry in our own kind:10009: offer to add it. */
+    canAddToList: Boolean = false,
+    onAddToListClick: () -> Unit = {},
     onJoinClick: (inviteCode: String?) -> Unit,
     onLeaveClick: () -> Unit,
     onTitleClick: () -> Unit = {},
@@ -311,6 +315,32 @@ fun GroupHeader(
                 horizontalArrangement = Arrangement.spacedBy(4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                // Relay grants membership but our list has no entry: one tap reconciles them.
+                // Placed before the join branch, which this state never reaches.
+                if (canAddToList) {
+                    Button(
+                        onClick = onAddToListClick,
+                        colors = ButtonDefaults.buttonColors(containerColor = NostrordColors.Primary),
+                        contentPadding =
+                        if (compact) {
+                            PaddingValues(horizontal = 8.dp, vertical = 8.dp)
+                        } else {
+                            PaddingValues(horizontal = 12.dp, vertical = 8.dp)
+                        },
+                        shape = RoundedCornerShape(8.dp),
+                    ) {
+                        Icon(
+                            Icons.Default.Add,
+                            contentDescription = "Add to my groups",
+                            modifier = Modifier.size(16.dp),
+                        )
+                        if (!compact) {
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text("Add to my groups", style = MaterialTheme.typography.labelMedium)
+                        }
+                    }
+                }
+
                 if (!isJoined) {
                     val showInviteButton = isClosed || initialInviteCode != null
                     var showInviteModal by remember { mutableStateOf(initialInviteCode != null) }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
@@ -60,6 +60,7 @@ import org.nostr.nostrord.ui.components.onboarding.FollowSuggestionRow
 import org.nostr.nostrord.ui.navigation.HomeTab
 import org.nostr.nostrord.ui.screens.onboarding.onboardingFollowSuggestions
 import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.utils.isJoinedOn
 
 private val FILTERS = listOf("My groups", "From friends", "Recommended", "People")
 
@@ -107,9 +108,9 @@ fun HomePageScreen(
     val recommendedGroupsLoading by vm.recommendedGroupsLoading.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()
     val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
-    // Group ids you're a member of, to flag the "Joined" badge on cards in mixed lists.
+    // Membership per (relay, id), to flag the "Joined" badge on cards in mixed lists: ids
+    // repeat across relays, so a flat id match badges a group you never joined.
     val joinedGroupsByRelay by AppModule.nostrRepository.joinedGroupsByRelay.collectAsState()
-    val joinedIds = joinedGroupsByRelay.values.flatten().toSet()
     // Active tab is owned by the router; selecting routes (mirror) instead of local state.
     val filter = tab.ordinal
     // Each tab is its own screen; carrying the filter text across tabs is confusing, so reset it.
@@ -346,7 +347,7 @@ fun HomePageScreen(
                                                 hasMetadata = group.hasMetadata,
                                                 relayUrl = group.relayUrl,
                                                 relayIconUrl = relayMetadata[group.relayUrl]?.icon,
-                                                isJoined = group.meta.id in joinedIds,
+                                                isJoined = joinedGroupsByRelay.isJoinedOn(group.relayUrl, group.meta.id),
                                                 onRelayClick = { onOpenRelay(group.relayUrl) },
                                                 onClick = { onOpenGroup(JoinedGroup(group.relayUrl, group.meta)) },
                                             )
@@ -415,7 +416,7 @@ fun HomePageScreen(
                                                 hasMetadata = fg.hasMetadata,
                                                 relayUrl = fg.relayUrl,
                                                 relayIconUrl = relayMetadata[fg.relayUrl]?.icon,
-                                                isJoined = fg.meta.id in joinedIds,
+                                                isJoined = joinedGroupsByRelay.isJoinedOn(fg.relayUrl, fg.meta.id),
                                                 onRelayClick = { onOpenRelay(fg.relayUrl) },
                                                 onClick = { onOpenGroup(JoinedGroup(fg.relayUrl, fg.meta)) },
                                             )
@@ -461,7 +462,7 @@ fun HomePageScreen(
                                             hasMetadata = group.hasMetadata,
                                             relayUrl = group.relayUrl,
                                             relayIconUrl = relayMetadata[group.relayUrl]?.icon,
-                                            isJoined = group.meta.id in joinedIds,
+                                            isJoined = joinedGroupsByRelay.isJoinedOn(group.relayUrl, group.meta.id),
                                             onRelayClick = { onOpenRelay(group.relayUrl) },
                                             onClick = { onOpenGroup(JoinedGroup(group.relayUrl, group.meta)) },
                                         )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelayPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/relay/RelayPageScreen.kt
@@ -53,6 +53,7 @@ import org.nostr.nostrord.ui.screens.home.HomePageViewModel
 import org.nostr.nostrord.ui.screens.home.RelayHeaderIcon
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
@@ -118,7 +119,6 @@ fun RelayPageScreen(
             ?: (pk.take(8) + "…")
     } ?: "Unknown"
     val software = info?.software?.let { it.substringAfterLast('/').ifBlank { it } } ?: "n/a"
-    val joinedIds = joinedByRelay.values.flatten().toSet()
 
     // My groups + friends' groups that live on this relay, de-duped, root-level only.
     val groups = (myGroups + friendsGroups)
@@ -278,7 +278,7 @@ fun RelayPageScreen(
                                                 hasMetadata = dg.hasMetadata,
                                                 relayUrl = dg.relayUrl,
                                                 relayIconUrl = info?.icon,
-                                                isJoined = dg.meta.id in joinedIds,
+                                                isJoined = joinedByRelay.isJoinedOn(dg.relayUrl, dg.meta.id),
                                                 onClick = { onOpenGroup(dg.relayUrl, dg.meta.id) },
                                             )
                                         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/GroupInfoModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/GroupInfoModal.kt
@@ -57,10 +57,11 @@ val GroupInfoModal =
         // on another relay.
         val vm = useViewModel("${props.relayUrl}|${group.id}") { GroupViewModel(AppModule.nostrRepository, group.id, props.relayUrl) }
         val memberCount = useStateFlow(vm.groupMembers)[group.id]?.size ?: 0
-        // Leaving is about the user's own kind:10009 list, so it must be offered whenever the
-        // group is in that list (any relay), even if the relay is dead and membership/posting
-        // can't be confirmed. Gating on "can post" would hide the only exit from a broken relay.
-        val isJoined = useStateFlow(AppModule.nostrRepository.joinedGroupsByRelay).values.any { group.id in it }
+        // Leaving is about the user's own kind:10009 list, so it is offered whenever the group is
+        // in that list for THIS relay, even if the relay is dead and membership/posting can't be
+        // confirmed. Gating on "can post" would hide the only exit from a broken relay; matching
+        // the id across all relays offered Leave for a same-id group joined somewhere else.
+        val isJoined = useStateFlow(vm.isJoinedHere)
         val focusedRelay = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
         val relayUrl = props.relayUrl ?: focusedRelay
         val relayMetadata = useStateFlow(AppModule.nostrRepository.relayMetadata)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -1186,6 +1186,9 @@ val ChatScreen =
         // raw group.isPublic/isOpen so an outsider sees Private/Closed even before any placeholder.
         val access = useStateFlow(vm.groupAccess)
         val canPost = membership.status == GroupMembership.MEMBER || membership.status == GroupMembership.ADMIN
+        // Relay-side member with no entry in our own kind:10009: readable, postable, but in no
+        // list and no rail. One tap reconciles them.
+        val canAddToMyList = useStateFlow(vm.canAddToMyList)
         val isPendingApproval = membership.status == GroupMembership.PENDING
         val membersResolving = membership.status == GroupMembership.RESOLVING
         val composerPending = isPendingApproval
@@ -1860,6 +1863,15 @@ val ChatScreen =
                                 onClick = { setModal("edit") }
                                 icon(Ic.Settings)
                             }
+                        }
+                    }
+                    if (canAddToMyList && !membersResolving && !isOrphaned) {
+                        button {
+                            className = ClassName("chat-join-btn")
+                            title = "You are a member on this relay but the group is not in your groups"
+                            onClick = { vm.addToMyList() }
+                            icon(Ic.Add)
+                            span { +"Add to my groups" }
                         }
                     }
                     if (!canPost && !membersResolving && !isOrphaned) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
@@ -9,6 +9,7 @@ import org.nostr.nostrord.ui.screens.home.Friend
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
 import org.nostr.nostrord.ui.screens.home.JoinedGroup
 import org.nostr.nostrord.ui.screens.onboarding.onboardingFollowSuggestions
+import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
@@ -72,8 +73,9 @@ val HomePage =
         val friendsGroupsLoading = useStateFlow(vm.friendsGroupsLoading)
         val recommendedGroupsLoading = useStateFlow(vm.recommendedGroupsLoading)
         val relayMeta = useStateFlow(vm.relayMetadata)
-        // Group ids you're a member of, to mark the "Joined" badge on cards in mixed lists.
-        val joinedIds = useStateFlow(AppModule.nostrRepository.joinedGroupsByRelay).values.flatten().toSet()
+        // Membership per (relay, id), to mark the "Joined" badge on cards in mixed lists: ids
+        // repeat across relays, so a flat id match badges a group you never joined.
+        val joinedByRelay = useStateFlow(AppModule.nostrRepository.joinedGroupsByRelay)
         // Follow state + actor metadata for the "People" filter's follow suggestions.
         val following = useStateFlow(AppModule.nostrRepository.following)
         val actorMeta = useStateFlow(AppModule.nostrRepository.userMetadata)
@@ -218,7 +220,7 @@ val HomePage =
                                     div {
                                         className = ClassName("card-grid")
                                         myGroups.forEach { group ->
-                                            discoverGroupCard(group, relayMeta[group.relayUrl]?.icon, group.meta.id in joinedIds) {
+                                            discoverGroupCard(group, relayMeta[group.relayUrl]?.icon, joinedByRelay.isJoinedOn(group.relayUrl, group.meta.id)) {
                                                 props.onOpenGroup(JoinedGroup(group.relayUrl, group.meta))
                                             }
                                         }
@@ -249,7 +251,7 @@ val HomePage =
                                     div {
                                         className = ClassName("card-grid")
                                         friendsGroups.forEach { fg ->
-                                            discoverGroupCard(fg, relayMeta[fg.relayUrl]?.icon, fg.meta.id in joinedIds) {
+                                            discoverGroupCard(fg, relayMeta[fg.relayUrl]?.icon, joinedByRelay.isJoinedOn(fg.relayUrl, fg.meta.id)) {
                                                 props.onOpenGroup(JoinedGroup(fg.relayUrl, fg.meta))
                                             }
                                         }
@@ -268,7 +270,7 @@ val HomePage =
                                 div {
                                     className = ClassName("card-grid")
                                     recommendedGroups.forEach { group ->
-                                        discoverGroupCard(group, relayMeta[group.relayUrl]?.icon, group.meta.id in joinedIds) {
+                                        discoverGroupCard(group, relayMeta[group.relayUrl]?.icon, joinedByRelay.isJoinedOn(group.relayUrl, group.meta.id)) {
                                             props.onOpenGroup(JoinedGroup(group.relayUrl, group.meta))
                                         }
                                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/OnboardingFlow.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/OnboardingFlow.kt
@@ -4,6 +4,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.screens.home.DiscoverGroup
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
 import org.nostr.nostrord.ui.screens.onboarding.onboardingFollowSuggestions
+import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
@@ -246,7 +247,8 @@ private val GroupsStep =
         val friendsGroupsResolving = useStateFlow(vm.friendsGroupsResolving)
         val relayMeta = useStateFlow(vm.relayMetadata)
         val following = useStateFlow(AppModule.nostrRepository.following)
-        val joinedIds = useStateFlow(AppModule.nostrRepository.joinedGroupsByRelay).values.flatten().toSet()
+        // Per (relay, id): a same-id group joined on another relay is not this one.
+        val joinedByRelay = useStateFlow(AppModule.nostrRepository.joinedGroupsByRelay)
 
         // Re-fire as the contact list resolves: a fresh login often reaches this step before
         // kind:3 arrives, so the first call requests nothing; keying on [following] picks up the
@@ -334,7 +336,7 @@ private val GroupsStep =
                         discoverGroupCard(
                             fg,
                             relayMeta[fg.relayUrl]?.icon,
-                            fg.meta.id in joinedIds,
+                            joinedByRelay.isJoinedOn(fg.relayUrl, fg.meta.id),
                             enableRelayLink = false,
                             showJoinCta = true,
                             interactive = false,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/RelayScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/RelayScreen.kt
@@ -4,6 +4,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.ui.screens.home.DiscoverGroup
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
+import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
@@ -45,7 +46,9 @@ val RelayScreen =
         val currentRelay = useStateFlow(repo.currentRelayUrl)
         val myRelays = useStateFlow(repo.kind10009Relays)
         val unreachable = useStateFlow(repo.unreachableRelays)
-        val joinedIds = useStateFlow(repo.joinedGroupsByRelay).values.flatten().toSet()
+        // Per (relay, id): this page lists ONE relay's groups, and a same-id group joined on
+        // another relay must not badge them as joined.
+        val joinedByRelay = useStateFlow(repo.joinedGroupsByRelay)
 
         val target = props.relayUrl.normalizeRelayUrl()
         val info = relayMeta[props.relayUrl] ?: relayMeta[target]
@@ -204,7 +207,7 @@ val RelayScreen =
                         div {
                             className = ClassName("card-grid")
                             groups.forEach { g ->
-                                discoverGroupCard(g, info?.icon, g.meta.id in joinedIds) { props.onOpenGroup(g) }
+                                discoverGroupCard(g, info?.icon, joinedByRelay.isJoinedOn(g.relayUrl, g.meta.id)) { props.onOpenGroup(g) }
                             }
                         }
                     }


### PR DESCRIPTION
NIP-29 group ids are relay-scoped, and short ones (`nostrord`, `lotus`) exist on several relays. Everything that answered "am I in this group, and who runs it" matched on the bare id, so two independent groups were treated as one. Reported from a real account that is a member of `nostrord` on both `wss://chat.wisp.talk` and `wss://groups.0xchat.com`, and an admin of only the first.

Membership now answers per (relay, id) everywhere. The flat bare-id maps are still there for callers with no relay in hand, but they are trusted for a group only while no other relay has served that id.

| Symptom | Cause | Fix |
|---|---|---|
| Group joined on the relay never reached kind:10009, no rail entry | `registerExternalAdd` skipped the invite when the id was joined on ANY relay | the guard, the left-marker self-heal and the invite bookkeeping all match on the invite's own relay |
| Approving the invite card did nothing, and the card was gone | the pending entry was discarded BEFORE adopting, so any guard that blocked the adoption spent the consent | the adoption drops the entry only once the membership is in the joined set, and clears the leave intent for that (relay, group) since an explicit accept IS the user's decision |
| Admin UI and 21 join requests shown on a group the account does not administer | the per-relay member/admin/role mirrors fell back to the flat map while the host relay was cold | the flat value is trusted only while no other relay has served the id; otherwise the entry reads absent until this relay answers |
| Info modal offered only Leave; "Joined" badges wrong on discovery cards | flat id checks in both UIs | `GroupViewModel.isJoinedHere` (consumed by Compose and web) and `Map.isJoinedOn(relay, id)` on every card |

Relay-side membership and the account's own list are separate states, so a missed prompt no longer strands a group: `canAddToMyList` detects "the relay lists me, my kind:10009 does not" and both headers offer **Add to my groups**. Native also stops conflating the two, with participation (composer, Join) following the relay's member list like the web `canPost` while Leave follows the list entry.

Five new tests in `GroupViewModelTest` and `GroupExternalMembershipAdoptionTest` (relay-scoped isJoinedHere/pendingInvite, admins not inherited, invite spent only by the adoption, manual add). One existing test changed: it asserted the member-list fallback this PR removes. 758 pass, plus `compileKotlinJvm` and `compileKotlinJs`.

Known residue, not in this PR: `getRelayForGroup` still resolves through a global hint keyed by bare id, which the most recently constructed `GroupViewModel` overwrites, and the in-memory left/dropped markers are still id-keyed.

- 6b0a5fb4 fix(nip29): scope group membership to the relay, not the bare group id