### PR TITLE
Threads: chat parity for content, reactions, context menu, replies and cache

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/EventJson.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/EventJson.kt
@@ -1,0 +1,23 @@
+package org.nostr.nostrord.network
+
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+
+/**
+ * The message re-serialized as NIP-01 event JSON (id/pubkey/created_at/kind/tags/content;
+ * no sig - [NostrGroupClient.NostrMessage] does not carry one). Backs "Copy event JSON" in
+ * the chat and thread context menus on both platforms.
+ */
+fun NostrGroupClient.NostrMessage.toEventJson(): String = buildJsonObject {
+    put("id", id)
+    put("pubkey", pubkey)
+    put("created_at", createdAt)
+    put("kind", kind)
+    put("content", content)
+    putJsonArray("tags") {
+        tags.forEach { tag -> addJsonArray { tag.forEach { add(it) } } }
+    }
+}.toString()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -3437,7 +3437,7 @@ class NostrRepository(
 
     override suspend fun fetchThread(groupId: String, rootId: String) = groupManager.fetchThread(groupId, rootId)
 
-    override suspend fun createThread(groupId: String, title: String, content: String): Result<Unit> {
+    override suspend fun createThread(groupId: String, title: String, content: String): Result<String> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
         return groupManager.createThread(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -4415,8 +4415,13 @@ class NostrRepository(
     // joined relays mutate this concurrently from Dispatchers.Default.
     private val _closedGroupSubscriptions = MutableStateFlow<Set<String>>(emptySet())
 
-    // Message IDs collected per msg_ subscription, used to fetch reactions after EOSE.
+    // Message IDs collected per msg_/thread subscription, used to fetch reactions after EOSE.
     private val pendingReactionFetch = mutableMapOf<String, MutableList<String>>()
+
+    /** Thread-pane subscriptions whose events get the same post-EOSE kind:7 backfill as msg_. */
+    private fun isThreadSub(subId: String) = subId.startsWith("threads_") ||
+        subId.startsWith("threadrepl_") ||
+        subId.startsWith("threadfocus_")
 
     // Pool relay URLs that have been actively connected during this session (were focused at
     // some point or were reconnected). Only these are eligible for reconnection on drop.
@@ -4781,8 +4786,8 @@ class NostrRepository(
                     if (subId.startsWith("mux_chat_")) {
                         detectAndFillGaps(client.getRelayUrl())
                     }
-                    // Fetch reactions for message IDs received in this msg_ subscription
-                    if (subId.startsWith("msg_")) {
+                    // Fetch reactions for message IDs received in this msg_ or thread subscription
+                    if (subId.startsWith("msg_") || isThreadSub(subId)) {
                         val messageIds = pendingReactionFetch.remove(subId)
                         if (!messageIds.isNullOrEmpty()) {
                             try {
@@ -4794,7 +4799,10 @@ class NostrRepository(
                             } catch (_: Exception) {}
                             // Zap receipts (kind 9735) carry no `h` tag, so they live on
                             // general relays, not the NIP-29 group relay — fetch them there.
-                            fetchZapReceiptsFromGeneralRelays(messageIds)
+                            // Chat only: the thread UI has no zap display.
+                            if (subId.startsWith("msg_")) {
+                                fetchZapReceiptsFromGeneralRelays(messageIds)
+                            }
                         }
                     }
                     // The forum thread-roots sub (threads_<groupId>) reached EOSE: stored threads
@@ -5096,7 +5104,7 @@ class NostrRepository(
                             }
                         }
                         // Track message ID for reaction fetch after EOSE
-                        if (subId.startsWith("msg_") && message.id.isNotBlank()) {
+                        if ((subId.startsWith("msg_") || isThreadSub(subId)) && message.id.isNotBlank()) {
                             pendingReactionFetch.getOrPut(subId) { mutableListOf() }.add(message.id)
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -555,7 +555,8 @@ interface NostrRepositoryApi {
     suspend fun fetchThread(groupId: String, rootId: String)
 
     /** Create a forum thread (kind:11 root). [title] becomes a NIP-14 subject tag when non-blank. */
-    suspend fun createThread(groupId: String, title: String, content: String): Result<Unit>
+    /** Publish a kind:11 thread root. Success carries the root's event id (stable NIP-01 id). */
+    suspend fun createThread(groupId: String, title: String, content: String): Result<String>
 
     /**
      * Publish a NIP-22 reply (kind:1111). [root] is the kind:11 thread root; [parent] is the item

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3262,7 +3262,7 @@ class GroupManager(
         content: String,
         pubKey: String,
         signEvent: suspend (Event) -> Event,
-    ): Result<Unit> = try {
+    ): Result<String> = try {
         val tags = ThreadTags.root(groupId, getRelayForGroup(groupId), title)
         publishThreadEvent(groupId, kind = 11, content = content, tags = tags, pubKey = pubKey, signEvent = signEvent)
     } catch (e: Throwable) {
@@ -3284,12 +3284,16 @@ class GroupManager(
         signEvent: suspend (Event) -> Event,
     ): Result<Unit> = try {
         val tags = ThreadTags.reply(groupId, getRelayForGroup(groupId), root, parent)
-        publishThreadEvent(groupId, kind = 1111, content = content, tags = tags, pubKey = pubKey, signEvent = signEvent)
+        when (val result = publishThreadEvent(groupId, kind = 1111, content = content, tags = tags, pubKey = pubKey, signEvent = signEvent)) {
+            is Result.Success -> Result.Success(Unit)
+            is Result.Error -> Result.Error(result.error)
+        }
     } catch (e: Throwable) {
         Result.Error(AppError.Group.SendFailed(groupId, e))
     }
 
     /** Shared sign + optimistic-insert + deliver pipeline for thread events (kind 11 / 1111). */
+    /** Returns the published event's id (computed before signing; the NIP-01 id is stable). */
     private suspend fun publishThreadEvent(
         groupId: String,
         kind: Int,
@@ -3297,7 +3301,7 @@ class GroupManager(
         tags: List<List<String>>,
         pubKey: String,
         signEvent: suspend (Event) -> Event,
-    ): Result<Unit> {
+    ): Result<String> {
         val event = Event(
             pubkey = pubKey,
             createdAt = epochMillis() / 1000,
@@ -3322,7 +3326,7 @@ class GroupManager(
         )
         _messageStatus.update { it + (eventId to MessageStatus.Sending) }
         scope.launch { signAndDeliver(groupId, event, eventId, signEvent) }
-        return Result.Success(Unit)
+        return Result.Success(eventId)
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -786,6 +786,9 @@ class GroupManager(
         // live subscription refreshes the tail.
         const val CACHE_HYDRATE_LIMIT = 300
 
+        // Threads hydration budget: one roots page + the reply batch the live subs would fetch.
+        const val THREAD_CACHE_HYDRATE_LIMIT = THREAD_PAGE_SIZE + THREAD_REPLY_BATCH
+
         // Quiet window before the periodic refresh force-re-arms a relay's mux subs
         // (see refreshLiveSubscriptions). Two timer ticks: long enough that a healthy
         // quiet relay re-proves itself at a lazy cadence, short enough that a deaf
@@ -3080,12 +3083,69 @@ class GroupManager(
     private fun threadRepliesSubId(groupId: String) = "threadrepl_$groupId"
 
     /** Route a parsed thread event into its store (kind:11 roots, kind:1111 replies), deduped. */
-    private fun applyThreadEvent(groupId: String, message: NostrGroupClient.NostrMessage) {
+    private fun applyThreadEvent(groupId: String, message: NostrGroupClient.NostrMessage, persist: Boolean = true) {
         val store = if (message.kind == 11) _threadRoots else _threadReplies
         store.update { current ->
             val list = current[groupId] ?: emptyList()
             if (list.any { it.id == message.id }) return@update current
             current + (groupId to (list + message).sortedBy { it.createdAt })
+        }
+        // Write-through OUTSIDE the in-memory dedup: the relay echo of an optimistic
+        // (relay-less) insert is deduped above, yet it is the first relay-attributed copy
+        // and the one that must reach the disk cache. Upserts are idempotent.
+        if (persist) cacheThreadEvent(groupId, message)
+    }
+
+    /**
+     * Disk-cache slot for a group's forum threads (kind:11 + 1111 together, split by kind on
+     * load) on one relay. The trailing segment keeps it disjoint from the chat history slot
+     * ("relay|groupId"); '|' cannot appear in a relay URL or group id.
+     */
+    private fun threadCacheSlot(
+        relayUrl: String,
+        groupId: String,
+    ): String = "${relayUrl.normalizeRelayUrl()}|$groupId|threads"
+
+    /**
+     * Write a thread event through to the persistent cache (fire-and-forget). Relay-less
+     * events (the optimistic insert before the relay echo) are skipped: hydration is
+     * relay-scoped and a send that never echoes must not rehydrate as a ghost.
+     */
+    private fun cacheThreadEvent(groupId: String, message: NostrGroupClient.NostrMessage) {
+        val account = currentPubkey ?: return
+        val relay = message.relayUrl ?: return
+        scope.launch {
+            try {
+                val slot = threadCacheSlot(relay, groupId)
+                cacheStore.upsertMessages(account, slot, listOf(message.toCachedMsg(slot)))
+            } catch (_: Exception) {
+            }
+        }
+        scheduleCacheEviction()
+    }
+
+    // Groups whose threads pane already hydrated from disk this session: keeps the VM's
+    // requestGroupThreads retry loop (and pane re-opens) from re-reading the store.
+    private val hydratedThreadGroups = mutableSetOf<String>()
+
+    /**
+     * Render a previously-seen threads pane instantly from the persistent cache, before any
+     * relay round-trip (stale-while-revalidate, the threads analogue of
+     * [hydrateMessagesFromCache]). The live subscriptions then refresh and dedupe by id;
+     * deletions were already evicted from the cache when their kind 5/9005 arrived.
+     */
+    private suspend fun hydrateThreadsFromCache(groupId: String) {
+        val account = currentPubkey ?: return
+        val relay = getRelayForGroup(groupId) ?: return
+        if (!hydratedThreadGroups.add(groupId)) return
+        val cached =
+            try {
+                cacheStore.loadLatest(account, threadCacheSlot(relay, groupId), THREAD_CACHE_HYDRATE_LIMIT)
+            } catch (_: Exception) {
+                return
+            }
+        for (row in cached) {
+            applyThreadEvent(groupId, row.toNostrMessage().withOriginRelay(relay), persist = false)
         }
     }
 
@@ -3100,6 +3160,10 @@ class GroupManager(
      * AUTH lands later, [resubscribeOpenThreadsAfterAuth] re-fires these.
      */
     suspend fun requestGroupThreads(groupId: String): Boolean {
+        // Show the known threads instantly from disk (stale-while-revalidate) - before the
+        // client check, so a cold or offline open still renders and the VM's retry loop
+        // (which re-enters here until the client is ready) hits the hydration guard.
+        hydrateThreadsFromCache(groupId)
         val client = clientForGroup(groupId) ?: return false
         openThreadGroups.add(groupId)
         if (client.requiresAuth() && !client.hasAuthSucceeded()) {
@@ -4989,6 +5053,7 @@ class GroupManager(
         _messages.value = emptyMap()
         _threadRoots.value = emptyMap()
         _threadReplies.value = emptyMap()
+        hydratedThreadGroups.clear()
         _threadsLoaded.value = emptySet()
         openThreadGroups.clear()
         groupMessageRecency.clear()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3177,6 +3177,9 @@ class GroupManager(
                 runCatching {
                     client.requestGroupMessageById(groupId, rootId)
                     client.requestThreadReplies(groupId, rootId = rootId, subscriptionId = "threadfocus_$rootId")
+                    // The root arrives via an id fetch (no post-EOSE kind:7 backfill like the
+                    // thread subs), so fetch its reactions directly.
+                    client.requestReactionsForMessages(listOf(rootId))
                 }
                 return
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ThreadTags.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ThreadTags.kt
@@ -10,14 +10,18 @@ import org.nostr.nostrord.network.NostrGroupClient
 internal object ThreadTags {
     /**
      * Tags for a kind:11 thread root: the NIP-29 group `h` tag (with a relay hint when known),
-     * the relay-wide `-` marker for the id-less `_` group, and an optional NIP-14 `subject`
-     * (the thread title; omitted when blank).
+     * the relay-wide `-` marker for the id-less `_` group, and the optional thread title as BOTH
+     * the NIP-7D `title` (what kind:11 readers like Squalk expect - issue #221) and the NIP-14
+     * `subject` (what older Nostrord releases and chat-style readers expect); omitted when blank.
      */
     fun root(groupId: String, relayHint: String?, subject: String?): List<List<String>> = buildList {
         add(listOfNotNull("h", groupId, relayHint))
         if (groupId == "_") add(listOf("-"))
         val s = subject?.trim().orEmpty()
-        if (s.isNotEmpty()) add(listOf("subject", s))
+        if (s.isNotEmpty()) {
+            add(listOf("title", s))
+            add(listOf("subject", s))
+        }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
@@ -46,12 +46,18 @@ data class GroupRoute(
 enum class GroupView { Chat, Threads }
 
 /**
- * Shareable web link for a thread: https://web.nostrord.com/#/g/<relay>/<id>/threads/<rootId>.
- * Backs "Copy event link" in the thread context menu (the chat's nostrord.com/open ?e= form
- * scrolls the chat, which never contains a kind:11/1111 event).
+ * Shareable web link for a thread: https://web.nostrord.com/#/g/<relay>/<id>/threads/<rootId>,
+ * plus `?e=<messageId>` targeting the specific message to scroll to and flash. Backs "Copy
+ * event link" in the thread context menu (the chat's nostrord.com/open ?e= form scrolls the
+ * chat, which never contains a kind:11/1111 event).
  */
-fun threadShareLink(relayUrl: String, groupId: String, rootId: String): String = "https://web.nostrord.com/" +
-    GroupRoute(relayUrl, groupId, view = GroupView.Threads, threadRootId = rootId).toHash()
+fun threadShareLink(
+    relayUrl: String,
+    groupId: String,
+    rootId: String,
+    messageId: String? = null,
+): String = "https://web.nostrord.com/" +
+    GroupRoute(relayUrl, groupId, view = GroupView.Threads, threadRootId = rootId, messageId = messageId).toHash()
 
 /**
  * The value to persist in the last-route slot ([SecureStorage.saveLastRoute]) for [route].

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
@@ -46,6 +46,14 @@ data class GroupRoute(
 enum class GroupView { Chat, Threads }
 
 /**
+ * Shareable web link for a thread: https://web.nostrord.com/#/g/<relay>/<id>/threads/<rootId>.
+ * Backs "Copy event link" in the thread context menu (the chat's nostrord.com/open ?e= form
+ * scrolls the chat, which never contains a kind:11/1111 event).
+ */
+fun threadShareLink(relayUrl: String, groupId: String, rootId: String): String = "https://web.nostrord.com/" +
+    GroupRoute(relayUrl, groupId, view = GroupView.Threads, threadRootId = rootId).toHash()
+
+/**
  * The value to persist in the last-route slot ([SecureStorage.saveLastRoute]) for [route].
  * Only groups and the home tabs are tracked for restore: a group persists its base hash
  * (no deep-link target / invite / thread pane), and the home tabs persist their hash (empty

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -695,7 +695,7 @@ class GroupViewModel(
         viewModelScope.launch {
             try {
                 when (val result = repo.sendReaction(groupId, targetEventId, targetPubkey, emoji)) {
-                    is Result.Error -> _reactionError.value = friendlyReactionError(result.error)
+                    is Result.Error -> _reactionError.value = friendlyRelayError(result.error)
                     is Result.Success -> Unit
                 }
             } finally {
@@ -865,15 +865,7 @@ class GroupViewModel(
     fun deleteMessage(messageId: String) {
         viewModelScope.launch {
             when (val result = repo.deleteMessage(groupId, messageId)) {
-                is Result.Error -> {
-                    val raw = result.error.cause?.message ?: result.error.toString()
-                    val friendly =
-                        raw
-                            .removePrefix("blocked: ")
-                            .removePrefix("error: ")
-                            .replaceFirstChar { it.uppercaseChar() }
-                    _deleteMessageError.value = friendly
-                }
+                is Result.Error -> _deleteMessageError.value = friendlyRelayError(result.error)
                 is Result.Success -> Unit
             }
         }
@@ -962,8 +954,8 @@ internal fun filterMutedReactions(
     }.toMap()
 }
 
-/** User-facing message for a failed kind:7 send, relay prefixes stripped. */
-internal fun friendlyReactionError(error: AppError): String = (error.cause?.message ?: error.toString())
+/** User-facing message for a relay-rejected publish (kind 5/7/...), relay prefixes stripped. */
+internal fun friendlyRelayError(error: AppError): String = (error.cause?.message ?: error.toString())
     .removePrefix("blocked: ")
     .removePrefix("error: ")
     .replaceFirstChar { it.uppercaseChar() }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -248,19 +248,8 @@ class GroupViewModel(
      * repo cache stays untouched, so an unmute restores their reactions instantly.
      */
     val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> =
-        combine(repo.reactions, repo.mutedPubkeys) { byMessage, muted ->
-            if (muted.isEmpty()) {
-                byMessage
-            } else {
-                byMessage.mapNotNull { (messageId, byEmoji) ->
-                    val filtered = byEmoji.mapNotNull { (emoji, info) ->
-                        val reactors = info.reactors.filter { it !in muted }
-                        if (reactors.isEmpty()) null else emoji to info.copy(reactors = reactors)
-                    }.toMap()
-                    if (filtered.isEmpty()) null else messageId to filtered
-                }.toMap()
-            }
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.reactions.value)
+        combine(repo.reactions, repo.mutedPubkeys, ::filterMutedReactions)
+            .stateIn(viewModelScope, SharingStarted.Eagerly, repo.reactions.value)
 
     /**
      * Member/admin/role lists, host-relay scoped: entries the host relay published win
@@ -706,15 +695,7 @@ class GroupViewModel(
         viewModelScope.launch {
             try {
                 when (val result = repo.sendReaction(groupId, targetEventId, targetPubkey, emoji)) {
-                    is Result.Error -> {
-                        val raw = result.error.cause?.message ?: result.error.toString()
-                        val friendly =
-                            raw
-                                .removePrefix("blocked: ")
-                                .removePrefix("error: ")
-                                .replaceFirstChar { it.uppercaseChar() }
-                        _reactionError.value = friendly
-                    }
+                    is Result.Error -> _reactionError.value = friendlyReactionError(result.error)
                     is Result.Success -> Unit
                 }
             } finally {
@@ -962,6 +943,30 @@ class GroupViewModel(
         viewModelScope.launch { repo.fetchGroupPreview(previewGroupId, relayUrl) }
     }
 }
+
+/**
+ * Reactions with NIP-51 muted reactors removed. The raw repo cache stays untouched, so an
+ * unmute restores their reactions instantly. Shared by [GroupViewModel] and [ThreadsViewModel].
+ */
+internal fun filterMutedReactions(
+    byMessage: Map<String, Map<String, GroupManager.ReactionInfo>>,
+    muted: Set<String>,
+): Map<String, Map<String, GroupManager.ReactionInfo>> {
+    if (muted.isEmpty()) return byMessage
+    return byMessage.mapNotNull { (messageId, byEmoji) ->
+        val filtered = byEmoji.mapNotNull { (emoji, info) ->
+            val reactors = info.reactors.filter { it !in muted }
+            if (reactors.isEmpty()) null else emoji to info.copy(reactors = reactors)
+        }.toMap()
+        if (filtered.isEmpty()) null else messageId to filtered
+    }.toMap()
+}
+
+/** User-facing message for a failed kind:7 send, relay prefixes stripped. */
+internal fun friendlyReactionError(error: AppError): String = (error.cause?.message ?: error.toString())
+    .removePrefix("blocked: ")
+    .removePrefix("error: ")
+    .replaceFirstChar { it.uppercaseChar() }
 
 /** How a failed reaction should be presented: the relay wants a join first, the signer could not sign the kind:7, or the relay rejected it. */
 enum class ReactionErrorKind { JoinRequired, SignerFailure, RelayRejected }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -39,11 +39,14 @@ data class ThreadDetail(
 /** The `E` (root-scope) tag of a kind:1111 reply: the id of the thread it belongs to. */
 internal fun NostrGroupClient.NostrMessage.threadRootIdTag(): String? = tags.firstOrNull { it.size >= 2 && it[0] == "E" }?.get(1)
 
+/** Cap [this] at [max] chars, appending an ellipsis when something was cut. */
+private fun String.takeWithEllipsis(max: Int): String = if (length > max) take(max) + "..." else this
+
 /** A thread's title: its NIP-14 `subject` tag, else the first non-blank line of the content. */
 internal fun NostrGroupClient.NostrMessage.threadTitle(): String {
     val subject = tags.firstOrNull { it.size >= 2 && it[0] == "subject" }?.get(1)?.trim()
     if (!subject.isNullOrEmpty()) return subject
-    return content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.take(80)
+    return content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.takeWithEllipsis(80)
         ?: "Untitled thread"
 }
 
@@ -62,7 +65,7 @@ internal fun buildThreadSummaries(
         .map { root ->
             val rs = repliesByRoot[root.id] ?: emptyList()
             val preview = root.content.lineSequence().map { it.trim() }
-                .firstOrNull { it.isNotEmpty() }.orEmpty().take(140)
+                .firstOrNull { it.isNotEmpty() }.orEmpty().takeWithEllipsis(140)
             ThreadSummary(
                 rootId = root.id,
                 authorPubkey = root.pubkey,
@@ -76,6 +79,36 @@ internal fun buildThreadSummaries(
         }
         .sortedByDescending { it.lastActivity }
 }
+
+/** A compact emoji+count chip shown on a thread list card (top reactions on the root). */
+data class ReactionChip(
+    val emoji: String,
+    val emojiUrl: String?,
+    val count: Int,
+)
+
+/**
+ * The top [maxChips] reactions on a message by reactor count (ties broken alphabetically),
+ * for the thread list cards. NIP-25 "+"/"-" display as thumbs so a chip never shows a bare sign.
+ * Shared by the Compose and web cards so both rank and label identically.
+ */
+fun topReactionChips(
+    byEmoji: Map<String, GroupManager.ReactionInfo>,
+    maxChips: Int = 3,
+): List<ReactionChip> = byEmoji.entries
+    .sortedWith(
+        compareByDescending<Map.Entry<String, GroupManager.ReactionInfo>> { it.value.reactors.size }
+            .thenBy { it.key },
+    )
+    .take(maxChips)
+    .map { (emoji, info) ->
+        val display = when (emoji) {
+            "+" -> "👍"
+            "-" -> "👎"
+            else -> emoji
+        }
+        ReactionChip(display, info.emojiUrl, info.reactors.size)
+    }
 
 /**
  * Shared screen logic for the forum-style Threads pane (Discord-like): the list of kind:11 roots

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.normalizeRelayUrl
@@ -175,6 +176,49 @@ class ThreadsViewModel(
     }
 
     fun getPublicKey() = repo.getPublicKey()
+
+    /** Reactions with NIP-51 muted reactors removed, same contract as [GroupViewModel.reactions]. */
+    val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> =
+        combine(repo.reactions, repo.mutedPubkeys, ::filterMutedReactions)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), repo.reactions.value)
+
+    // Reactions with an in-flight send, keyed "$targetEventId|$emoji" — pending badge + spinner
+    // during the sign round-trip (1-2s on a NIP-46 bunker), mirroring GroupViewModel.
+    private val _pendingReactions = MutableStateFlow<Set<String>>(emptySet())
+    val pendingReactions: StateFlow<Set<String>> = _pendingReactions
+
+    private val _reactionError = MutableStateFlow<String?>(null)
+    val reactionError: StateFlow<String?> = _reactionError
+
+    fun clearReactionError() {
+        _reactionError.value = null
+    }
+
+    /** Join the group (offered by the reaction-error dialog when the relay wants a member). */
+    fun joinGroup() {
+        viewModelScope.launch { repo.joinGroup(groupId) }
+    }
+
+    /** React (kind:7) to a thread root or reply; dedupes an in-flight send of the same emoji. */
+    fun sendReaction(
+        targetEventId: String,
+        targetPubkey: String,
+        emoji: String,
+    ) {
+        val key = "$targetEventId|$emoji"
+        if (key in _pendingReactions.value) return
+        _pendingReactions.value = _pendingReactions.value + key
+        viewModelScope.launch {
+            try {
+                when (val result = repo.sendReaction(groupId, targetEventId, targetPubkey, emoji)) {
+                    is Result.Error -> _reactionError.value = friendlyReactionError(result.error)
+                    is Result.Success -> Unit
+                }
+            } finally {
+                _pendingReactions.value = _pendingReactions.value - key
+            }
+        }
+    }
 
     /** Delete a thread you authored (NIP-09/NIP-29 deletion of the kind:11 root). The relay echo
      *  removes it from the list. Runs on viewModelScope, which survives list <-> detail nav. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -200,13 +200,22 @@ class ThreadsViewModel(
 
     /**
      * Create a forum thread (kind:11). No-op on blank content. [shareToChat] also announces it
-     * in the group chat via [shareThreadToChat] once the root id is known.
+     * in the group chat via [shareThreadToChat] once the root id is known; [onCreated] fires
+     * with the root id so the screen can open the new thread right away.
      */
-    fun createThread(title: String, content: String, shareToChat: Boolean = false) {
+    fun createThread(
+        title: String,
+        content: String,
+        shareToChat: Boolean = false,
+        onCreated: (rootId: String) -> Unit = {},
+    ) {
         if (content.isBlank()) return
         viewModelScope.launch {
             when (val result = repo.createThread(groupId, title.trim(), content.trim())) {
-                is Result.Success -> if (shareToChat) announceThread(result.data, title.trim(), repo.getPublicKey())
+                is Result.Success -> {
+                    onCreated(result.data)
+                    if (shareToChat) announceThread(result.data, title.trim(), repo.getPublicKey())
+                }
                 is Result.Error -> Unit
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -262,7 +262,7 @@ class ThreadsViewModel(
         viewModelScope.launch {
             try {
                 when (val result = repo.sendReaction(groupId, targetEventId, targetPubkey, emoji)) {
-                    is Result.Error -> _reactionError.value = friendlyReactionError(result.error)
+                    is Result.Error -> _reactionError.value = friendlyRelayError(result.error)
                     is Result.Success -> Unit
                 }
             } finally {
@@ -271,10 +271,25 @@ class ThreadsViewModel(
         }
     }
 
-    /** Delete a thread you authored (NIP-09/NIP-29 deletion of the kind:11 root). The relay echo
-     *  removes it from the list. Runs on viewModelScope, which survives list <-> detail nav. */
+    private val _deleteError = MutableStateFlow<String?>(null)
+
+    /** The relay's rejection of a kind:5/9005 delete ("kind 5 not allowed", ...), user-facing. */
+    val deleteError: StateFlow<String?> = _deleteError
+
+    fun clearDeleteError() {
+        _deleteError.value = null
+    }
+
+    /** Delete a thread root or reply you authored (NIP-09/NIP-29 deletion). The relay echo
+     *  removes it from local state; a rejection surfaces via [deleteError]. Runs on
+     *  viewModelScope, which survives list <-> detail nav. */
     fun deleteThread(rootId: String) {
-        viewModelScope.launch { repo.deleteMessage(groupId, rootId) }
+        viewModelScope.launch {
+            when (val result = repo.deleteMessage(groupId, rootId)) {
+                is Result.Error -> _deleteError.value = friendlyRelayError(result.error)
+                is Result.Success -> Unit
+            }
+        }
     }
 
     fun retrySend(eventId: String) = repo.retrySend(eventId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.normalizeRelayUrl
@@ -197,10 +198,37 @@ class ThreadsViewModel(
         }
     }
 
-    /** Create a forum thread (kind:11). No-op on blank content. */
-    fun createThread(title: String, content: String) {
+    /**
+     * Create a forum thread (kind:11). No-op on blank content. [shareToChat] also announces it
+     * in the group chat via [shareThreadToChat] once the root id is known.
+     */
+    fun createThread(title: String, content: String, shareToChat: Boolean = false) {
         if (content.isBlank()) return
-        viewModelScope.launch { repo.createThread(groupId, title.trim(), content.trim()) }
+        viewModelScope.launch {
+            when (val result = repo.createThread(groupId, title.trim(), content.trim())) {
+                is Result.Success -> if (shareToChat) announceThread(result.data, title.trim(), repo.getPublicKey())
+                is Result.Error -> Unit
+            }
+        }
+    }
+
+    /**
+     * Announce a thread in the group chat: a plain kind:9 with the title and the root's
+     * nostr:nevent, so every NIP-29 client renders it (ours as a tappable quoted card).
+     * Opt-in only - never fired automatically without the author asking.
+     */
+    fun shareThreadToChat(root: NostrGroupClient.NostrMessage) {
+        viewModelScope.launch { announceThread(root.id, root.threadTitle(), root.pubkey) }
+    }
+
+    private suspend fun announceThread(rootId: String, title: String, authorPubkey: String?) {
+        val nevent = try {
+            Nip19.encodeNevent(rootId, relays = listOfNotNull(hostRelay), authorHex = authorPubkey, kind = 11)
+        } catch (_: Exception) {
+            return
+        }
+        val text = if (title.isBlank()) "Started a thread" else "Started a thread: $title"
+        repo.sendMessage(groupId, "$text\nnostr:$nevent")
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -39,6 +39,13 @@ data class ThreadDetail(
 /** The `E` (root-scope) tag of a kind:1111 reply: the id of the thread it belongs to. */
 internal fun NostrGroupClient.NostrMessage.threadRootIdTag(): String? = tags.firstOrNull { it.size >= 2 && it[0] == "E" }?.get(1)
 
+/**
+ * The lowercase `e` (parent) tag of a kind:1111 reply: the specific message it answers.
+ * Present only on nested replies - a top-level reply's parent IS the root, so ThreadTags
+ * omits the lowercase triple (see [org.nostr.nostrord.network.managers.ThreadTags.reply]).
+ */
+internal fun NostrGroupClient.NostrMessage.threadParentIdTag(): String? = tags.firstOrNull { it.size >= 2 && it[0] == "e" }?.get(1)
+
 /** Cap [this] at [max] chars, appending an ellipsis when something was cut. */
 private fun String.takeWithEllipsis(max: Int): String = if (length > max) take(max) + "..." else this
 
@@ -197,15 +204,21 @@ class ThreadsViewModel(
     }
 
     /**
-     * Post a top-level reply (kind:1111) to the open thread. No-op on blank content. [onSuccess]/
-     * [onFailure] fire after the local build/sign step (the reply then appears with a Sending
-     * status and delivers in the background), so the composer can show a send spinner like chat.
+     * Post a reply (kind:1111) to the open thread. [parent] targets a specific message for a
+     * nested reply; null (or the root itself) posts top-level. No-op on blank content.
+     * [onSuccess]/[onFailure] fire after the local build/sign step (the reply then appears with
+     * a Sending status and delivers in the background), so the composer can show a send spinner.
      */
-    fun sendReply(content: String, onSuccess: () -> Unit = {}, onFailure: () -> Unit = {}) {
+    fun sendReply(
+        content: String,
+        parent: NostrGroupClient.NostrMessage? = null,
+        onSuccess: () -> Unit = {},
+        onFailure: () -> Unit = {},
+    ) {
         if (content.isBlank()) return
         val root = openThread.value?.root ?: return
         viewModelScope.launch {
-            val result = withMinDuration { repo.sendThreadReply(groupId, root = root, parent = root, content = content.trim()) }
+            val result = withMinDuration { repo.sendThreadReply(groupId, root = root, parent = parent ?: root, content = content.trim()) }
             when (result) {
                 is Result.Error -> onFailure()
                 is Result.Success -> onSuccess()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -42,10 +42,15 @@ internal fun NostrGroupClient.NostrMessage.threadRootIdTag(): String? = tags.fir
 /** Cap [this] at [max] chars, appending an ellipsis when something was cut. */
 private fun String.takeWithEllipsis(max: Int): String = if (length > max) take(max) + "..." else this
 
-/** A thread's title: its NIP-14 `subject` tag, else the first non-blank line of the content. */
+/**
+ * A thread's title: its NIP-14 `subject` tag (what we write), else the NIP-7D `title` tag
+ * (what other kind:11 clients write), else the first non-blank line of the content.
+ */
 internal fun NostrGroupClient.NostrMessage.threadTitle(): String {
-    val subject = tags.firstOrNull { it.size >= 2 && it[0] == "subject" }?.get(1)?.trim()
-    if (!subject.isNullOrEmpty()) return subject
+    for (name in listOf("subject", "title")) {
+        val value = tags.firstOrNull { it.size >= 2 && it[0] == name }?.get(1)?.trim()
+        if (!value.isNullOrEmpty()) return value
+    }
     return content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.takeWithEllipsis(80)
         ?: "Untitled thread"
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -414,10 +414,15 @@ class FakeNostrRepository : NostrRepositoryApi {
 
     override fun dismissFailed(groupId: String, eventId: String) = dismissFailedAction(groupId, eventId)
 
+    var deleteMessageResult: Result<Unit> = Result.Success(Unit)
+
     override suspend fun deleteMessage(
         groupId: String,
         messageId: String,
-    ): Result<Unit> = Result.Success(Unit)
+    ): Result<Unit> {
+        calls += "deleteMessage:$groupId:$messageId"
+        return deleteMessageResult
+    }
 
     override fun getMessagesForGroup(groupId: String): List<NostrGroupClient.NostrMessage> = messages.value[groupId] ?: emptyList()
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -288,9 +288,10 @@ class FakeNostrRepository : NostrRepositoryApi {
         calls += "fetchThread:$groupId:$rootId"
     }
 
-    override suspend fun createThread(groupId: String, title: String, content: String): Result<Unit> {
+    override suspend fun createThread(groupId: String, title: String, content: String): Result<String> {
         calls += "createThread:$groupId:$title"
-        return Result.Success(Unit)
+        // A real 32-byte hex id so callers can bech32-encode it (nevent).
+        return Result.Success("ab".repeat(32))
     }
 
     override suspend fun sendThreadReply(

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -615,12 +615,17 @@ class FakeNostrRepository : NostrRepositoryApi {
         _joinedGroupsByRelay.update { it + (relay to (it[relay].orEmpty() + groupId)) }
     }
 
+    var sendReactionResult: Result<Unit> = Result.Success(Unit)
+
     override suspend fun sendReaction(
         groupId: String,
         targetEventId: String,
         targetPubkey: String,
         emoji: String,
-    ): Result<Unit> = Result.Success(Unit)
+    ): Result<Unit> {
+        calls += "sendReaction:$groupId:$targetEventId:$emoji"
+        return sendReactionResult
+    }
 
     override val zaps: StateFlow<Map<String, ZapManager.ZapInfo>> = MutableStateFlow(emptyMap())
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadCacheTest.kt
@@ -1,0 +1,98 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.storage.cache.InMemoryCacheStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val PUBKEY = "00000000000000000000000000000000000000000000000000000000cafed00d"
+private const val GROUP = "thread-cache-group"
+private const val RELAY = "wss://relay.test"
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThreadCacheTest {
+    private fun makeManager(scope: TestScope, store: InMemoryCacheStore): GroupManager = GroupManager(connectionManager = ConnectionManager(scope), scope = scope, cacheStore = store)
+
+    private fun threadMsg(id: String, kind: Int, createdAt: Long) = NostrGroupClient.NostrMessage(
+        id = id,
+        pubkey = "author",
+        content = "body $id",
+        createdAt = createdAt,
+        kind = kind,
+        tags = listOf(listOf("h", GROUP)),
+    )
+
+    // The raw relay frame handleMessage parses the group id ("h" tag) out of.
+    private fun rawFrame(id: String, kind: Int) = """["EVENT","threads_$GROUP",{"id":"$id","kind":$kind,"tags":[["h","$GROUP"]]}]"""
+
+    private fun deliver(manager: GroupManager, msg: NostrGroupClient.NostrMessage) {
+        manager.handleMessage(msg, rawFrame(msg.id, msg.kind), "threads_$GROUP", RELAY)
+    }
+
+    @Test
+    fun `thread roots and replies persist and hydrate a fresh manager before any relay`() = runTest {
+        val scope = TestScope(testScheduler)
+        val store = InMemoryCacheStore()
+        val writer = makeManager(scope, store)
+        writer.setCurrentPubkey(PUBKEY)
+        writer.setGroupRelayHint(GROUP, RELAY)
+
+        deliver(writer, threadMsg("root1", kind = 11, createdAt = 100))
+        deliver(writer, threadMsg("reply1", kind = 1111, createdAt = 200))
+        testScheduler.advanceUntilIdle() // flush the fire-and-forget cache writes
+
+        // Cold start: a fresh manager with no connected client hydrates from the shared store.
+        val reader = makeManager(scope, store)
+        reader.setCurrentPubkey(PUBKEY)
+        reader.setGroupRelayHint(GROUP, RELAY)
+        assertEquals(false, reader.requestGroupThreads(GROUP)) // no client -> false, but hydrated
+        assertEquals(listOf("root1"), reader.threadRoots.value[GROUP]?.map { it.id })
+        assertEquals(listOf("reply1"), reader.threadReplies.value[GROUP]?.map { it.id })
+        // Restored events carry the relay stamp so relay-scoped screens accept them.
+        assertEquals(RELAY, reader.threadRoots.value[GROUP]?.single()?.relayUrl)
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a deleted thread root does not rehydrate from cache`() = runTest {
+        val scope = TestScope(testScheduler)
+        val store = InMemoryCacheStore()
+        val writer = makeManager(scope, store)
+        writer.setCurrentPubkey(PUBKEY)
+        writer.setGroupRelayHint(GROUP, RELAY)
+
+        deliver(writer, threadMsg("root1", kind = 11, createdAt = 100))
+        testScheduler.advanceUntilIdle()
+
+        // The author's kind:5 delete arrives; the cache row must be evicted with it.
+        val deletion = NostrGroupClient.NostrMessage(
+            id = "del1",
+            pubkey = "author",
+            content = "",
+            createdAt = 300,
+            kind = 5,
+            tags = listOf(listOf("h", GROUP), listOf("e", "root1")),
+        )
+        writer.handleMessage(
+            deletion,
+            """["EVENT","threads_$GROUP",{"id":"del1","kind":5,"tags":[["h","$GROUP"],["e","root1"]]}]""",
+            "threads_$GROUP",
+            RELAY,
+        )
+        testScheduler.advanceUntilIdle()
+
+        val reader = makeManager(scope, store)
+        reader.setCurrentPubkey(PUBKEY)
+        reader.setGroupRelayHint(GROUP, RELAY)
+        reader.requestGroupThreads(GROUP)
+        assertTrue(reader.threadRoots.value[GROUP].isNullOrEmpty())
+
+        scope.cancel()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadTagsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadTagsTest.kt
@@ -8,17 +8,19 @@ class ThreadTagsTest {
     private fun msg(id: String, pubkey: String, kind: Int) = NostrGroupClient.NostrMessage(id = id, pubkey = pubkey, content = "", createdAt = 0, kind = kind)
 
     @Test
-    fun `root carries group h tag with relay hint and subject`() {
+    fun `root carries group h tag with relay hint and the title as both title and subject`() {
         val tags = ThreadTags.root("grp", "wss://groups.0xchat.com", "My title")
         assertEquals(listOf("h", "grp", "wss://groups.0xchat.com"), tags[0])
+        // NIP-7D readers (Squalk - issue #221) want `title`; NIP-14 readers want `subject`.
+        assertEquals(listOf("title", "My title"), tags.first { it[0] == "title" })
         assertEquals(listOf("subject", "My title"), tags.first { it[0] == "subject" })
     }
 
     @Test
-    fun `root omits subject when blank and h has no hint when relay unknown`() {
+    fun `root omits the title tags when blank and h has no hint when relay unknown`() {
         val tags = ThreadTags.root("grp", null, "   ")
         assertEquals(listOf("h", "grp"), tags[0])
-        assertEquals(0, tags.count { it[0] == "subject" })
+        assertEquals(0, tags.count { it[0] == "subject" || it[0] == "title" })
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -14,6 +14,8 @@ import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.buildThreadSummaries
 import org.nostr.nostrord.ui.screens.group.filterMutedReactions
 import org.nostr.nostrord.ui.screens.group.friendlyReactionError
+import org.nostr.nostrord.ui.screens.group.threadParentIdTag
+import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
@@ -129,6 +131,22 @@ class ThreadsViewModelTest {
                 listOf(reply("r1", "a", "p", 110), reply("r2", "b", "p", 200)),
             ).map { it.rootId },
         )
+    }
+
+    @Test
+    fun `threadParentIdTag reads only the lowercase e tag of a nested reply`() {
+        val nested = NostrGroupClient.NostrMessage(
+            id = "n",
+            pubkey = "p",
+            content = "re",
+            createdAt = 1,
+            kind = 1111,
+            tags = listOf(listOf("E", "rootid", "", "rootpk"), listOf("e", "parentid", "", "parentpk")),
+        )
+        assertEquals("rootid", nested.threadRootIdTag())
+        assertEquals("parentid", nested.threadParentIdTag())
+        // A top-level reply carries only the uppercase root scope.
+        assertNull(reply("r1", "rootid", "p", 1).threadParentIdTag())
     }
 
     // -------------------------------------------------------------------------

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -1,11 +1,43 @@
 package org.nostr.nostrord.ui
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.nostr.nostrord.network.FakeNostrRepository
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.buildThreadSummaries
+import org.nostr.nostrord.ui.screens.group.filterMutedReactions
+import org.nostr.nostrord.ui.screens.group.friendlyReactionError
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class ThreadsViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Drain Main-dispatched viewModelScope jobs before resetMain (see GroupViewModelTest).
+        testDispatcher.scheduler.advanceUntilIdle()
+        Dispatchers.resetMain()
+    }
+
     private fun root(id: String, createdAt: Long, content: String, subject: String? = null) = NostrGroupClient.NostrMessage(
         id = id,
         pubkey = "author_$id",
@@ -70,5 +102,56 @@ class ThreadsViewModelTest {
                 listOf(reply("r1", "a", "p", 110), reply("r2", "b", "p", 200)),
             ).map { it.rootId },
         )
+    }
+
+    // -------------------------------------------------------------------------
+    // Reactions
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `sendReaction marks the emoji pending, dedupes in-flight, then clears`() = runTest {
+        val fake = FakeNostrRepository()
+        val vm = ThreadsViewModel(fake, "g1")
+        vm.sendReaction("ev1", "pk1", "🔥")
+        vm.sendReaction("ev1", "pk1", "🔥") // in-flight duplicate, ignored
+        assertEquals(setOf("ev1|🔥"), vm.pendingReactions.value)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(vm.pendingReactions.value.isEmpty())
+        assertEquals(1, fake.calls.count { it.startsWith("sendReaction:g1:ev1") })
+        assertNull(vm.reactionError.value)
+    }
+
+    @Test
+    fun `sendReaction failure surfaces a friendly error and still clears pending`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.sendReactionResult = Result.Error(AppError.Auth.SigningFailed(cause = Exception("blocked: unknown member")))
+        val vm = ThreadsViewModel(fake, "g1")
+        vm.sendReaction("ev1", "pk1", "👍")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("Unknown member", vm.reactionError.value)
+        assertTrue(vm.pendingReactions.value.isEmpty())
+        vm.clearReactionError()
+        assertNull(vm.reactionError.value)
+    }
+
+    @Test
+    fun `filterMutedReactions drops muted reactors and empty leftovers`() {
+        val raw = mapOf(
+            "m1" to mapOf(
+                "👍" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("alice", "bob")),
+                "🔥" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("bob")),
+            ),
+            "m2" to mapOf("👍" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("bob"))),
+        )
+        val filtered = filterMutedReactions(raw, setOf("bob"))
+        assertEquals(mapOf("m1" to mapOf("👍" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("alice")))), filtered)
+        // No mutes: the raw map passes through untouched.
+        assertEquals(raw, filterMutedReactions(raw, emptySet()))
+    }
+
+    @Test
+    fun `friendlyReactionError strips relay prefixes and capitalizes`() {
+        val err = AppError.Auth.SigningFailed(cause = Exception("blocked: not a member"))
+        assertEquals("Not a member", friendlyReactionError(err))
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -188,8 +188,11 @@ class ThreadsViewModelTest {
             Result.Success(Unit)
         }
         val vm = ThreadsViewModel(fake, "g1")
-        vm.createThread("My title", "body", shareToChat = true)
+        var openedRootId: String? = null
+        vm.createThread("My title", "body", shareToChat = true) { openedRootId = it }
         testDispatcher.scheduler.advanceUntilIdle()
+        // The screen opens the new thread via onCreated.
+        assertEquals("ab".repeat(32), openedRootId)
         val text = announced ?: error("no chat announcement sent")
         assertTrue(text.startsWith("Started a thread: My title\nnostr:nevent1"), text)
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -82,6 +82,20 @@ class ThreadsViewModelTest {
     }
 
     @Test
+    fun `a NIP-7D title tag names the thread when there is no subject`() {
+        val msg = NostrGroupClient.NostrMessage(
+            id = "a",
+            pubkey = "p",
+            content = "body text",
+            createdAt = 1,
+            kind = 11,
+            tags = listOf(listOf("title", "From another client")),
+        )
+        val s = buildThreadSummaries(listOf(msg), emptyList()).single()
+        assertEquals("From another client", s.title)
+    }
+
+    @Test
     fun `preview and fallback title end in an ellipsis when the content is cut`() {
         val long = "x".repeat(200)
         val s = buildThreadSummaries(listOf(root("a", 1, long)), emptyList()).single()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -180,6 +180,27 @@ class ThreadsViewModelTest {
     }
 
     @Test
+    fun `createThread with shareToChat announces a kind9 with the thread nevent`() = runTest {
+        val fake = FakeNostrRepository()
+        var announced: String? = null
+        fake.sendMessageAction = { _, content, _, _, _ ->
+            announced = content
+            Result.Success(Unit)
+        }
+        val vm = ThreadsViewModel(fake, "g1")
+        vm.createThread("My title", "body", shareToChat = true)
+        testDispatcher.scheduler.advanceUntilIdle()
+        val text = announced ?: error("no chat announcement sent")
+        assertTrue(text.startsWith("Started a thread: My title\nnostr:nevent1"), text)
+
+        // Opting out sends nothing.
+        announced = null
+        vm.createThread("Quiet", "body", shareToChat = false)
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertNull(announced)
+    }
+
+    @Test
     fun `deleteThread surfaces the relay rejection as a friendly error`() = runTest {
         val fake = FakeNostrRepository()
         fake.deleteMessageResult = Result.Error(AppError.Group.SendFailed("g1", Exception("blocked: event kind 5 not allowed")))

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -9,10 +9,12 @@ import kotlinx.coroutines.test.setMain
 import org.nostr.nostrord.network.FakeNostrRepository
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.ui.screens.group.ReactionChip
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.buildThreadSummaries
 import org.nostr.nostrord.ui.screens.group.filterMutedReactions
 import org.nostr.nostrord.ui.screens.group.friendlyReactionError
+import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import kotlin.test.AfterTest
@@ -77,6 +79,17 @@ class ThreadsViewModelTest {
     fun `title falls back to the first non-blank content line when no subject`() {
         val s = buildThreadSummaries(listOf(root("a", 1, "\n  First line  \nsecond")), emptyList()).single()
         assertEquals("First line", s.title)
+    }
+
+    @Test
+    fun `preview and fallback title end in an ellipsis when the content is cut`() {
+        val long = "x".repeat(200)
+        val s = buildThreadSummaries(listOf(root("a", 1, long)), emptyList()).single()
+        assertEquals("x".repeat(140) + "...", s.preview)
+        assertEquals("x".repeat(80) + "...", s.title)
+        // Exactly at the cap: nothing was cut, no ellipsis.
+        val exact = buildThreadSummaries(listOf(root("b", 1, "y".repeat(140))), emptyList()).single()
+        assertEquals("y".repeat(140), exact.preview)
     }
 
     @Test
@@ -147,6 +160,26 @@ class ThreadsViewModelTest {
         assertEquals(mapOf("m1" to mapOf("👍" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("alice")))), filtered)
         // No mutes: the raw map passes through untouched.
         assertEquals(raw, filterMutedReactions(raw, emptySet()))
+    }
+
+    @Test
+    fun `topReactionChips ranks by count, caps the list, and shows plus as thumbs`() {
+        val byEmoji = mapOf(
+            "🎯" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("a", "b", "c")),
+            "+" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("a", "b", "c", "d")),
+            "🔥" to GroupManager.ReactionInfo(emojiUrl = null, reactors = listOf("a")),
+            ":pepe:" to GroupManager.ReactionInfo(emojiUrl = "https://x/pepe.png", reactors = listOf("a", "b")),
+        )
+        val chips = topReactionChips(byEmoji, maxChips = 3)
+        assertEquals(
+            listOf(
+                ReactionChip("👍", null, 4),
+                ReactionChip("🎯", null, 3),
+                ReactionChip(":pepe:", "https://x/pepe.png", 2),
+            ),
+            chips,
+        )
+        assertTrue(topReactionChips(emptyMap()).isEmpty())
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -13,7 +13,7 @@ import org.nostr.nostrord.ui.screens.group.ReactionChip
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.buildThreadSummaries
 import org.nostr.nostrord.ui.screens.group.filterMutedReactions
-import org.nostr.nostrord.ui.screens.group.friendlyReactionError
+import org.nostr.nostrord.ui.screens.group.friendlyRelayError
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.topReactionChips
@@ -180,6 +180,18 @@ class ThreadsViewModelTest {
     }
 
     @Test
+    fun `deleteThread surfaces the relay rejection as a friendly error`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.deleteMessageResult = Result.Error(AppError.Group.SendFailed("g1", Exception("blocked: event kind 5 not allowed")))
+        val vm = ThreadsViewModel(fake, "g1")
+        vm.deleteThread("root1")
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("Event kind 5 not allowed", vm.deleteError.value)
+        vm.clearDeleteError()
+        assertNull(vm.deleteError.value)
+    }
+
+    @Test
     fun `filterMutedReactions drops muted reactors and empty leftovers`() {
         val raw = mapOf(
             "m1" to mapOf(
@@ -215,8 +227,8 @@ class ThreadsViewModelTest {
     }
 
     @Test
-    fun `friendlyReactionError strips relay prefixes and capitalizes`() {
+    fun `friendlyRelayError strips relay prefixes and capitalizes`() {
         val err = AppError.Auth.SigningFailed(cause = Exception("blocked: not a member"))
-        assertEquals("Not a member", friendlyReactionError(err))
+        assertEquals("Not a member", friendlyRelayError(err))
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -429,12 +429,22 @@ fun MessageContent(
                             Spacer(modifier = Modifier.height(8.dp))
                             val apostrophe = firstPart.url.indexOf('\'')
                             if (apostrophe > 0) {
-                                // NIP-29 group address: relay'groupId
-                                GroupLinkCard(
-                                    groupId = firstPart.url.substring(apostrophe + 1),
-                                    relayUrl = firstPart.url.substring(0, apostrophe),
-                                    onNavigateToGroup = onNavigateToGroup,
-                                )
+                                // NIP-29 group address relay'groupId: the full card only when the
+                                // message IS the link; mixed with text it renders as the compact
+                                // chip (web parity).
+                                if (content.trim() == firstPart.url) {
+                                    GroupLinkCard(
+                                        groupId = firstPart.url.substring(apostrophe + 1),
+                                        relayUrl = firstPart.url.substring(0, apostrophe),
+                                        onNavigateToGroup = onNavigateToGroup,
+                                    )
+                                } else {
+                                    GroupMentionChip(
+                                        groupId = firstPart.url.substring(apostrophe + 1),
+                                        relayUrl = firstPart.url.substring(0, apostrophe),
+                                        onNavigateToGroup = onNavigateToGroup,
+                                    )
+                                }
                             } else {
                                 RelayContent(
                                     url = firstPart.url,
@@ -2654,6 +2664,62 @@ private fun GroupLinkCard(
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Compact chip for a group reference mixed with running text (group avatar + name); the full
+ * [GroupLinkCard] is reserved for a message that is only the group link. Mirrors the web
+ * `.msg-mention-chip` rendering of inline group refs.
+ */
+@Composable
+private fun GroupMentionChip(
+    groupId: String,
+    relayUrl: String?,
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
+) {
+    val repo = AppModule.nostrRepository
+    val groups by repo.groups.collectAsState()
+    val groupsByRelay by repo.groupsByRelay.collectAsState()
+    val groupMeta =
+        groups.find { it.id == groupId }
+            ?: groupsByRelay.values.flatten().find { it.id == groupId }
+
+    LaunchedEffect(groupId, relayUrl) {
+        if (relayUrl != null && groupMeta?.name == null) {
+            repo.fetchGroupPreview(groupId, relayUrl)
+        }
+    }
+
+    val displayName = groupMeta?.name?.takeIf { it.isNotBlank() } ?: groupId
+    DisableSelection {
+        Row(
+            modifier =
+            Modifier
+                .clip(RoundedCornerShape(6.dp))
+                .background(NostrordColors.PrimarySubtle)
+                .clickable { onNavigateToGroup(groupId, groupMeta?.name, relayUrl, null) }
+                .pointerHoverIcon(PointerIcon.Hand)
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            GroupHeaderIcon(
+                pictureUrl = groupMeta?.picture,
+                groupId = groupId,
+                displayName = displayName,
+                size = 16.dp,
+                cornerRadius = 4.dp,
+            )
+            Text(
+                text = displayName,
+                color = NostrordColors.Primary,
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+            )
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
@@ -43,6 +44,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
@@ -68,6 +70,9 @@ import org.nostr.nostrord.ui.components.avatars.OptimizedUserAvatar
 import org.nostr.nostrord.ui.components.media.AudioPlayerContent
 import org.nostr.nostrord.ui.components.media.PlatformVideoPlayer
 import org.nostr.nostrord.ui.components.media.YouTubeLinkCard
+import org.nostr.nostrord.ui.navigation.GroupRoute
+import org.nostr.nostrord.ui.navigation.GroupView
+import org.nostr.nostrord.ui.navigation.LocalFrameNavigator
 import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
@@ -1339,6 +1344,103 @@ private fun extractGroupFromEvent(event: CachedEvent): Pair<String, String?>? {
 }
 
 /**
+ * A quoted kind:11 thread root, rendered as a tappable thread card ("Thread" header + title +
+ * snippet) that opens the thread page via [LocalFrameNavigator]. Used by [QuotedEvent] ahead of
+ * the forwarded-event rendering; mirrors the web `.thread-quote-card`.
+ */
+@Composable
+private fun ThreadQuoteCard(
+    event: CachedEvent,
+    eventId: String,
+    relayHint: String?,
+    currentGroupId: String?,
+    modifier: Modifier = Modifier,
+) {
+    val groupId = extractGroupFromEvent(event)?.first ?: currentGroupId
+    val navigate = LocalFrameNavigator.current
+    val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
+    val groupName = groupId?.let { gid -> groupsByRelay.values.flatten().firstOrNull { it.id == gid }?.name }
+        ?.takeIf { it.isNotBlank() }
+
+    val title = event.tags.firstOrNull { it.size >= 2 && (it[0] == "subject" || it[0] == "title") }
+        ?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
+        ?: event.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.take(80)
+        ?: "Thread"
+    val snippet = event.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }
+        ?.take(140)?.takeIf { it != title }
+
+    val openThread: (() -> Unit)? =
+        if (navigate != null && groupId != null && relayHint != null) {
+            { navigate(GroupRoute(relayHint, groupId, view = GroupView.Threads, threadRootId = eventId)) }
+        } else {
+            null
+        }
+
+    DisableSelection {
+        Column(
+            modifier =
+            modifier
+                .fillMaxWidth()
+                .widthIn(max = 380.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(NostrordColors.Surface)
+                .then(
+                    if (openThread != null) {
+                        Modifier.clickable(onClick = openThread).pointerHoverIcon(PointerIcon.Hand)
+                    } else {
+                        Modifier
+                    },
+                ).padding(horizontal = Spacing.sm, vertical = Spacing.sm),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                Icon(
+                    imageVector = Icons.Outlined.Forum,
+                    contentDescription = null,
+                    tint = NostrordColors.Primary,
+                    modifier = Modifier.size(14.dp),
+                )
+                Text(
+                    "Thread",
+                    color = NostrordColors.Primary,
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.Bold,
+                )
+                if (groupName != null) {
+                    Text(
+                        "· $groupName",
+                        color = NostrordColors.TextMuted,
+                        fontSize = 11.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Text(
+                title,
+                color = NostrordColors.TextPrimary,
+                fontSize = 14.sp,
+                fontWeight = FontWeight.SemiBold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (snippet != null) {
+                Text(
+                    snippet,
+                    color = NostrordColors.TextSecondary,
+                    fontSize = 13.sp,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+/**
  * Forwarded event card - displays an event that originated from a different group.
  * Shows "forwarded from [group name]" header with group info, author info,
  * optional reply preview (if q tag exists), and the message content.
@@ -1709,6 +1811,20 @@ private fun QuotedEvent(
             authorPicture = metadata?.picture,
             pubkey = event.pubkey,
             onClick = onClick,
+            modifier = modifier,
+        )
+        return
+    }
+
+    // A quoted kind:11 renders as a thread card that opens the thread page - both the
+    // "Share to chat" announcement and any pasted thread nevent land here. Takes precedence
+    // over the forwarded-event rendering (a thread is a destination, not a chat quote).
+    if (event?.kind == 11) {
+        ThreadQuoteCard(
+            event = event,
+            eventId = eventId,
+            relayHint = extractGroupFromEvent(event)?.second ?: relayHints.firstOrNull() ?: currentRelayUrl,
+            currentGroupId = currentGroupId,
             modifier = modifier,
         )
         return

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -86,6 +86,9 @@ sealed class MessageContextAction {
 
     data object Reply : MessageContextAction()
 
+    /** Threads: announce the thread in the group chat (kind:9 with the root's nevent). */
+    data object ShareToChat : MessageContextAction()
+
     data object ZapMessage : MessageContextAction()
 
     data object CopyText : MessageContextAction()
@@ -158,6 +161,8 @@ fun ThreadMessageContextMenu(
     onAction: (MessageContextAction) -> Unit,
     anchorOffsetPx: Offset? = null,
     isAuthor: Boolean = false,
+    // Roots only: announce the thread in the group chat.
+    canShareToChat: Boolean = false,
 ) {
     if (!visible) return
     ContextMenuPopup(onDismiss, anchorOffsetPx, anchorWidthPx = 0) {
@@ -183,6 +188,17 @@ fun ThreadMessageContextMenu(
                     onDismiss()
                 },
             )
+
+            if (canShareToChat) {
+                ContextMenuItem(
+                    icon = Icons.Outlined.Forum,
+                    label = "Share to chat",
+                    onClick = {
+                        onAction(MessageContextAction.ShareToChat)
+                        onDismiss()
+                    },
+                )
+            }
 
             ContextMenuDivider()
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -176,6 +176,17 @@ fun ThreadMessageContextMenu(
             ContextMenuDivider()
 
             ContextMenuItem(
+                icon = Icons.AutoMirrored.Outlined.Reply,
+                label = "Reply",
+                onClick = {
+                    onAction(MessageContextAction.Reply)
+                    onDismiss()
+                },
+            )
+
+            ContextMenuDivider()
+
+            ContextMenuItem(
                 icon = Icons.Outlined.ContentCopy,
                 label = "Copy text",
                 onClick = {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -134,57 +134,125 @@ fun MessageContextMenu(
 ) {
     // Only render Popup when visible to avoid layout participation
     if (visible) {
-        val marginPx = with(LocalDensity.current) { 8.dp.roundToPx() }
-        // Open at the click position (web parity); fall back to the row's
-        // top-right when there's no cursor anchor (the hover More button).
-        val positionProvider =
-            remember(anchorOffsetPx, anchorWidthPx, marginPx) {
-                MessageMenuPositionProvider(anchorOffsetPx, anchorWidthPx, marginPx)
+        ContextMenuPopup(onDismiss, anchorOffsetPx, anchorWidthPx) {
+            ContextMenuContent(
+                onAction = onAction,
+                onDismiss = onDismiss,
+                isAuthor = isAuthor,
+                isAdmin = isAdmin,
+                canZap = canZap,
+            )
+        }
+    }
+}
+
+/**
+ * Compact context menu for thread messages (right-click / long-press): the quick-reactions
+ * row, copy text, and delete for the author. Shares the chat menu's chrome and action
+ * vocabulary ([MessageContextAction]) but not its chat-only items (reply, zap, pin, links).
+ */
+@Composable
+fun ThreadMessageContextMenu(
+    visible: Boolean,
+    onDismiss: () -> Unit,
+    onAction: (MessageContextAction) -> Unit,
+    anchorOffsetPx: Offset? = null,
+    isAuthor: Boolean = false,
+) {
+    if (!visible) return
+    ContextMenuPopup(onDismiss, anchorOffsetPx, anchorWidthPx = 0) {
+        ContextMenuSurface {
+            QuickReactionsRow(
+                onQuickReact = { emoji ->
+                    onAction(MessageContextAction.QuickReact(emoji))
+                    onDismiss()
+                },
+                onOpenPicker = {
+                    onAction(MessageContextAction.AddReaction)
+                    onDismiss()
+                },
+            )
+
+            ContextMenuDivider()
+
+            ContextMenuItem(
+                icon = Icons.Outlined.ContentCopy,
+                label = "Copy text",
+                onClick = {
+                    onAction(MessageContextAction.CopyText)
+                    onDismiss()
+                },
+            )
+
+            if (isAuthor) {
+                ContextMenuDivider()
+
+                ContextMenuItem(
+                    icon = Icons.Outlined.Delete,
+                    label = "Delete message",
+                    onClick = {
+                        onAction(MessageContextAction.DeleteMessage)
+                        onDismiss()
+                    },
+                    isDestructive = true,
+                )
             }
-        // Grow from the cursor (top-left) when opened at a click, from the
-        // top-right when hung off the More button.
-        val transformOrigin =
-            if (anchorOffsetPx != null) TransformOrigin(0f, 0f) else TransformOrigin(1f, 0f)
-        Popup(
-            popupPositionProvider = positionProvider,
-            onDismissRequest = onDismiss,
-            properties =
-            PopupProperties(
-                // focusable = true allows clicking outside to dismiss
-                // but must be careful not to steal focus from selection
-                focusable = true,
-                // Don't dismiss on back press automatically - let onDismissRequest handle it
-                dismissOnBackPress = true,
-                dismissOnClickOutside = true,
-            ),
-        ) {
-            // DisableSelection prevents the menu itself from participating in text selection
-            DisableSelection {
-                // Animated content inside the popup
-                AnimatedVisibility(
-                    visible = true, // Always visible when popup is shown
-                    enter =
-                    fadeIn(animationSpec = tween(NostrordAnimation.popupEnter)) +
-                        scaleIn(
-                            animationSpec = tween(NostrordAnimation.popupEnter),
-                            initialScale = 0.9f,
-                            transformOrigin = transformOrigin,
-                        ),
-                    exit =
-                    fadeOut(animationSpec = tween(NostrordAnimation.popupExit)) +
-                        scaleOut(
-                            animationSpec = tween(NostrordAnimation.popupExit),
-                            transformOrigin = transformOrigin,
-                        ),
-                ) {
-                    ContextMenuContent(
-                        onAction = onAction,
-                        onDismiss = onDismiss,
-                        isAuthor = isAuthor,
-                        isAdmin = isAdmin,
-                        canZap = canZap,
-                    )
-                }
+        }
+    }
+}
+
+/** Popup chrome shared by the chat and thread menus: cursor-anchored position + scale/fade in. */
+@Composable
+private fun ContextMenuPopup(
+    onDismiss: () -> Unit,
+    anchorOffsetPx: Offset?,
+    anchorWidthPx: Int,
+    content: @Composable () -> Unit,
+) {
+    val marginPx = with(LocalDensity.current) { 8.dp.roundToPx() }
+    // Open at the click position (web parity); fall back to the row's
+    // top-right when there's no cursor anchor (the hover More button).
+    val positionProvider =
+        remember(anchorOffsetPx, anchorWidthPx, marginPx) {
+            MessageMenuPositionProvider(anchorOffsetPx, anchorWidthPx, marginPx)
+        }
+    // Grow from the cursor (top-left) when opened at a click, from the
+    // top-right when hung off the More button.
+    val transformOrigin =
+        if (anchorOffsetPx != null) TransformOrigin(0f, 0f) else TransformOrigin(1f, 0f)
+    Popup(
+        popupPositionProvider = positionProvider,
+        onDismissRequest = onDismiss,
+        properties =
+        PopupProperties(
+            // focusable = true allows clicking outside to dismiss
+            // but must be careful not to steal focus from selection
+            focusable = true,
+            // Don't dismiss on back press automatically - let onDismissRequest handle it
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        ),
+    ) {
+        // DisableSelection prevents the menu itself from participating in text selection
+        DisableSelection {
+            // Animated content inside the popup
+            AnimatedVisibility(
+                visible = true, // Always visible when popup is shown
+                enter =
+                fadeIn(animationSpec = tween(NostrordAnimation.popupEnter)) +
+                    scaleIn(
+                        animationSpec = tween(NostrordAnimation.popupEnter),
+                        initialScale = 0.9f,
+                        transformOrigin = transformOrigin,
+                    ),
+                exit =
+                fadeOut(animationSpec = tween(NostrordAnimation.popupExit)) +
+                    scaleOut(
+                        animationSpec = tween(NostrordAnimation.popupExit),
+                        transformOrigin = transformOrigin,
+                    ),
+            ) {
+                content()
             }
         }
     }
@@ -230,14 +298,9 @@ internal class MessageMenuPositionProvider(
 /**
  * The actual menu content, separated for clarity.
  */
+/** The menu card chrome (width, shadow, border), shared by the chat and thread menu contents. */
 @Composable
-private fun ContextMenuContent(
-    onAction: (MessageContextAction) -> Unit,
-    onDismiss: () -> Unit,
-    isAuthor: Boolean,
-    isAdmin: Boolean,
-    canZap: Boolean,
-) {
+private fun ContextMenuSurface(content: @Composable ColumnScope.() -> Unit) {
     Column(
         modifier =
         Modifier
@@ -259,7 +322,19 @@ private fun ContextMenuContent(
             .pointerInput(Unit) {
                 detectTapGestures { /* consume */ }
             },
-    ) {
+        content = content,
+    )
+}
+
+@Composable
+private fun ContextMenuContent(
+    onAction: (MessageContextAction) -> Unit,
+    onDismiss: () -> Unit,
+    isAuthor: Boolean,
+    isAdmin: Boolean,
+    canZap: Boolean,
+) {
+    ContextMenuSurface {
         // Quick reactions row (one tap to react) + an affordance to open the full picker.
         QuickReactionsRow(
             onQuickReact = { emoji ->

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -184,6 +184,33 @@ fun ThreadMessageContextMenu(
                 },
             )
 
+            ContextMenuItem(
+                icon = Icons.Outlined.Link,
+                label = "Copy event link",
+                onClick = {
+                    onAction(MessageContextAction.CopyMessageLink)
+                    onDismiss()
+                },
+            )
+
+            ContextMenuItem(
+                icon = Icons.Outlined.Code,
+                label = "Copy nevent",
+                onClick = {
+                    onAction(MessageContextAction.CopyNevent)
+                    onDismiss()
+                },
+            )
+
+            ContextMenuItem(
+                icon = Icons.Outlined.Code,
+                label = "Copy event JSON",
+                onClick = {
+                    onAction(MessageContextAction.CopyEventJson)
+                    onDismiss()
+                },
+            )
+
             if (isAuthor) {
                 ContextMenuDivider()
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -521,6 +521,8 @@ fun MessageItem(
                         MessageContextAction.DeleteMessage -> currentOnDeleteMessage()
                         MessageContextAction.ZapMessage -> ZapController.request(message.pubkey, message.id)
                         MessageContextAction.ReportMessage -> showReportModal = true
+                        // Thread-menu-only action; the chat menu never offers it.
+                        MessageContextAction.ShareToChat -> Unit
                     }
                 },
                 isAuthor = isAuthor,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReactionBadges.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReactionBadges.kt
@@ -19,7 +19,12 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -51,6 +56,7 @@ import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.utils.proxyViaWeserv
+import org.nostr.nostrord.utils.shortNpub
 
 /**
  * Displays reaction badges for a message.
@@ -61,7 +67,7 @@ import org.nostr.nostrord.utils.proxyViaWeserv
  * @param resolveMetadata Resolves pubkey to UserMetadata for reactor avatars
  * @param onReactionClick Called when a reaction badge is clicked (for adding/removing reactions)
  */
-@OptIn(ExperimentalLayoutApi::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun ReactionBadges(
     reactions: Map<String, GroupManager.ReactionInfo>,
@@ -119,15 +125,22 @@ fun ReactionBadges(
         sortedReactions.forEach { (emoji, info) ->
             val hasCurrentUserReacted = currentUserPubkey != null && currentUserPubkey in info.reactors
 
-            ReactionBadge(
-                emoji = emoji,
-                emojiUrl = info.emojiUrl,
-                reactors = info.reactors,
-                count = info.reactors.size,
-                isUserReacted = hasCurrentUserReacted,
-                resolveMetadata = resolveMetadata,
-                onClick = { onReactionClick(emoji) },
-            )
+            // Who reacted: tooltip on hover (desktop) or long-press (touch).
+            TooltipBox(
+                positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+                tooltip = { PlainTooltip { Text(reactorNames(info.reactors, resolveMetadata)) } },
+                state = rememberTooltipState(),
+            ) {
+                ReactionBadge(
+                    emoji = emoji,
+                    emojiUrl = info.emojiUrl,
+                    reactors = info.reactors,
+                    count = info.reactors.size,
+                    isUserReacted = hasCurrentUserReacted,
+                    resolveMetadata = resolveMetadata,
+                    onClick = { onReactionClick(emoji) },
+                )
+            }
         }
 
         // In-flight reactions: emoji with a spinner where the avatar stack would be.
@@ -273,6 +286,22 @@ private fun ReactionBadge(
     }
 }
 
+/** Tooltip content: who reacted, capped so a popular badge doesn't build a huge string. */
+private fun reactorNames(
+    reactors: List<String>,
+    resolveMetadata: (String) -> UserMetadata?,
+): String {
+    val names = reactors.take(MAX_TOOLTIP_NAMES).map { pk ->
+        val meta = resolveMetadata(pk)
+        meta?.displayName?.takeIf { it.isNotBlank() }
+            ?: meta?.name?.takeIf { it.isNotBlank() }
+            ?: shortNpub(pk)
+    }
+    val extra = reactors.size - MAX_TOOLTIP_NAMES
+    return names.joinToString(", ") + if (extra > 0) " +$extra" else ""
+}
+
+private const val MAX_TOOLTIP_NAMES = 20
 private const val MAX_VISIBLE_AVATARS = 3
 private val AVATAR_SIZE = 16.dp
 private val AVATAR_OVERLAP = 6.dp

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -797,7 +797,7 @@ private fun FrameContent(
                         // Smart "up": pop to the threads list when it's the entry we came from,
                         // else push it (a deep link straight to a thread has no list behind it).
                         onBack = { onNavigateBackOr(route.copy(threadRootId = null)) },
-                        onOpenDrawer = onOpenDrawer ?: {},
+                        onOpenDrawer = onOpenDrawer,
                     )
                 } else {
                     val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -87,6 +88,7 @@ import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.HashRoute
 import org.nostr.nostrord.ui.navigation.threadShareLink
 import org.nostr.nostrord.ui.screens.group.components.CreateThreadDialog
+import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
@@ -107,7 +109,8 @@ fun ThreadsScreen(
     route: GroupRoute,
     onNavigate: (HashRoute) -> Unit,
     onBack: () -> Unit = { onNavigate(route.copy(threadRootId = null)) },
-    onOpenDrawer: () -> Unit = {},
+    // Non-null only on the mobile layout, where it opens the groups drawer (chat parity).
+    onOpenDrawer: (() -> Unit)? = null,
 ) {
     // Distinct key prefix: GroupSidebar/GroupScreen use viewModel(key = groupId) for GroupViewModel
     // in the same ViewModelStore, so a bare groupId key here collided with it and the two evicted +
@@ -165,209 +168,245 @@ fun ThreadsScreen(
     // Shared with MessageContent via LocalImageViewerUrl: tap an inline image -> fullscreen viewer.
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
 
-    BoxWithConstraints(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
-        // Discord-style split on large widths: the list keeps living on the left and the open
-        // thread docks on the right; compact widths keep the swap (detail replaces the list).
-        val split = maxWidth >= 840.dp
-        val detailPane: @Composable ColumnScope.() -> Unit = {
-            // ---- Single thread (detail) ----
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.sm, vertical = Spacing.xs),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-            ) {
-                if (!split) {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back to threads",
-                            tint = NostrordColors.TextSecondary,
-                        )
-                    }
-                }
-                Text(
-                    "Thread",
-                    color = NostrordColors.TextPrimary,
-                    fontSize = 17.sp,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.weight(1f),
-                )
-                val ownRoot = openThread?.root
-                if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
-                    IconButton(onClick = { deleteTarget = ownRoot }) {
-                        Icon(Icons.Default.Delete, contentDescription = "Delete thread", tint = NostrordColors.TextSecondary)
-                    }
-                }
-                if (split) {
-                    // Desktop closes the docked thread via the X, Discord-style.
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.Default.Close, contentDescription = "Close thread", tint = NostrordColors.TextSecondary)
-                    }
+    Column(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
+        // Page header: group identity over the whole pane, mirroring the chat header
+        // (drawer ≡ on mobile, avatar + name).
+        val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
+        val groupMeta = groupsByRelay[route.relayUrl]?.firstOrNull { it.id == route.groupId }
+            ?: groupsByRelay.values.flatten().firstOrNull { it.id == route.groupId }
+        val groupName = groupMeta?.name?.takeIf { it.isNotBlank() } ?: "#${route.groupId.take(8)}"
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            if (onOpenDrawer != null) {
+                IconButton(onClick = onOpenDrawer) {
+                    Icon(Icons.Default.Menu, contentDescription = "Open groups", tint = NostrordColors.TextSecondary)
                 }
             }
-            HorizontalDivider(color = NostrordColors.Divider)
+            GroupHeaderIcon(
+                pictureUrl = groupMeta?.picture,
+                groupId = route.groupId,
+                displayName = groupName,
+                size = 28.dp,
+                cornerRadius = 8.dp,
+            )
+            Text(
+                groupName,
+                color = NostrordColors.TextPrimary,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        HorizontalDivider(color = NostrordColors.Divider)
 
-            val detail = openThread
-            if (detail == null) {
-                EmptyState("Loading thread...")
-            } else {
-                Column(
-                    modifier = Modifier.weight(1f).fillMaxWidth()
-                        .verticalScroll(threadScroll).padding(Spacing.md),
+        BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            // Discord-style split on large widths: the list keeps living on the left and the open
+            // thread docks on the right; compact widths keep the swap (detail replaces the list).
+            val split = maxWidth >= 840.dp
+            val detailPane: @Composable ColumnScope.() -> Unit = {
+                // ---- Single thread (detail) ----
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.sm, vertical = Spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                 ) {
-                    CompositionLocalProvider(
-                        LocalImageViewerUrl provides imageViewerUrl,
-                        LocalAnimatedImageHidden provides (imageViewerUrl.value != null),
-                    ) {
-                        // Nested replies resolve their lowercase-e parent from the loaded thread.
-                        val messagesById = remember(detail) { (detail.replies + detail.root).associateBy { it.id } }
-                        val renderMessage: @Composable (NostrGroupClient.NostrMessage, Boolean) -> Unit = { msg, isRoot ->
-                            ThreadMessage(
-                                msg = msg,
-                                userMetadata = userMetadata,
-                                isRoot = isRoot,
-                                myPubkey = myPubkey,
-                                route = route,
-                                status = messageStatus[msg.id],
-                                reactions = reactions[msg.id] ?: emptyMap(),
-                                // Pending sends for this message: "eventId|emoji" keys -> emojis.
-                                pendingEmojis = pendingReactions
-                                    .filter { it.startsWith("${msg.id}|") }
-                                    .map { it.substringAfter('|') }
-                                    .toSet(),
-                                parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
-                                highlighted = msg.id == highlightId,
-                                onPositioned = if (msg.id == route.messageId) ({ y -> highlightTargetY = y }) else null,
-                                resolveMetadata = { userMetadata[it] },
-                                onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
-                                onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
-                                onReply = { replyingTo = msg },
-                                onDelete = { deleteTarget = msg },
-                                // A group ref in the body opens that group's chat page.
-                                onNavigateToGroup = { gid, _, relay, _ ->
-                                    onNavigate(GroupRoute(relay ?: route.relayUrl, gid))
-                                },
-                                onRetry = { vm.retrySend(msg.id) },
-                                onDismiss = { vm.dismissFailed(msg.id) },
-                            )
-                        }
-                        renderMessage(detail.root, true)
-                        Text(
-                            if (detail.replies.size == 1) "1 REPLY" else "${detail.replies.size} REPLIES",
-                            color = NostrordColors.TextMuted,
-                            fontSize = 11.sp,
-                            fontWeight = FontWeight.Bold,
-                            letterSpacing = 0.5.sp,
-                            modifier = Modifier.padding(vertical = Spacing.sm),
-                        )
-                        detail.replies.forEach { renderMessage(it, false) }
-                    }
-                }
-                // Reply chip above the composer while answering a specific message (web parity).
-                replyingTo?.let { target ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md).padding(top = Spacing.sm),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-                    ) {
-                        Text("Replying to", color = NostrordColors.TextMuted, fontSize = 12.sp)
-                        Text(
-                            threadDisplayName(target.pubkey, userMetadata[target.pubkey]),
-                            color = NostrordColors.Primary,
-                            fontSize = 12.sp,
-                            fontWeight = FontWeight.SemiBold,
-                        )
-                        Text(
-                            target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty(),
-                            color = NostrordColors.TextMuted,
-                            fontSize = 12.sp,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f),
-                        )
-                        IconButton(onClick = { replyingTo = null }, modifier = Modifier.size(24.dp)) {
+                    if (!split) {
+                        IconButton(onClick = onBack) {
                             Icon(
-                                Icons.Default.Close,
-                                contentDescription = "Cancel reply",
-                                tint = NostrordColors.TextMuted,
-                                modifier = Modifier.size(16.dp),
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Back to threads",
+                                tint = NostrordColors.TextSecondary,
                             )
+                        }
+                    }
+                    Text(
+                        "Thread",
+                        color = NostrordColors.TextPrimary,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f),
+                    )
+                    val ownRoot = openThread?.root
+                    if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
+                        IconButton(onClick = { deleteTarget = ownRoot }) {
+                            Icon(Icons.Default.Delete, contentDescription = "Delete thread", tint = NostrordColors.TextSecondary)
+                        }
+                    }
+                    if (split) {
+                        // Desktop closes the docked thread via the X, Discord-style.
+                        IconButton(onClick = onBack) {
+                            Icon(Icons.Default.Close, contentDescription = "Close thread", tint = NostrordColors.TextSecondary)
                         }
                     }
                 }
-                MessageComposer(
-                    value = reply,
-                    onValueChange = { reply = it },
-                    onSend = {
-                        if (reply.text.isNotBlank() && !sending) {
-                            sending = true
-                            vm.sendReply(
-                                reply.text.trim(),
-                                parent = replyingTo,
-                                onSuccess = {
-                                    reply = TextFieldValue("")
-                                    replyingTo = null
-                                    sending = false
-                                },
-                                onFailure = { sending = false },
-                            )
-                        }
-                    },
-                    placeholder = "Write a reply...",
-                    isSending = sending,
-                    modifier = Modifier.padding(Spacing.md),
-                )
-            }
-        }
-        val listPane: @Composable ColumnScope.() -> Unit = {
-            // ---- Threads list ----
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md, vertical = Spacing.sm),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-            ) {
-                Text(
-                    "Threads",
-                    color = NostrordColors.TextPrimary,
-                    fontSize = 17.sp,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.weight(1f),
-                )
-                AppButton(
-                    text = "New thread",
-                    onClick = { showCompose = true },
-                    icon = Icons.Filled.Forum,
-                    size = AppButtonSize.Small,
-                )
-            }
-            HorizontalDivider(color = NostrordColors.Divider)
+                HorizontalDivider(color = NostrordColors.Divider)
 
-            when {
-                isLoading && threads.isEmpty() -> EmptyState("Loading threads...")
-                threads.isEmpty() -> EmptyState("No threads yet. Start the first one.")
-                else ->
-                    LazyColumn(modifier = Modifier.weight(1f), contentPadding = PaddingValues(Spacing.sm)) {
-                        items(threads, key = { it.rootId }) { t ->
-                            ThreadCard(
-                                t,
-                                userMetadata,
-                                chips = topReactionChips(reactions[t.rootId] ?: emptyMap()),
-                                selected = t.rootId == route.threadRootId,
-                            ) { onNavigate(route.copy(threadRootId = t.rootId)) }
+                val detail = openThread
+                if (detail == null) {
+                    EmptyState("Loading thread...")
+                } else {
+                    Column(
+                        modifier = Modifier.weight(1f).fillMaxWidth()
+                            .verticalScroll(threadScroll).padding(Spacing.md),
+                    ) {
+                        CompositionLocalProvider(
+                            LocalImageViewerUrl provides imageViewerUrl,
+                            LocalAnimatedImageHidden provides (imageViewerUrl.value != null),
+                        ) {
+                            // Nested replies resolve their lowercase-e parent from the loaded thread.
+                            val messagesById = remember(detail) { (detail.replies + detail.root).associateBy { it.id } }
+                            val renderMessage: @Composable (NostrGroupClient.NostrMessage, Boolean) -> Unit = { msg, isRoot ->
+                                ThreadMessage(
+                                    msg = msg,
+                                    userMetadata = userMetadata,
+                                    isRoot = isRoot,
+                                    myPubkey = myPubkey,
+                                    route = route,
+                                    status = messageStatus[msg.id],
+                                    reactions = reactions[msg.id] ?: emptyMap(),
+                                    // Pending sends for this message: "eventId|emoji" keys -> emojis.
+                                    pendingEmojis = pendingReactions
+                                        .filter { it.startsWith("${msg.id}|") }
+                                        .map { it.substringAfter('|') }
+                                        .toSet(),
+                                    parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
+                                    highlighted = msg.id == highlightId,
+                                    onPositioned = if (msg.id == route.messageId) ({ y -> highlightTargetY = y }) else null,
+                                    resolveMetadata = { userMetadata[it] },
+                                    onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
+                                    onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
+                                    onReply = { replyingTo = msg },
+                                    onDelete = { deleteTarget = msg },
+                                    // A group ref in the body opens that group's chat page.
+                                    onNavigateToGroup = { gid, _, relay, _ ->
+                                        onNavigate(GroupRoute(relay ?: route.relayUrl, gid))
+                                    },
+                                    onRetry = { vm.retrySend(msg.id) },
+                                    onDismiss = { vm.dismissFailed(msg.id) },
+                                )
+                            }
+                            renderMessage(detail.root, true)
+                            Text(
+                                if (detail.replies.size == 1) "1 REPLY" else "${detail.replies.size} REPLIES",
+                                color = NostrordColors.TextMuted,
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                letterSpacing = 0.5.sp,
+                                modifier = Modifier.padding(vertical = Spacing.sm),
+                            )
+                            detail.replies.forEach { renderMessage(it, false) }
                         }
                     }
+                    // Reply chip above the composer while answering a specific message (web parity).
+                    replyingTo?.let { target ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md).padding(top = Spacing.sm),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                        ) {
+                            Text("Replying to", color = NostrordColors.TextMuted, fontSize = 12.sp)
+                            Text(
+                                threadDisplayName(target.pubkey, userMetadata[target.pubkey]),
+                                color = NostrordColors.Primary,
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.SemiBold,
+                            )
+                            Text(
+                                target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty(),
+                                color = NostrordColors.TextMuted,
+                                fontSize = 12.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.weight(1f),
+                            )
+                            IconButton(onClick = { replyingTo = null }, modifier = Modifier.size(24.dp)) {
+                                Icon(
+                                    Icons.Default.Close,
+                                    contentDescription = "Cancel reply",
+                                    tint = NostrordColors.TextMuted,
+                                    modifier = Modifier.size(16.dp),
+                                )
+                            }
+                        }
+                    }
+                    MessageComposer(
+                        value = reply,
+                        onValueChange = { reply = it },
+                        onSend = {
+                            if (reply.text.isNotBlank() && !sending) {
+                                sending = true
+                                vm.sendReply(
+                                    reply.text.trim(),
+                                    parent = replyingTo,
+                                    onSuccess = {
+                                        reply = TextFieldValue("")
+                                        replyingTo = null
+                                        sending = false
+                                    },
+                                    onFailure = { sending = false },
+                                )
+                            }
+                        },
+                        placeholder = "Write a reply...",
+                        isSending = sending,
+                        modifier = Modifier.padding(Spacing.md),
+                    )
+                }
             }
-        }
+            val listPane: @Composable ColumnScope.() -> Unit = {
+                // ---- Threads list ----
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                ) {
+                    Text(
+                        "Threads",
+                        color = NostrordColors.TextPrimary,
+                        fontSize = 17.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.weight(1f),
+                    )
+                    AppButton(
+                        text = "New thread",
+                        onClick = { showCompose = true },
+                        icon = Icons.Filled.Forum,
+                        size = AppButtonSize.Small,
+                    )
+                }
+                HorizontalDivider(color = NostrordColors.Divider)
 
-        if (split && route.threadRootId != null) {
-            Row(modifier = Modifier.fillMaxSize()) {
-                Column(modifier = Modifier.weight(1f).fillMaxHeight()) { listPane() }
-                VerticalDivider(color = NostrordColors.Divider)
-                Column(modifier = Modifier.weight(1.2f).fillMaxHeight()) { detailPane() }
+                when {
+                    isLoading && threads.isEmpty() -> EmptyState("Loading threads...")
+                    threads.isEmpty() -> EmptyState("No threads yet. Start the first one.")
+                    else ->
+                        LazyColumn(modifier = Modifier.weight(1f), contentPadding = PaddingValues(Spacing.sm)) {
+                            items(threads, key = { it.rootId }) { t ->
+                                ThreadCard(
+                                    t,
+                                    userMetadata,
+                                    chips = topReactionChips(reactions[t.rootId] ?: emptyMap()),
+                                    selected = t.rootId == route.threadRootId,
+                                ) { onNavigate(route.copy(threadRootId = t.rootId)) }
+                            }
+                        }
+                }
             }
-        } else {
-            Column(modifier = Modifier.fillMaxSize()) {
-                if (route.threadRootId != null) detailPane() else listPane()
+
+            if (split && route.threadRootId != null) {
+                Row(modifier = Modifier.fillMaxSize()) {
+                    Column(modifier = Modifier.weight(1f).fillMaxHeight()) { listPane() }
+                    VerticalDivider(color = NostrordColors.Divider)
+                    Column(modifier = Modifier.weight(1.2f).fillMaxHeight()) { detailPane() }
+                }
+            } else {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    if (route.threadRootId != null) detailPane() else listPane()
+                }
             }
         }
     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -169,44 +170,45 @@ fun ThreadsScreen(
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
 
     Column(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
-        // Page header: group identity over the whole pane, mirroring the chat header
-        // (drawer ≡ on mobile, avatar + name).
-        val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
-        val groupMeta = groupsByRelay[route.relayUrl]?.firstOrNull { it.id == route.groupId }
-            ?: groupsByRelay.values.flatten().firstOrNull { it.id == route.groupId }
-        val groupName = groupMeta?.name?.takeIf { it.isNotBlank() } ?: "#${route.groupId.take(8)}"
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.sm, vertical = Spacing.xs),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-        ) {
-            if (onOpenDrawer != null) {
+        // Page header (mobile only, chat-header metrics): group identity + the drawer ≡.
+        // Desktop skips it - the sidebar already names the group.
+        if (onOpenDrawer != null) {
+            val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
+            val groupMeta = groupsByRelay[route.relayUrl]?.firstOrNull { it.id == route.groupId }
+                ?: groupsByRelay.values.flatten().firstOrNull { it.id == route.groupId }
+            val groupName = groupMeta?.name?.takeIf { it.isNotBlank() } ?: "#${route.groupId.take(8)}"
+            Row(
+                modifier = Modifier.fillMaxWidth().height(Spacing.headerHeight).padding(horizontal = Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+            ) {
                 IconButton(onClick = onOpenDrawer) {
                     Icon(Icons.Default.Menu, contentDescription = "Open groups", tint = NostrordColors.TextSecondary)
                 }
+                GroupHeaderIcon(
+                    pictureUrl = groupMeta?.picture,
+                    groupId = route.groupId,
+                    displayName = groupName,
+                    size = 26.dp,
+                    cornerRadius = 8.dp,
+                )
+                Text(
+                    groupName,
+                    color = NostrordColors.TextPrimary,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
-            GroupHeaderIcon(
-                pictureUrl = groupMeta?.picture,
-                groupId = route.groupId,
-                displayName = groupName,
-                size = 28.dp,
-                cornerRadius = 8.dp,
-            )
-            Text(
-                groupName,
-                color = NostrordColors.TextPrimary,
-                fontSize = 16.sp,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
+            HorizontalDivider(color = NostrordColors.Divider)
         }
-        HorizontalDivider(color = NostrordColors.Divider)
 
         BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxWidth()) {
             // Discord-style split on large widths: the list keeps living on the left and the open
             // thread docks on the right; compact widths keep the swap (detail replaces the list).
-            val split = maxWidth >= 840.dp
+            // 768dp matches the web media query and AppFrame's own mobile boundary.
+            val split = maxWidth >= 768.dp
             val detailPane: @Composable ColumnScope.() -> Unit = {
                 // ---- Single thread (detail) ----
                 Row(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -121,6 +121,7 @@ fun ThreadsScreen(
     val reactions by vm.reactions.collectAsState()
     val pendingReactions by vm.pendingReactions.collectAsState()
     val reactionError by vm.reactionError.collectAsState()
+    val deleteError by vm.deleteError.collectAsState()
     val myPubkey = remember { vm.getPublicKey() }
 
     // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
@@ -408,6 +409,19 @@ fun ThreadsScreen(
                 )
             }
         }
+    }
+
+    // Relay rejected the kind:5/9005 delete - show the reason instead of silently swallowing
+    // (chat parity: "Could Not Delete Message" + the relay's OK message).
+    deleteError?.let { error ->
+        ConfirmDialog(
+            title = "Could Not Delete Message",
+            message = error,
+            confirmLabel = "OK",
+            cancelLabel = null,
+            onConfirm = { vm.clearDeleteError() },
+            onDismiss = { vm.clearDeleteError() },
+        )
     }
 
     // Reaction error dialog (relay rejected the kind:7), same classification as chat.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -422,7 +422,13 @@ fun ThreadsScreen(
     if (showCompose) {
         CreateThreadDialog(
             onDismiss = { showCompose = false },
-            onCreate = { title, content, shareToChat -> vm.createThread(title, content, shareToChat) },
+            onCreate = { title, content, shareToChat ->
+                // Open the new thread right away (Discord parity; the optimistic root is
+                // already in the store, so the detail renders instantly).
+                vm.createThread(title, content, shareToChat) { rootId ->
+                    onNavigate(route.copy(threadRootId = rootId))
+                }
+            },
         )
     }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -48,7 +49,11 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonSize
+import org.nostr.nostrord.ui.components.chat.ImageViewerModal
+import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
+import org.nostr.nostrord.ui.components.chat.LocalImageViewerUrl
 import org.nostr.nostrord.ui.components.chat.MessageComposer
+import org.nostr.nostrord.ui.components.chat.MessageContent
 import org.nostr.nostrord.ui.components.chat.MessageStatusIndicator
 import org.nostr.nostrord.ui.components.chat.SendStateIcon
 import org.nostr.nostrord.ui.navigation.GroupRoute
@@ -94,6 +99,8 @@ fun ThreadsScreen(
     var showDeleteConfirm by remember { mutableStateOf(false) }
     var reply by remember { mutableStateOf(TextFieldValue("")) }
     var sending by remember { mutableStateOf(false) }
+    // Shared with MessageContent via LocalImageViewerUrl: tap an inline image -> fullscreen viewer.
+    val imageViewerUrl = remember { mutableStateOf<String?>(null) }
 
     Column(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
         if (route.threadRootId != null) {
@@ -134,33 +141,40 @@ fun ThreadsScreen(
                     modifier = Modifier.weight(1f).fillMaxWidth()
                         .verticalScroll(rememberScrollState()).padding(Spacing.md),
                 ) {
-                    ThreadMessage(
-                        detail.root,
-                        userMetadata,
-                        isRoot = true,
-                        myPubkey,
-                        messageStatus[detail.root.id],
-                        { vm.retrySend(detail.root.id) },
-                        { vm.dismissFailed(detail.root.id) },
-                    )
-                    Text(
-                        if (detail.replies.size == 1) "1 REPLY" else "${detail.replies.size} REPLIES",
-                        color = NostrordColors.TextMuted,
-                        fontSize = 11.sp,
-                        fontWeight = FontWeight.Bold,
-                        letterSpacing = 0.5.sp,
-                        modifier = Modifier.padding(vertical = Spacing.sm),
-                    )
-                    detail.replies.forEach {
+                    CompositionLocalProvider(
+                        LocalImageViewerUrl provides imageViewerUrl,
+                        LocalAnimatedImageHidden provides (imageViewerUrl.value != null),
+                    ) {
                         ThreadMessage(
-                            it,
+                            detail.root,
                             userMetadata,
-                            isRoot = false,
+                            isRoot = true,
                             myPubkey,
-                            messageStatus[it.id],
-                            { vm.retrySend(it.id) },
-                            { vm.dismissFailed(it.id) },
+                            route,
+                            messageStatus[detail.root.id],
+                            { vm.retrySend(detail.root.id) },
+                            { vm.dismissFailed(detail.root.id) },
                         )
+                        Text(
+                            if (detail.replies.size == 1) "1 REPLY" else "${detail.replies.size} REPLIES",
+                            color = NostrordColors.TextMuted,
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = 0.5.sp,
+                            modifier = Modifier.padding(vertical = Spacing.sm),
+                        )
+                        detail.replies.forEach {
+                            ThreadMessage(
+                                it,
+                                userMetadata,
+                                isRoot = false,
+                                myPubkey,
+                                route,
+                                messageStatus[it.id],
+                                { vm.retrySend(it.id) },
+                                { vm.dismissFailed(it.id) },
+                            )
+                        }
                     }
                 }
                 MessageComposer(
@@ -247,6 +261,13 @@ fun ThreadsScreen(
             },
         )
     }
+
+    imageViewerUrl.value?.let { url ->
+        ImageViewerModal(
+            imageUrl = url,
+            onDismiss = { imageViewerUrl.value = null },
+        )
+    }
 }
 
 private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = meta?.displayName?.takeIf { it.isNotBlank() }
@@ -310,6 +331,7 @@ private fun ThreadMessage(
     userMetadata: Map<String, UserMetadata>,
     isRoot: Boolean,
     myPubkey: String?,
+    route: GroupRoute,
     status: GroupManager.MessageStatus?,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
@@ -345,10 +367,12 @@ private fun ThreadMessage(
                 )
             }
             Row(verticalAlignment = Alignment.Bottom) {
-                Text(
-                    msg.content,
-                    color = NostrordColors.TextContent,
-                    fontSize = 14.sp,
+                // Same rich renderer as chat: media embeds, links, mentions, custom emoji, markdown.
+                MessageContent(
+                    content = msg.content,
+                    tags = msg.tags,
+                    currentGroupId = route.groupId,
+                    currentRelayUrl = route.relayUrl,
                     modifier = Modifier.weight(1f, fill = false).padding(top = 2.dp),
                 )
                 if (myPubkey != null && myPubkey == msg.pubkey && status != null) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -16,12 +16,12 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Forum
-import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -39,6 +39,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
@@ -55,14 +56,18 @@ import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonSize
+import org.nostr.nostrord.ui.components.chat.EmojiImage
 import org.nostr.nostrord.ui.components.chat.ImageViewerModal
 import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
 import org.nostr.nostrord.ui.components.chat.LocalImageViewerUrl
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.chat.MessageContent
+import org.nostr.nostrord.ui.components.chat.MessageContextAction
 import org.nostr.nostrord.ui.components.chat.MessageStatusIndicator
 import org.nostr.nostrord.ui.components.chat.ReactionBadges
 import org.nostr.nostrord.ui.components.chat.SendStateIcon
+import org.nostr.nostrord.ui.components.chat.ThreadMessageContextMenu
+import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.HashRoute
@@ -70,7 +75,10 @@ import org.nostr.nostrord.ui.screens.group.components.CreateThreadDialog
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.utils.formatTimestamp
+import org.nostr.nostrord.utils.getDateLabel
+import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.utils.shortNpub
 
 /**
@@ -110,7 +118,8 @@ fun ThreadsScreen(
     LaunchedEffect(route.threadRootId) { vm.openThread(route.threadRootId) }
 
     var showCompose by remember { mutableStateOf(false) }
-    var showDeleteConfirm by remember { mutableStateOf(false) }
+    // Message pending delete confirmation (the root or any reply, from the header or the menu).
+    var deleteTarget by remember { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
     var reply by remember { mutableStateOf(TextFieldValue("")) }
     var sending by remember { mutableStateOf(false) }
     // Shared with MessageContent via LocalImageViewerUrl: tap an inline image -> fullscreen viewer.
@@ -140,7 +149,7 @@ fun ThreadsScreen(
                 )
                 val ownRoot = openThread?.root
                 if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
-                    IconButton(onClick = { showDeleteConfirm = true }) {
+                    IconButton(onClick = { deleteTarget = ownRoot }) {
                         Icon(Icons.Default.Delete, contentDescription = "Delete thread", tint = NostrordColors.TextSecondary)
                     }
                 }
@@ -176,6 +185,11 @@ fun ThreadsScreen(
                                 resolveMetadata = { userMetadata[it] },
                                 onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                                 onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
+                                onDelete = { deleteTarget = msg },
+                                // A group ref in the body opens that group's chat page.
+                                onNavigateToGroup = { gid, _, relay, _ ->
+                                    onNavigate(GroupRoute(relay ?: route.relayUrl, gid))
+                                },
                                 onRetry = { vm.retrySend(msg.id) },
                                 onDismiss = { vm.dismissFailed(msg.id) },
                             )
@@ -242,7 +256,11 @@ fun ThreadsScreen(
                 else ->
                     LazyColumn(modifier = Modifier.weight(1f), contentPadding = PaddingValues(Spacing.sm)) {
                         items(threads, key = { it.rootId }) { t ->
-                            ThreadCard(t, userMetadata) { onNavigate(route.copy(threadRootId = t.rootId)) }
+                            ThreadCard(
+                                t,
+                                userMetadata,
+                                chips = topReactionChips(reactions[t.rootId] ?: emptyMap()),
+                            ) { onNavigate(route.copy(threadRootId = t.rootId)) }
                         }
                     }
             }
@@ -256,23 +274,21 @@ fun ThreadsScreen(
         )
     }
 
-    if (showDeleteConfirm) {
-        val ownRoot = openThread?.root
+    deleteTarget?.let { target ->
+        val isRoot = target.id == openThread?.root?.id
         AlertDialog(
-            onDismissRequest = { showDeleteConfirm = false },
-            title = { Text("Delete thread?") },
+            onDismissRequest = { deleteTarget = null },
+            title = { Text(if (isRoot) "Delete thread?" else "Delete message?") },
             text = { Text("This cannot be undone.") },
             confirmButton = {
                 TextButton(onClick = {
-                    showDeleteConfirm = false
-                    if (ownRoot != null) {
-                        vm.deleteThread(ownRoot.id)
-                        onBack()
-                    }
+                    deleteTarget = null
+                    vm.deleteThread(target.id)
+                    if (isRoot) onBack()
                 }) { Text("Delete", color = NostrordColors.Error) }
             },
             dismissButton = {
-                TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel") }
+                TextButton(onClick = { deleteTarget = null }) { Text("Cancel") }
             },
         )
     }
@@ -353,7 +369,12 @@ private fun ColumnScope.EmptyState(text: String) {
 }
 
 @Composable
-private fun ThreadCard(t: ThreadSummary, userMetadata: Map<String, UserMetadata>, onClick: () -> Unit) {
+private fun ThreadCard(
+    t: ThreadSummary,
+    userMetadata: Map<String, UserMetadata>,
+    chips: List<ReactionChip>,
+    onClick: () -> Unit,
+) {
     val meta = userMetadata[t.authorPubkey]
     Row(
         modifier = Modifier.fillMaxWidth().clip(NostrordShapes.shapeLarge).clickable(onClick = onClick).padding(Spacing.md),
@@ -383,16 +404,44 @@ private fun ThreadCard(t: ThreadSummary, userMetadata: Map<String, UserMetadata>
                     overflow = TextOverflow.Ellipsis,
                 )
             }
-            val replies = if (t.replyCount == 1) "1 reply" else "${t.replyCount} replies"
-            Text(
-                "${threadDisplayName(t.authorPubkey, meta)} · $replies · ${formatTimestamp(t.lastActivity)}",
-                color = NostrordColors.TextSecondary,
-                fontSize = 12.sp,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+            // Meta row: top reactions on the root, then author / replies / publication date.
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                 modifier = Modifier.padding(top = 2.dp),
-            )
+            ) {
+                chips.forEach { ReactionChipBadge(it) }
+                val replies = if (t.replyCount == 1) "1 reply" else "${t.replyCount} replies"
+                Text(
+                    "${threadDisplayName(t.authorPubkey, meta)} · $replies · ${getDateLabel(t.createdAt)}",
+                    color = NostrordColors.TextSecondary,
+                    fontSize = 12.sp,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
         }
+    }
+}
+
+/** Compact emoji+count chip on a thread list card (a root's top reactions, Discord-style). */
+@Composable
+private fun ReactionChipBadge(chip: ReactionChip) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(3.dp),
+        modifier =
+        Modifier
+            .clip(RoundedCornerShape(6.dp))
+            .background(NostrordColors.SurfaceVariant.copy(alpha = 0.6f))
+            .padding(horizontal = 6.dp, vertical = 1.dp),
+    ) {
+        if (chip.emojiUrl != null) {
+            EmojiImage(url = chip.emojiUrl, contentDescription = chip.emoji, modifier = Modifier.size(14.dp))
+        } else {
+            Text(chip.emoji, fontSize = 12.sp, fontFamily = rememberEmojiFontFamily())
+        }
+        Text("${chip.count}", color = NostrordColors.TextSecondary, fontSize = 11.sp)
     }
 }
 
@@ -409,77 +458,98 @@ private fun ThreadMessage(
     resolveMetadata: (String) -> UserMetadata?,
     onReact: (String) -> Unit,
     onOpenReactionPicker: () -> Unit,
+    onDelete: () -> Unit,
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     val meta = userMetadata[msg.pubkey]
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.sm),
-        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+    val isAuthor = myPubkey != null && myPubkey == msg.pubkey
+    var menuVisible by remember { mutableStateOf(false) }
+    var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
+    val writeClipboard = rememberClipboardWriter()
+    Box(
+        modifier =
+        Modifier
+            .fillMaxWidth()
+            // Right-click (desktop) / long-press (mobile) opens the thread context menu.
+            .then(
+                rightClickContextMenuModifier { clickOffset ->
+                    menuAnchorPx = clickOffset
+                    menuVisible = true
+                },
+            ),
     ) {
-        ProfileAvatar(
-            imageUrl = meta?.picture,
-            displayName = threadDisplayName(msg.pubkey, meta),
-            pubkey = msg.pubkey,
-            size = 36.dp,
-        )
-        Column(modifier = Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
-                Text(
-                    threadDisplayName(msg.pubkey, meta),
-                    color = NostrordColors.TextPrimary,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(formatTimestamp(msg.createdAt), color = NostrordColors.TextMuted, fontSize = 12.sp)
-            }
-            if (isRoot) {
-                Text(
-                    msg.threadTitle(),
-                    color = NostrordColors.TextPrimary,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(vertical = Spacing.xs),
-                )
-            }
-            Row(verticalAlignment = Alignment.Bottom) {
-                // Same rich renderer as chat: media embeds, links, mentions, custom emoji, markdown.
-                MessageContent(
-                    content = msg.content,
-                    tags = msg.tags,
-                    currentGroupId = route.groupId,
-                    currentRelayUrl = route.relayUrl,
-                    modifier = Modifier.weight(1f, fill = false).padding(top = 2.dp),
-                )
-                if (myPubkey != null && myPubkey == msg.pubkey && status != null) {
-                    SendStateIcon(status)
+        ThreadMessageContextMenu(
+            visible = menuVisible,
+            onDismiss = { menuVisible = false },
+            anchorOffsetPx = menuAnchorPx,
+            isAuthor = isAuthor,
+            onAction = { action ->
+                when (action) {
+                    is MessageContextAction.QuickReact -> onReact(action.emoji)
+                    MessageContextAction.AddReaction -> onOpenReactionPicker()
+                    MessageContextAction.CopyText -> writeClipboard(msg.content)
+                    MessageContextAction.DeleteMessage -> onDelete()
+                    else -> Unit
                 }
-            }
-            if (myPubkey != null && myPubkey == msg.pubkey && status is GroupManager.MessageStatus.Failed) {
-                MessageStatusIndicator(status, onRetry, onDismiss)
-            }
-            // Reaction badges + the always-visible add-reaction affordance (threads have no
-            // hover-action row like chat, so the button is the way in to the full picker).
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
-            ) {
+            },
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.sm),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+        ) {
+            ProfileAvatar(
+                imageUrl = meta?.picture,
+                displayName = threadDisplayName(msg.pubkey, meta),
+                pubkey = msg.pubkey,
+                size = 36.dp,
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                    Text(
+                        threadDisplayName(msg.pubkey, meta),
+                        color = NostrordColors.TextPrimary,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                    Text(formatTimestamp(msg.createdAt), color = NostrordColors.TextMuted, fontSize = 12.sp)
+                }
+                if (isRoot) {
+                    Text(
+                        msg.threadTitle(),
+                        color = NostrordColors.TextPrimary,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.padding(vertical = Spacing.xs),
+                    )
+                }
+                Row(verticalAlignment = Alignment.Bottom) {
+                    // Same rich renderer as chat: media embeds, links, mentions, custom emoji, markdown.
+                    MessageContent(
+                        content = msg.content,
+                        tags = msg.tags,
+                        currentGroupId = route.groupId,
+                        currentRelayUrl = route.relayUrl,
+                        onNavigateToGroup = onNavigateToGroup,
+                        modifier = Modifier.weight(1f, fill = false).padding(top = 2.dp),
+                    )
+                    if (myPubkey != null && myPubkey == msg.pubkey && status != null) {
+                        SendStateIcon(status)
+                    }
+                }
+                if (myPubkey != null && myPubkey == msg.pubkey && status is GroupManager.MessageStatus.Failed) {
+                    MessageStatusIndicator(status, onRetry, onDismiss)
+                }
+                // Reaction badges; adding a reaction goes through the context menu (quick row
+                // or the full picker), so there is no always-visible add button.
                 ReactionBadges(
                     reactions = reactions,
                     currentUserPubkey = myPubkey,
                     resolveMetadata = resolveMetadata,
                     onReactionClick = onReact,
                     pendingEmojis = pendingEmojis,
-                    modifier = Modifier.weight(1f, fill = false),
                 )
-                IconButton(onClick = onOpenReactionPicker, modifier = Modifier.size(28.dp)) {
-                    Icon(
-                        Icons.Outlined.EmojiEmotions,
-                        contentDescription = "Add reaction",
-                        tint = NostrordColors.TextMuted,
-                        modifier = Modifier.size(18.dp),
-                    )
-                }
             }
         }
     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -1,8 +1,11 @@
 package org.nostr.nostrord.ui.screens.group
 
+import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -41,6 +44,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
@@ -49,6 +55,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
@@ -122,6 +129,24 @@ fun ThreadsScreen(
     // Message being answered by the composer (context-menu Reply); null posts top-level.
     var replyingTo by remember { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
 
+    // Deep-link target (?e=): the message to scroll to and flash once the thread loads.
+    var highlightId by remember { mutableStateOf<String?>(null) }
+    val highlightLoaded = route.messageId != null &&
+        openThread?.let { d -> (d.replies + d.root).any { it.id == route.messageId } } == true
+    LaunchedEffect(route.messageId, highlightLoaded) {
+        if (route.messageId != null && highlightLoaded) {
+            highlightId = route.messageId
+            delay(HIGHLIGHT_FLASH_MS)
+            highlightId = null
+        }
+    }
+    val threadScroll = rememberScrollState()
+    // Scroll target: the flashed message's y inside the scrolled column, reported on layout.
+    var highlightTargetY by remember(route.messageId) { mutableStateOf<Int?>(null) }
+    LaunchedEffect(highlightTargetY) {
+        highlightTargetY?.let { threadScroll.animateScrollTo((it - HIGHLIGHT_SCROLL_MARGIN_PX).coerceAtLeast(0)) }
+    }
+
     // Keep the open thread synced with the route (#/g/<relay>/<id>/threads/<rootId>).
     LaunchedEffect(route.threadRootId) {
         vm.openThread(route.threadRootId)
@@ -173,7 +198,7 @@ fun ThreadsScreen(
             } else {
                 Column(
                     modifier = Modifier.weight(1f).fillMaxWidth()
-                        .verticalScroll(rememberScrollState()).padding(Spacing.md),
+                        .verticalScroll(threadScroll).padding(Spacing.md),
                 ) {
                     CompositionLocalProvider(
                         LocalImageViewerUrl provides imageViewerUrl,
@@ -196,6 +221,8 @@ fun ThreadsScreen(
                                     .map { it.substringAfter('|') }
                                     .toSet(),
                                 parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
+                                highlighted = msg.id == highlightId,
+                                onPositioned = if (msg.id == route.messageId) ({ y -> highlightTargetY = y }) else null,
                                 resolveMetadata = { userMetadata[it] },
                                 onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                                 onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
@@ -406,6 +433,11 @@ fun ThreadsScreen(
     }
 }
 
+// Deep-link flash: duration mirrors the web msg-flash animation; the margin keeps a bit of
+// context visible above the target instead of pinning it to the very top.
+private const val HIGHLIGHT_FLASH_MS = 2_400L
+private const val HIGHLIGHT_SCROLL_MARGIN_PX = 120
+
 private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = meta?.displayName?.takeIf { it.isNotBlank() }
     ?: meta?.name?.takeIf { it.isNotBlank() }
     ?: shortNpub(pubkey)
@@ -505,6 +537,8 @@ private fun ThreadMessage(
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: Set<String>,
     parentMsg: NostrGroupClient.NostrMessage?,
+    highlighted: Boolean,
+    onPositioned: ((Int) -> Unit)?,
     resolveMetadata: (String) -> UserMetadata?,
     onReact: (String) -> Unit,
     onOpenReactionPicker: () -> Unit,
@@ -519,10 +553,30 @@ private fun ThreadMessage(
     var menuVisible by remember { mutableStateOf(false) }
     var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
     val writeClipboard = rememberClipboardWriter()
+    val interaction = remember { MutableInteractionSource() }
+    val isHovered by interaction.collectIsHoveredAsState()
+    // Hover tint like chat rows; the deep-link flash overrides it and fades back out.
+    val rowBackground by animateColorAsState(
+        when {
+            highlighted -> NostrordColors.Primary.copy(alpha = 0.18f)
+            isHovered -> NostrordColors.MessageHover
+            else -> Color.Transparent
+        },
+    )
     Box(
         modifier =
         Modifier
             .fillMaxWidth()
+            .clip(NostrordShapes.shapeMedium)
+            .background(rowBackground)
+            .hoverable(interaction)
+            .then(
+                if (onPositioned != null) {
+                    Modifier.onGloballyPositioned { onPositioned(it.positionInParent().y.toInt()) }
+                } else {
+                    Modifier
+                },
+            )
             // Right-click (desktop) / long-press (mobile) opens the thread context menu.
             .then(
                 rightClickContextMenuModifier { clickOffset ->
@@ -542,9 +596,12 @@ private fun ThreadMessage(
                     MessageContextAction.AddReaction -> onOpenReactionPicker()
                     MessageContextAction.Reply -> onReply()
                     MessageContextAction.CopyText -> writeClipboard(msg.content)
-                    // A reply links to its thread page too (the root id from the E tag).
+                    // A reply links to its thread page (root id from the E tag), targeting
+                    // this message via ?e= so opening it scrolls to and flashes it.
                     MessageContextAction.CopyMessageLink ->
-                        writeClipboard(threadShareLink(route.relayUrl, route.groupId, msg.threadRootIdTag() ?: msg.id))
+                        writeClipboard(
+                            threadShareLink(route.relayUrl, route.groupId, msg.threadRootIdTag() ?: msg.id, messageId = msg.id),
+                        )
                     MessageContextAction.CopyNevent ->
                         writeClipboard(
                             Nip19.encodeNevent(msg.id, relays = listOf(route.relayUrl), authorHex = msg.pubkey, kind = msg.kind),

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -90,6 +90,7 @@ import org.nostr.nostrord.ui.navigation.HashRoute
 import org.nostr.nostrord.ui.navigation.threadShareLink
 import org.nostr.nostrord.ui.screens.group.components.CreateThreadDialog
 import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
+import org.nostr.nostrord.ui.screens.group.components.UserProfileModal
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
@@ -133,6 +134,9 @@ fun ThreadsScreen(
 
     // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
     var reactingTo by remember { mutableStateOf<Pair<String, String>?>(null) }
+
+    // Avatar / author-name / mention tap target: opens the user profile modal (chat parity).
+    var selectedUserPubkey by remember { mutableStateOf<String?>(null) }
 
     // Message being answered by the composer (context-menu Reply); null posts top-level.
     var replyingTo by remember { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
@@ -283,6 +287,7 @@ fun ThreadsScreen(
                                     onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
                                     onReply = { replyingTo = msg },
                                     onShareToChat = { vm.shareThreadToChat(msg) },
+                                    onUserClick = { selectedUserPubkey = it },
                                     onDelete = { deleteTarget = msg },
                                     // A group ref in the body opens that group's chat page.
                                     onNavigateToGroup = { gid, _, relay, _ ->
@@ -481,6 +486,16 @@ fun ThreadsScreen(
         }
     }
 
+    // User profile modal (avatar / author-name / mention tap), same modal as chat.
+    selectedUserPubkey?.let { pk ->
+        UserProfileModal(
+            pubkey = pk,
+            metadata = userMetadata[pk],
+            userMetadata = userMetadata,
+            onDismiss = { selectedUserPubkey = null },
+        )
+    }
+
     // Relay rejected the kind:5/9005 delete - show the reason instead of silently swallowing
     // (chat parity: "Could Not Delete Message" + the relay's OK message).
     deleteError?.let { error ->
@@ -632,6 +647,7 @@ private fun ThreadMessage(
     onOpenReactionPicker: () -> Unit,
     onReply: () -> Unit,
     onShareToChat: () -> Unit,
+    onUserClick: (String) -> Unit,
     onDelete: () -> Unit,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
     onRetry: () -> Unit,
@@ -707,12 +723,15 @@ private fun ThreadMessage(
             modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.sm),
             horizontalArrangement = Arrangement.spacedBy(Spacing.md),
         ) {
-            ProfileAvatar(
-                imageUrl = meta?.picture,
-                displayName = threadDisplayName(msg.pubkey, meta),
-                pubkey = msg.pubkey,
-                size = 36.dp,
-            )
+            // Avatar and author name open the user profile modal (chat parity).
+            Box(modifier = Modifier.clip(NostrordShapes.shapeMedium).clickable { onUserClick(msg.pubkey) }) {
+                ProfileAvatar(
+                    imageUrl = meta?.picture,
+                    displayName = threadDisplayName(msg.pubkey, meta),
+                    pubkey = msg.pubkey,
+                    size = 36.dp,
+                )
+            }
             Column(modifier = Modifier.weight(1f)) {
                 Row(verticalAlignment = Alignment.Bottom, horizontalArrangement = Arrangement.spacedBy(Spacing.sm)) {
                     Text(
@@ -720,6 +739,7 @@ private fun ThreadMessage(
                         color = NostrordColors.TextPrimary,
                         fontSize = 14.sp,
                         fontWeight = FontWeight.SemiBold,
+                        modifier = Modifier.clickable { onUserClick(msg.pubkey) },
                     )
                     Text(formatTimestamp(msg.createdAt), color = NostrordColors.TextMuted, fontSize = 12.sp)
                 }
@@ -748,6 +768,7 @@ private fun ThreadMessage(
                         tags = msg.tags,
                         currentGroupId = route.groupId,
                         currentRelayUrl = route.relayUrl,
+                        onMentionClick = onUserClick,
                         onNavigateToGroup = onNavigateToGroup,
                         modifier = Modifier.weight(1f, fill = false).padding(top = 2.dp),
                     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -8,10 +8,12 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -32,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -162,20 +165,25 @@ fun ThreadsScreen(
     // Shared with MessageContent via LocalImageViewerUrl: tap an inline image -> fullscreen viewer.
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
 
-    Column(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
-        if (route.threadRootId != null) {
+    BoxWithConstraints(modifier = Modifier.fillMaxSize().background(NostrordColors.Background)) {
+        // Discord-style split on large widths: the list keeps living on the left and the open
+        // thread docks on the right; compact widths keep the swap (detail replaces the list).
+        val split = maxWidth >= 840.dp
+        val detailPane: @Composable ColumnScope.() -> Unit = {
             // ---- Single thread (detail) ----
             Row(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.sm, vertical = Spacing.xs),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
             ) {
-                IconButton(onClick = onBack) {
-                    Icon(
-                        Icons.AutoMirrored.Filled.ArrowBack,
-                        contentDescription = "Back to threads",
-                        tint = NostrordColors.TextSecondary,
-                    )
+                if (!split) {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back to threads",
+                            tint = NostrordColors.TextSecondary,
+                        )
+                    }
                 }
                 Text(
                     "Thread",
@@ -188,6 +196,12 @@ fun ThreadsScreen(
                 if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
                     IconButton(onClick = { deleteTarget = ownRoot }) {
                         Icon(Icons.Default.Delete, contentDescription = "Delete thread", tint = NostrordColors.TextSecondary)
+                    }
+                }
+                if (split) {
+                    // Desktop closes the docked thread via the X, Discord-style.
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.Close, contentDescription = "Close thread", tint = NostrordColors.TextSecondary)
                     }
                 }
             }
@@ -304,7 +318,8 @@ fun ThreadsScreen(
                     modifier = Modifier.padding(Spacing.md),
                 )
             }
-        } else {
+        }
+        val listPane: @Composable ColumnScope.() -> Unit = {
             // ---- Threads list ----
             Row(
                 modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md, vertical = Spacing.sm),
@@ -337,9 +352,22 @@ fun ThreadsScreen(
                                 t,
                                 userMetadata,
                                 chips = topReactionChips(reactions[t.rootId] ?: emptyMap()),
+                                selected = t.rootId == route.threadRootId,
                             ) { onNavigate(route.copy(threadRootId = t.rootId)) }
                         }
                     }
+            }
+        }
+
+        if (split && route.threadRootId != null) {
+            Row(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.weight(1f).fillMaxHeight()) { listPane() }
+                VerticalDivider(color = NostrordColors.Divider)
+                Column(modifier = Modifier.weight(1.2f).fillMaxHeight()) { detailPane() }
+            }
+        } else {
+            Column(modifier = Modifier.fillMaxSize()) {
+                if (route.threadRootId != null) detailPane() else listPane()
             }
         }
     }
@@ -468,11 +496,15 @@ private fun ThreadCard(
     t: ThreadSummary,
     userMetadata: Map<String, UserMetadata>,
     chips: List<ReactionChip>,
+    selected: Boolean,
     onClick: () -> Unit,
 ) {
     val meta = userMetadata[t.authorPubkey]
     Row(
-        modifier = Modifier.fillMaxWidth().clip(NostrordShapes.shapeLarge).clickable(onClick = onClick).padding(Spacing.md),
+        modifier = Modifier.fillMaxWidth().clip(NostrordShapes.shapeLarge)
+            // The thread open in the split view stays visibly selected in the list.
+            .background(if (selected) NostrordColors.MessageHover else Color.Transparent)
+            .clickable(onClick = onClick).padding(Spacing.md),
         horizontalArrangement = Arrangement.spacedBy(Spacing.md),
     ) {
         ProfileAvatar(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -52,6 +52,8 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.toEventJson
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
@@ -71,6 +73,7 @@ import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.HashRoute
+import org.nostr.nostrord.ui.navigation.threadShareLink
 import org.nostr.nostrord.ui.screens.group.components.CreateThreadDialog
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
@@ -490,6 +493,14 @@ private fun ThreadMessage(
                     is MessageContextAction.QuickReact -> onReact(action.emoji)
                     MessageContextAction.AddReaction -> onOpenReactionPicker()
                     MessageContextAction.CopyText -> writeClipboard(msg.content)
+                    // A reply links to its thread page too (the root id from the E tag).
+                    MessageContextAction.CopyMessageLink ->
+                        writeClipboard(threadShareLink(route.relayUrl, route.groupId, msg.threadRootIdTag() ?: msg.id))
+                    MessageContextAction.CopyNevent ->
+                        writeClipboard(
+                            Nip19.encodeNevent(msg.id, relays = listOf(route.relayUrl), authorHex = msg.pubkey, kind = msg.kind),
+                        )
+                    MessageContextAction.CopyEventJson -> writeClipboard(msg.toEventJson())
                     MessageContextAction.DeleteMessage -> onDelete()
                     else -> Unit
                 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui.screens.group
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -19,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -41,11 +44,14 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonSize
@@ -55,7 +61,9 @@ import org.nostr.nostrord.ui.components.chat.LocalImageViewerUrl
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.chat.MessageContent
 import org.nostr.nostrord.ui.components.chat.MessageStatusIndicator
+import org.nostr.nostrord.ui.components.chat.ReactionBadges
 import org.nostr.nostrord.ui.components.chat.SendStateIcon
+import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.HashRoute
 import org.nostr.nostrord.ui.screens.group.components.CreateThreadDialog
@@ -90,7 +98,13 @@ fun ThreadsScreen(
     val openThread by vm.openThread.collectAsState()
     val userMetadata by vm.userMetadata.collectAsState()
     val messageStatus by vm.messageStatus.collectAsState()
+    val reactions by vm.reactions.collectAsState()
+    val pendingReactions by vm.pendingReactions.collectAsState()
+    val reactionError by vm.reactionError.collectAsState()
     val myPubkey = remember { vm.getPublicKey() }
+
+    // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
+    var reactingTo by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     // Keep the open thread synced with the route (#/g/<relay>/<id>/threads/<rootId>).
     LaunchedEffect(route.threadRootId) { vm.openThread(route.threadRootId) }
@@ -145,16 +159,28 @@ fun ThreadsScreen(
                         LocalImageViewerUrl provides imageViewerUrl,
                         LocalAnimatedImageHidden provides (imageViewerUrl.value != null),
                     ) {
-                        ThreadMessage(
-                            detail.root,
-                            userMetadata,
-                            isRoot = true,
-                            myPubkey,
-                            route,
-                            messageStatus[detail.root.id],
-                            { vm.retrySend(detail.root.id) },
-                            { vm.dismissFailed(detail.root.id) },
-                        )
+                        val renderMessage: @Composable (NostrGroupClient.NostrMessage, Boolean) -> Unit = { msg, isRoot ->
+                            ThreadMessage(
+                                msg = msg,
+                                userMetadata = userMetadata,
+                                isRoot = isRoot,
+                                myPubkey = myPubkey,
+                                route = route,
+                                status = messageStatus[msg.id],
+                                reactions = reactions[msg.id] ?: emptyMap(),
+                                // Pending sends for this message: "eventId|emoji" keys -> emojis.
+                                pendingEmojis = pendingReactions
+                                    .filter { it.startsWith("${msg.id}|") }
+                                    .map { it.substringAfter('|') }
+                                    .toSet(),
+                                resolveMetadata = { userMetadata[it] },
+                                onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
+                                onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
+                                onRetry = { vm.retrySend(msg.id) },
+                                onDismiss = { vm.dismissFailed(msg.id) },
+                            )
+                        }
+                        renderMessage(detail.root, true)
                         Text(
                             if (detail.replies.size == 1) "1 REPLY" else "${detail.replies.size} REPLIES",
                             color = NostrordColors.TextMuted,
@@ -163,18 +189,7 @@ fun ThreadsScreen(
                             letterSpacing = 0.5.sp,
                             modifier = Modifier.padding(vertical = Spacing.sm),
                         )
-                        detail.replies.forEach {
-                            ThreadMessage(
-                                it,
-                                userMetadata,
-                                isRoot = false,
-                                myPubkey,
-                                route,
-                                messageStatus[it.id],
-                                { vm.retrySend(it.id) },
-                                { vm.dismissFailed(it.id) },
-                            )
-                        }
+                        detail.replies.forEach { renderMessage(it, false) }
                     }
                 }
                 MessageComposer(
@@ -268,6 +283,62 @@ fun ThreadsScreen(
             onDismiss = { imageViewerUrl.value = null },
         )
     }
+
+    // Full emoji picker for a reaction (opened by the add-reaction button).
+    reactingTo?.let { (targetEventId, targetPubkey) ->
+        Popup(
+            alignment = Alignment.Center,
+            onDismissRequest = { reactingTo = null },
+            properties =
+            PopupProperties(
+                focusable = true,
+                dismissOnClickOutside = false,
+                dismissOnBackPress = true,
+            ),
+        ) {
+            Box(
+                modifier =
+                Modifier
+                    .fillMaxSize()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = { reactingTo = null },
+                    ),
+            ) {
+                EmojiPicker(
+                    onEmojiSelect = { emoji ->
+                        vm.sendReaction(targetEventId, targetPubkey, emoji)
+                        reactingTo = null
+                    },
+                    onDismiss = { reactingTo = null },
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
+        }
+    }
+
+    // Reaction error dialog (relay rejected the kind:7), same classification as chat.
+    reactionError?.let { error ->
+        val errorKind = classifyReactionError(error)
+        val isUnknownMember = errorKind == ReactionErrorKind.JoinRequired
+        ConfirmDialog(
+            title = if (isUnknownMember) "Join Required" else "Cannot React",
+            message =
+            when (errorKind) {
+                ReactionErrorKind.JoinRequired -> "You need to join this group before you can react to messages."
+                ReactionErrorKind.SignerFailure -> "Your signer could not sign the reaction. Please try again.\n\n$error"
+                ReactionErrorKind.RelayRejected -> "This relay does not support reactions.\n\n$error"
+            },
+            confirmLabel = if (isUnknownMember) "Join Group" else "OK",
+            cancelLabel = if (isUnknownMember) "Cancel" else null,
+            onConfirm = {
+                vm.clearReactionError()
+                if (isUnknownMember) vm.joinGroup()
+            },
+            onDismiss = { vm.clearReactionError() },
+        )
+    }
 }
 
 private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = meta?.displayName?.takeIf { it.isNotBlank() }
@@ -333,6 +404,11 @@ private fun ThreadMessage(
     myPubkey: String?,
     route: GroupRoute,
     status: GroupManager.MessageStatus?,
+    reactions: Map<String, GroupManager.ReactionInfo>,
+    pendingEmojis: Set<String>,
+    resolveMetadata: (String) -> UserMetadata?,
+    onReact: (String) -> Unit,
+    onOpenReactionPicker: () -> Unit,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -381,6 +457,29 @@ private fun ThreadMessage(
             }
             if (myPubkey != null && myPubkey == msg.pubkey && status is GroupManager.MessageStatus.Failed) {
                 MessageStatusIndicator(status, onRetry, onDismiss)
+            }
+            // Reaction badges + the always-visible add-reaction affordance (threads have no
+            // hover-action row like chat, so the button is the way in to the full picker).
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                ReactionBadges(
+                    reactions = reactions,
+                    currentUserPubkey = myPubkey,
+                    resolveMetadata = resolveMetadata,
+                    onReactionClick = onReact,
+                    pendingEmojis = pendingEmojis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                IconButton(onClick = onOpenReactionPicker, modifier = Modifier.size(28.dp)) {
+                    Icon(
+                        Icons.Outlined.EmojiEmotions,
+                        contentDescription = "Add reaction",
+                        tint = NostrordColors.TextMuted,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material3.AlertDialog
@@ -67,6 +68,7 @@ import org.nostr.nostrord.ui.components.chat.MessageContent
 import org.nostr.nostrord.ui.components.chat.MessageContextAction
 import org.nostr.nostrord.ui.components.chat.MessageStatusIndicator
 import org.nostr.nostrord.ui.components.chat.ReactionBadges
+import org.nostr.nostrord.ui.components.chat.ReplyPreview
 import org.nostr.nostrord.ui.components.chat.SendStateIcon
 import org.nostr.nostrord.ui.components.chat.ThreadMessageContextMenu
 import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
@@ -117,8 +119,14 @@ fun ThreadsScreen(
     // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
     var reactingTo by remember { mutableStateOf<Pair<String, String>?>(null) }
 
+    // Message being answered by the composer (context-menu Reply); null posts top-level.
+    var replyingTo by remember { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
+
     // Keep the open thread synced with the route (#/g/<relay>/<id>/threads/<rootId>).
-    LaunchedEffect(route.threadRootId) { vm.openThread(route.threadRootId) }
+    LaunchedEffect(route.threadRootId) {
+        vm.openThread(route.threadRootId)
+        replyingTo = null
+    }
 
     var showCompose by remember { mutableStateOf(false) }
     // Message pending delete confirmation (the root or any reply, from the header or the menu).
@@ -171,6 +179,8 @@ fun ThreadsScreen(
                         LocalImageViewerUrl provides imageViewerUrl,
                         LocalAnimatedImageHidden provides (imageViewerUrl.value != null),
                     ) {
+                        // Nested replies resolve their lowercase-e parent from the loaded thread.
+                        val messagesById = remember(detail) { (detail.replies + detail.root).associateBy { it.id } }
                         val renderMessage: @Composable (NostrGroupClient.NostrMessage, Boolean) -> Unit = { msg, isRoot ->
                             ThreadMessage(
                                 msg = msg,
@@ -185,9 +195,11 @@ fun ThreadsScreen(
                                     .filter { it.startsWith("${msg.id}|") }
                                     .map { it.substringAfter('|') }
                                     .toSet(),
+                                parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
                                 resolveMetadata = { userMetadata[it] },
                                 onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                                 onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
+                                onReply = { replyingTo = msg },
                                 onDelete = { deleteTarget = msg },
                                 // A group ref in the body opens that group's chat page.
                                 onNavigateToGroup = { gid, _, relay, _ ->
@@ -209,6 +221,38 @@ fun ThreadsScreen(
                         detail.replies.forEach { renderMessage(it, false) }
                     }
                 }
+                // Reply chip above the composer while answering a specific message (web parity).
+                replyingTo?.let { target ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md).padding(top = Spacing.sm),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                    ) {
+                        Text("Replying to", color = NostrordColors.TextMuted, fontSize = 12.sp)
+                        Text(
+                            threadDisplayName(target.pubkey, userMetadata[target.pubkey]),
+                            color = NostrordColors.Primary,
+                            fontSize = 12.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty(),
+                            color = NostrordColors.TextMuted,
+                            fontSize = 12.sp,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                        IconButton(onClick = { replyingTo = null }, modifier = Modifier.size(24.dp)) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = "Cancel reply",
+                                tint = NostrordColors.TextMuted,
+                                modifier = Modifier.size(16.dp),
+                            )
+                        }
+                    }
+                }
                 MessageComposer(
                     value = reply,
                     onValueChange = { reply = it },
@@ -217,8 +261,10 @@ fun ThreadsScreen(
                             sending = true
                             vm.sendReply(
                                 reply.text.trim(),
+                                parent = replyingTo,
                                 onSuccess = {
                                     reply = TextFieldValue("")
+                                    replyingTo = null
                                     sending = false
                                 },
                                 onFailure = { sending = false },
@@ -458,9 +504,11 @@ private fun ThreadMessage(
     status: GroupManager.MessageStatus?,
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: Set<String>,
+    parentMsg: NostrGroupClient.NostrMessage?,
     resolveMetadata: (String) -> UserMetadata?,
     onReact: (String) -> Unit,
     onOpenReactionPicker: () -> Unit,
+    onReply: () -> Unit,
     onDelete: () -> Unit,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
     onRetry: () -> Unit,
@@ -492,6 +540,7 @@ private fun ThreadMessage(
                 when (action) {
                     is MessageContextAction.QuickReact -> onReact(action.emoji)
                     MessageContextAction.AddReaction -> onOpenReactionPicker()
+                    MessageContextAction.Reply -> onReply()
                     MessageContextAction.CopyText -> writeClipboard(msg.content)
                     // A reply links to its thread page too (the root id from the E tag).
                     MessageContextAction.CopyMessageLink ->
@@ -533,6 +582,15 @@ private fun ThreadMessage(
                         fontSize = 18.sp,
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.padding(vertical = Spacing.xs),
+                    )
+                }
+                // Nested reply: quote the answered message above the body (placeholder when the
+                // parent has not loaded), like chat's reply preview.
+                if (!isRoot && (parentMsg != null || msg.threadParentIdTag() != null)) {
+                    ReplyPreview(
+                        parentMessage = parentMsg,
+                        parentMetadata = parentMsg?.let { resolveMetadata(it.pubkey) },
+                        resolveMetadata = resolveMetadata,
                     )
                 }
                 Row(verticalAlignment = Alignment.Bottom) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -282,6 +282,7 @@ fun ThreadsScreen(
                                     onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                                     onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
                                     onReply = { replyingTo = msg },
+                                    onShareToChat = { vm.shareThreadToChat(msg) },
                                     onDelete = { deleteTarget = msg },
                                     // A group ref in the body opens that group's chat page.
                                     onNavigateToGroup = { gid, _, relay, _ ->
@@ -416,7 +417,7 @@ fun ThreadsScreen(
     if (showCompose) {
         CreateThreadDialog(
             onDismiss = { showCompose = false },
-            onCreate = { title, content -> vm.createThread(title, content) },
+            onCreate = { title, content, shareToChat -> vm.createThread(title, content, shareToChat) },
         )
     }
 
@@ -630,6 +631,7 @@ private fun ThreadMessage(
     onReact: (String) -> Unit,
     onOpenReactionPicker: () -> Unit,
     onReply: () -> Unit,
+    onShareToChat: () -> Unit,
     onDelete: () -> Unit,
     onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
     onRetry: () -> Unit,
@@ -677,11 +679,13 @@ private fun ThreadMessage(
             onDismiss = { menuVisible = false },
             anchorOffsetPx = menuAnchorPx,
             isAuthor = isAuthor,
+            canShareToChat = isRoot,
             onAction = { action ->
                 when (action) {
                     is MessageContextAction.QuickReact -> onReact(action.emoji)
                     MessageContextAction.AddReaction -> onOpenReactionPicker()
                     MessageContextAction.Reply -> onReply()
+                    MessageContextAction.ShareToChat -> onShareToChat()
                     MessageContextAction.CopyText -> writeClipboard(msg.content)
                     // A reply links to its thread page (root id from the E tag), targeting
                     // this message via ?e= so opening it scrolls to and flashes it.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -44,10 +45,13 @@ import org.nostr.nostrord.ui.theme.Spacing
 @Composable
 fun CreateThreadDialog(
     onDismiss: () -> Unit,
-    onCreate: (title: String, content: String) -> Unit,
+    onCreate: (title: String, content: String, shareToChat: Boolean) -> Unit,
 ) {
     var title by remember { mutableStateOf("") }
     var body by remember { mutableStateOf("") }
+
+    // Default on: announcing the new thread in chat is the common case; one click opts out.
+    var shareToChat by remember { mutableStateOf(true) }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -103,13 +107,23 @@ fun CreateThreadDialog(
                         minLines = 4,
                     )
 
-                    Spacer(Modifier.height(Spacing.lg))
+                    Spacer(Modifier.height(Spacing.sm))
+                    // Announce the new thread in the group chat (kind:9 with the root's nevent).
+                    Row(
+                        modifier = Modifier.clickable { shareToChat = !shareToChat },
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Checkbox(checked = shareToChat, onCheckedChange = { shareToChat = it })
+                        Text("Share to chat", color = NostrordColors.TextSecondary, fontSize = 13.sp)
+                    }
+
+                    Spacer(Modifier.height(Spacing.md))
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(Spacing.sm, Alignment.End)) {
                         AppButton(text = "Cancel", onClick = onDismiss, variant = AppButtonVariant.Ghost)
                         AppButton(
                             text = "Publish thread",
                             onClick = {
-                                onCreate(title, body)
+                                onCreate(title, body, shareToChat)
                                 onDismiss()
                             },
                             enabled = title.isNotBlank() && body.isNotBlank(),

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.window.DialogProperties
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
 import org.nostr.nostrord.ui.components.forms.AppField
+import org.nostr.nostrord.ui.components.upload.MessageUploadButton
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
@@ -82,7 +83,16 @@ fun CreateThreadDialog(
                     AppField(value = title, onValueChange = { title = it }, placeholder = "Thread title", modifier = Modifier.fillMaxWidth())
 
                     Spacer(Modifier.height(Spacing.md))
-                    Text("Content", color = NostrordColors.TextSecondary, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+                    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+                        Text("Content", color = NostrordColors.TextSecondary, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+                        Spacer(Modifier.weight(1f))
+                        // Attach media to the thread body (rendered inline like chat).
+                        MessageUploadButton(
+                            onUploadComplete = { result ->
+                                body = if (body.isBlank()) result.url else "$body ${result.url}"
+                            },
+                        )
+                    }
                     Spacer(Modifier.height(Spacing.xs))
                     AppField(
                         value = body,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
@@ -68,8 +68,10 @@ fun CreateThreadDialog(
             Surface(
                 modifier =
                 Modifier
-                    .fillMaxWidth(0.92f)
+                    // Cap BEFORE fillMaxWidth: fillMaxWidth fixes min=max, so a later
+                    // widthIn(max) cannot shrink it and the dialog spanned the desktop window.
                     .widthIn(max = 480.dp)
+                    .fillMaxWidth(0.92f)
                     .padding(Spacing.lg)
                     // Absorb clicks so tapping the card doesn't fall through to the scrim.
                     .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {},

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -57,15 +57,12 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.buildJsonArray
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.put
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrGroupClient.NostrMessage
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.ui.components.badges.UnreadBadge
 import org.nostr.nostrord.ui.components.chat.DateSeparator
 import org.nostr.nostrord.ui.components.chat.ImageViewerModal
@@ -783,28 +780,7 @@ fun MessagesList(
                                                 shareText(buildShareMessageLink(relay, groupId, item.message.id))
                                             },
                                             onCopyJson = {
-                                                val msg = item.message
-                                                val json =
-                                                    buildJsonObject {
-                                                        put("id", msg.id)
-                                                        put("pubkey", msg.pubkey)
-                                                        put("created_at", msg.createdAt)
-                                                        put("kind", msg.kind)
-                                                        put(
-                                                            "tags",
-                                                            buildJsonArray {
-                                                                msg.tags.forEach { tag ->
-                                                                    add(
-                                                                        buildJsonArray {
-                                                                            tag.forEach { add(JsonPrimitive(it)) }
-                                                                        },
-                                                                    )
-                                                                }
-                                                            },
-                                                        )
-                                                        put("content", msg.content)
-                                                    }.toString()
-                                                copyToClipboard(json)
+                                                copyToClipboard(item.message.toEventJson())
                                             },
                                         )
                                     is ChatItem.ZapEvent ->

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -680,6 +680,7 @@ val AppFrame =
                             this.route = r
                             this.group = selectedGroup
                             onNavigate = { pushRoute(it) }
+                            onOpenDrawer = { setDrawerOpen(true) }
                         }
                     r is GroupRoute && selectedGroup != null ->
                         // The legacy full-featured chat (messages, composer, search, member

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ReactionBadges.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ReactionBadges.kt
@@ -24,6 +24,23 @@ private fun displayEmoji(emoji: String): String = when (emoji) {
     else -> emoji
 }
 
+/** Hover tooltip content: who reacted, capped so a popular badge doesn't build a huge string. */
+private fun reactorNames(
+    reactors: List<String>,
+    userMetadata: Map<String, UserMetadata>,
+): String {
+    val names = reactors.take(MAX_TOOLTIP_NAMES).map { pk ->
+        val meta = userMetadata[pk]
+        meta?.displayName?.takeIf { it.isNotBlank() }
+            ?: meta?.name?.takeIf { it.isNotBlank() }
+            ?: shortNpub(pk)
+    }
+    val extra = reactors.size - MAX_TOOLTIP_NAMES
+    return names.joinToString(", ") + if (extra > 0) " +$extra" else ""
+}
+
+private const val MAX_TOOLTIP_NAMES = 20
+
 fun ChildrenBuilder.reactionBadges(
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: Collection<String>,
@@ -39,6 +56,8 @@ fun ChildrenBuilder.reactionBadges(
             val mine = myPubkey != null && myPubkey in info.reactors
             button {
                 className = ClassName(if (mine) "reaction-badge mine" else "reaction-badge")
+                // Desktop hover shows who reacted (mobile already stacks the reactor avatars).
+                title = reactorNames(info.reactors, userMetadata)
                 onClick = { onReact(emoji) }
                 val emojiUrl = info.emojiUrl
                 if (!emojiUrl.isNullOrBlank()) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ReactionBadges.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ReactionBadges.kt
@@ -1,0 +1,77 @@
+package org.nostr.nostrord.web.components
+
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.utils.shortNpub
+import react.ChildrenBuilder
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.img
+import react.dom.html.ReactHTML.span
+import web.cssom.ClassName
+
+/**
+ * Reaction badge row under a message (`.msg-reactions`): one badge per emoji with the reactor
+ * avatar stack and +N overflow, plus spinner badges for sends still in flight. Clicking a badge
+ * reacts with (or toggles) that emoji. Shared by the chat message row and the thread messages.
+ * Pending emojis already merged into [reactions] by the optimistic update are hidden so a
+ * spinner badge never shows next to its real counterpart.
+ */
+fun ChildrenBuilder.reactionBadges(
+    reactions: Map<String, GroupManager.ReactionInfo>,
+    pendingEmojis: Collection<String>,
+    myPubkey: String?,
+    userMetadata: Map<String, UserMetadata>,
+    onReact: (String) -> Unit,
+) {
+    val visiblePending = pendingEmojis.filter { it !in reactions }
+    if (reactions.isEmpty() && visiblePending.isEmpty()) return
+    div {
+        className = ClassName("msg-reactions")
+        reactions.forEach { (emoji, info) ->
+            val mine = myPubkey != null && myPubkey in info.reactors
+            button {
+                className = ClassName(if (mine) "reaction-badge mine" else "reaction-badge")
+                onClick = { onReact(emoji) }
+                val emojiUrl = info.emojiUrl
+                if (!emojiUrl.isNullOrBlank()) {
+                    img {
+                        className = ClassName("reaction-emoji")
+                        src = emojiUrl
+                        alt = emoji
+                    }
+                } else {
+                    +emoji
+                }
+                // Stacked avatars of who reacted (up to 3, overlapping), then +N overflow.
+                div {
+                    className = ClassName("reaction-avatars")
+                    info.reactors.take(3).forEach { reactor ->
+                        val meta = userMetadata[reactor]
+                        WebAvatar {
+                            url = meta?.picture
+                            seed = reactor
+                            this.name = meta?.displayName?.takeIf { it.isNotBlank() }
+                                ?: meta?.name?.takeIf { it.isNotBlank() }
+                                ?: shortNpub(reactor)
+                            cls = "reaction-avatar"
+                        }
+                    }
+                }
+                if (info.reactors.size > 3) {
+                    span {
+                        className = ClassName("reaction-count")
+                        +"+${info.reactors.size - 3}"
+                    }
+                }
+            }
+        }
+        visiblePending.forEach { emoji ->
+            div {
+                className = ClassName("reaction-badge pending")
+                +emoji
+                span { className = ClassName("reaction-spinner") }
+            }
+        }
+    }
+}

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ReactionBadges.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ReactionBadges.kt
@@ -17,6 +17,13 @@ import web.cssom.ClassName
  * Pending emojis already merged into [reactions] by the optimistic update are hidden so a
  * spinner badge never shows next to its real counterpart.
  */
+/** NIP-25 "+"/"-" display as thumbs, never as a bare sign (parity with the native badges). */
+private fun displayEmoji(emoji: String): String = when (emoji) {
+    "+" -> "👍"
+    "-" -> "👎"
+    else -> emoji
+}
+
 fun ChildrenBuilder.reactionBadges(
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: Collection<String>,
@@ -41,7 +48,7 @@ fun ChildrenBuilder.reactionBadges(
                         alt = emoji
                     }
                 } else {
-                    +emoji
+                    +displayEmoji(emoji)
                 }
                 // Stacked avatars of who reacted (up to 3, overlapping), then +N overflow.
                 div {
@@ -69,7 +76,7 @@ fun ChildrenBuilder.reactionBadges(
         visiblePending.forEach { emoji ->
             div {
                 className = ClassName("reaction-badge pending")
-                +emoji
+                +displayEmoji(emoji)
                 span { className = ClassName("reaction-spinner") }
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt
@@ -9,15 +9,18 @@ import react.Props
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.input
+import react.dom.html.ReactHTML.label
 import react.dom.html.ReactHTML.textarea
 import react.useState
 import web.cssom.ClassName
+import web.html.InputType
+import web.html.checkbox
 
 external interface CreateThreadModalProps : Props {
     var onClose: () -> Unit
 
-    /** Publish a new thread: (title, content). Title is optional (becomes a NIP-14 subject). */
-    var onCreate: (String, String) -> Unit
+    /** Publish a new thread: (title, content, shareToChat). Title becomes the subject/title tags. */
+    var onCreate: (String, String, Boolean) -> Unit
 }
 
 /**
@@ -30,6 +33,8 @@ val CreateThreadModal =
         val (title, setTitle) = useState { "" }
         val (body, setBody) = useState { "" }
         val (uploadError, setUploadError) = useState<String?> { null }
+        // Default on: announcing the new thread in chat is the common case; one click opts out.
+        val (shareToChat, setShareToChat) = useState { true }
 
         useEscClose { props.onClose() }
 
@@ -97,6 +102,16 @@ val CreateThreadModal =
                     }
                 }
 
+                label {
+                    className = ClassName("thread-share-check")
+                    input {
+                        type = InputType.checkbox
+                        checked = shareToChat
+                        onChange = { event -> setShareToChat(event.currentTarget.checked) }
+                    }
+                    +"Share to chat"
+                }
+
                 div {
                     className = ClassName("modal-footer")
                     button {
@@ -108,7 +123,7 @@ val CreateThreadModal =
                         className = ClassName("btn-primary")
                         disabled = title.isBlank() || body.isBlank()
                         onClick = {
-                            props.onCreate(title, body)
+                            props.onCreate(title, body, shareToChat)
                             props.onClose()
                         }
                         +"Publish thread"

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.web.modals
 
 import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.useEscClose
 import react.FC
@@ -28,6 +29,7 @@ val CreateThreadModal =
     FC<CreateThreadModalProps> { props ->
         val (title, setTitle) = useState { "" }
         val (body, setBody) = useState { "" }
+        val (uploadError, setUploadError) = useState<String?> { null }
 
         useEscClose { props.onClose() }
 
@@ -69,14 +71,30 @@ val CreateThreadModal =
                     onChange = { event -> setTitle(event.currentTarget.value) }
                 }
                 div {
-                    className = ClassName("field-label")
+                    className = ClassName("field-label field-label-row")
                     +"Content"
+                    // Attach media to the thread body (rendered inline like chat).
+                    UploadButton {
+                        cls = "thread-compose-attach"
+                        icon = Ic.AttachFile
+                        onUploaded = { up ->
+                            setUploadError(null)
+                            setBody { prev -> if (prev.isBlank()) up.url else "$prev ${up.url}" }
+                        }
+                        onError = { setUploadError(it) }
+                    }
                 }
                 textarea {
                     className = ClassName("modal-textarea")
                     placeholder = "Start a discussion..."
                     value = body
                     onChange = { event -> setBody(event.currentTarget.value) }
+                }
+                uploadError?.let {
+                    div {
+                        className = ClassName("form-error")
+                        +it
+                    }
                 }
 
                 div {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -5,7 +5,6 @@ import kotlinx.browser.window
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.add
-import kotlinx.serialization.json.addJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
@@ -17,6 +16,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip57
@@ -1147,7 +1147,7 @@ val ChatScreen =
                     m.id to
                         RowMeta(
                             nevent = Nip19.encodeNevent(m.id, relays = listOf(neventRelay), authorHex = m.pubkey, kind = m.kind),
-                            eventJson = eventJsonOf(m),
+                            eventJson = m.toEventJson(),
                             link = "https://nostrord.com/open/?relay=$host&group=${group.id}&e=${m.id}",
                         )
                 }
@@ -3408,17 +3408,6 @@ private fun ChildrenBuilder.systemEventRow(
         }
     }
 }
-
-private fun eventJsonOf(message: NostrGroupClient.NostrMessage): String = buildJsonObject {
-    put("id", message.id)
-    put("pubkey", message.pubkey)
-    put("created_at", message.createdAt)
-    put("kind", message.kind)
-    put("content", message.content)
-    putJsonArray("tags") {
-        message.tags.forEach { tag -> addJsonArray { tag.forEach { add(it) } } }
-    }
-}.toString()
 
 private val URL_REGEX =
     Regex(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2675,7 +2675,7 @@ private fun ChildrenBuilder.joinErrorDialog(message: String, onDismiss: () -> Un
 
 /** Error dialog shown when the relay rejects a kind:5. Single OK button —
  *  matches the native AlertDialog at GroupScreen.kt:548-562. */
-private fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss: () -> Unit) {
+internal fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss: () -> Unit) {
     div {
         className = ClassName("modal-overlay")
         onClick = { onDismiss() }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -3663,27 +3663,20 @@ private fun ChildrenBuilder.renderEntities(
             }
             if (url.length < token.length) +token.substring(url.length)
         } else if (token.startsWith("wss://") || token.startsWith("ws://")) {
-            // NIP-29 group address `wss://relay'groupId` renders as a tappable group card,
-            // mirroring native MessageContent (RelayPart). A bare relay url stays plain text.
+            // NIP-29 group address `wss://relay'groupId`: the full tappable card only when the
+            // message IS the link; mixed with text it renders as the compact chip, mirroring
+            // native MessageContent (RelayPart). A bare relay url stays plain text.
             val apostrophe = token.indexOf('\'')
             if (apostrophe > 0) {
-                GroupLinkCard {
-                    groupId = token.substring(apostrophe + 1)
-                    relayUrl = token.substring(0, apostrophe)
-                    onNavigate = onGroupRef
-                }
+                groupRef(token.substring(apostrophe + 1), token.substring(0, apostrophe), asCard = content.trim() == token, onGroupRef)
             } else {
                 +token
             }
         } else if (token.contains('\'')) {
             // Bare NIP-29 group address `relay'groupId` (no scheme): normalize with wss:// and
-            // render the same group card as the scheme form.
+            // render the same card-or-chip as the scheme form.
             val apostrophe = token.indexOf('\'')
-            GroupLinkCard {
-                groupId = token.substring(apostrophe + 1)
-                relayUrl = "wss://" + token.substring(0, apostrophe)
-                onNavigate = onGroupRef
-            }
+            groupRef(token.substring(apostrophe + 1), "wss://" + token.substring(0, apostrophe), asCard = content.trim() == token, onGroupRef)
         } else {
             // A mention standing alone (on its own line) keeps the rich form (group card,
             // @name); inline with other text it becomes a compact avatar+name chip, matching
@@ -4205,6 +4198,28 @@ private val GroupLinkCard =
  * group's square avatar + name when resolved, or `#name` when it has no picture. Clicking opens
  * the group. Standalone group references still render as the full GroupLinkCard.
  */
+/** A group reference in message text: the full card when the message is only the link, else the chip. */
+private fun ChildrenBuilder.groupRef(
+    gid: String,
+    relay: String?,
+    asCard: Boolean,
+    onNav: (String, String?) -> Unit,
+) {
+    if (asCard) {
+        GroupLinkCard {
+            groupId = gid
+            relayUrl = relay
+            onNavigate = onNav
+        }
+    } else {
+        GroupMentionChip {
+            groupId = gid
+            relayUrl = relay
+            onNavigate = onNav
+        }
+    }
+}
+
 private val GroupMentionChip =
     FC<GroupLinkCardProps> { props ->
         val repo = AppModule.nostrRepository

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -24,6 +24,7 @@ import org.nostr.nostrord.nostr.Nip68
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.keyboard.VirtualKeyboardPolicy
 import org.nostr.nostrord.ui.navigation.GroupRoute
+import org.nostr.nostrord.ui.navigation.GroupView
 import org.nostr.nostrord.ui.screens.group.GroupMembership
 import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.MentionableGroup
@@ -3912,6 +3913,56 @@ private val QuotedEvent =
         useEffect(replyPubkey) {
             val pk = replyPubkey
             if (pk != null && userMetadata[pk] == null) launchApp { repo.requestUserMetadata(setOf(pk)) }
+        }
+
+        // A quoted kind:11 renders as a thread card that opens the thread page - both the
+        // "Share to chat" announcement and any pasted thread nevent land here. Takes precedence
+        // over the forwarded rendering (mirrors native ThreadQuoteCard).
+        val resolvedKind = local?.kind ?: cachedEv?.kind ?: props.kind
+        if (resolvedKind == 11) {
+            val threadTitle = quotedTags.firstOrNull { it.size >= 2 && (it[0] == "subject" || it[0] == "title") }
+                ?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
+                ?: content?.lineSequence()?.map { it.trim() }?.firstOrNull { it.isNotEmpty() }?.take(80)
+            val threadSnippet = content?.lineSequence()?.map { it.trim() }?.firstOrNull { it.isNotEmpty() }
+                ?.take(140)?.takeIf { it != threadTitle }
+            val canOpen = refGroupId != null && fwdRelay != null
+            div {
+                className = ClassName(if (canOpen) "thread-quote-card" else "thread-quote-card static")
+                if (canOpen) {
+                    onClick = {
+                        pushRoute(
+                            GroupRoute(
+                                relayUrl = fwdRelay!!,
+                                groupId = refGroupId!!,
+                                view = GroupView.Threads,
+                                threadRootId = props.eventId,
+                            ),
+                        )
+                    }
+                }
+                div {
+                    className = ClassName("thread-quote-head")
+                    icon(Ic.Forum)
+                    span { +"Thread" }
+                    if (refGroupId != null && fwdGroupName.isNotBlank()) {
+                        span {
+                            className = ClassName("thread-quote-group")
+                            +"· $fwdGroupName"
+                        }
+                    }
+                }
+                div {
+                    className = ClassName("thread-quote-title")
+                    +(threadTitle ?: if (notFound) "Thread not found" else "Loading thread...")
+                }
+                threadSnippet?.let {
+                    div {
+                        className = ClassName("thread-quote-snippet")
+                        +it
+                    }
+                }
+            }
+            return@FC
         }
 
         // Clickable only when the referenced event is a local message we can scroll to; an

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -63,6 +63,7 @@ import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.memberSkeleton
 import org.nostr.nostrord.web.components.messageSendStatus
 import org.nostr.nostrord.web.components.messageSkeleton
+import org.nostr.nostrord.web.components.reactionBadges
 import org.nostr.nostrord.web.components.searchInput
 import org.nostr.nostrord.web.components.sendStateIcon
 import org.nostr.nostrord.web.components.uploadBlob
@@ -2739,7 +2740,7 @@ private fun ChildrenBuilder.uploadErrorDialog(message: String, onDismiss: () -> 
  *  GroupScreen: a "Join Required" variant (offers Join) when the relay says we're an
  *  unknown member, a signer-failure variant when the signer could not sign, otherwise
  *  "Cannot React" + OK. Classification is shared via classifyReactionError. */
-private fun ChildrenBuilder.reactionErrorDialog(message: String, onDismiss: () -> Unit, onJoin: () -> Unit) {
+internal fun ChildrenBuilder.reactionErrorDialog(message: String, onDismiss: () -> Unit, onJoin: () -> Unit) {
     val errorKind = classifyReactionError(message)
     val isUnknownMember = errorKind == ReactionErrorKind.JoinRequired
     div {
@@ -3170,57 +3171,7 @@ private val MessageRow =
                 if (props.myPubkey != null && props.myPubkey == props.pubkey) {
                     messageSendStatus(props.status, props.onRetrySend, props.onDismissFailed)
                 }
-                // Pending emojis still waiting on signEvent + relay; hide any
-                // that the optimistic update already merged into props.reactions
-                // so we never show a spinner badge next to its real counterpart.
-                val visiblePending = pendingEmojis.filter { it !in props.reactions }
-                if (props.reactions.isNotEmpty() || visiblePending.isNotEmpty()) {
-                    div {
-                        className = ClassName("msg-reactions")
-                        props.reactions.forEach { (emoji, info) ->
-                            val mine = props.myPubkey != null && props.myPubkey in info.reactors
-                            button {
-                                className = ClassName(if (mine) "reaction-badge mine" else "reaction-badge")
-                                onClick = { react(emoji) }
-                                val emojiUrl = info.emojiUrl
-                                if (!emojiUrl.isNullOrBlank()) {
-                                    img {
-                                        className = ClassName("reaction-emoji")
-                                        src = emojiUrl
-                                        alt = emoji
-                                    }
-                                } else {
-                                    +emoji
-                                }
-                                // Stacked avatars of who reacted (up to 3, overlapping), then +N overflow.
-                                div {
-                                    className = ClassName("reaction-avatars")
-                                    info.reactors.take(3).forEach { reactor ->
-                                        WebAvatar {
-                                            url = props.userMetadata[reactor]?.picture
-                                            seed = reactor
-                                            this.name = displayName(reactor, props.userMetadata[reactor])
-                                            cls = "reaction-avatar"
-                                        }
-                                    }
-                                }
-                                if (info.reactors.size > 3) {
-                                    span {
-                                        className = ClassName("reaction-count")
-                                        +"+${info.reactors.size - 3}"
-                                    }
-                                }
-                            }
-                        }
-                        visiblePending.forEach { emoji ->
-                            div {
-                                className = ClassName("reaction-badge pending")
-                                +emoji
-                                span { className = ClassName("reaction-spinner") }
-                            }
-                        }
-                    }
-                }
+                reactionBadges(props.reactions, pendingEmojis, props.myPubkey, props.userMetadata) { react(it) }
                 if (props.zapTotalMsats > 0) {
                     div {
                         className = ClassName("msg-zaps")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -37,6 +37,7 @@ import org.nostr.nostrord.web.components.reactionBadges
 import org.nostr.nostrord.web.components.sendStateIcon
 import org.nostr.nostrord.web.components.uploadBlob
 import org.nostr.nostrord.web.modals.CreateThreadModal
+import org.nostr.nostrord.web.modals.UserProfileModal
 import react.ChildrenBuilder
 import react.FC
 import react.Props
@@ -117,6 +118,9 @@ val ThreadsScreen =
 
         // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
         val (reactingTo, setReactingTo) = useState<Pair<String, String>?> { null }
+
+        // Avatar / author-name / mention tap target: opens the user profile modal (chat parity).
+        val (profilePubkey, setProfilePubkey) = useState<String?> { null }
 
         // Context menu (right-click / long-press) over a thread message.
         val (ctxMenu, setCtxMenu) = useState<ThreadCtxMenu?> { null }
@@ -409,6 +413,7 @@ val ThreadsScreen =
                                 highlighted = msg.id == highlightId,
                                 onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                                 onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
+                                onUser = { setProfilePubkey(it) },
                                 // A group ref in the body opens that group's chat page.
                                 onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
                                 onRetry = { vm.retrySend(msg.id) },
@@ -627,6 +632,15 @@ val ThreadsScreen =
                     }
                 }
             }
+            // User profile modal (avatar / author-name / mention tap), same modal as chat.
+            profilePubkey?.let { pk ->
+                UserProfileModal {
+                    pubkey = pk
+                    groupId = route.groupId
+                    onClose = { setProfilePubkey(null) }
+                }
+            }
+
             // Delete confirm modal (chat parity: destructive confirm, no window.confirm).
             deleteTarget?.let { target ->
                 val isRoot = target.id == route.threadRootId
@@ -706,6 +720,7 @@ private fun ChildrenBuilder.threadMessage(
     highlighted: Boolean,
     onReact: (String) -> Unit,
     onOpenMenu: (Double, Double) -> Unit,
+    onUser: (String) -> Unit,
     onGroupRef: (String, String?) -> Unit,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
@@ -725,12 +740,17 @@ private fun ChildrenBuilder.threadMessage(
                 onOpenMenu(e.clientX, e.clientY)
             }
         }
-        WebAvatar {
-            url = userMetadata[msg.pubkey]?.picture
-            seed = msg.pubkey
-            this.name = threadDisplayName(msg.pubkey, userMetadata[msg.pubkey])
-            kind = AvatarKind.USER
-            cls = "thread-msg-avatar"
+        // Avatar and author name open the user profile modal (chat parity).
+        div {
+            className = ClassName("thread-msg-avatar-btn")
+            onClick = { onUser(msg.pubkey) }
+            WebAvatar {
+                url = userMetadata[msg.pubkey]?.picture
+                seed = msg.pubkey
+                this.name = threadDisplayName(msg.pubkey, userMetadata[msg.pubkey])
+                kind = AvatarKind.USER
+                cls = "thread-msg-avatar"
+            }
         }
         div {
             className = ClassName("thread-msg-main")
@@ -738,6 +758,7 @@ private fun ChildrenBuilder.threadMessage(
                 className = ClassName("thread-msg-head")
                 span {
                     className = ClassName("thread-msg-author")
+                    onClick = { onUser(msg.pubkey) }
                     +threadDisplayName(msg.pubkey, userMetadata[msg.pubkey])
                 }
                 span {
@@ -780,7 +801,7 @@ private fun ChildrenBuilder.threadMessage(
                     msg.tags,
                     userMetadata,
                     emptyMap(),
-                    onUser = {},
+                    onUser = onUser,
                     onEventRef = {},
                     onGroupRef = onGroupRef,
                 )

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -7,10 +7,13 @@ import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.threadTitle
+import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.getDateLabel
 import org.nostr.nostrord.utils.shortNpub
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
@@ -21,6 +24,7 @@ import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.Portal
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.components.copyToClipboard
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.messageSendStatus
 import org.nostr.nostrord.web.components.reactionBadges
@@ -33,12 +37,14 @@ import react.Props
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.h2
+import react.dom.html.ReactHTML.img
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.textarea
 import react.useEffect
 import react.useRef
 import react.useState
 import web.cssom.ClassName
+import web.html.HTMLDivElement
 import web.html.HTMLTextAreaElement
 import kotlin.js.Date
 
@@ -58,6 +64,13 @@ private fun relativeTime(createdAtSeconds: Long): String {
         else -> "${diff / 604_800}w"
     }
 }
+
+/** Right-click target for the thread context menu: the message plus the click viewport coords. */
+private data class ThreadCtxMenu(
+    val msg: NostrGroupClient.NostrMessage,
+    val x: Double,
+    val y: Double,
+)
 
 external interface ThreadsScreenProps : Props {
     var route: GroupRoute
@@ -90,6 +103,25 @@ val ThreadsScreen =
 
         // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
         val (reactingTo, setReactingTo) = useState<Pair<String, String>?> { null }
+
+        // Context menu (right-click / long-press) over a thread message.
+        val (ctxMenu, setCtxMenu) = useState<ThreadCtxMenu?> { null }
+        val ctxMenuRef = useRef<HTMLDivElement>(null)
+
+        // Clamp the menu into the viewport once it mounts (.ctx-menu starts visibility:hidden).
+        useEffect(ctxMenu) {
+            val el = ctxMenuRef.current?.asDynamic() ?: return@useEffect
+            val m = ctxMenu ?: return@useEffect
+            val w = el.offsetWidth as Int
+            val h = el.offsetHeight as Int
+            var left = m.x
+            if (left + w > window.innerWidth - 8) left = (window.innerWidth - 8.0 - w).coerceAtLeast(8.0)
+            var top = m.y
+            if (top + h > window.innerHeight - 8) top = (m.y - h).coerceAtLeast(8.0)
+            el.style.left = "${left}px"
+            el.style.top = "${top}px"
+            el.style.visibility = "visible"
+        }
 
         // Keep the open thread synced with the URL (#/g/<relay>/<id>/threads/<rootId>).
         useEffect(route.threadRootId) { vm.openThread(route.threadRootId) }
@@ -194,7 +226,9 @@ val ThreadsScreen =
                         reactions[msg.id] ?: emptyMap(),
                         pendingFor(msg.id),
                         onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
-                        onOpenPicker = { setReactingTo(msg.id to msg.pubkey) },
+                        onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
+                        // A group ref in the body opens that group's chat page.
+                        onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
                         onRetry = { vm.retrySend(msg.id) },
                         onDismiss = { vm.dismissFailed(msg.id) },
                     )
@@ -354,6 +388,25 @@ val ThreadsScreen =
                                         }
                                         div {
                                             className = ClassName("thread-card-meta")
+                                            // Top reactions on the root, then author / replies / publication date.
+                                            topReactionChips(reactions[t.rootId] ?: emptyMap()).forEach { chip ->
+                                                span {
+                                                    className = ClassName("thread-card-chip")
+                                                    if (!chip.emojiUrl.isNullOrBlank()) {
+                                                        img {
+                                                            className = ClassName("reaction-emoji")
+                                                            src = chip.emojiUrl
+                                                            alt = chip.emoji
+                                                        }
+                                                    } else {
+                                                        +chip.emoji
+                                                    }
+                                                    span {
+                                                        className = ClassName("thread-card-chip-count")
+                                                        +"${chip.count}"
+                                                    }
+                                                }
+                                            }
                                             +threadDisplayName(t.authorPubkey, userMetadata[t.authorPubkey])
                                             span {
                                                 className = ClassName("thread-card-dot")
@@ -364,7 +417,7 @@ val ThreadsScreen =
                                                 className = ClassName("thread-card-dot")
                                                 +"·"
                                             }
-                                            +relativeTime(t.lastActivity)
+                                            +getDateLabel(t.createdAt)
                                         }
                                     }
                                 }
@@ -372,6 +425,61 @@ val ThreadsScreen =
                         }
                 }
             }
+            // Thread message context menu: quick reactions, copy text, delete (own message).
+            ctxMenu?.let { m ->
+                div {
+                    className = ClassName("ctx-overlay")
+                    onClick = { setCtxMenu(null) }
+                    onContextMenu = {
+                        it.preventDefault()
+                        setCtxMenu(null)
+                    }
+                }
+                div {
+                    ref = ctxMenuRef
+                    className = ClassName("ctx-menu")
+                    div {
+                        className = ClassName("ctx-reactions")
+                        for (emoji in QuickReactions) {
+                            button {
+                                className = ClassName("ctx-reaction")
+                                onClick = {
+                                    vm.sendReaction(m.msg.id, m.msg.pubkey, emoji)
+                                    setCtxMenu(null)
+                                }
+                                +emoji
+                            }
+                        }
+                        button {
+                            className = ClassName("ctx-reaction ctx-reaction-more")
+                            title = "Add reaction"
+                            onClick = {
+                                setCtxMenu(null)
+                                setReactingTo(m.msg.id to m.msg.pubkey)
+                            }
+                            icon(Ic.EmojiEmotions)
+                        }
+                    }
+                    div { className = ClassName("ctx-divider") }
+                    ctxItem(Ic.ContentCopy, "Copy text") {
+                        copyToClipboard(m.msg.content)
+                        setCtxMenu(null)
+                    }
+                    if (myPubkey != null && myPubkey == m.msg.pubkey) {
+                        div { className = ClassName("ctx-divider") }
+                        ctxItem(Ic.Delete, "Delete message", danger = true) {
+                            setCtxMenu(null)
+                            val isRoot = m.msg.id == route.threadRootId
+                            val prompt = if (isRoot) "Delete this thread? This cannot be undone." else "Delete this message? This cannot be undone."
+                            if (window.confirm(prompt)) {
+                                vm.deleteThread(m.msg.id)
+                                if (isRoot) props.onNavigate(route.copy(threadRootId = null))
+                            }
+                        }
+                    }
+                }
+            }
+
             // Full emoji picker for a reaction (opened by the add-reaction button).
             reactingTo?.let { (targetEventId, targetPubkey) ->
                 Portal {
@@ -442,12 +550,22 @@ private fun ChildrenBuilder.threadMessage(
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: List<String>,
     onReact: (String) -> Unit,
-    onOpenPicker: () -> Unit,
+    onOpenMenu: (Double, Double) -> Unit,
+    onGroupRef: (String, String?) -> Unit,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
 ) {
     div {
         className = ClassName(if (isRoot) "thread-msg thread-msg-root" else "thread-msg")
+        // Right-click (desktop) / long-press (mobile browsers) opens the thread context menu.
+        // Right-click directly on a hyperlink keeps the browser's native menu (chat parity),
+        // so "Copy link address" copies the actual URL.
+        onContextMenu = { e ->
+            if (e.target.asDynamic().closest("a") == null) {
+                e.preventDefault()
+                onOpenMenu(e.clientX, e.clientY)
+            }
+        }
         WebAvatar {
             url = userMetadata[msg.pubkey]?.picture
             seed = msg.pubkey
@@ -484,7 +602,7 @@ private fun ChildrenBuilder.threadMessage(
                     emptyMap(),
                     onUser = {},
                     onEventRef = {},
-                    onGroupRef = { _, _ -> },
+                    onGroupRef = onGroupRef,
                 )
                 // Inline send-state icon (clock/check) so no extra line shifts the list.
                 if (myPubkey != null && myPubkey == msg.pubkey) {
@@ -494,18 +612,9 @@ private fun ChildrenBuilder.threadMessage(
             if (myPubkey != null && myPubkey == msg.pubkey) {
                 messageSendStatus(status, onRetry, onDismiss)
             }
-            // Reaction badges + the always-visible add-reaction affordance (threads have no
-            // hover-action row like chat, so the button is the way in to the full picker).
-            div {
-                className = ClassName("thread-msg-react-row")
-                reactionBadges(reactions, pendingEmojis, myPubkey, userMetadata, onReact)
-                button {
-                    className = ClassName("thread-react-btn")
-                    title = "Add reaction"
-                    onClick = { onOpenPicker() }
-                    icon(Ic.EmojiEmotions)
-                }
-            }
+            // Reaction badges; adding a reaction goes through the context menu (quick row
+            // or the full picker), so there is no always-visible add button.
+            reactionBadges(reactions, pendingEmojis, myPubkey, userMetadata, onReact)
         }
     }
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -49,6 +49,7 @@ import react.useEffect
 import react.useRef
 import react.useState
 import web.cssom.ClassName
+import web.dom.ElementId
 import web.html.HTMLDivElement
 import web.html.HTMLTextAreaElement
 import kotlin.js.Date
@@ -69,6 +70,9 @@ private fun relativeTime(createdAtSeconds: Long): String {
         else -> "${diff / 604_800}w"
     }
 }
+
+// Deep-link flash duration; mirrors the .thread-msg.highlight animation (2.4s msg-flash).
+private const val HIGHLIGHT_FLASH_MS = 2_400
 
 /** Right-click target for the thread context menu: the message plus the click viewport coords. */
 private data class ThreadCtxMenu(
@@ -130,6 +134,20 @@ val ThreadsScreen =
 
         // Message being answered by the composer (context-menu Reply); null posts top-level.
         val (replyingTo, setReplyingTo) = useState<NostrGroupClient.NostrMessage?> { null }
+
+        // Deep-link target (?e=): scroll to and flash the message once the thread loads.
+        val (highlightId, setHighlightId) = useState<String?> { null }
+        val highlightLoaded = route.messageId != null &&
+            openThread?.let { d -> (d.replies + d.root).any { it.id == route.messageId } } == true
+        useEffect(route.messageId, highlightLoaded) {
+            val target = route.messageId
+            if (target != null && highlightLoaded) {
+                setHighlightId(target)
+                document.getElementById("thread-msg-$target")?.asDynamic()
+                    ?.scrollIntoView(js("{ block: 'center', behavior: 'smooth' }"))
+                window.setTimeout({ setHighlightId(null) }, HIGHLIGHT_FLASH_MS)
+            }
+        }
 
         // Keep the open thread synced with the URL (#/g/<relay>/<id>/threads/<rootId>).
         useEffect(route.threadRootId) {
@@ -242,6 +260,7 @@ val ThreadsScreen =
                         reactions[msg.id] ?: emptyMap(),
                         pendingFor(msg.id),
                         parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
+                        highlighted = msg.id == highlightId,
                         onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                         onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
                         // A group ref in the body opens that group's chat page.
@@ -515,8 +534,9 @@ val ThreadsScreen =
                         setCtxMenu(null)
                     }
                     ctxItem(Ic.Link, "Copy event link") {
-                        // A reply links to its thread page too (the root id from the E tag).
-                        copyToClipboard(threadShareLink(route.relayUrl, route.groupId, m.msg.threadRootIdTag() ?: m.msg.id))
+                        // A reply links to its thread page (root id from the E tag), targeting
+                        // this message via ?e= so opening it scrolls to and flashes it.
+                        copyToClipboard(threadShareLink(route.relayUrl, route.groupId, m.msg.threadRootIdTag() ?: m.msg.id, messageId = m.msg.id))
                         setCtxMenu(null)
                     }
                     ctxItem(Ic.Code, "Copy nevent") {
@@ -612,6 +632,7 @@ private fun ChildrenBuilder.threadMessage(
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: List<String>,
     parentMsg: NostrGroupClient.NostrMessage?,
+    highlighted: Boolean,
     onReact: (String) -> Unit,
     onOpenMenu: (Double, Double) -> Unit,
     onGroupRef: (String, String?) -> Unit,
@@ -619,7 +640,11 @@ private fun ChildrenBuilder.threadMessage(
     onDismiss: () -> Unit,
 ) {
     div {
-        className = ClassName(if (isRoot) "thread-msg thread-msg-root" else "thread-msg")
+        id = ElementId("thread-msg-${msg.id}")
+        className = ClassName(
+            (if (isRoot) "thread-msg thread-msg-root" else "thread-msg") +
+                (if (highlighted) " highlight" else ""),
+        )
         // Right-click (desktop) / long-press (mobile browsers) opens the thread context menu.
         // Right-click directly on a hyperlink keeps the browser's native menu (chat parity),
         // so "Copy link address" copies the actual URL.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -212,181 +212,12 @@ val ThreadsScreen =
         }
 
         div {
-            className = ClassName("threads-page")
+            className = ClassName(if (route.threadRootId != null) "threads-page detail-open" else "threads-page")
 
-            if (route.threadRootId != null) {
-                // ---- Single thread (detail) ----
-                div {
-                    className = ClassName("threads-header")
-                    button {
-                        className = ClassName("icon-btn")
-                        title = "Back to threads"
-                        onClick = { props.onNavigate(route.copy(threadRootId = null)) }
-                        icon(Ic.ArrowBack)
-                    }
-                    span {
-                        className = ClassName("threads-title")
-                        +"Thread"
-                    }
-                    val ownRoot = openThread?.root
-                    if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
-                        button {
-                            className = ClassName("icon-btn")
-                            title = "Delete thread"
-                            onClick = { setDeleteTarget(ownRoot) }
-                            icon(Ic.Delete)
-                        }
-                    }
-                }
-                val detail = openThread
-                if (detail == null) {
-                    div {
-                        className = ClassName("threads-empty")
-                        +"Loading thread..."
-                    }
-                } else {
-                    // Pending sends for one message: "eventId|emoji" keys -> that message's emojis.
-                    fun pendingFor(id: String) = pendingReactions.filter { it.startsWith("$id|") }.map { it.substringAfter('|') }
-
-                    // Nested replies resolve their lowercase-e parent from the loaded thread.
-                    val messagesById = (detail.replies + detail.root).associateBy { it.id }
-
-                    fun ChildrenBuilder.renderThreadMessage(msg: NostrGroupClient.NostrMessage, isRoot: Boolean) = threadMessage(
-                        msg,
-                        userMetadata,
-                        isRoot = isRoot,
-                        myPubkey,
-                        messageStatus[msg.id],
-                        reactions[msg.id] ?: emptyMap(),
-                        pendingFor(msg.id),
-                        parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
-                        highlighted = msg.id == highlightId,
-                        onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
-                        onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
-                        // A group ref in the body opens that group's chat page.
-                        onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
-                        onRetry = { vm.retrySend(msg.id) },
-                        onDismiss = { vm.dismissFailed(msg.id) },
-                    )
-
-                    div {
-                        className = ClassName("thread-detail-body")
-                        renderThreadMessage(detail.root, isRoot = true)
-                        div {
-                            className = ClassName("thread-replies-divider")
-                            +(if (detail.replies.size == 1) "1 reply" else "${detail.replies.size} replies")
-                        }
-                        detail.replies.forEach { r -> renderThreadMessage(r, isRoot = false) }
-                    }
-                    // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
-                    div {
-                        className = ClassName("dm-composer-wrap")
-                        // Reply chip above the composer while answering a specific message.
-                        replyingTo?.let { target ->
-                            div {
-                                className = ClassName("composer-reply")
-                                icon(Ic.Reply)
-                                span {
-                                    className = ClassName("composer-reply-label")
-                                    +"Replying to"
-                                }
-                                span {
-                                    className = ClassName("composer-reply-name")
-                                    +threadDisplayName(target.pubkey, userMetadata[target.pubkey])
-                                }
-                                target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.let { preview ->
-                                    span {
-                                        className = ClassName("composer-reply-text")
-                                        +preview
-                                    }
-                                }
-                                button {
-                                    className = ClassName("composer-reply-close")
-                                    onClick = { setReplyingTo(null) }
-                                    icon(Ic.Close)
-                                }
-                            }
-                        }
-                        div {
-                            className = ClassName("dm-composer")
-                            UploadButton {
-                                cls = "dm-composer-btn"
-                                icon = Ic.AttachFile
-                                busy = uploadCount > 0
-                                onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
-                                onPickerClosed = { composerInputRef.current?.focus() }
-                                onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
-                                onError = { setUploadError(it) }
-                            }
-                            textarea {
-                                ref = composerInputRef
-                                rows = 1
-                                value = reply
-                                placeholder = "Write a reply..."
-                                onChange = { setReply((it.target as HTMLTextAreaElement).value) }
-                                onKeyDown = { e ->
-                                    if (e.key == "Enter" && !e.shiftKey) {
-                                        e.preventDefault()
-                                        sendReply()
-                                    }
-                                }
-                                onPaste = { event ->
-                                    val items = event.asDynamic().clipboardData?.items
-                                    val count = (items?.length as? Int) ?: 0
-                                    for (i in 0 until count) {
-                                        val item = items[i]
-                                        val type = item.type.unsafeCast<String?>()
-                                        if (item.kind == "file" && isMediaMime(type)) {
-                                            val file = item.getAsFile()
-                                            if (file != null) {
-                                                event.preventDefault()
-                                                handleMediaFile(file)
-                                            }
-                                        }
-                                    }
-                                }
-                                onDragOver = { it.preventDefault() }
-                                onDrop = { event ->
-                                    val files = event.asDynamic().dataTransfer?.files
-                                    val count = (files?.length as? Int) ?: 0
-                                    if (count > 0) event.preventDefault()
-                                    for (i in 0 until count) {
-                                        val file = files[i]
-                                        if (isMediaMime(file.type.unsafeCast<String?>())) handleMediaFile(file)
-                                    }
-                                }
-                            }
-                            button {
-                                className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
-                                title = "Emoji"
-                                onClick = { setEmojiOpen(!emojiOpen) }
-                                icon(Ic.EmojiEmotions)
-                            }
-                            button {
-                                className = ClassName("dm-composer-btn send")
-                                title = "Send"
-                                disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
-                                onMouseDown = { e -> e.preventDefault() }
-                                onClick = { sendReply() }
-                                if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
-                            }
-                            if (emojiOpen) {
-                                div {
-                                    className = ClassName("emoji-overlay")
-                                    onClick = { setEmojiOpen(false) }
-                                    EmojiPicker {
-                                        onPick = { emoji ->
-                                            insertAtCursor(emoji)
-                                            setEmojiOpen(false)
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            } else {
-                // ---- Threads list ----
+            // ---- Threads list pane: always mounted. On desktop the open thread docks beside
+            // it (Discord-style split); on mobile .detail-open hides this pane instead. ----
+            div {
+                className = ClassName("threads-list-pane")
                 div {
                     className = ClassName("threads-header")
                     span {
@@ -398,15 +229,6 @@ val ThreadsScreen =
                         onClick = { setComposing(true) }
                         icon(Ic.Forum)
                         span { +"New thread" }
-                    }
-                }
-
-                if (composing) {
-                    Portal {
-                        CreateThreadModal {
-                            onClose = { setComposing(false) }
-                            onCreate = { title, content -> vm.createThread(title, content) }
-                        }
                     }
                 }
 
@@ -427,7 +249,7 @@ val ThreadsScreen =
                             threads.forEach { t ->
                                 button {
                                     key = t.rootId
-                                    className = ClassName("thread-card")
+                                    className = ClassName(if (t.rootId == route.threadRootId) "thread-card active" else "thread-card")
                                     onClick = { props.onNavigate(route.copy(threadRootId = t.rootId)) }
                                     WebAvatar {
                                         url = userMetadata[t.authorPubkey]?.picture
@@ -485,6 +307,199 @@ val ThreadsScreen =
                                 }
                             }
                         }
+                }
+            }
+
+            if (composing) {
+                Portal {
+                    CreateThreadModal {
+                        onClose = { setComposing(false) }
+                        onCreate = { title, content -> vm.createThread(title, content) }
+                    }
+                }
+            }
+
+            if (route.threadRootId != null) {
+                // ---- Open thread: full page on mobile, right dock on desktop ----
+                div {
+                    className = ClassName("thread-detail-pane")
+                    div {
+                        className = ClassName("threads-header")
+                        button {
+                            // Mobile only; on desktop the split stays and the X on the right closes.
+                            className = ClassName("icon-btn thread-back")
+                            title = "Back to threads"
+                            onClick = { props.onNavigate(route.copy(threadRootId = null)) }
+                            icon(Ic.ArrowBack)
+                        }
+                        span {
+                            className = ClassName("threads-title")
+                            +"Thread"
+                        }
+                        val ownRoot = openThread?.root
+                        if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
+                            button {
+                                className = ClassName("icon-btn")
+                                title = "Delete thread"
+                                onClick = { setDeleteTarget(ownRoot) }
+                                icon(Ic.Delete)
+                            }
+                        }
+                        button {
+                            // Desktop only (CSS): closes the docked thread, Discord-style.
+                            className = ClassName("icon-btn thread-close")
+                            title = "Close thread"
+                            onClick = { props.onNavigate(route.copy(threadRootId = null)) }
+                            icon(Ic.Close)
+                        }
+                    }
+                    val detail = openThread
+                    if (detail == null) {
+                        div {
+                            className = ClassName("threads-empty")
+                            +"Loading thread..."
+                        }
+                    } else {
+                        // Pending sends for one message: "eventId|emoji" keys -> that message's emojis.
+                        fun pendingFor(id: String) = pendingReactions.filter { it.startsWith("$id|") }.map { it.substringAfter('|') }
+
+                        // Nested replies resolve their lowercase-e parent from the loaded thread.
+                        val messagesById = (detail.replies + detail.root).associateBy { it.id }
+
+                        fun ChildrenBuilder.renderThreadMessage(msg: NostrGroupClient.NostrMessage, isRoot: Boolean) = threadMessage(
+                            msg,
+                            userMetadata,
+                            isRoot = isRoot,
+                            myPubkey,
+                            messageStatus[msg.id],
+                            reactions[msg.id] ?: emptyMap(),
+                            pendingFor(msg.id),
+                            parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
+                            highlighted = msg.id == highlightId,
+                            onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
+                            onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
+                            // A group ref in the body opens that group's chat page.
+                            onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
+                            onRetry = { vm.retrySend(msg.id) },
+                            onDismiss = { vm.dismissFailed(msg.id) },
+                        )
+
+                        div {
+                            className = ClassName("thread-detail-body")
+                            renderThreadMessage(detail.root, isRoot = true)
+                            div {
+                                className = ClassName("thread-replies-divider")
+                                +(if (detail.replies.size == 1) "1 reply" else "${detail.replies.size} replies")
+                            }
+                            detail.replies.forEach { r -> renderThreadMessage(r, isRoot = false) }
+                        }
+                        // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
+                        div {
+                            className = ClassName("dm-composer-wrap")
+                            // Reply chip above the composer while answering a specific message.
+                            replyingTo?.let { target ->
+                                div {
+                                    className = ClassName("composer-reply")
+                                    icon(Ic.Reply)
+                                    span {
+                                        className = ClassName("composer-reply-label")
+                                        +"Replying to"
+                                    }
+                                    span {
+                                        className = ClassName("composer-reply-name")
+                                        +threadDisplayName(target.pubkey, userMetadata[target.pubkey])
+                                    }
+                                    target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.let { preview ->
+                                        span {
+                                            className = ClassName("composer-reply-text")
+                                            +preview
+                                        }
+                                    }
+                                    button {
+                                        className = ClassName("composer-reply-close")
+                                        onClick = { setReplyingTo(null) }
+                                        icon(Ic.Close)
+                                    }
+                                }
+                            }
+                            div {
+                                className = ClassName("dm-composer")
+                                UploadButton {
+                                    cls = "dm-composer-btn"
+                                    icon = Ic.AttachFile
+                                    busy = uploadCount > 0
+                                    onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
+                                    onPickerClosed = { composerInputRef.current?.focus() }
+                                    onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
+                                    onError = { setUploadError(it) }
+                                }
+                                textarea {
+                                    ref = composerInputRef
+                                    rows = 1
+                                    value = reply
+                                    placeholder = "Write a reply..."
+                                    onChange = { setReply((it.target as HTMLTextAreaElement).value) }
+                                    onKeyDown = { e ->
+                                        if (e.key == "Enter" && !e.shiftKey) {
+                                            e.preventDefault()
+                                            sendReply()
+                                        }
+                                    }
+                                    onPaste = { event ->
+                                        val items = event.asDynamic().clipboardData?.items
+                                        val count = (items?.length as? Int) ?: 0
+                                        for (i in 0 until count) {
+                                            val item = items[i]
+                                            val type = item.type.unsafeCast<String?>()
+                                            if (item.kind == "file" && isMediaMime(type)) {
+                                                val file = item.getAsFile()
+                                                if (file != null) {
+                                                    event.preventDefault()
+                                                    handleMediaFile(file)
+                                                }
+                                            }
+                                        }
+                                    }
+                                    onDragOver = { it.preventDefault() }
+                                    onDrop = { event ->
+                                        val files = event.asDynamic().dataTransfer?.files
+                                        val count = (files?.length as? Int) ?: 0
+                                        if (count > 0) event.preventDefault()
+                                        for (i in 0 until count) {
+                                            val file = files[i]
+                                            if (isMediaMime(file.type.unsafeCast<String?>())) handleMediaFile(file)
+                                        }
+                                    }
+                                }
+                                button {
+                                    className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
+                                    title = "Emoji"
+                                    onClick = { setEmojiOpen(!emojiOpen) }
+                                    icon(Ic.EmojiEmotions)
+                                }
+                                button {
+                                    className = ClassName("dm-composer-btn send")
+                                    title = "Send"
+                                    disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
+                                    onMouseDown = { e -> e.preventDefault() }
+                                    onClick = { sendReply() }
+                                    if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
+                                }
+                                if (emojiOpen) {
+                                    div {
+                                        className = ClassName("emoji-overlay")
+                                        onClick = { setEmojiOpen(false) }
+                                        EmojiPicker {
+                                            onPick = { emoji ->
+                                                insertAtCursor(emoji)
+                                                setEmojiOpen(false)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
             // Thread message context menu: quick reactions, copy text, delete (own message).

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -86,6 +86,9 @@ external interface ThreadsScreenProps : Props {
     var route: GroupRoute
     var group: GroupMetadata
     var onNavigate: (GroupRoute) -> Unit
+
+    /** Mobile-only: opens the groups-sidebar drawer (the ≡ in the page header). */
+    var onOpenDrawer: () -> Unit
 }
 
 /**
@@ -214,285 +217,314 @@ val ThreadsScreen =
         div {
             className = ClassName(if (route.threadRootId != null) "threads-page detail-open" else "threads-page")
 
-            // ---- Threads list pane: always mounted. On desktop the open thread docks beside
-            // it (Discord-style split); on mobile .detail-open hides this pane instead. ----
+            // Page header: group identity over the whole pane, mirroring the chat header
+            // (drawer ≡ on mobile, avatar + name).
             div {
-                className = ClassName("threads-list-pane")
+                className = ClassName("chat-header")
+                button {
+                    className = ClassName("chat-icon-btn chat-drawer-btn")
+                    onClick = { props.onOpenDrawer() }
+                    icon(Ic.Menu)
+                }
                 div {
-                    className = ClassName("threads-header")
-                    span {
-                        className = ClassName("threads-title")
-                        +"Threads"
+                    className = ClassName("chat-header-title")
+                    WebAvatar {
+                        url = props.group.picture
+                        seed = props.group.id
+                        kind = AvatarKind.GROUP
+                        this.name = props.group.name?.takeIf { it.isNotBlank() } ?: "#${props.group.id.take(8)}"
+                        cls = "chat-header-icon"
                     }
-                    button {
-                        className = ClassName("btn-primary thread-new-btn")
-                        onClick = { setComposing(true) }
-                        icon(Ic.Forum)
-                        span { +"New thread" }
+                    div {
+                        className = ClassName("chat-header-name")
+                        +(props.group.name?.takeIf { it.isNotBlank() } ?: "#${props.group.id.take(8)}")
                     }
                 }
+            }
 
-                when {
-                    isLoading && threads.isEmpty() ->
-                        div {
-                            className = ClassName("threads-empty")
-                            +"Loading threads..."
+            div {
+                className = ClassName("threads-body")
+
+                // ---- Threads list pane: always mounted. On desktop the open thread docks beside
+                // it (Discord-style split); on mobile .detail-open hides this pane instead. ----
+                div {
+                    className = ClassName("threads-list-pane")
+                    div {
+                        className = ClassName("threads-header")
+                        span {
+                            className = ClassName("threads-title")
+                            +"Threads"
                         }
-                    threads.isEmpty() ->
-                        div {
-                            className = ClassName("threads-empty")
-                            +"No threads yet. Start the first one."
+                        button {
+                            className = ClassName("btn-primary thread-new-btn")
+                            onClick = { setComposing(true) }
+                            icon(Ic.Forum)
+                            span { +"New thread" }
                         }
-                    else ->
-                        div {
-                            className = ClassName("thread-list")
-                            threads.forEach { t ->
-                                button {
-                                    key = t.rootId
-                                    className = ClassName(if (t.rootId == route.threadRootId) "thread-card active" else "thread-card")
-                                    onClick = { props.onNavigate(route.copy(threadRootId = t.rootId)) }
-                                    WebAvatar {
-                                        url = userMetadata[t.authorPubkey]?.picture
-                                        seed = t.authorPubkey
-                                        this.name = threadDisplayName(t.authorPubkey, userMetadata[t.authorPubkey])
-                                        kind = AvatarKind.USER
-                                        cls = "thread-card-avatar"
-                                    }
-                                    div {
-                                        className = ClassName("thread-card-main")
-                                        span {
-                                            className = ClassName("thread-card-title")
-                                            +t.title
-                                        }
-                                        if (t.preview.isNotBlank()) {
-                                            span {
-                                                className = ClassName("thread-card-preview")
-                                                +t.preview
-                                            }
+                    }
+
+                    when {
+                        isLoading && threads.isEmpty() ->
+                            div {
+                                className = ClassName("threads-empty")
+                                +"Loading threads..."
+                            }
+                        threads.isEmpty() ->
+                            div {
+                                className = ClassName("threads-empty")
+                                +"No threads yet. Start the first one."
+                            }
+                        else ->
+                            div {
+                                className = ClassName("thread-list")
+                                threads.forEach { t ->
+                                    button {
+                                        key = t.rootId
+                                        className = ClassName(if (t.rootId == route.threadRootId) "thread-card active" else "thread-card")
+                                        onClick = { props.onNavigate(route.copy(threadRootId = t.rootId)) }
+                                        WebAvatar {
+                                            url = userMetadata[t.authorPubkey]?.picture
+                                            seed = t.authorPubkey
+                                            this.name = threadDisplayName(t.authorPubkey, userMetadata[t.authorPubkey])
+                                            kind = AvatarKind.USER
+                                            cls = "thread-card-avatar"
                                         }
                                         div {
-                                            className = ClassName("thread-card-meta")
-                                            // Top reactions on the root, then author / replies / publication date.
-                                            topReactionChips(reactions[t.rootId] ?: emptyMap()).forEach { chip ->
+                                            className = ClassName("thread-card-main")
+                                            span {
+                                                className = ClassName("thread-card-title")
+                                                +t.title
+                                            }
+                                            if (t.preview.isNotBlank()) {
                                                 span {
-                                                    className = ClassName("thread-card-chip")
-                                                    if (!chip.emojiUrl.isNullOrBlank()) {
-                                                        img {
-                                                            className = ClassName("reaction-emoji")
-                                                            src = chip.emojiUrl
-                                                            alt = chip.emoji
-                                                        }
-                                                    } else {
-                                                        +chip.emoji
-                                                    }
-                                                    span {
-                                                        className = ClassName("thread-card-chip-count")
-                                                        +"${chip.count}"
-                                                    }
+                                                    className = ClassName("thread-card-preview")
+                                                    +t.preview
                                                 }
                                             }
-                                            +threadDisplayName(t.authorPubkey, userMetadata[t.authorPubkey])
-                                            span {
-                                                className = ClassName("thread-card-dot")
-                                                +"·"
+                                            div {
+                                                className = ClassName("thread-card-meta")
+                                                // Top reactions on the root, then author / replies / publication date.
+                                                topReactionChips(reactions[t.rootId] ?: emptyMap()).forEach { chip ->
+                                                    span {
+                                                        className = ClassName("thread-card-chip")
+                                                        if (!chip.emojiUrl.isNullOrBlank()) {
+                                                            img {
+                                                                className = ClassName("reaction-emoji")
+                                                                src = chip.emojiUrl
+                                                                alt = chip.emoji
+                                                            }
+                                                        } else {
+                                                            +chip.emoji
+                                                        }
+                                                        span {
+                                                            className = ClassName("thread-card-chip-count")
+                                                            +"${chip.count}"
+                                                        }
+                                                    }
+                                                }
+                                                +threadDisplayName(t.authorPubkey, userMetadata[t.authorPubkey])
+                                                span {
+                                                    className = ClassName("thread-card-dot")
+                                                    +"·"
+                                                }
+                                                +(if (t.replyCount == 1) "1 reply" else "${t.replyCount} replies")
+                                                span {
+                                                    className = ClassName("thread-card-dot")
+                                                    +"·"
+                                                }
+                                                +getDateLabel(t.createdAt)
                                             }
-                                            +(if (t.replyCount == 1) "1 reply" else "${t.replyCount} replies")
-                                            span {
-                                                className = ClassName("thread-card-dot")
-                                                +"·"
-                                            }
-                                            +getDateLabel(t.createdAt)
                                         }
                                     }
                                 }
                             }
-                        }
-                }
-            }
-
-            if (composing) {
-                Portal {
-                    CreateThreadModal {
-                        onClose = { setComposing(false) }
-                        onCreate = { title, content -> vm.createThread(title, content) }
                     }
                 }
-            }
 
-            if (route.threadRootId != null) {
-                // ---- Open thread: full page on mobile, right dock on desktop ----
-                div {
-                    className = ClassName("thread-detail-pane")
+                if (composing) {
+                    Portal {
+                        CreateThreadModal {
+                            onClose = { setComposing(false) }
+                            onCreate = { title, content -> vm.createThread(title, content) }
+                        }
+                    }
+                }
+
+                if (route.threadRootId != null) {
+                    // ---- Open thread: full page on mobile, right dock on desktop ----
                     div {
-                        className = ClassName("threads-header")
-                        button {
-                            // Mobile only; on desktop the split stays and the X on the right closes.
-                            className = ClassName("icon-btn thread-back")
-                            title = "Back to threads"
-                            onClick = { props.onNavigate(route.copy(threadRootId = null)) }
-                            icon(Ic.ArrowBack)
-                        }
-                        span {
-                            className = ClassName("threads-title")
-                            +"Thread"
-                        }
-                        val ownRoot = openThread?.root
-                        if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
+                        className = ClassName("thread-detail-pane")
+                        div {
+                            className = ClassName("threads-header")
                             button {
-                                className = ClassName("icon-btn")
-                                title = "Delete thread"
-                                onClick = { setDeleteTarget(ownRoot) }
-                                icon(Ic.Delete)
+                                // Mobile only; on desktop the split stays and the X on the right closes.
+                                className = ClassName("icon-btn thread-back")
+                                title = "Back to threads"
+                                onClick = { props.onNavigate(route.copy(threadRootId = null)) }
+                                icon(Ic.ArrowBack)
+                            }
+                            span {
+                                className = ClassName("threads-title")
+                                +"Thread"
+                            }
+                            val ownRoot = openThread?.root
+                            if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
+                                button {
+                                    className = ClassName("icon-btn")
+                                    title = "Delete thread"
+                                    onClick = { setDeleteTarget(ownRoot) }
+                                    icon(Ic.Delete)
+                                }
+                            }
+                            button {
+                                // Desktop only (CSS): closes the docked thread, Discord-style.
+                                className = ClassName("icon-btn thread-close")
+                                title = "Close thread"
+                                onClick = { props.onNavigate(route.copy(threadRootId = null)) }
+                                icon(Ic.Close)
                             }
                         }
-                        button {
-                            // Desktop only (CSS): closes the docked thread, Discord-style.
-                            className = ClassName("icon-btn thread-close")
-                            title = "Close thread"
-                            onClick = { props.onNavigate(route.copy(threadRootId = null)) }
-                            icon(Ic.Close)
-                        }
-                    }
-                    val detail = openThread
-                    if (detail == null) {
-                        div {
-                            className = ClassName("threads-empty")
-                            +"Loading thread..."
-                        }
-                    } else {
-                        // Pending sends for one message: "eventId|emoji" keys -> that message's emojis.
-                        fun pendingFor(id: String) = pendingReactions.filter { it.startsWith("$id|") }.map { it.substringAfter('|') }
-
-                        // Nested replies resolve their lowercase-e parent from the loaded thread.
-                        val messagesById = (detail.replies + detail.root).associateBy { it.id }
-
-                        fun ChildrenBuilder.renderThreadMessage(msg: NostrGroupClient.NostrMessage, isRoot: Boolean) = threadMessage(
-                            msg,
-                            userMetadata,
-                            isRoot = isRoot,
-                            myPubkey,
-                            messageStatus[msg.id],
-                            reactions[msg.id] ?: emptyMap(),
-                            pendingFor(msg.id),
-                            parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
-                            highlighted = msg.id == highlightId,
-                            onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
-                            onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
-                            // A group ref in the body opens that group's chat page.
-                            onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
-                            onRetry = { vm.retrySend(msg.id) },
-                            onDismiss = { vm.dismissFailed(msg.id) },
-                        )
-
-                        div {
-                            className = ClassName("thread-detail-body")
-                            renderThreadMessage(detail.root, isRoot = true)
+                        val detail = openThread
+                        if (detail == null) {
                             div {
-                                className = ClassName("thread-replies-divider")
-                                +(if (detail.replies.size == 1) "1 reply" else "${detail.replies.size} replies")
+                                className = ClassName("threads-empty")
+                                +"Loading thread..."
                             }
-                            detail.replies.forEach { r -> renderThreadMessage(r, isRoot = false) }
-                        }
-                        // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
-                        div {
-                            className = ClassName("dm-composer-wrap")
-                            // Reply chip above the composer while answering a specific message.
-                            replyingTo?.let { target ->
+                        } else {
+                            // Pending sends for one message: "eventId|emoji" keys -> that message's emojis.
+                            fun pendingFor(id: String) = pendingReactions.filter { it.startsWith("$id|") }.map { it.substringAfter('|') }
+
+                            // Nested replies resolve their lowercase-e parent from the loaded thread.
+                            val messagesById = (detail.replies + detail.root).associateBy { it.id }
+
+                            fun ChildrenBuilder.renderThreadMessage(msg: NostrGroupClient.NostrMessage, isRoot: Boolean) = threadMessage(
+                                msg,
+                                userMetadata,
+                                isRoot = isRoot,
+                                myPubkey,
+                                messageStatus[msg.id],
+                                reactions[msg.id] ?: emptyMap(),
+                                pendingFor(msg.id),
+                                parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
+                                highlighted = msg.id == highlightId,
+                                onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
+                                onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
+                                // A group ref in the body opens that group's chat page.
+                                onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
+                                onRetry = { vm.retrySend(msg.id) },
+                                onDismiss = { vm.dismissFailed(msg.id) },
+                            )
+
+                            div {
+                                className = ClassName("thread-detail-body")
+                                renderThreadMessage(detail.root, isRoot = true)
                                 div {
-                                    className = ClassName("composer-reply")
-                                    icon(Ic.Reply)
-                                    span {
-                                        className = ClassName("composer-reply-label")
-                                        +"Replying to"
-                                    }
-                                    span {
-                                        className = ClassName("composer-reply-name")
-                                        +threadDisplayName(target.pubkey, userMetadata[target.pubkey])
-                                    }
-                                    target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.let { preview ->
+                                    className = ClassName("thread-replies-divider")
+                                    +(if (detail.replies.size == 1) "1 reply" else "${detail.replies.size} replies")
+                                }
+                                detail.replies.forEach { r -> renderThreadMessage(r, isRoot = false) }
+                            }
+                            // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
+                            div {
+                                className = ClassName("dm-composer-wrap")
+                                // Reply chip above the composer while answering a specific message.
+                                replyingTo?.let { target ->
+                                    div {
+                                        className = ClassName("composer-reply")
+                                        icon(Ic.Reply)
                                         span {
-                                            className = ClassName("composer-reply-text")
-                                            +preview
+                                            className = ClassName("composer-reply-label")
+                                            +"Replying to"
+                                        }
+                                        span {
+                                            className = ClassName("composer-reply-name")
+                                            +threadDisplayName(target.pubkey, userMetadata[target.pubkey])
+                                        }
+                                        target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.let { preview ->
+                                            span {
+                                                className = ClassName("composer-reply-text")
+                                                +preview
+                                            }
+                                        }
+                                        button {
+                                            className = ClassName("composer-reply-close")
+                                            onClick = { setReplyingTo(null) }
+                                            icon(Ic.Close)
+                                        }
+                                    }
+                                }
+                                div {
+                                    className = ClassName("dm-composer")
+                                    UploadButton {
+                                        cls = "dm-composer-btn"
+                                        icon = Ic.AttachFile
+                                        busy = uploadCount > 0
+                                        onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
+                                        onPickerClosed = { composerInputRef.current?.focus() }
+                                        onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
+                                        onError = { setUploadError(it) }
+                                    }
+                                    textarea {
+                                        ref = composerInputRef
+                                        rows = 1
+                                        value = reply
+                                        placeholder = "Write a reply..."
+                                        onChange = { setReply((it.target as HTMLTextAreaElement).value) }
+                                        onKeyDown = { e ->
+                                            if (e.key == "Enter" && !e.shiftKey) {
+                                                e.preventDefault()
+                                                sendReply()
+                                            }
+                                        }
+                                        onPaste = { event ->
+                                            val items = event.asDynamic().clipboardData?.items
+                                            val count = (items?.length as? Int) ?: 0
+                                            for (i in 0 until count) {
+                                                val item = items[i]
+                                                val type = item.type.unsafeCast<String?>()
+                                                if (item.kind == "file" && isMediaMime(type)) {
+                                                    val file = item.getAsFile()
+                                                    if (file != null) {
+                                                        event.preventDefault()
+                                                        handleMediaFile(file)
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        onDragOver = { it.preventDefault() }
+                                        onDrop = { event ->
+                                            val files = event.asDynamic().dataTransfer?.files
+                                            val count = (files?.length as? Int) ?: 0
+                                            if (count > 0) event.preventDefault()
+                                            for (i in 0 until count) {
+                                                val file = files[i]
+                                                if (isMediaMime(file.type.unsafeCast<String?>())) handleMediaFile(file)
+                                            }
                                         }
                                     }
                                     button {
-                                        className = ClassName("composer-reply-close")
-                                        onClick = { setReplyingTo(null) }
-                                        icon(Ic.Close)
+                                        className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
+                                        title = "Emoji"
+                                        onClick = { setEmojiOpen(!emojiOpen) }
+                                        icon(Ic.EmojiEmotions)
                                     }
-                                }
-                            }
-                            div {
-                                className = ClassName("dm-composer")
-                                UploadButton {
-                                    cls = "dm-composer-btn"
-                                    icon = Ic.AttachFile
-                                    busy = uploadCount > 0
-                                    onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
-                                    onPickerClosed = { composerInputRef.current?.focus() }
-                                    onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
-                                    onError = { setUploadError(it) }
-                                }
-                                textarea {
-                                    ref = composerInputRef
-                                    rows = 1
-                                    value = reply
-                                    placeholder = "Write a reply..."
-                                    onChange = { setReply((it.target as HTMLTextAreaElement).value) }
-                                    onKeyDown = { e ->
-                                        if (e.key == "Enter" && !e.shiftKey) {
-                                            e.preventDefault()
-                                            sendReply()
-                                        }
+                                    button {
+                                        className = ClassName("dm-composer-btn send")
+                                        title = "Send"
+                                        disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
+                                        onMouseDown = { e -> e.preventDefault() }
+                                        onClick = { sendReply() }
+                                        if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
                                     }
-                                    onPaste = { event ->
-                                        val items = event.asDynamic().clipboardData?.items
-                                        val count = (items?.length as? Int) ?: 0
-                                        for (i in 0 until count) {
-                                            val item = items[i]
-                                            val type = item.type.unsafeCast<String?>()
-                                            if (item.kind == "file" && isMediaMime(type)) {
-                                                val file = item.getAsFile()
-                                                if (file != null) {
-                                                    event.preventDefault()
-                                                    handleMediaFile(file)
+                                    if (emojiOpen) {
+                                        div {
+                                            className = ClassName("emoji-overlay")
+                                            onClick = { setEmojiOpen(false) }
+                                            EmojiPicker {
+                                                onPick = { emoji ->
+                                                    insertAtCursor(emoji)
+                                                    setEmojiOpen(false)
                                                 }
-                                            }
-                                        }
-                                    }
-                                    onDragOver = { it.preventDefault() }
-                                    onDrop = { event ->
-                                        val files = event.asDynamic().dataTransfer?.files
-                                        val count = (files?.length as? Int) ?: 0
-                                        if (count > 0) event.preventDefault()
-                                        for (i in 0 until count) {
-                                            val file = files[i]
-                                            if (isMediaMime(file.type.unsafeCast<String?>())) handleMediaFile(file)
-                                        }
-                                    }
-                                }
-                                button {
-                                    className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
-                                    title = "Emoji"
-                                    onClick = { setEmojiOpen(!emojiOpen) }
-                                    icon(Ic.EmojiEmotions)
-                                }
-                                button {
-                                    className = ClassName("dm-composer-btn send")
-                                    title = "Send"
-                                    disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
-                                    onMouseDown = { e -> e.preventDefault() }
-                                    onClick = { sendReply() }
-                                    if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
-                                }
-                                if (emojiOpen) {
-                                    div {
-                                        className = ClassName("emoji-overlay")
-                                        onClick = { setEmojiOpen(false) }
-                                        EmojiPicker {
-                                            onPick = { emoji ->
-                                                insertAtCursor(emoji)
-                                                setEmojiOpen(false)
                                             }
                                         }
                                     }
@@ -502,6 +534,7 @@ val ThreadsScreen =
                     }
                 }
             }
+
             // Thread message context menu: quick reactions, copy text, delete (own message).
             ctxMenu?.let { m ->
                 div {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -349,7 +349,13 @@ val ThreadsScreen =
                     Portal {
                         CreateThreadModal {
                             onClose = { setComposing(false) }
-                            onCreate = { title, content, shareToChat -> vm.createThread(title, content, shareToChat) }
+                            onCreate = { title, content, shareToChat ->
+                                // Open the new thread right away (Discord parity; the optimistic
+                                // root is already in the store, so the detail renders instantly).
+                                vm.createThread(title, content, shareToChat) { rootId ->
+                                    props.onNavigate(route.copy(threadRootId = rootId))
+                                }
+                            }
                         }
                     }
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -13,6 +13,7 @@ import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.threadShareLink
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
+import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.threadTitle
 import org.nostr.nostrord.ui.screens.group.topReactionChips
@@ -127,8 +128,14 @@ val ThreadsScreen =
             el.style.visibility = "visible"
         }
 
+        // Message being answered by the composer (context-menu Reply); null posts top-level.
+        val (replyingTo, setReplyingTo) = useState<NostrGroupClient.NostrMessage?> { null }
+
         // Keep the open thread synced with the URL (#/g/<relay>/<id>/threads/<rootId>).
-        useEffect(route.threadRootId) { vm.openThread(route.threadRootId) }
+        useEffect(route.threadRootId) {
+            vm.openThread(route.threadRootId)
+            setReplyingTo(null)
+        }
 
         val (composing, setComposing) = useState { false }
         val (reply, setReply) = useState { "" }
@@ -160,8 +167,10 @@ val ThreadsScreen =
             setSending(true)
             vm.sendReply(
                 reply,
+                parent = replyingTo,
                 onSuccess = {
                     setReply("")
+                    setReplyingTo(null)
                     setSending(false)
                 },
                 onFailure = { setSending(false) },
@@ -221,6 +230,9 @@ val ThreadsScreen =
                     // Pending sends for one message: "eventId|emoji" keys -> that message's emojis.
                     fun pendingFor(id: String) = pendingReactions.filter { it.startsWith("$id|") }.map { it.substringAfter('|') }
 
+                    // Nested replies resolve their lowercase-e parent from the loaded thread.
+                    val messagesById = (detail.replies + detail.root).associateBy { it.id }
+
                     fun ChildrenBuilder.renderThreadMessage(msg: NostrGroupClient.NostrMessage, isRoot: Boolean) = threadMessage(
                         msg,
                         userMetadata,
@@ -229,6 +241,7 @@ val ThreadsScreen =
                         messageStatus[msg.id],
                         reactions[msg.id] ?: emptyMap(),
                         pendingFor(msg.id),
+                        parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
                         onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                         onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
                         // A group ref in the body opens that group's chat page.
@@ -249,6 +262,32 @@ val ThreadsScreen =
                     // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
                     div {
                         className = ClassName("dm-composer-wrap")
+                        // Reply chip above the composer while answering a specific message.
+                        replyingTo?.let { target ->
+                            div {
+                                className = ClassName("composer-reply")
+                                icon(Ic.Reply)
+                                span {
+                                    className = ClassName("composer-reply-label")
+                                    +"Replying to"
+                                }
+                                span {
+                                    className = ClassName("composer-reply-name")
+                                    +threadDisplayName(target.pubkey, userMetadata[target.pubkey])
+                                }
+                                target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.let { preview ->
+                                    span {
+                                        className = ClassName("composer-reply-text")
+                                        +preview
+                                    }
+                                }
+                                button {
+                                    className = ClassName("composer-reply-close")
+                                    onClick = { setReplyingTo(null) }
+                                    icon(Ic.Close)
+                                }
+                            }
+                        }
                         div {
                             className = ClassName("dm-composer")
                             UploadButton {
@@ -465,6 +504,12 @@ val ThreadsScreen =
                         }
                     }
                     div { className = ClassName("ctx-divider") }
+                    ctxItem(Ic.Reply, "Reply") {
+                        setReplyingTo(m.msg)
+                        setCtxMenu(null)
+                        composerInputRef.current?.focus()
+                    }
+                    div { className = ClassName("ctx-divider") }
                     ctxItem(Ic.ContentCopy, "Copy text") {
                         copyToClipboard(m.msg.content)
                         setCtxMenu(null)
@@ -566,6 +611,7 @@ private fun ChildrenBuilder.threadMessage(
     status: GroupManager.MessageStatus?,
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: List<String>,
+    parentMsg: NostrGroupClient.NostrMessage?,
     onReact: (String) -> Unit,
     onOpenMenu: (Double, Double) -> Unit,
     onGroupRef: (String, String?) -> Unit,
@@ -607,6 +653,27 @@ private fun ChildrenBuilder.threadMessage(
                 h2 {
                     className = ClassName("thread-msg-title")
                     +msg.threadTitle()
+                }
+            }
+            // Nested reply: quote the answered message above the body (placeholder when the
+            // parent has not loaded), like chat's reply preview.
+            if (!isRoot && (parentMsg != null || msg.threadParentIdTag() != null)) {
+                div {
+                    className = ClassName("msg-reply")
+                    div { className = ClassName("msg-reply-bar") }
+                    div {
+                        className = ClassName("msg-reply-content")
+                        div {
+                            className = ClassName("msg-reply-author")
+                            +(parentMsg?.let { threadDisplayName(it.pubkey, userMetadata[it.pubkey]) } ?: "Replying to a message...")
+                        }
+                        parentMsg?.let { p ->
+                            div {
+                                className = ClassName("msg-reply-text")
+                                +p.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }.orEmpty()
+                            }
+                        }
+                    }
                 }
             }
             div {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -29,6 +29,7 @@ import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.Portal
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.components.confirmDialog
 import org.nostr.nostrord.web.components.copyToClipboard
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.messageSendStatus
@@ -108,6 +109,7 @@ val ThreadsScreen =
         val reactions = useStateFlow(vm.reactions)
         val pendingReactions = useStateFlow(vm.pendingReactions)
         val reactionError = useStateFlow(vm.reactionError)
+        val deleteError = useStateFlow(vm.deleteError)
         val myPubkey = vm.getPublicKey()
 
         // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
@@ -134,6 +136,9 @@ val ThreadsScreen =
 
         // Message being answered by the composer (context-menu Reply); null posts top-level.
         val (replyingTo, setReplyingTo) = useState<NostrGroupClient.NostrMessage?> { null }
+
+        // Message pending delete confirmation (the root or any reply; header or menu).
+        val (deleteTarget, setDeleteTarget) = useState<NostrGroupClient.NostrMessage?> { null }
 
         // Deep-link target (?e=): scroll to and flash the message once the thread loads.
         val (highlightId, setHighlightId) = useState<String?> { null }
@@ -228,12 +233,7 @@ val ThreadsScreen =
                         button {
                             className = ClassName("icon-btn")
                             title = "Delete thread"
-                            onClick = {
-                                if (window.confirm("Delete this thread? This cannot be undone.")) {
-                                    vm.deleteThread(ownRoot.id)
-                                    props.onNavigate(route.copy(threadRootId = null))
-                                }
-                            }
+                            onClick = { setDeleteTarget(ownRoot) }
                             icon(Ic.Delete)
                         }
                     }
@@ -551,12 +551,7 @@ val ThreadsScreen =
                         div { className = ClassName("ctx-divider") }
                         ctxItem(Ic.Delete, "Delete message", danger = true) {
                             setCtxMenu(null)
-                            val isRoot = m.msg.id == route.threadRootId
-                            val prompt = if (isRoot) "Delete this thread? This cannot be undone." else "Delete this message? This cannot be undone."
-                            if (window.confirm(prompt)) {
-                                vm.deleteThread(m.msg.id)
-                                if (isRoot) props.onNavigate(route.copy(threadRootId = null))
-                            }
+                            setDeleteTarget(m.msg)
                         }
                     }
                 }
@@ -576,6 +571,27 @@ val ThreadsScreen =
                         }
                     }
                 }
+            }
+            // Delete confirm modal (chat parity: destructive confirm, no window.confirm).
+            deleteTarget?.let { target ->
+                val isRoot = target.id == route.threadRootId
+                confirmDialog(
+                    title = if (isRoot) "Delete Thread" else "Delete Message",
+                    body = "Are you sure you want to delete this ${if (isRoot) "thread" else "message"}? This action cannot be undone.",
+                    confirmLabel = "Delete",
+                    danger = true,
+                    onCancel = { setDeleteTarget(null) },
+                    onConfirm = {
+                        setDeleteTarget(null)
+                        // A relay rejection surfaces via vm.deleteError below.
+                        vm.deleteThread(target.id)
+                        if (isRoot) props.onNavigate(route.copy(threadRootId = null))
+                    },
+                )
+            }
+            // Relay rejected the kind:5/9005 - show the reason (chat parity).
+            deleteError?.let { err ->
+                deleteMessageErrorDialog(err) { vm.clearDeleteError() }
             }
             reactionError?.let { err ->
                 reactionErrorDialog(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -441,7 +441,16 @@ private fun ChildrenBuilder.threadMessage(
             }
             div {
                 className = ClassName("thread-msg-content")
-                +msg.content
+                // Same rich renderer as chat: media embeds, links, mentions, custom emoji, markdown.
+                renderMessageContent(
+                    msg.content,
+                    msg.tags,
+                    userMetadata,
+                    emptyMap(),
+                    onUser = {},
+                    onEventRef = {},
+                    onGroupRef = { _, _ -> },
+                )
                 // Inline send-state icon (clock/check) so no extra line shifts the list.
                 if (myPubkey != null && myPubkey == msg.pubkey) {
                     sendStateIcon(status)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -23,6 +23,7 @@ import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.messageSendStatus
+import org.nostr.nostrord.web.components.reactionBadges
 import org.nostr.nostrord.web.components.sendStateIcon
 import org.nostr.nostrord.web.components.uploadBlob
 import org.nostr.nostrord.web.modals.CreateThreadModal
@@ -82,7 +83,13 @@ val ThreadsScreen =
         val openThread = useStateFlow(vm.openThread)
         val userMetadata = useStateFlow(vm.userMetadata)
         val messageStatus = useStateFlow(vm.messageStatus)
+        val reactions = useStateFlow(vm.reactions)
+        val pendingReactions = useStateFlow(vm.pendingReactions)
+        val reactionError = useStateFlow(vm.reactionError)
         val myPubkey = vm.getPublicKey()
+
+        // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
+        val (reactingTo, setReactingTo) = useState<Pair<String, String>?> { null }
 
         // Keep the open thread synced with the URL (#/g/<relay>/<id>/threads/<rootId>).
         useEffect(route.threadRootId) { vm.openThread(route.threadRootId) }
@@ -175,32 +182,31 @@ val ThreadsScreen =
                         +"Loading thread..."
                     }
                 } else {
+                    // Pending sends for one message: "eventId|emoji" keys -> that message's emojis.
+                    fun pendingFor(id: String) = pendingReactions.filter { it.startsWith("$id|") }.map { it.substringAfter('|') }
+
+                    fun ChildrenBuilder.renderThreadMessage(msg: NostrGroupClient.NostrMessage, isRoot: Boolean) = threadMessage(
+                        msg,
+                        userMetadata,
+                        isRoot = isRoot,
+                        myPubkey,
+                        messageStatus[msg.id],
+                        reactions[msg.id] ?: emptyMap(),
+                        pendingFor(msg.id),
+                        onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
+                        onOpenPicker = { setReactingTo(msg.id to msg.pubkey) },
+                        onRetry = { vm.retrySend(msg.id) },
+                        onDismiss = { vm.dismissFailed(msg.id) },
+                    )
+
                     div {
                         className = ClassName("thread-detail-body")
-                        threadMessage(
-                            detail.root,
-                            userMetadata,
-                            isRoot = true,
-                            myPubkey,
-                            messageStatus[detail.root.id],
-                            { vm.retrySend(detail.root.id) },
-                            { vm.dismissFailed(detail.root.id) },
-                        )
+                        renderThreadMessage(detail.root, isRoot = true)
                         div {
                             className = ClassName("thread-replies-divider")
                             +(if (detail.replies.size == 1) "1 reply" else "${detail.replies.size} replies")
                         }
-                        detail.replies.forEach { r ->
-                            threadMessage(
-                                r,
-                                userMetadata,
-                                isRoot = false,
-                                myPubkey,
-                                messageStatus[r.id],
-                                { vm.retrySend(r.id) },
-                                { vm.dismissFailed(r.id) },
-                            )
-                        }
+                        detail.replies.forEach { r -> renderThreadMessage(r, isRoot = false) }
                     }
                     // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
                     div {
@@ -366,6 +372,31 @@ val ThreadsScreen =
                         }
                 }
             }
+            // Full emoji picker for a reaction (opened by the add-reaction button).
+            reactingTo?.let { (targetEventId, targetPubkey) ->
+                Portal {
+                    div {
+                        className = ClassName("emoji-overlay")
+                        onClick = { setReactingTo(null) }
+                        EmojiPicker {
+                            onPick = { emoji ->
+                                vm.sendReaction(targetEventId, targetPubkey, emoji)
+                                setReactingTo(null)
+                            }
+                        }
+                    }
+                }
+            }
+            reactionError?.let { err ->
+                reactionErrorDialog(
+                    err,
+                    onDismiss = { vm.clearReactionError() },
+                    onJoin = {
+                        vm.clearReactionError()
+                        vm.joinGroup()
+                    },
+                )
+            }
             uploadError?.let { uploadErrorDialog(it) { setUploadError(null) } }
         }
     }
@@ -408,6 +439,10 @@ private fun ChildrenBuilder.threadMessage(
     isRoot: Boolean,
     myPubkey: String?,
     status: GroupManager.MessageStatus?,
+    reactions: Map<String, GroupManager.ReactionInfo>,
+    pendingEmojis: List<String>,
+    onReact: (String) -> Unit,
+    onOpenPicker: () -> Unit,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -458,6 +493,18 @@ private fun ChildrenBuilder.threadMessage(
             }
             if (myPubkey != null && myPubkey == msg.pubkey) {
                 messageSendStatus(status, onRetry, onDismiss)
+            }
+            // Reaction badges + the always-visible add-reaction affordance (threads have no
+            // hover-action row like chat, so the button is the way in to the full picker).
+            div {
+                className = ClassName("thread-msg-react-row")
+                reactionBadges(reactions, pendingEmojis, myPubkey, userMetadata, onReact)
+                button {
+                    className = ClassName("thread-react-btn")
+                    title = "Add reaction"
+                    onClick = { onOpenPicker() }
+                    icon(Ic.EmojiEmotions)
+                }
             }
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -7,9 +7,13 @@ import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.toEventJson
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.navigation.GroupRoute
+import org.nostr.nostrord.ui.navigation.threadShareLink
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
+import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.threadTitle
 import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.Result
@@ -463,6 +467,19 @@ val ThreadsScreen =
                     div { className = ClassName("ctx-divider") }
                     ctxItem(Ic.ContentCopy, "Copy text") {
                         copyToClipboard(m.msg.content)
+                        setCtxMenu(null)
+                    }
+                    ctxItem(Ic.Link, "Copy event link") {
+                        // A reply links to its thread page too (the root id from the E tag).
+                        copyToClipboard(threadShareLink(route.relayUrl, route.groupId, m.msg.threadRootIdTag() ?: m.msg.id))
+                        setCtxMenu(null)
+                    }
+                    ctxItem(Ic.Code, "Copy nevent") {
+                        copyToClipboard(Nip19.encodeNevent(m.msg.id, relays = listOf(route.relayUrl), authorHex = m.msg.pubkey, kind = m.msg.kind))
+                        setCtxMenu(null)
+                    }
+                    ctxItem(Ic.Code, "Copy event JSON") {
+                        copyToClipboard(m.msg.toEventJson())
                         setCtxMenu(null)
                     }
                     if (myPubkey != null && myPubkey == m.msg.pubkey) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -345,7 +345,7 @@ val ThreadsScreen =
                     Portal {
                         CreateThreadModal {
                             onClose = { setComposing(false) }
-                            onCreate = { title, content -> vm.createThread(title, content) }
+                            onCreate = { title, content, shareToChat -> vm.createThread(title, content, shareToChat) }
                         }
                     }
                 }
@@ -575,6 +575,13 @@ val ThreadsScreen =
                         setReplyingTo(m.msg)
                         setCtxMenu(null)
                         composerInputRef.current?.focus()
+                    }
+                    // Announce the thread in the group chat (kind:9 with the root's nevent).
+                    if (m.msg.kind == 11) {
+                        ctxItem(Ic.Forum, "Share to chat") {
+                            vm.shareThreadToChat(m.msg)
+                            setCtxMenu(null)
+                        }
                     }
                     div { className = ClassName("ctx-divider") }
                     ctxItem(Ic.ContentCopy, "Copy text") {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2319,37 +2319,21 @@ body {
     word-break: break-word;
 }
 
-/* Reaction badges + add-reaction button under a thread message. */
-.thread-msg-react-row {
-    display: flex;
-    align-items: center;
-    gap: var(--space-xs);
-    margin-top: 2px;
-}
-
-.thread-react-btn {
+/* Compact emoji+count chip on a thread list card (top reactions on the root). */
+.thread-card-chip {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    width: 24px;
-    height: 24px;
-    padding: 0;
-    border: none;
+    gap: 4px;
+    padding: 1px 6px;
     border-radius: var(--radius-sm);
-    background: none;
-    color: var(--color-text-muted);
-    cursor: pointer;
-    opacity: 0.55;
+    background: var(--color-surface-variant);
+    font-size: 12px;
+    line-height: 1.4;
 }
 
-.thread-react-btn:hover {
-    background: var(--color-hover);
-    opacity: 1;
-}
-
-.thread-react-btn svg {
-    width: 16px;
-    height: 16px;
+.thread-card-chip-count {
+    font-size: 11px;
+    color: var(--color-text-secondary);
 }
 
 .thread-replies-divider {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2396,6 +2396,20 @@ body {
     word-break: break-word;
 }
 
+/* Avatar and author name open the profile modal. */
+.thread-msg-avatar-btn {
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.thread-msg-author {
+    cursor: pointer;
+}
+
+.thread-msg-author:hover {
+    text-decoration: underline;
+}
+
 /* "Share to chat" opt-in in the create-thread modal. */
 .thread-share-check {
     display: flex;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2276,6 +2276,16 @@ body {
     display: flex;
     gap: var(--space-md);
     padding: var(--space-sm) 0;
+    border-radius: var(--radius-md);
+}
+
+.thread-msg:hover {
+    background: var(--color-message-hover);
+}
+
+/* Deep-link target (?e=): same flash as the chat's .msg.highlight. */
+.thread-msg.highlight {
+    animation: msg-flash 2.4s ease-out;
 }
 
 .thread-msg-root {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2154,9 +2154,17 @@ body {
    Compose ThreadsScreen and the prototype's GroupPanels.ThreadsPanel / ThreadPanel, as a page. */
 .threads-page {
     display: flex;
+    flex-direction: column;
     min-height: 0;
     height: 100%;
     background: var(--color-background);
+}
+
+/* The panes row under the page header. */
+.threads-body {
+    display: flex;
+    flex: 1;
+    min-height: 0;
 }
 
 /* Discord-style split: the list keeps living on the left, the open thread docks right. */
@@ -2166,7 +2174,6 @@ body {
     flex-direction: column;
     min-height: 0;
     min-width: 0;
-    height: 100%;
 }
 
 .threads-list-pane {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -4838,6 +4838,29 @@ body {
     color: var(--color-text-secondary);
 }
 
+/* Field label with a trailing control (e.g. the attach button in CreateThreadModal). */
+.field-label-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.thread-compose-attach {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    cursor: pointer;
+}
+
+.thread-compose-attach:hover {
+    background: var(--color-hover);
+    color: var(--color-text-content);
+}
+
 .field-label.danger {
     color: var(--color-error);
 }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2396,6 +2396,67 @@ body {
     word-break: break-word;
 }
 
+/* Quoted kind:11 thread card (Share to chat announcement / pasted thread nevent). */
+.thread-quote-card {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-width: 380px;
+    margin-top: var(--space-xs);
+    padding: var(--space-sm) var(--space-md);
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+}
+
+.thread-quote-card.static {
+    cursor: default;
+}
+
+.thread-quote-card:not(.static):hover {
+    background: var(--color-hover);
+}
+
+.thread-quote-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    font-size: 11px;
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.thread-quote-head svg {
+    width: 14px;
+    height: 14px;
+}
+
+.thread-quote-group {
+    font-weight: 400;
+    color: var(--color-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.thread-quote-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.thread-quote-snippet {
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
 /* Avatar and author name open the profile modal. */
 .thread-msg-avatar-btn {
     cursor: pointer;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2153,11 +2153,21 @@ body {
 /* Threads pane (forum-style kind:11 root + NIP-22 kind:1111 replies). Web mirror of the
    Compose ThreadsScreen and the prototype's GroupPanels.ThreadsPanel / ThreadPanel, as a page. */
 .threads-page {
+    /* .chat-header consumes this; matches .chat-main's single-source value so the
+       threads page header sizes exactly like the chat one. */
+    --chat-header-height: 48px;
     display: flex;
     flex-direction: column;
     min-height: 0;
     height: 100%;
     background: var(--color-background);
+}
+
+/* The page header is mobile-only: on desktop the sidebar already names the group. */
+@media (min-width: 768px) {
+    .threads-page > .chat-header {
+        display: none;
+    }
 }
 
 /* The panes row under the page header. */

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2319,6 +2319,39 @@ body {
     word-break: break-word;
 }
 
+/* Reaction badges + add-reaction button under a thread message. */
+.thread-msg-react-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-top: 2px;
+}
+
+.thread-react-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    padding: 0;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    opacity: 0.55;
+}
+
+.thread-react-btn:hover {
+    background: var(--color-hover);
+    opacity: 1;
+}
+
+.thread-react-btn svg {
+    width: 16px;
+    height: 16px;
+}
+
 .thread-replies-divider {
     margin: var(--space-md) 0;
     padding-bottom: var(--space-xs);

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2154,10 +2154,60 @@ body {
    Compose ThreadsScreen and the prototype's GroupPanels.ThreadsPanel / ThreadPanel, as a page. */
 .threads-page {
     display: flex;
-    flex-direction: column;
     min-height: 0;
     height: 100%;
     background: var(--color-background);
+}
+
+/* Discord-style split: the list keeps living on the left, the open thread docks right. */
+.threads-list-pane,
+.thread-detail-pane {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    min-width: 0;
+    height: 100%;
+}
+
+.threads-list-pane {
+    flex: 1;
+}
+
+.thread-detail-pane {
+    flex: 1.2;
+    border-left: 1px solid var(--color-divider);
+}
+
+/* Desktop: the docked thread closes via the X on the right, not the back arrow. */
+.thread-back {
+    display: none;
+}
+
+.thread-close {
+    margin-left: auto;
+}
+
+.thread-card.active {
+    background: var(--color-message-hover);
+}
+
+@media (max-width: 767px) {
+    /* Mobile keeps the swap behavior: the open thread replaces the list. */
+    .threads-page.detail-open .threads-list-pane {
+        display: none;
+    }
+
+    .thread-detail-pane {
+        border-left: none;
+    }
+
+    .thread-back {
+        display: inline-flex;
+    }
+
+    .thread-close {
+        display: none;
+    }
 }
 
 .threads-header {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2396,6 +2396,18 @@ body {
     word-break: break-word;
 }
 
+/* "Share to chat" opt-in in the create-thread modal. */
+.thread-share-check {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    margin-top: var(--space-sm);
+    font-size: 13px;
+    color: var(--color-text-secondary);
+    cursor: pointer;
+    user-select: none;
+}
+
 /* Compact emoji+count chip on a thread list card (top reactions on the root). */
 .thread-card-chip {
     display: inline-flex;


### PR DESCRIPTION
Brings the Threads pages up to chat parity on both platforms (Compose + web), driven by device testing and issue #221. Thread messages render through the chat's rich content pipeline, get reactions with the full badge/picker/error treatment, a context menu (quick reactions, reply, share to chat, copy text/link/nevent/JSON, delete), per-message hover, profile modal on avatars/mentions, and message-targeted share links that scroll + flash on open. Threads persist in the message cache (cold/offline opens render instantly), creating a thread opens it right away, and on desktop an open thread docks beside the list, Discord-style, under a mobile-only group page header.

| Area | What changed |
| --- | --- |
| Content | `MessageContent` / `renderMessageContent` in thread bodies: media, links, mentions, custom emoji, markdown; group refs navigate; inline group refs render as a chip (card only when posted alone) |
| Reactions | kind:7 backfill on thread subs EOSE; badges + toggle + pending + error dialog (with Join offer); hover/long-press tooltip naming reactors (chat too) |
| Context menu | right-click / long-press: quick reactions, Reply (nested `e/k/p` + quoted parent preview), Share to chat (roots), copy text / event link / nevent / event JSON, delete |
| Share to chat | opt-in kind:9 announcement ("Started a thread: ..." + `nostr:nevent`), checkbox on create (default on) + menu action; a quoted kind:11 renders as a tappable thread card on both platforms, opening the thread |
| Profile | avatar / author name / NIP-27 mentions open the chat's UserProfileModal |
| List cards | top-reaction chips, publication date, data-cap ellipsis, selected-card highlight |
| Links | `?e=<messageId>` on thread URLs; opening scrolls to and flashes the target |
| Cache | kind 11/1111 write-through + hydration in the `CacheStore` (slot `relay|group|threads`); deletions never rehydrate |
| Delete | chat-style confirm modal + relay-rejection dialog on both platforms |
| Interop | thread title written as both NIP-7D `title` and NIP-14 `subject`, read as subject → title → first line |
| Layout | desktop split view (≥768) with X close; mobile keeps the swap under a chat-sized group page header (mobile-only); create opens the new thread; create dialog capped at the standard 480dp |

Fixes #221

Commits:
- 7d8ddd0b feat(threads): render thread messages with the chat's rich content parser
- 47c7e5f5 feat(threads): reactions on thread roots and replies
- 2707a4d9 feat(threads): media upload in the create-thread composer
- 373e43e0 feat(threads): richer list cards and a message context menu
- fc9daef3 fix(threads): thread title interop with NIP-7D clients
- bd0ae44e feat(chat): inline group refs render as a chip, the card only when posted alone
- 3afdad3e feat(threads): copy event link / nevent / JSON in the thread context menu
- 09095098 feat(threads): reply to a specific message from the context menu
- 44825842 feat(chat): reaction badges show who reacted on hover
- dc426959 feat(threads): per-message hover, and event links that target the exact message
- ae7ac381 feat(threads): persist threads in the message cache like chat history
- 8bc81961 feat(threads): chat-style delete confirm modal and relay-rejection dialog
- 839e5fbb feat(threads): Discord-style split view on desktop
- b6f3e502 feat(threads): group page header over the threads pane
- b5bdb353 fix(threads): page header is mobile-only and sized like the chat header
- bcfcf274 feat(threads): opt-in Share to chat announcement (kind:9 with the thread nevent)
- 4839b630 feat(threads): avatar, author name and mentions open the user profile modal
- ed77020c feat(chat): quoted kind:11 renders as a thread card that opens the thread
- c1601ed5 feat(threads): open the thread right after creating it
- 58a82075 fix(threads): cap the create-thread dialog at the standard 480dp on desktop

Verified with compileKotlinJvm + compileKotlinJs + :composeApp:jvmTest (new tests: reactions VM, thread tags, chips, cache roundtrip + delete eviction, delete error, share-to-chat announcement + open-on-create); desktop + browser device-tested along the way.