### PR TITLE
Render NIP-84 highlights and retry unresolved reference cards

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip84.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip84.kt
@@ -1,0 +1,43 @@
+package org.nostr.nostrord.nostr
+
+/**
+ * NIP-84 highlights (kind 9802): a verbatim excerpt of a source, optionally annotated with the
+ * highlighter's own comment and attributed to the URL it was taken from.
+ */
+object Nip84 {
+    const val KIND = 9802
+
+    data class Highlight(
+        /** The highlighted excerpt (the event content), rendered as a quote block. */
+        val excerpt: String,
+        /** The highlighter's own note about the excerpt (`comment` tag). */
+        val comment: String?,
+        /** Source URL (`r` tag) when the highlight came from the web. */
+        val sourceUrl: String?,
+    ) {
+        /** Source URL without scheme or trailing slash, e.g. `x.com/varosbr/status/123`. */
+        val sourceLabel: String?
+            get() =
+                sourceUrl
+                    ?.removePrefix("https://")
+                    ?.removePrefix("http://")
+                    ?.trimEnd('/')
+                    ?.takeIf { it.isNotEmpty() }
+    }
+
+    fun isHighlight(kind: Int?): Boolean = kind == KIND
+
+    fun parse(
+        content: String,
+        tags: List<List<String>>,
+    ): Highlight = Highlight(
+        excerpt = content.trim(),
+        comment = tags.tagValue("comment"),
+        sourceUrl = tags.tagValue("r")?.takeIf { it.startsWith("http://") || it.startsWith("https://") },
+    )
+
+    private fun List<List<String>>.tagValue(name: String): String? = firstOrNull { it.size >= 2 && it[0] == name }
+        ?.get(1)
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip84Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip84Test.kt
@@ -1,0 +1,56 @@
+package org.nostr.nostrord.nostr
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class Nip84Test {
+    private val tags =
+        listOf(
+            listOf("comment", "Ótima thread para você entender."),
+            listOf("r", "https://x.com/varosbr/status/2083221408901902834"),
+            listOf("textpositionselector", "2790", "3442"),
+        )
+
+    @Test
+    fun parsesCommentAndSource() {
+        val h = Nip84.parse("  the highlighted excerpt  ", tags)
+        assertEquals("the highlighted excerpt", h.excerpt)
+        assertEquals("Ótima thread para você entender.", h.comment)
+        assertEquals("https://x.com/varosbr/status/2083221408901902834", h.sourceUrl)
+        assertEquals("x.com/varosbr/status/2083221408901902834", h.sourceLabel)
+    }
+
+    @Test
+    fun missingTagsAreNull() {
+        val h = Nip84.parse("excerpt", listOf(listOf("e", "abc")))
+        assertNull(h.comment)
+        assertNull(h.sourceUrl)
+        assertNull(h.sourceLabel)
+    }
+
+    @Test
+    fun blankCommentIsNull() {
+        assertNull(Nip84.parse("x", listOf(listOf("comment", "   "))).comment)
+    }
+
+    @Test
+    fun nonHttpSourceIsIgnored() {
+        // An `r` tag can also carry a relay URL; only web sources are shown as "From <url>".
+        assertNull(Nip84.parse("x", listOf(listOf("r", "wss://relay.example"))).sourceUrl)
+    }
+
+    @Test
+    fun sourceLabelDropsTrailingSlash() {
+        assertEquals("example.com/post", Nip84.parse("x", listOf(listOf("r", "http://example.com/post/"))).sourceLabel)
+    }
+
+    @Test
+    fun kindCheck() {
+        assertTrue(Nip84.isHighlight(9802))
+        assertFalse(Nip84.isHighlight(1))
+        assertFalse(Nip84.isHighlight(null))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Movie
 import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.outlined.Forum
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.CircularProgressIndicator
@@ -66,6 +67,7 @@ import org.nostr.nostrord.isAndroid
 import org.nostr.nostrord.isLinuxDesktop
 import org.nostr.nostrord.network.CachedEvent
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip84
 import org.nostr.nostrord.ui.components.avatars.OptimizedUserAvatar
 import org.nostr.nostrord.ui.components.media.AudioPlayerContent
 import org.nostr.nostrord.ui.components.media.PlatformVideoPlayer
@@ -1774,8 +1776,13 @@ private fun QuotedEvent(
     // Track if event was not found after timeout
     var eventNotFound by remember { mutableStateOf(false) }
 
-    LaunchedEffect(eventId, relayHints, author) {
+    // Bumped by the not-found card's Retry button to re-run the fetch effect: the relay the event
+    // lives on is often connected only after the card first rendered.
+    var retryTick by remember { mutableStateOf(0) }
+
+    LaunchedEffect(eventId, relayHints, author, retryTick) {
         if (!cachedEvents.containsKey(eventId)) {
+            eventNotFound = false
             AppModule.nostrRepository.requestEventById(eventId, relayHints, author)
             // Poll every 500ms up to 5s — yields the coroutine instead of blocking 5s solid
             repeat(10) {
@@ -1914,6 +1921,7 @@ private fun QuotedEvent(
                         color = NostrordColors.TextMuted,
                         style = NostrordTypography.Caption,
                     )
+                    RetryChip(onClick = { retryTick++ })
                 }
                 // Show full parsed content
                 if (kind != null) {
@@ -2109,7 +2117,120 @@ private fun QuotedEvent(
                 }
             }
             Spacer(modifier = Modifier.height(Spacing.sm))
-            QuotedEventContent(content = event.content, tags = event.tags, onMentionClick = onMentionClick)
+            // A NIP-84 highlight is comment + quoted excerpt + source, not one body of text.
+            if (Nip84.isHighlight(event.kind)) {
+                HighlightBody(
+                    highlight = remember(event.id) { Nip84.parse(event.content, event.tags) },
+                    tags = event.tags,
+                    onMentionClick = onMentionClick,
+                )
+            } else {
+                QuotedEventContent(content = event.content, tags = event.tags, onMentionClick = onMentionClick)
+            }
+        }
+    }
+}
+
+/**
+ * NIP-84 highlight body: the highlighter's comment, the excerpt as a quote block, and a link to
+ * the source it was taken from.
+ */
+@Composable
+private fun HighlightBody(
+    highlight: Nip84.Highlight,
+    tags: List<List<String>>,
+    onMentionClick: (String) -> Unit,
+) {
+    val uriHandler = LocalUriHandler.current
+    val copyToClipboard = rememberClipboardWriter()
+
+    Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+        highlight.comment?.let { comment ->
+            QuotedEventContent(content = comment, tags = tags, onMentionClick = onMentionClick)
+        }
+        if (highlight.excerpt.isNotEmpty()) {
+            Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+                Box(
+                    modifier =
+                    Modifier
+                        .width(3.dp)
+                        .fillMaxHeight()
+                        .clip(RoundedCornerShape(NostrordShapes.radiusSmall))
+                        .background(NostrordColors.Primary),
+                )
+                Spacer(modifier = Modifier.width(Spacing.sm))
+                Text(
+                    text = highlight.excerpt,
+                    color = NostrordColors.TextPrimary,
+                    style = NostrordTypography.MessageBody,
+                    fontStyle = FontStyle.Italic,
+                )
+            }
+        }
+        val label = highlight.sourceLabel
+        val url = highlight.sourceUrl
+        if (label != null && url != null) {
+            DisableSelection {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "From ",
+                        color = NostrordColors.TextMuted,
+                        style = NostrordTypography.Caption,
+                    )
+                    Text(
+                        text = label,
+                        color = NostrordColors.Primary,
+                        style = NostrordTypography.Caption,
+                        textDecoration = TextDecoration.Underline,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier =
+                        Modifier
+                            .clickable {
+                                // Linux desktop can't raise the browser reliably, same as the card's open action.
+                                if (isLinuxDesktop) {
+                                    copyToClipboard(url)
+                                    AppModule.postSystemMessage("Link copied")
+                                } else {
+                                    try {
+                                        uriHandler.openUri(url)
+                                    } catch (_: Exception) {
+                                    }
+                                }
+                            }
+                            .pointerHoverIcon(PointerIcon.Hand),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** Retry affordance on a reference card whose event never resolved. */
+@Composable
+private fun RetryChip(onClick: () -> Unit) {
+    DisableSelection {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
+            modifier =
+            Modifier
+                .clip(RoundedCornerShape(NostrordShapes.radiusSmall))
+                .clickable { onClick() }
+                .padding(horizontal = Spacing.xs, vertical = Spacing.xxs)
+                .pointerHoverIcon(PointerIcon.Hand),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Refresh,
+                contentDescription = "Retry",
+                tint = NostrordColors.Primary,
+                modifier = Modifier.size(14.dp),
+            )
+            Text(
+                text = "Retry",
+                color = NostrordColors.Primary,
+                style = NostrordTypography.Caption,
+            )
         }
     }
 }
@@ -2863,9 +2984,13 @@ private fun AddressableEvent(
     // Track if event was not found after timeout
     var eventNotFound by remember { mutableStateOf(false) }
 
+    // Bumped by the not-found card's Retry button to re-run the fetch effect.
+    var retryTick by remember { mutableStateOf(0) }
+
     // Request the addressable event
-    LaunchedEffect(addressKey, relayHints) {
+    LaunchedEffect(addressKey, relayHints, retryTick) {
         if (!cachedEvents.containsKey(addressKey)) {
+            eventNotFound = false
             AppModule.nostrRepository.requestAddressableEvent(
                 kind = kind,
                 pubkey = pubkey,
@@ -2927,6 +3052,7 @@ private fun AddressableEvent(
                         color = NostrordColors.TextMuted,
                         style = NostrordTypography.Caption,
                     )
+                    RetryChip(onClick = { retryTick++ })
                 }
                 // Show full parsed naddr content
                 Text(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -21,6 +21,7 @@ import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.nostr.Nip68
+import org.nostr.nostrord.nostr.Nip84
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.keyboard.VirtualKeyboardPolicy
 import org.nostr.nostrord.ui.navigation.GroupRoute
@@ -3831,14 +3832,18 @@ private val QuotedEvent =
         val (notFound, setNotFound) = useState { false }
         val (menuOpen, setMenuOpen) = useState { false }
 
-        useEffect(props.eventId) {
+        // Bumped by the not-found card's Retry button to re-run the fetch: the relay the event
+        // lives on is often connected only after the card first rendered.
+        val (retryTick, setRetryTick) = useState { 0 }
+
+        useEffect(props.eventId, retryTick) {
             setNotFound(false)
             if (props.eventId !in cached && local == null) {
                 launchApp { repo.requestEventById(props.eventId, props.relays, props.author) }
             }
         }
         // Give up after 5s of no resolution. Re-runs when content arrives (cancels the timer).
-        useEffect(content, props.eventId) {
+        useEffect(content, props.eventId, retryTick) {
             if (content != null) return@useEffect
             val timer = window.setTimeout({ setNotFound(true) }, 5000)
             try {
@@ -4079,17 +4084,57 @@ private val QuotedEvent =
                         }
                     }
                 }
-                div {
-                    className = ClassName("quoted-event-content")
-                    renderMessageContent(
-                        content.trim(),
-                        quotedTags,
-                        userMetadata,
-                        props.localById,
-                        props.onUser,
-                        props.onScrollTo,
-                        props.onGroupRef,
-                    )
+                // A NIP-84 highlight is comment + quoted excerpt + source, not one body of text.
+                val highlight = if (Nip84.isHighlight(resolvedKind)) Nip84.parse(content, quotedTags) else null
+                if (highlight != null) {
+                    highlight.comment?.let { comment ->
+                        div {
+                            className = ClassName("quoted-event-content")
+                            renderMessageContent(
+                                comment,
+                                quotedTags,
+                                userMetadata,
+                                props.localById,
+                                props.onUser,
+                                props.onScrollTo,
+                                props.onGroupRef,
+                            )
+                        }
+                    }
+                    if (highlight.excerpt.isNotEmpty()) {
+                        div {
+                            className = ClassName("highlight-excerpt")
+                            +highlight.excerpt
+                        }
+                    }
+                    val sourceUrl = highlight.sourceUrl
+                    val sourceLabel = highlight.sourceLabel
+                    if (sourceUrl != null && sourceLabel != null) {
+                        div {
+                            className = ClassName("highlight-source")
+                            +"From "
+                            a {
+                                href = sourceUrl
+                                asDynamic().target = "_blank"
+                                rel = "noopener noreferrer"
+                                onClick = { it.stopPropagation() }
+                                +sourceLabel
+                            }
+                        }
+                    }
+                } else {
+                    div {
+                        className = ClassName("quoted-event-content")
+                        renderMessageContent(
+                            content.trim(),
+                            quotedTags,
+                            userMetadata,
+                            props.localById,
+                            props.onUser,
+                            props.onScrollTo,
+                            props.onGroupRef,
+                        )
+                    }
                 }
             } else if (notFound) {
                 div {
@@ -4100,6 +4145,16 @@ private val QuotedEvent =
                         span {
                             className = ClassName("quoted-event-notfound-label")
                             +"Event not found"
+                        }
+                        button {
+                            className = ClassName("quoted-event-retry")
+                            title = "Try loading this event again"
+                            onClick = { ev ->
+                                ev.stopPropagation()
+                                setRetryTick(retryTick + 1)
+                            }
+                            icon(Ic.Refresh)
+                            span { +"Retry" }
                         }
                         div {
                             className = ClassName("quoted-event-menu")

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -6400,6 +6400,49 @@ body {
 .quoted-event-notfound-label {
     flex: 1;
 }
+/* Retry on a reference card whose event never resolved: its relay is often connected only
+   after the card first rendered. */
+.quoted-event-retry {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border: none;
+    background: transparent;
+    color: var(--color-primary);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    border-radius: 4px;
+}
+.quoted-event-retry:hover {
+    background: var(--color-surface-variant);
+}
+.quoted-event-retry svg {
+    width: 14px;
+    height: 14px;
+}
+/* NIP-84 highlight (kind 9802): the excerpt reads as a quote block under the highlighter's own
+   comment, attributed to the page it was taken from. */
+.highlight-excerpt {
+    margin: 6px 0;
+    padding-left: 10px;
+    border-left: 3px solid var(--color-primary);
+    color: var(--color-text-primary);
+    font-style: italic;
+    font-size: 14px;
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+.highlight-source {
+    color: var(--color-text-muted);
+    font-size: 12px;
+}
+.highlight-source a {
+    color: var(--color-primary);
+    overflow-wrap: anywhere;
+}
 /* Kebab menu on the not-found card: a single "Copy Parsed JSON" action (the event JSON is
    unavailable, so the parsed reference is what's copyable). Mirrors the native card's menu. */
 .quoted-event-menu {


### PR DESCRIPTION
A quoted kind:9802 (NIP-84 highlight) fell through every kind branch in both quoted-event cards and rendered only its `content`, so the highlighter's own comment and the page the excerpt came from were dropped. `Nip84` in commonMain parses the three parts out of the raw event and both UIs render comment, an italic excerpt quote block, and "From <source>" (scheme stripped, so it reads `x.com/varosbr/status/2083221408901902834`). Non-http `r` values are ignored since that tag also carries relay URLs.

Reference cards that time out now offer a Retry: the relay an event lives on is often connected only after the card first rendered, and the fetch effect ran exactly once. Retry re-keys the effect and clears the not-found state. Web's non-39000 naddr path renders a bare link with no card, so it has nothing to retry - pre-existing parity gap, left alone.

| Surface | Change |
|---|---|
| `commonMain/nostr/Nip84.kt` | new: comment / excerpt / source url parsing + `sourceLabel` |
| `commonTest/nostr/Nip84Test.kt` | new: 6 tests |
| Compose `MessageContent.kt` | `HighlightBody` + `RetryChip`; retry on nevent and naddr cards |
| Web `ChatScreen.kt` | highlight body + Retry button on the not-found card |
| Web `styles.css` | `.highlight-excerpt`, `.highlight-source`, `.quoted-event-retry` |

`compileKotlinJvm`, `compileKotlinJs`, `:composeApp:jvmTest` and `spotlessCheck` pass. Not device-validated.

- a69d7055 feat(chat): render NIP-84 highlights and retry unresolved reference cards