### PR TITLE
feat(threads): let admins delete threads and replies (#226)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3424,10 +3424,14 @@ class GroupManager(
      * Delete a message from a group.
      *
      * The deletion kind is chosen by who is deleting whose message:
-     * - Authors deleting their own message use kind 5 (NIP-09 standard deletion).
+     * - Authors deleting their own message use kind 5 (NIP-09 standard deletion), which stays
+     *   honored outside this relay by anything that mirrored the event.
      * - Admins deleting another member's message use kind 9005 (NIP-29
      *   delete-event moderation action). NIP-29 relays only honor a kind 5 from
      *   the author; removing someone else's message requires the admin kind 9005.
+     * - A kind 5 an admin sends is retried as 9005 when the relay refuses the kind outright
+     *   ("kind 5 not allowed"): some NIP-29 relays accept only the moderation route, and an
+     *   admin must not be the one member who cannot delete their own message there.
      *
      * Sends the deletion event to the relay; the relay broadcasts it and
      * handleDeletion() removes it from local state when received back.
@@ -3447,15 +3451,14 @@ class GroupManager(
                 _threadRoots.value[groupId].orEmpty() +
                 _threadReplies.value[groupId].orEmpty()
             ).firstOrNull { it.id == messageId }?.pubkey
-        val deletionKind = deletionKindFor(
-            isOwnMessage = messageAuthor == pubKey,
-            isAdmin = isGroupAdmin(groupId, pubKey),
-        )
-        return try {
+        val isAdmin = isGroupAdmin(groupId, pubKey)
+        val deletionKind = deletionKindFor(isOwnMessage = messageAuthor == pubKey, isAdmin = isAdmin)
+
+        suspend fun publish(kind: Int): org.nostr.nostrord.network.PublishResult {
             val event = Event(
                 pubkey = pubKey,
                 createdAt = epochMillis() / 1000,
-                kind = deletionKind,
+                kind = kind,
                 tags = listOf(
                     listOf("h", groupId),
                     listOf("e", messageId),
@@ -3464,12 +3467,25 @@ class GroupManager(
             )
             val signedEvent = signEvent(event)
             val eventId = signedEvent.id
-                ?: return Result.Error(AppError.Group.SendFailed(groupId, Exception("Event ID not generated")))
+                ?: return org.nostr.nostrord.network.PublishResult.Error("", Exception("Event ID not generated"))
             val message = buildJsonArray {
                 add("EVENT")
                 add(signedEvent.toJsonObject())
             }.toString()
-            when (val result = currentClient.sendAndAwaitOk(message, eventId)) {
+            return currentClient.sendAndAwaitOk(message, eventId)
+        }
+
+        return try {
+            val first = publish(deletionKind)
+            // Only a rejection escalates: a timeout is a connectivity problem, and resending
+            // would race a delete the relay may still be processing.
+            val result =
+                if (first is org.nostr.nostrord.network.PublishResult.Rejected && deletionKind == 5 && isAdmin) {
+                    publish(ADMIN_DELETE_EVENT_KIND)
+                } else {
+                    first
+                }
+            when (result) {
                 is org.nostr.nostrord.network.PublishResult.Success -> Result.Success(Unit)
                 is org.nostr.nostrord.network.PublishResult.Rejected ->
                     Result.Error(AppError.Group.SendFailed(groupId, Exception(result.reason)))
@@ -5321,6 +5337,9 @@ class GroupManager(
     }
 }
 
+/** NIP-29 delete-event: the admin moderation action that removes any member's event. */
+internal const val ADMIN_DELETE_EVENT_KIND = 9005
+
 /**
  * Pick the deletion event kind for a group message.
  *
@@ -5328,6 +5347,8 @@ class GroupManager(
  * - Kind 9005 is the NIP-29 delete-event moderation action; NIP-29 relays only let an
  *   admin remove another member's message through it, never through kind 5.
  *
- * An admin deleting their own message stays on kind 5 (they are the author).
+ * An admin deleting their own message stays on kind 5 (they are the author, and the NIP-09
+ * deletion also travels outside this relay). [GroupManager.deleteMessage] falls back to 9005
+ * if the relay rejects kind 5.
  */
-internal fun deletionKindFor(isOwnMessage: Boolean, isAdmin: Boolean): Int = if (!isOwnMessage && isAdmin) 9005 else 5
+internal fun deletionKindFor(isOwnMessage: Boolean, isAdmin: Boolean): Int = if (!isOwnMessage && isAdmin) ADMIN_DELETE_EVENT_KIND else 5

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -65,6 +65,29 @@ fun buildFriendCandidates(
         )
     }.sortedWith(compareBy({ it.name == null }, { it.name?.lowercase() ?: it.pubkey }))
 
+/** Value under [hostRelay]'s key, tolerating maps keyed by non-normalized URLs. */
+internal fun <T> Map<String, T>.atRelay(hostRelay: String?): T? = hostRelay?.let { hr -> this[hr] ?: entries.firstOrNull { it.key.normalizeRelayUrl() == hr }?.value }
+
+/**
+ * The host relay's own mirror of a per-relay map, laid over the flat (bare-id) one.
+ *
+ * The flat map is last-writer-wins across relays, so for [groupId] it is trustworthy only
+ * while no OTHER relay has served that id: once one has, inheriting it reports another
+ * group's members and admins as ours — which handed out the admin UI, and its join-request
+ * list, on a group we do not administer. In that case the entry reads absent until this
+ * relay answers. Other groups' entries pass through untouched.
+ */
+internal fun <T> Map<String, Map<String, T>>.scopedOverFlat(
+    flat: Map<String, T>,
+    groupId: String,
+    hostRelay: String?,
+): Map<String, T> {
+    val mine = atRelay(hostRelay).orEmpty()
+    if (groupId in mine) return flat + mine
+    val servedElsewhere = entries.any { it.key.normalizeRelayUrl() != hostRelay && groupId in it.value }
+    return if (servedElsewhere) (flat - groupId) + mine else flat + mine
+}
+
 /** Relay hosting [groupId] (the relay whose group list carries it), else [fallbackRelay]. */
 fun groupHostRelay(
     groupId: String,
@@ -173,23 +196,9 @@ class GroupViewModel(
     }
 
     /** Value under [hostRelay]'s key, tolerating maps keyed by non-normalized URLs. */
-    private fun <T> Map<String, T>.atHostRelay(): T? = hostRelay?.let { hr -> this[hr] ?: entries.firstOrNull { it.key.normalizeRelayUrl() == hr }?.value }
+    private fun <T> Map<String, T>.atHostRelay(): T? = atRelay(hostRelay)
 
-    /**
-     * The host relay's own mirror of a per-relay map, laid over the flat (bare-id) one.
-     *
-     * The flat map is last-writer-wins across relays, so for [groupId] it is trustworthy only
-     * while no OTHER relay has served that id: once one has, inheriting it reports another
-     * group's members and admins as ours — which handed out the admin UI, and its join-request
-     * list, on a group we do not administer. In that case the entry reads absent until this
-     * relay answers. Other groups' entries pass through untouched.
-     */
-    private fun <T> Map<String, Map<String, T>>.scopedOverFlat(flat: Map<String, T>): Map<String, T> {
-        val mine = atHostRelay().orEmpty()
-        if (groupId in mine) return flat + mine
-        val servedElsewhere = entries.any { it.key.normalizeRelayUrl() != hostRelay && groupId in it.value }
-        return if (servedElsewhere) (flat - groupId) + mine else flat + mine
-    }
+    private fun <T> Map<String, Map<String, T>>.scopedOverFlat(flat: Map<String, T>): Map<String, T> = scopedOverFlat(flat, groupId, hostRelay)
 
     /**
      * Chat messages with NIP-51 muted authors filtered out. The raw repo cache stays

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -122,6 +123,34 @@ fun topReactionChips(
         }
         ReactionChip(display, info.emojiUrl, info.reactors.size)
     }
+
+/**
+ * Who may delete a thread root or reply: its author (NIP-09 kind:5) and the group's admins
+ * (NIP-29 kind:9005 moderation). Shared by both thread UIs so the header button and the
+ * context menu offer the action under the same rule chat already uses.
+ */
+fun canDeleteThreadMessage(
+    authorPubkey: String,
+    myPubkey: String?,
+    isAdmin: Boolean,
+): Boolean = myPubkey != null && (authorPubkey == myPubkey || isAdmin)
+
+/**
+ * Body of the delete confirmation for a thread root or reply. Pass [authorName] only when the
+ * content is someone else's: an admin sees the delete action on every message, so moderating
+ * has to read as moderating (named author, group-wide effect) and not as retracting your own.
+ */
+fun deleteThreadConfirmBody(
+    isRoot: Boolean,
+    authorName: String?,
+): String {
+    val what = if (isRoot) "thread" else "message"
+    return if (authorName == null) {
+        "Are you sure you want to delete this $what? This cannot be undone."
+    } else {
+        "Delete this $what by $authorName? Everyone in the group stops seeing it, and this cannot be undone."
+    }
+}
 
 /**
  * Shared screen logic for the forum-style Threads pane (Discord-like): the list of kind:11 roots
@@ -308,6 +337,25 @@ class ThreadsViewModel(
         }
     }
 
+    /**
+     * Whether the signed-in account administers this group, host-relay scoped like
+     * [GroupViewModel.groupAdmins]: a same-id group on another relay must not hand out
+     * moderation rights here. Drives the admin delete affordances on threads.
+     */
+    val isAdmin: StateFlow<Boolean> =
+        (
+            if (hostRelay == null) {
+                repo.groupAdmins
+            } else {
+                combine(repo.groupAdmins, repo.groupAdminsByRelay) { flat, byRelay ->
+                    byRelay.scopedOverFlat(flat, groupId, hostRelay)
+                }
+            }
+            ).map { admins ->
+            val me = repo.getPublicKey()
+            me != null && me in admins[groupId].orEmpty()
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
     private val _deleteError = MutableStateFlow<String?>(null)
 
     /** The relay's rejection of a kind:5/9005 delete ("kind 5 not allowed", ...), user-facing. */
@@ -317,9 +365,10 @@ class ThreadsViewModel(
         _deleteError.value = null
     }
 
-    /** Delete a thread root or reply you authored (NIP-09/NIP-29 deletion). The relay echo
-     *  removes it from local state; a rejection surfaces via [deleteError]. Runs on
-     *  viewModelScope, which survives list <-> detail nav. */
+    /** Delete a thread root or reply (NIP-09 kind:5 as its author, NIP-29 kind:9005 as an admin;
+     *  [GroupManager.deleteMessage] picks the kind). The relay echo removes it from local state;
+     *  a rejection surfaces via [deleteError]. Runs on viewModelScope, which survives
+     *  list <-> detail nav. */
     fun deleteThread(rootId: String) {
         viewModelScope.launch {
             when (val result = repo.deleteMessage(groupId, rootId)) {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DeletionKindTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DeletionKindTest.kt
@@ -12,6 +12,7 @@ class DeletionKindTest {
     @Test
     fun `admin deleting own message uses kind 5`() {
         // An admin is still the author of their own message, so it is a standard deletion.
+        // A relay that refuses kind 5 gets the 9005 retry from deleteMessage instead.
         assertEquals(5, deletionKindFor(isOwnMessage = true, isAdmin = true))
     }
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -12,6 +12,8 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.ui.screens.group.ReactionChip
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.buildThreadSummaries
+import org.nostr.nostrord.ui.screens.group.canDeleteThreadMessage
+import org.nostr.nostrord.ui.screens.group.deleteThreadConfirmBody
 import org.nostr.nostrord.ui.screens.group.filterMutedReactions
 import org.nostr.nostrord.ui.screens.group.friendlyRelayError
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
@@ -23,6 +25,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -248,6 +251,31 @@ class ThreadsViewModelTest {
             chips,
         )
         assertTrue(topReactionChips(emptyMap()).isEmpty())
+    }
+
+    @Test
+    fun `canDeleteThreadMessage covers the author and any admin`() {
+        val me = "me"
+        val other = "other"
+        // Author deletes their own (kind:5), admin deletes anyone's (kind:9005).
+        assertTrue(canDeleteThreadMessage(me, me, isAdmin = false))
+        assertTrue(canDeleteThreadMessage(other, me, isAdmin = true))
+        assertTrue(canDeleteThreadMessage(me, me, isAdmin = true))
+        // A plain member gets no delete on someone else's thread, and logged out none at all.
+        assertFalse(canDeleteThreadMessage(other, me, isAdmin = false))
+        assertFalse(canDeleteThreadMessage(other, null, isAdmin = true))
+    }
+
+    @Test
+    fun `deleteThreadConfirmBody names the author only when moderating`() {
+        assertEquals(
+            "Are you sure you want to delete this thread? This cannot be undone.",
+            deleteThreadConfirmBody(isRoot = true, authorName = null),
+        )
+        assertEquals(
+            "Delete this message by Alice? Everyone in the group stops seeing it, and this cannot be undone.",
+            deleteThreadConfirmBody(isRoot = false, authorName = "Alice"),
+        )
     }
 
     @Test

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -160,7 +160,8 @@ fun ThreadMessageContextMenu(
     onDismiss: () -> Unit,
     onAction: (MessageContextAction) -> Unit,
     anchorOffsetPx: Offset? = null,
-    isAuthor: Boolean = false,
+    // Author (kind:5) or group admin (kind:9005); see canDeleteThreadMessage.
+    canDelete: Boolean = false,
     // Roots only: announce the thread in the group chat.
     canShareToChat: Boolean = false,
 ) {
@@ -238,7 +239,7 @@ fun ThreadMessageContextMenu(
                 },
             )
 
-            if (isAuthor) {
+            if (canDelete) {
                 ContextMenuDivider()
 
                 ContextMenuItem(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -130,6 +130,7 @@ fun ThreadsScreen(
     val pendingReactions by vm.pendingReactions.collectAsState()
     val reactionError by vm.reactionError.collectAsState()
     val deleteError by vm.deleteError.collectAsState()
+    val isAdmin by vm.isAdmin.collectAsState()
     val myPubkey = remember { vm.getPublicKey() }
 
     // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
@@ -236,9 +237,9 @@ fun ThreadsScreen(
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.weight(1f),
                     )
-                    val ownRoot = openThread?.root
-                    if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
-                        IconButton(onClick = { deleteTarget = ownRoot }) {
+                    val root = openThread?.root
+                    if (root != null && canDeleteThreadMessage(root.pubkey, myPubkey, isAdmin)) {
+                        IconButton(onClick = { deleteTarget = root }) {
                             Icon(Icons.Default.Delete, contentDescription = "Delete thread", tint = NostrordColors.TextSecondary)
                         }
                     }
@@ -271,6 +272,7 @@ fun ThreadsScreen(
                                     userMetadata = userMetadata,
                                     isRoot = isRoot,
                                     myPubkey = myPubkey,
+                                    isAdmin = isAdmin,
                                     route = route,
                                     status = messageStatus[msg.id],
                                     reactions = reactions[msg.id] ?: emptyMap(),
@@ -434,10 +436,11 @@ fun ThreadsScreen(
 
     deleteTarget?.let { target ->
         val isRoot = target.id == openThread?.root?.id
+        val moderatedAuthor = if (target.pubkey == myPubkey) null else threadDisplayName(target.pubkey, userMetadata[target.pubkey])
         AlertDialog(
             onDismissRequest = { deleteTarget = null },
             title = { Text(if (isRoot) "Delete thread?" else "Delete message?") },
-            text = { Text("This cannot be undone.") },
+            text = { Text(deleteThreadConfirmBody(isRoot, moderatedAuthor)) },
             confirmButton = {
                 TextButton(onClick = {
                     deleteTarget = null
@@ -641,6 +644,7 @@ private fun ThreadMessage(
     userMetadata: Map<String, UserMetadata>,
     isRoot: Boolean,
     myPubkey: String?,
+    isAdmin: Boolean,
     route: GroupRoute,
     status: GroupManager.MessageStatus?,
     reactions: Map<String, GroupManager.ReactionInfo>,
@@ -660,7 +664,7 @@ private fun ThreadMessage(
     onDismiss: () -> Unit,
 ) {
     val meta = userMetadata[msg.pubkey]
-    val isAuthor = myPubkey != null && myPubkey == msg.pubkey
+    val canDelete = canDeleteThreadMessage(msg.pubkey, myPubkey, isAdmin)
     var menuVisible by remember { mutableStateOf(false) }
     var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
     val writeClipboard = rememberClipboardWriter()
@@ -700,7 +704,7 @@ private fun ThreadMessage(
             visible = menuVisible,
             onDismiss = { menuVisible = false },
             anchorOffsetPx = menuAnchorPx,
-            isAuthor = isAuthor,
+            canDelete = canDelete,
             canShareToChat = isRoot,
             onAction = { action ->
                 when (action) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -13,6 +13,8 @@ import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.threadShareLink
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
+import org.nostr.nostrord.ui.screens.group.canDeleteThreadMessage
+import org.nostr.nostrord.ui.screens.group.deleteThreadConfirmBody
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.threadTitle
@@ -114,6 +116,7 @@ val ThreadsScreen =
         val pendingReactions = useStateFlow(vm.pendingReactions)
         val reactionError = useStateFlow(vm.reactionError)
         val deleteError = useStateFlow(vm.deleteError)
+        val isAdmin = useStateFlow(vm.isAdmin)
         val myPubkey = vm.getPublicKey()
 
         // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
@@ -377,12 +380,12 @@ val ThreadsScreen =
                                 className = ClassName("threads-title")
                                 +"Thread"
                             }
-                            val ownRoot = openThread?.root
-                            if (myPubkey != null && ownRoot != null && ownRoot.pubkey == myPubkey) {
+                            val root = openThread?.root
+                            if (root != null && canDeleteThreadMessage(root.pubkey, myPubkey, isAdmin)) {
                                 button {
                                     className = ClassName("icon-btn")
                                     title = "Delete thread"
-                                    onClick = { setDeleteTarget(ownRoot) }
+                                    onClick = { setDeleteTarget(root) }
                                     icon(Ic.Delete)
                                 }
                             }
@@ -613,7 +616,7 @@ val ThreadsScreen =
                         copyToClipboard(m.msg.toEventJson())
                         setCtxMenu(null)
                     }
-                    if (myPubkey != null && myPubkey == m.msg.pubkey) {
+                    if (canDeleteThreadMessage(m.msg.pubkey, myPubkey, isAdmin)) {
                         div { className = ClassName("ctx-divider") }
                         ctxItem(Ic.Delete, "Delete message", danger = true) {
                             setCtxMenu(null)
@@ -650,9 +653,10 @@ val ThreadsScreen =
             // Delete confirm modal (chat parity: destructive confirm, no window.confirm).
             deleteTarget?.let { target ->
                 val isRoot = target.id == route.threadRootId
+                val moderatedAuthor = if (target.pubkey == myPubkey) null else threadDisplayName(target.pubkey, userMetadata[target.pubkey])
                 confirmDialog(
                     title = if (isRoot) "Delete Thread" else "Delete Message",
-                    body = "Are you sure you want to delete this ${if (isRoot) "thread" else "message"}? This action cannot be undone.",
+                    body = deleteThreadConfirmBody(isRoot, moderatedAuthor),
                     confirmLabel = "Delete",
                     danger = true,
                     onCancel = { setDeleteTarget(null) },


### PR DESCRIPTION
Closes #226.

The relay side was already in place: `GroupManager.deleteMessage` picks kind:9005 for an admin deleting someone else's event, and `handleDeletion` evicts thread roots and replies. Only the UI gate was missing — both thread screens offered delete to the author alone, while chat already used author-or-admin.

`canDeleteThreadMessage` is the shared rule, so the header button and the context menu agree. The confirm dialog names the author when moderating someone else's content: the action shows up on every message once you are an admin, so it has to read as moderating rather than as retracting your own.

`deleteMessage` also retries a rejected kind:5 as 9005 when the sender is an admin. Some NIP-29 relays refuse kind 5 outright, which left an admin as the one member who could not delete their own message there. Only a rejection escalates — a timeout stays a timeout, since resending would race a delete the relay may still be processing.

| File | Change |
|---|---|
| `GroupManager.kt` | `ADMIN_DELETE_EVENT_KIND`, publish-per-kind refactor, 5 → 9005 fallback |
| `ThreadsViewModel.kt` | `canDeleteThreadMessage`, `deleteThreadConfirmBody`, host-relay-scoped `isAdmin` |
| `GroupViewModel.kt` | `atRelay` / `scopedOverFlat` lifted to internal top-level so the threads VM can scope admins the same way |
| `MessageContextMenu.kt` | `ThreadMessageContextMenu`: `isAuthor` → `canDelete` |
| `ThreadsScreen.kt` (Compose + web) | header button, context menu and confirm body behind the shared rule |
| `ThreadsViewModelTest` / `DeletionKindTest` | the rule and the confirm copy |

Verified with `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid` and `:composeApp:jvmTest`. iOS is untested (no macOS here); it shares the same `uiComposeMain` screen as Android and Desktop.