### PR TITLE
feat(threads): private-group gate, join, notifications and cross-device sync

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -254,6 +254,9 @@ object AppModule {
             onNewMessagesFlushed = { groupId, newMessages ->
                 unreadManager.onMessagesFlushed(groupId, newMessages)
             },
+            onThreadEventReceived = { groupId, event ->
+                unreadManager.onThreadEventReceived(groupId, event)
+            },
         ).also { gm ->
             // Feed + popup for "an admin added you to a group" (kind:9000, live or catch-up).
             // Fires when the add lands as a PENDING invite; the group itself is only adopted
@@ -487,6 +490,52 @@ object AppModule {
                     )
                 }
             },
+            onThreadReplyNotify = { groupId, reply ->
+                val relayUrl = reply.relayUrl
+                    ?: groupManager.getRelayForGroup(groupId) ?: ""
+                val preview = resolveMentionsForNotification(reply.content).take(120)
+                val groupName = groupDisplayName(groupId)
+                val relayName = relayDisplayName(relayUrl)
+                // The E tag is the thread root; without it the entry would open the chat, where a
+                // kind:1111 does not exist. Falls back to the reply itself so the pane still opens.
+                val rootId = reply.tags.firstOrNull { it.size >= 2 && it[0] == "E" }?.get(1) ?: reply.id
+                notificationHistoryStore.add(
+                    NotificationEntry(
+                        id = reply.id,
+                        type = NotificationType.REPLY,
+                        groupId = groupId,
+                        relayUrl = relayUrl,
+                        actorPubkey = reply.pubkey,
+                        createdAt = reply.createdAt,
+                        preview = preview,
+                        messageId = reply.id,
+                        threadRootId = rootId,
+                        groupName = groupName,
+                        relayName = relayName,
+                    ),
+                )
+                val realtime = isRealtime(reply.createdAt)
+                if (realtime && notificationSettings.soundEnabled.value) {
+                    playNotificationSound()
+                }
+                if (realtime &&
+                    notificationSettings.systemNotificationsEnabled.value &&
+                    notificationService.isSupported() &&
+                    notificationService.permission.value == NotificationPermission.Granted
+                ) {
+                    val authorName = displayLabelFor(reply.pubkey, prefixAt = false)
+                        ?: (reply.pubkey.take(8) + "…")
+                    notificationService.notify(
+                        NotificationRequest(
+                            relayUrl = relayUrl,
+                            groupId = groupId,
+                            title = groupName,
+                            body = "$authorName replied in a thread: $preview",
+                            messageId = reply.id,
+                        ),
+                    )
+                }
+            },
             onMentionNotify = { groupId, message ->
                 val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
                     ?: groupManager.getRelayForGroup(groupId) ?: ""
@@ -547,6 +596,12 @@ object AppModule {
                             createdAt = reaction.createdAt,
                             preview = emoji,
                             messageId = reaction.targetEventId,
+                            // A reaction to a thread root/reply must open the threads pane; the
+                            // target does not exist in the chat. The reaction's own E tag is
+                            // authoritative and works even when the target was never loaded here;
+                            // the local scan covers reactors that omit it.
+                            threadRootId = reaction.threadRootId
+                                ?: groupManager.threadRootForEvent(reaction.targetEventId),
                             emoji = emoji,
                             groupName = groupName,
                             relayName = relayName,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -320,6 +320,7 @@ class NostrGroupClient(
     suspend fun connect(onMessage: (String) -> Unit) {
         isDisconnecting = false
         authCompleted = CompletableDeferred()
+        authedPubkey = null
         connectionJob = clientScope.launch {
             try {
                 client.webSocket(relayUrl) {
@@ -447,10 +448,22 @@ class NostrGroupClient(
         } ?: false
     }
 
-    /** Called after the AUTH response has been sent to the relay. */
-    fun notifyAuthCompleted() {
+    // Pubkey this socket answered NIP-42 with. The relay serves reads under the identity that
+    // AUTH'd the SOCKET, not under whatever account the app considers active, so a socket left
+    // over from a previous account keeps returning that account's private-group events.
+    private var authedPubkey: String? = null
+
+    /** Called after the AUTH response has been sent to the relay, signed by [pubkey]. */
+    fun notifyAuthCompleted(pubkey: String?) {
+        authedPubkey = pubkey
         authCompleted.complete(Unit)
     }
+
+    /**
+     * True when this socket is authenticated as an account other than [pubkey]. Sockets that
+     * never authenticated (public relays) are not "other": they serve everyone the same.
+     */
+    fun isAuthedAsOther(pubkey: String?): Boolean = authedPubkey != null && authedPubkey != pubkey
 
     suspend fun send(message: String) {
         trackSubLifecycle(message)
@@ -1309,6 +1322,13 @@ class NostrGroupClient(
                             putJsonArray("kinds") {
                                 add(5)
                                 add(9)
+                                // Forum threads ride the chat mux so a reply reaches the client
+                                // with the threads pane closed. Their own threads_/threadrepl_
+                                // subs only exist while that pane is open, so without these two
+                                // a thread reply is invisible until the user goes looking - no
+                                // notification, and a cold list on open.
+                                add(11)
+                                add(1111)
                                 add(9000)
                                 add(9001)
                                 add(9002)
@@ -1851,6 +1871,9 @@ class NostrGroupClient(
         val targetAuthorPubkey: String? = null,
         // NIP-29 `h` tag: group id the reaction was published to.
         val groupId: String? = null,
+        // NIP-22 `E` tag: the thread root the target belongs to, set when reacting inside a
+        // thread. Lets a notification open the threads pane without the target being in memory.
+        val threadRootId: String? = null,
     )
 
     fun parseMessage(message: String): NostrMessage? {
@@ -1916,6 +1939,7 @@ class NostrGroupClient(
 
             val targetAuthorPubkey = tags.firstOrNull { it.size >= 2 && it[0] == "p" }?.get(1)
             val groupId = tags.firstOrNull { it.size >= 2 && it[0] == "h" }?.get(1)
+            val threadRootId = tags.firstOrNull { it.size >= 2 && it[0] == "E" }?.get(1)
 
             NostrReaction(
                 id = event["id"]?.jsonPrimitive?.content ?: return null,
@@ -1926,6 +1950,7 @@ class NostrGroupClient(
                 createdAt = event["created_at"]?.jsonPrimitive?.long ?: (epochMillis() / 1000),
                 targetAuthorPubkey = targetAuthorPubkey,
                 groupId = groupId,
+                threadRootId = threadRootId,
             )
         } catch (e: Exception) {
             null

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2351,6 +2351,15 @@ class NostrRepository(
                     connectionManager.disconnectRelay(norm)
                 }
             } catch (_: Exception) {}
+            // The loop above only covers the INCOMING account's joined relays, which is empty for
+            // a brand-new account — leaving the outgoing account's sockets open and still AUTH'd
+            // as it. Opening a private group only that account belongs to then reads it in full,
+            // because the relay answers under the socket's identity. Sweep by AUTH identity so
+            // every leftover socket is dropped regardless of whose relay list it is on.
+            try {
+                connectionManager.disconnectSocketsAuthedAsOther(pubkey)
+                    .forEach { connectedPoolRelays.remove(it) }
+            } catch (_: Exception) {}
             try {
                 ensureJoinedRelaysConnected(focusedRelay.takeIf { it.isNotBlank() })
             } catch (_: Exception) {}
@@ -3576,7 +3585,13 @@ class NostrRepository(
         )
     }
 
-    override suspend fun sendReaction(groupId: String, targetEventId: String, targetPubkey: String, emoji: String): Result<Unit> {
+    override suspend fun sendReaction(
+        groupId: String,
+        targetEventId: String,
+        targetPubkey: String,
+        emoji: String,
+        threadRootId: String?,
+    ): Result<Unit> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
         return groupManager.sendReaction(
@@ -3586,6 +3601,7 @@ class NostrRepository(
             emoji = emoji,
             pubKey = pubKey,
             signEvent = { sessionManager.signEvent(it) },
+            threadRootId = threadRootId,
         )
     }
 
@@ -4761,7 +4777,7 @@ class NostrRepository(
                     if (sessionManager.handleAuthChallenge(client, authChallenge)) {
                         // Signal that AUTH is done so connect()/switchRelay() can
                         // proceed with requestGroups() after the relay accepted auth.
-                        client.notifyAuthCompleted()
+                        client.notifyAuthCompleted(sessionManager.getPublicKey())
                         resubscribeAfterAuth(client)
                         // Queued sends blocked on this relay's AUTH (resolveClientForGroup
                         // fails closed pre-AUTH) can flush now.
@@ -4838,8 +4854,16 @@ class NostrRepository(
                     }
                     // The forum thread-roots sub (threads_<groupId>) reached EOSE: stored threads
                     // are in, so the list can settle (show "No threads yet" only now, not on a timer).
+                    // The answer is also authoritative for what still exists, so anything we hold
+                    // for this relay that it did not serve was deleted elsewhere - drop it. Skipped
+                    // while AUTH is still pending, when an empty answer proves nothing.
                     if (subId.startsWith("threads_")) {
-                        groupManager.markThreadsLoaded(subId.removePrefix("threads_"))
+                        val threadGroupId = subId.removePrefix("threads_")
+                        groupManager.markThreadsLoaded(threadGroupId)
+                        if (!authBlocked) groupManager.reconcileThreadRootsAtEose(threadGroupId, sourceRelayUrl)
+                    }
+                    if (subId.startsWith("threadrepl_") && !authBlocked) {
+                        groupManager.reconcileThreadRepliesAtEose(subId.removePrefix("threadrepl_"), sourceRelayUrl)
                     }
                     closeOneShotSubAfterEose(subId, client)
                 }
@@ -5018,6 +5042,12 @@ class NostrRepository(
 
             "EVENT" -> {
                 if (arr.size < 3) return
+                // A socket still AUTH'd as another account answers REQs under THAT identity, so
+                // its events belong to a read scope this session does not have (a private group's
+                // messages and member lists). Drop them instead of letting them land in the active
+                // account's state and get cached under its key. Public sockets never authenticated
+                // and are not filtered.
+                if (client.isAuthedAsOther(sessionManager.getPublicKey())) return
                 val subId = arr[1].jsonPrimitive.content
                 val event = arr[2].jsonObject
                 val kind = event["kind"]?.jsonPrimitive?.int
@@ -5097,7 +5127,7 @@ class NostrRepository(
 
                     7 -> {
                         val reaction = client.parseReaction(event) ?: return
-                        val reactorPubkey = groupManager.handleReaction(reaction)
+                        val reactorPubkey = groupManager.handleReaction(reaction, relayUrl = client.getRelayUrl())
                         if (reactorPubkey != null && !metadataManager.hasMetadata(reactorPubkey)) {
                             scope.launch {
                                 requestUserMetadata(setOf(reactorPubkey))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -609,6 +609,8 @@ interface NostrRepositoryApi {
         targetEventId: String,
         targetPubkey: String,
         emoji: String,
+        /** Thread root when reacting inside a thread; null for chat reactions. */
+        threadRootId: String? = null,
     ): Result<Unit>
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ConnectionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/ConnectionManager.kt
@@ -709,6 +709,34 @@ class ConnectionManager(
     }
 
     /**
+     * Drop every socket that answered NIP-42 as an account other than [pubkey].
+     *
+     * A relay serves reads under the identity that AUTH'd the socket. After an account swap the
+     * old sockets are still authenticated as the outgoing account, so the incoming account's REQ
+     * on one of them comes back with events it must not see (a private group only the previous
+     * account belongs to reads as fully visible). Closing subscriptions is not enough — the next
+     * REQ over the same socket is answered under the same stale identity. NIP-42 is reactive, so
+     * only a fresh socket produces a challenge the new account can answer.
+     *
+     * Public sockets (never challenged) are left alone. Reconnecting is the caller's job: the
+     * pool reopens them on demand. Returns the normalized URLs that were dropped.
+     */
+    suspend fun disconnectSocketsAuthedAsOther(pubkey: String?): List<String> {
+        // Collect under the lock, disconnect outside it: disconnectRelay takes the same mutex.
+        val stale =
+            poolMutex.withLock {
+                relayPool.entries.filter { (_, client) -> client.isAuthedAsOther(pubkey) }.map { it.key }
+            }
+        for (url in stale) {
+            try {
+                disconnectRelay(url)
+            } catch (_: Exception) {
+            }
+        }
+        return stale
+    }
+
+    /**
      * Clear all connections, disconnecting pool clients in parallel.
      */
     suspend fun clearAll() {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -88,6 +88,10 @@ class GroupManager(
     private val adaptiveConfig: AdaptiveConfig? = null,
     private val cacheStore: CacheStore = InMemoryCacheStore(),
     private val onNewMessagesFlushed: ((groupId: String, newMessages: List<NostrGroupClient.NostrMessage>) -> Unit)? = null,
+    // Forum thread events (kind:11 / 1111) as they land from a relay. Separate from
+    // [onNewMessagesFlushed]: threads live in their own stores and never enter the chat
+    // batch, so notifications would otherwise never see a thread reply.
+    private val onThreadEventReceived: ((groupId: String, event: NostrGroupClient.NostrMessage) -> Unit)? = null,
 ) {
     private val json = Json { ignoreUnknownKeys = true }
     private val eventDeduplicator = EventDeduplicator()
@@ -3086,14 +3090,81 @@ class GroupManager(
 
     private fun threadRepliesSubId(groupId: String) = "threadrepl_$groupId"
 
+    /**
+     * Ids the current threads REQ delivered, per group. Its EOSE compares them against what we
+     * hold to tell "the relay no longer serves this" from "we never asked": a thread deleted on
+     * another device is simply absent from the answer, and the kind:5/9005 that removed it is
+     * never replayed to this one, so the disk cache would rehydrate it forever.
+     *
+     * A StateFlow (not a plain map) because the ingest path writes it off the relay socket while
+     * the pane's REQ resets it: `update` is atomic, a shared MutableMap would race.
+     */
+    private val threadSubSeenIds = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+
+    /** Start a fresh answer window for [groupId]; called every time the threads REQ is issued. */
+    private fun resetThreadSubSeen(groupId: String) {
+        threadSubSeenIds.update { it + (groupId to emptySet()) }
+    }
+
+    /** Record an id the relay served for [groupId]'s threads REQ (before dedup drops replays). */
+    private fun noteThreadSubSeen(groupId: String, eventId: String) {
+        threadSubSeenIds.update { current ->
+            val seen = current[groupId] ?: return@update current
+            if (eventId in seen) current else current + (groupId to (seen + eventId))
+        }
+    }
+
+    /**
+     * Drop stored thread events the relay's answer did not include: they were deleted elsewhere.
+     *
+     * Bounded by the answer's own window. The REQ is limit-capped, so anything older than the
+     * oldest event served is simply outside what the relay was asked for and must be kept -
+     * without that guard, a group with more threads than [THREAD_PAGE_SIZE] would lose its
+     * history on every EOSE. Entries from another relay and un-echoed optimistic sends (no
+     * relayUrl) are never touched. Removals are evicted from the disk cache too, otherwise the
+     * next cold open rehydrates exactly what was just reconciled away.
+     */
+    private fun reconcileThreadsAtEose(groupId: String, relayUrl: String, kind: Int) {
+        val seen = threadSubSeenIds.value[groupId] ?: return
+        val relay = relayUrl.normalizeRelayUrl()
+        val store = if (kind == 11) _threadRoots else _threadReplies
+        val removed = mutableSetOf<String>()
+        store.update { current ->
+            val list = current[groupId] ?: return@update current
+            val stale = staleThreadEventIds(list.filter { it.kind == kind && it.relayUrl?.normalizeRelayUrl() == relay }, seen)
+            if (stale.isEmpty()) return@update current
+            removed += stale
+            current + (groupId to list.filterNot { it.id in stale })
+        }
+        if (removed.isEmpty()) return
+        val account = currentPubkey ?: return
+        scope.launch {
+            try {
+                cacheStore.deleteByIds(account, removed)
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /** Reconcile roots against the relay's answer; called on the threads_ sub's EOSE. */
+    fun reconcileThreadRootsAtEose(groupId: String, relayUrl: String) = reconcileThreadsAtEose(groupId, relayUrl, kind = 11)
+
+    /** Reconcile replies against the relay's answer; called on the threadrepl_ sub's EOSE. */
+    fun reconcileThreadRepliesAtEose(groupId: String, relayUrl: String) = reconcileThreadsAtEose(groupId, relayUrl, kind = 1111)
+
     /** Route a parsed thread event into its store (kind:11 roots, kind:1111 replies), deduped. */
     private fun applyThreadEvent(groupId: String, message: NostrGroupClient.NostrMessage, persist: Boolean = true) {
         val store = if (message.kind == 11) _threadRoots else _threadReplies
+        var inserted = false
         store.update { current ->
             val list = current[groupId] ?: emptyList()
             if (list.any { it.id == message.id }) return@update current
+            inserted = true
             current + (groupId to (list + message).sortedBy { it.createdAt })
         }
+        // Notify only on a real insert of a relay-delivered event: a disk hydration is not news,
+        // and an un-echoed optimistic send is our own.
+        if (inserted && persist && message.relayUrl != null) onThreadEventReceived?.invoke(groupId, message)
         // Write-through OUTSIDE the in-memory dedup: the relay echo of an optimistic
         // (relay-less) insert is deduped above, yet it is the first relay-attributed copy
         // and the one that must reach the disk cache. Upserts are idempotent.
@@ -3115,6 +3186,54 @@ class GroupManager(
      * events (the optimistic insert before the relay echo) are skipped: hydration is
      * relay-scoped and a send that never echoes must not rehydrate as a ghost.
      */
+    /**
+     * Persist a reaction that targets a thread event into that thread's cache slot, so reopening
+     * the pane shows its chips from disk instead of a bare card until the relay answers. Chat
+     * reactions are not cached (their slot is the chat history and nothing rehydrates them).
+     *
+     * The tags are rebuilt from the parsed reaction rather than kept raw: only e/p/h/E/emoji
+     * matter to [toNostrReaction], and this keeps the row the same shape a thread event has.
+     */
+    private fun cacheThreadReaction(reaction: NostrGroupClient.NostrReaction, relayUrl: String) {
+        val account = currentPubkey ?: return
+        val groupId = reaction.groupId ?: return
+        val rootId = reaction.threadRootId ?: threadRootForEvent(reaction.targetEventId) ?: return
+        val slot = threadCacheSlot(relayUrl, groupId)
+        val tags = threadReactionCacheTags(reaction, groupId, rootId)
+        scope.launch {
+            try {
+                cacheStore.upsertMessages(
+                    account,
+                    slot,
+                    listOf(
+                        CachedMsg(
+                            id = reaction.id,
+                            groupId = slot,
+                            pubkey = reaction.pubkey,
+                            createdAt = reaction.createdAt,
+                            kind = 7,
+                            content = reaction.emoji,
+                            tagsJson = json.encodeToString(tagsSerializer, tags),
+                        ),
+                    ),
+                )
+            } catch (_: Exception) {
+            }
+        }
+        scheduleCacheEviction()
+    }
+
+    /** Rebuild a reaction from its cached row; null when the row is not a usable kind:7. */
+    private fun CachedMsg.toNostrReaction(): NostrGroupClient.NostrReaction? {
+        if (kind != 7) return null
+        val tags = try {
+            json.decodeFromString(tagsSerializer, tagsJson)
+        } catch (_: Exception) {
+            return null
+        }
+        return reactionFromCacheRow(id, pubkey, createdAt, content, tags)
+    }
+
     private fun cacheThreadEvent(groupId: String, message: NostrGroupClient.NostrMessage) {
         val account = currentPubkey ?: return
         val relay = message.relayUrl ?: return
@@ -3149,7 +3268,13 @@ class GroupManager(
                 return
             }
         for (row in cached) {
-            applyThreadEvent(groupId, row.toNostrMessage().withOriginRelay(relay), persist = false)
+            // The slot holds the thread's reactions alongside its events; a kind:7 must rebuild
+            // a reaction, not be filed as a reply.
+            if (row.kind == 7) {
+                row.toNostrReaction()?.let { handleReaction(it) }
+            } else {
+                applyThreadEvent(groupId, row.toNostrMessage().withOriginRelay(relay), persist = false)
+            }
         }
     }
 
@@ -3174,6 +3299,7 @@ class GroupManager(
             client.awaitAuthOrTimeout(INITIAL_READ_AUTH_TIMEOUT_MS)
         }
         return try {
+            resetThreadSubSeen(groupId)
             client.requestGroupThreadRoots(
                 groupId,
                 limit = THREAD_PAGE_SIZE,
@@ -3202,6 +3328,7 @@ class GroupManager(
             if (getRelayForGroup(groupId)?.normalizeRelayUrl() != normalized) continue
             val client = clientForGroup(groupId) ?: continue
             runCatching {
+                resetThreadSubSeen(groupId)
                 client.requestGroupThreadRoots(groupId, limit = THREAD_PAGE_SIZE, subscriptionId = threadRootsSubId(groupId))
                 client.requestThreadReplies(groupId, rootId = null, limit = THREAD_REPLY_BATCH, subscriptionId = threadRepliesSubId(groupId))
             }
@@ -3344,6 +3471,9 @@ class GroupManager(
         emoji: String,
         pubKey: String,
         signEvent: suspend (Event) -> Event,
+        // Set when reacting inside a thread: carries the root so the target's readers can open
+        // the thread without having the reacted-to event loaded.
+        threadRootId: String? = null,
     ): Result<Unit> {
         val currentClient = clientForGroup(groupId)
             ?: return Result.Error(AppError.Network.Disconnected(""))
@@ -3354,6 +3484,7 @@ class GroupManager(
                 add(listOf("h", groupId, groupRelayUrl))
                 add(listOf("e", targetEventId, "", "", targetPubkey))
                 add(listOf("p", targetPubkey))
+                if (threadRootId != null) add(listOf("E", threadRootId))
                 // Include emoji tag for custom emojis (NIP-30) so other clients can resolve the URL
                 val shortcode = emoji.trim(':')
                 if (emoji.startsWith(":") && emoji.endsWith(":") && shortcode.isNotEmpty()) {
@@ -4500,9 +4631,13 @@ class GroupManager(
         // buffer). Returning the author pubkey still backfills their profile metadata.
         if (message.kind in threadKinds) {
             if (message.id.isBlank()) return null
-            if (!eventDeduplicator.tryAddSync(message.id)) return null
             val groupId = extractGroupIdFromMessage(rawMsg) ?: return null
             if (isRecentlyLeft(groupId)) return null
+            // Ahead of the dedup: a resubscribe replays the same roots, and those replays are
+            // exactly what proves the relay still serves them. Deduping first would leave the
+            // answer window looking empty and the EOSE would reconcile live threads away.
+            noteThreadSubSeen(groupId, message.id)
+            if (!eventDeduplicator.tryAddSync(message.id)) return null
             applyThreadEvent(groupId, message.withOriginRelay(relayUrl))
             return message.pubkey
         }
@@ -4862,10 +4997,35 @@ class GroupManager(
      */
     fun getMessagesForGroup(groupId: String): List<NostrGroupClient.NostrMessage> = _messages.value[groupId] ?: emptyList()
 
+    /**
+     * The thread root to open for [eventId] when it is a forum event: the root itself for a
+     * kind:11, its uppercase-E scope for a kind:1111. Null for chat events, which open the chat.
+     * Lets a notification about a thread event deep-link into the threads pane.
+     */
+    fun threadRootForEvent(eventId: String): String? {
+        _threadRoots.value.values.forEach { roots ->
+            if (roots.any { it.id == eventId }) return eventId
+        }
+        _threadReplies.value.values.forEach { replies ->
+            val reply = replies.firstOrNull { it.id == eventId }
+            if (reply != null) return reply.tags.firstOrNull { it.size >= 2 && it[0] == "E" }?.get(1)
+        }
+        return null
+    }
+
     fun findMessageByIdAcrossGroups(messageId: String): Pair<String, NostrGroupClient.NostrMessage>? {
         for ((groupId, msgs) in _messages.value) {
             val msg = msgs.firstOrNull { it.id == messageId } ?: continue
             return groupId to msg
+        }
+        // Thread roots and replies live outside _messages; without them a reaction to a thread
+        // event whose sender omitted the NIP-25 `p` tag resolves to no author and never counts
+        // as an interaction with us.
+        for (store in listOf(_threadRoots.value, _threadReplies.value)) {
+            for ((groupId, events) in store) {
+                val event = events.firstOrNull { it.id == messageId } ?: continue
+                return groupId to event
+            }
         }
         return null
     }
@@ -4889,6 +5049,9 @@ class GroupManager(
     fun handleReaction(
         reaction: NostrGroupClient.NostrReaction,
         immediate: Boolean = false,
+        // Origin relay, for the disk cache slot. Null skips persistence (optimistic local
+        // reactions, which the relay echo re-caches with its relay attributed).
+        relayUrl: String? = null,
     ): String? {
         val messageId = reaction.targetEventId
         if (messageId.isBlank()) return null
@@ -4897,6 +5060,8 @@ class GroupManager(
         if (!eventDeduplicator.tryAddSync(reaction.id)) {
             return null
         }
+
+        if (relayUrl != null) cacheThreadReaction(reaction, relayUrl)
 
         // Check pending (staged) reactions first, then committed state.
         val currentReactions = _pendingReactions[messageId]
@@ -5335,6 +5500,66 @@ class GroupManager(
         val pubkey = currentPubkey ?: return
         SecureStorage.clearMessagesForGroup(pubkey, groupId)
     }
+}
+
+/**
+ * Which of [stored] a limit-capped REQ answer ([seen]) proves are gone, i.e. deleted on another
+ * device: this one never receives that kind:5/9005, so absence from the answer is the only signal.
+ *
+ * Only the answer's own window counts. The REQ is limit-capped, so events older than the oldest
+ * one served were never asked for and stay - otherwise a group with more threads than the page
+ * size would lose its history on every EOSE. An empty answer is authoritative (callers reconcile
+ * only a settled, authenticated sub), so it clears the whole window.
+ *
+ * [stored] must already be narrowed to one kind on the answering relay; un-echoed optimistic
+ * sends (no relay) never reach here.
+ */
+internal fun staleThreadEventIds(
+    stored: List<NostrGroupClient.NostrMessage>,
+    seen: Set<String>,
+): Set<String> {
+    if (stored.isEmpty()) return emptySet()
+    val windowStart = stored.filter { it.id in seen }.minOfOrNull { it.createdAt } ?: Long.MIN_VALUE
+    return stored.filter { it.id !in seen && it.createdAt >= windowStart }.map { it.id }.toSet()
+}
+
+/**
+ * Tags a cached thread reaction keeps. Only what [reactionFromCacheRow] needs to rebuild it:
+ * the target (`e`), its author (`p`), the group (`h`), the thread root (`E`) and the custom
+ * emoji URL. Written instead of the raw event tags so the row shape stays stable.
+ */
+internal fun threadReactionCacheTags(
+    reaction: NostrGroupClient.NostrReaction,
+    groupId: String,
+    rootId: String,
+): List<List<String>> = buildList {
+    add(listOf("e", reaction.targetEventId))
+    reaction.targetAuthorPubkey?.let { add(listOf("p", it)) }
+    add(listOf("h", groupId))
+    add(listOf("E", rootId))
+    reaction.emojiUrl?.let { add(listOf("emoji", reaction.emoji.trim(':'), it)) }
+}
+
+/** Inverse of [threadReactionCacheTags]; null when the row carries no target to react to. */
+internal fun reactionFromCacheRow(
+    id: String,
+    pubkey: String,
+    createdAt: Long,
+    emoji: String,
+    tags: List<List<String>>,
+): NostrGroupClient.NostrReaction? {
+    val target = tags.firstOrNull { it.size >= 2 && it[0] == "e" }?.get(1) ?: return null
+    return NostrGroupClient.NostrReaction(
+        id = id,
+        pubkey = pubkey,
+        emoji = emoji,
+        emojiUrl = tags.firstOrNull { it.size >= 3 && it[0] == "emoji" }?.get(2),
+        targetEventId = target,
+        createdAt = createdAt,
+        targetAuthorPubkey = tags.firstOrNull { it.size >= 2 && it[0] == "p" }?.get(1),
+        groupId = tags.firstOrNull { it.size >= 2 && it[0] == "h" }?.get(1),
+        threadRootId = tags.firstOrNull { it.size >= 2 && it[0] == "E" }?.get(1),
+    )
 }
 
 /** NIP-29 delete-event: the admin moderation action that removes any member's event. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -31,6 +31,12 @@ import org.nostr.nostrord.utils.LruCache
 import org.nostr.nostrord.utils.epochMillis
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
+/** How long a by-id fetch waits for a gated relay's NIP-42 to land before giving up on it. */
+private const val EVENT_FETCH_AUTH_TIMEOUT_MS = 8_000L
+
+/** How long a by-id fetch blocks an identical one. Must stay under the UI's give-up window. */
+private const val EVENT_FETCH_RETRY_AFTER_MS = 4_000L
+
 class MetadataManager(
     private val connectionManager: ConnectionManager,
     private val outboxManager: OutboxManager,
@@ -438,12 +444,31 @@ class MetadataManager(
             // it while another connected relay actually has it. This is how native effectively
             // resolves these — it has those relays connected. (Includes the focused + author
             // outbox relays already in the pool.)
-            connectionManager.getAllConnectedClients().forEach { client ->
+            val connected = connectionManager.getAllConnectedClients()
+            connected.forEach { client ->
                 try {
                     client.requestEventById(eventId)
                 } catch (_: Exception) {
                 }
             }
+
+            // An auth-gating relay withholds its group events until NIP-42 completes, and answers
+            // the REQ above with CLOSED "auth-required" — which is why a quoted kind:11 in a private
+            // group resolved only when the socket happened to be authed already (the card read as removed
+            // otherwise). Re-ask each gated relay once AUTH lands. Launched per client so a slow
+            // (bunker) signer on one relay does not hold up the others.
+            connected
+                .filter { it.requiresAuth() && !it.hasAuthSucceeded() }
+                .forEach { client ->
+                    scope.launch {
+                        if (client.awaitAuthOrTimeout(EVENT_FETCH_AUTH_TIMEOUT_MS) && !_cachedEvents.value.containsKey(eventId)) {
+                            try {
+                                client.requestEventById(eventId)
+                            } catch (_: Exception) {
+                            }
+                        }
+                    }
+                }
 
             // Plus any relay hint we are NOT connected to: connect on demand and REQ there, so a
             // correct hint to a relay outside the pool (an event whose group relay we never joined)
@@ -462,10 +487,10 @@ class MetadataManager(
                     }
                 }
         } finally {
-            // Remove after a delay to allow the response to arrive and be cached.
-            // If not cached after 10s, subsequent requests can try again.
+            // Release the in-flight guard sooner than the reference card gives up (5s), or the
+            // card's Retry button lands inside the guard and no-ops silently.
             scope.launch {
-                delay(10_000)
+                delay(EVENT_FETCH_RETRY_AFTER_MS)
                 inFlightEventsMutex.withLock { inFlightEvents.remove(eventId) }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -30,6 +30,9 @@ class UnreadManager(
     private val onReplyNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
     private val onMentionNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
     private val onReactionNotify: ((groupId: String, reaction: NostrGroupClient.NostrReaction) -> Unit)? = null,
+    // A kind:1111 reply under a thread event of ours. Fired instead of [onReplyNotify] so the
+    // entry can deep-link into the threads pane rather than the chat.
+    private val onThreadReplyNotify: ((groupId: String, reply: NostrGroupClient.NostrMessage) -> Unit)? = null,
     // Called when a group is marked read so the notification feed can drop the
     // group's entries in lockstep with the unread badge (issue #67).
     private val onGroupRead: ((groupId: String) -> Unit)? = null,
@@ -231,6 +234,38 @@ class UnreadManager(
         }
     }
 
+    /**
+     * A forum thread event (kind:11 root or kind:1111 reply) arrived from a relay.
+     *
+     * Only replies under something of ours notify: a reply to your thread root or to one of your
+     * replies, or one that p-tags you. New roots by others are group activity, not an interaction,
+     * and would turn every thread into a push.
+     *
+     * The group's unread badge and high-water are deliberately untouched. Those count chat
+     * messages and are cleared by reading the chat; letting a thread reply bump them would leave
+     * a badge that opening the chat cannot clear.
+     *
+     * No lastRead/high-water anchor either, unlike chat: those track chat reading, so a group
+     * whose chat was just opened would silently swallow every thread reply that follows within
+     * the same second. Re-announcing is handled where it belongs - the feed dedupes by event id,
+     * and AppModule gates sound and popup on the event being realtime.
+     */
+    fun onThreadEventReceived(groupId: String, event: NostrGroupClient.NostrMessage) {
+        val pubkey = currentPubkey
+        val verdict = when {
+            pubkey == null -> "no-session"
+            event.kind != 1111 -> "not-a-reply(${event.kind})"
+            event.pubkey == pubkey -> "own-reply"
+            isMutedAuthor(event.pubkey) -> "muted-author"
+            !isJoined(groupId) -> "not-joined"
+            !threadReplyTargetsMe(event.tags, pubkey, findMessageAuthor) -> "not-for-me"
+            !shouldNotify(groupId, true) -> "group-muted"
+            else -> null
+        }
+        if (verdict != null) return
+        onThreadReplyNotify?.invoke(groupId, event)
+    }
+
     fun onReactionReceived(groupId: String, reaction: NostrGroupClient.NostrReaction) {
         val pubkey = currentPubkey ?: return
         if (reaction.pubkey == pubkey) return
@@ -293,4 +328,25 @@ class UnreadManager(
         }
         SecureStorage.saveUnreadEntries(pubkey, entries)
     }
+}
+
+/**
+ * Whether a kind:1111 reply is a reply to [pubkey], read from the reply's own NIP-22 tags.
+ *
+ * The tags are authoritative and need no local state: uppercase `P` is the thread root's author
+ * and `E`/`e` carry theirs in the 4th element. That matters because a top-level reply carries no
+ * lowercase `p` (the parent IS the root, and duplicating the triple trips relays that cap
+ * indexable tags), and the root itself is usually not in memory on a device that never opened
+ * the pane. [findMessageAuthor] stays as the last resort for clients that send a leaner tag set.
+ */
+internal fun threadReplyTargetsMe(
+    tags: List<List<String>>,
+    pubkey: String,
+    findMessageAuthor: (String) -> String?,
+): Boolean {
+    val pTagsMe = tags.any { it.size >= 2 && (it[0] == "p" || it[0] == "P") && it[1] == pubkey }
+    if (pTagsMe) return true
+    val scopeAuthorIsMe = tags.any { it.size >= 4 && (it[0] == "E" || it[0] == "e") && it[3] == pubkey }
+    if (scopeAuthorIsMe) return true
+    return tags.any { it.size >= 2 && (it[0] == "E" || it[0] == "e") && findMessageAuthor(it[1]) == pubkey }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
@@ -22,6 +22,11 @@ data class NotificationEntry(
     val createdAt: Long,
     val preview: String,
     val messageId: String? = null,
+    /**
+     * Set when the entry is about a forum thread event: the kind:11 root to open. Chat entries
+     * leave it null. Defaulted so entries persisted before threads notified still deserialize.
+     */
+    val threadRootId: String? = null,
     val emoji: String? = null,
     val read: Boolean = false,
     // Snapshot of the group/relay display names at the moment the notification
@@ -75,11 +80,33 @@ class NotificationHistoryStore {
     }
 
     /** Mark every unread notification for [groupId] as read. No-op if none match. */
+    /**
+     * Mark a group's CHAT notifications read, as reading its chat does.
+     *
+     * Thread entries are left alone: their event is not in the chat, so opening the chat is no
+     * evidence the user saw it. They clear via [markReadForThread] when that thread is opened.
+     */
     fun markReadForGroup(groupId: String) {
         var changed = false
         _entries.update { current ->
             current.map {
-                if (it.groupId == groupId && !it.read) {
+                if (it.groupId == groupId && it.threadRootId == null && !it.read) {
+                    changed = true
+                    it.copy(read = true)
+                } else {
+                    it
+                }
+            }
+        }
+        if (changed) persist()
+    }
+
+    /** Mark every notification about thread [rootId] read: the user opened that thread. */
+    fun markReadForThread(rootId: String) {
+        var changed = false
+        _entries.update { current ->
+            current.map {
+                if (it.threadRootId == rootId && !it.read) {
                     changed = true
                     it.copy(read = true)
                 } else {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
@@ -46,6 +46,22 @@ data class GroupRoute(
 enum class GroupView { Chat, Threads }
 
 /**
+ * Where a notification entry opens. Thread entries carry the root to open and land on the
+ * threads pane, targeting the reply/reaction inside it; everything else opens the chat at its
+ * message. Shared so both UIs route a notification the same way.
+ */
+fun notificationRoute(
+    relayUrl: String,
+    groupId: String,
+    messageId: String?,
+    threadRootId: String?,
+): GroupRoute = if (threadRootId != null) {
+    GroupRoute(relayUrl, groupId, messageId = messageId, view = GroupView.Threads, threadRootId = threadRootId)
+} else {
+    GroupRoute(relayUrl, groupId, messageId = messageId)
+}
+
+/**
  * Shareable web link for a thread: https://web.nostrord.com/#/g/<relay>/<id>/threads/<rootId>,
  * plus `?e=<messageId>` targeting the specific message to scroll to and flash. Backs "Copy
  * event link" in the thread context menu (the chat's nostrord.com/open ?e= form scrolls the

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
@@ -1,0 +1,162 @@
+package org.nostr.nostrord.ui.screens.group
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.GroupMetadata
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.utils.normalizeRelayUrl
+
+/**
+ * One group's roster and the active account's standing in it, host-relay scoped.
+ *
+ * Every screen that renders a join affordance, a member badge or a moderation control needs the
+ * same verdict, so it is derived once here and shared: [GroupViewModel] (chat) and
+ * [ThreadsViewModel] (forum) both delegate. Deriving it per screen is how the two drift, and a
+ * wrong verdict hands out admin controls or hides the join button.
+ *
+ * [hostRelay] must already be normalized. When set, only that relay's mirror of a list decides:
+ * a same-id group on another relay is a different group.
+ */
+class GroupMembershipModel(
+    private val repo: NostrRepositoryApi,
+    private val groupId: String,
+    private val hostRelay: String?,
+    private val scope: CoroutineScope,
+) {
+    /** Members, host-relay scoped: entries the host relay published win over the flat compat map. */
+    val members: StateFlow<Map<String, List<String>>> =
+        if (hostRelay == null) {
+            repo.groupMembers
+        } else {
+            combine(repo.groupMembers, repo.groupMembersByRelay) { flat, byRelay ->
+                byRelay.scopedOverFlat(flat, groupId, hostRelay)
+            }.stateIn(scope, SharingStarted.Eagerly, repo.groupMembers.value)
+        }
+
+    /** Admins, scoped like [members]. */
+    val admins: StateFlow<Map<String, List<String>>> =
+        if (hostRelay == null) {
+            repo.groupAdmins
+        } else {
+            combine(repo.groupAdmins, repo.groupAdminsByRelay) { flat, byRelay ->
+                byRelay.scopedOverFlat(flat, groupId, hostRelay)
+            }.stateIn(scope, SharingStarted.Eagerly, repo.groupAdmins.value)
+        }
+
+    /**
+     * The active account's standing in this group (None / Resolving / Pending / Member / Admin),
+     * the single source of truth both UIs read to choose between the join button, the pending bar,
+     * and the composer - and to label leaving as "Cancel join request" vs "Leave group".
+     * `accountStore.activeId` is folded in so switching accounts (which leaves groupId unchanged)
+     * re-reads getPublicKey() and re-derives instead of going stale.
+     */
+    @Suppress("UNCHECKED_CAST")
+    val membershipState: StateFlow<GroupMembershipState> =
+        combine(
+            listOf(
+                repo.joinedGroupsByRelay,
+                members,
+                admins,
+                repo.messages,
+                repo.groups,
+                AppModule.accountStore.activeId,
+                repo.pendingApprovalSince,
+                repo.leftGroups,
+                repo.groupsByRelay,
+            ),
+        ) { arr ->
+            val joinedByRelay = arr[0] as Map<String, Set<String>>
+            val membersByGroup = arr[1] as Map<String, List<String>>
+            val adminsByGroup = arr[2] as Map<String, List<String>>
+            val messagesByGroup = arr[3] as Map<String, List<NostrGroupClient.NostrMessage>>
+            val allGroups = arr[4] as List<GroupMetadata>
+            val pendingByGroup = arr[6] as Map<String, Long>
+            val leftSet = arr[7] as Set<String>
+            val byRelay = arr[8] as Map<String, List<GroupMetadata>>
+
+            val pubkey = repo.getPublicKey()
+            val locallyLeft = groupId in leftSet
+            // With an explicit host relay only ITS joined set counts: being in the same-id
+            // group on another relay is membership in a different group.
+            val joined =
+                if (hostRelay != null) {
+                    joinedByRelay.atRelay(hostRelay)?.contains(groupId) == true
+                } else {
+                    joinedByRelay.values.any { groupId in it }
+                }
+            val members = membersByGroup[groupId].orEmpty()
+            val admins = adminsByGroup[groupId].orEmpty()
+            // Absent metadata defaults to open (the permissive NIP-29 default), so we don't
+            // wrongly hold a group as pending before its kind:39000 arrives.
+            val meta = metadataFor(allGroups, byRelay)
+            val isOpen = meta?.isOpen ?: true
+            // Outstanding join request: prefer the LOCAL pendingApprovalSince (set on our 9021, cleared
+            // the instant we leave / are approved) — it is the reliable in-session truth. The kind:9021
+            // in the message feed is the fallback that survives a restart, but it is gated on `joined`:
+            // a left group is removed from our joined list, so a stale 9021 still echoed in a re-fetched
+            // feed no longer reads as pending. (`leaveGroup` clears the feed and a re-fetch races, which
+            // is why the feed alone left a left group stuck on "Request pending" until a reload.)
+            val localPendingAt = pendingByGroup[groupId]
+            val ownEvents = messagesByGroup[groupId].orEmpty().asSequence()
+                .filter { it.pubkey == pubkey }
+                .filter { hostRelay == null || it.relayUrl == null || it.relayUrl == hostRelay }
+            val lastJoinReq = ownEvents.filter { it.kind == 9021 }.maxOfOrNull { it.createdAt }
+            val lastLeave = ownEvents.filter { it.kind == 9022 }.maxOfOrNull { it.createdAt }
+            val feedRequestedAt =
+                lastJoinReq?.takeIf { (lastLeave == null || it > lastLeave) && joined }
+            val requestedAt = localPendingAt ?: feedRequestedAt
+
+            val status =
+                deriveMembershipStatus(
+                    pubkey = pubkey,
+                    joined = joined,
+                    isOpen = isOpen,
+                    hasOwnJoinRequest = requestedAt != null,
+                    members = members,
+                    admins = admins,
+                    locallyLeft = locallyLeft,
+                )
+            GroupMembershipState(status, requestedAt)
+        }.stateIn(scope, SharingStarted.Eagerly, GroupMembershipState())
+
+    /**
+     * Access shape (Private/Closed) for UI labels. Trusts the kind:39000 metadata when present;
+     * otherwise (withheld from a non-member) infers from the relay's restricted signal so an outsider
+     * sees "Private"/"Request to Join" instead of the misleading public/open default. Both UIs read
+     * this for the badges and the Join-vs-Request-to-Join label.
+     */
+    val access: StateFlow<GroupAccess> =
+        combine(repo.groups, repo.groupsByRelay, repo.restrictedGroups) { groups, byRelay, restricted ->
+            val meta = metadataFor(groups, byRelay)
+            if (meta != null) {
+                GroupAccess(isPrivate = !meta.isPublic, isOpen = meta.isOpen)
+            } else {
+                val restrictedHere = groupId in restricted
+                GroupAccess(isPrivate = restrictedHere, isOpen = !restrictedHere)
+            }
+        }.stateIn(scope, SharingStarted.Eagerly, GroupAccess())
+
+    /** True when the active account administers this group. */
+    val isAdmin: StateFlow<Boolean> =
+        combine(admins, AppModule.accountStore.activeId) { byGroup, _ ->
+            val me = repo.getPublicKey()
+            me != null && me in byGroup[groupId].orEmpty()
+        }.stateIn(scope, SharingStarted.Eagerly, false)
+
+    private fun metadataFor(
+        flat: List<GroupMetadata>,
+        byRelay: Map<String, List<GroupMetadata>>,
+    ): GroupMetadata? = if (hostRelay != null) {
+        byRelay.atRelay(hostRelay)?.firstOrNull { it.id == groupId }
+    } else {
+        flat.find { it.id == groupId }
+    }
+}
+
+/** Normalized host relay for a route, or null when the route carries none. */
+internal fun hostRelayOf(relayUrl: String?): String? = relayUrl?.normalizeRelayUrl()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -265,22 +265,10 @@ class GroupViewModel(
      * over the flat compat maps (where a same-id group on another relay overwrites).
      * The flat value stays the fallback while the per-relay mirror is still cold.
      */
-    val groupMembers: StateFlow<Map<String, List<String>>> =
-        if (hostRelay == null) {
-            repo.groupMembers
-        } else {
-            combine(repo.groupMembers, repo.groupMembersByRelay) { flat, byRelay ->
-                byRelay.scopedOverFlat(flat)
-            }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupMembers.value)
-        }
-    val groupAdmins: StateFlow<Map<String, List<String>>> =
-        if (hostRelay == null) {
-            repo.groupAdmins
-        } else {
-            combine(repo.groupAdmins, repo.groupAdminsByRelay) { flat, byRelay ->
-                byRelay.scopedOverFlat(flat)
-            }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupAdmins.value)
-        }
+    private val membershipModel = GroupMembershipModel(repo, groupId, hostRelay, viewModelScope)
+
+    val groupMembers: StateFlow<Map<String, List<String>>> = membershipModel.members
+    val groupAdmins: StateFlow<Map<String, List<String>>> = membershipModel.admins
     val groupRoles: StateFlow<Map<String, List<RoleDefinition>>> =
         if (hostRelay == null) {
             repo.groupRoles
@@ -334,110 +322,11 @@ class GroupViewModel(
                 .distinctBy { it.meta.id }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
-    /**
-     * The active account's standing in this group (None / Resolving / Pending / Member / Admin),
-     * the single source of truth both UIs read to choose between the join button, the pending bar,
-     * and the composer - and to label leaving as "Cancel join request" vs "Leave group".
-     * `accountStore.activeId` is folded in so switching accounts (which leaves groupId unchanged)
-     * re-reads getPublicKey() and re-derives instead of going stale.
-     */
-    @Suppress("UNCHECKED_CAST")
-    val membershipState: StateFlow<GroupMembershipState> =
-        combine(
-            listOf(
-                repo.joinedGroupsByRelay,
-                // The VM's own host-relay-scoped lists, so a same-id group on another
-                // relay can't decide membership here.
-                groupMembers,
-                groupAdmins,
-                repo.messages,
-                repo.groups,
-                AppModule.accountStore.activeId,
-                repo.pendingApprovalSince,
-                repo.leftGroups,
-                repo.groupsByRelay,
-            ),
-        ) { arr ->
-            val joinedByRelay = arr[0] as Map<String, Set<String>>
-            val membersByGroup = arr[1] as Map<String, List<String>>
-            val adminsByGroup = arr[2] as Map<String, List<String>>
-            val messagesByGroup = arr[3] as Map<String, List<NostrGroupClient.NostrMessage>>
-            val allGroups = arr[4] as List<GroupMetadata>
-            val pendingByGroup = arr[6] as Map<String, Long>
-            val leftSet = arr[7] as Set<String>
-            val byRelay = arr[8] as Map<String, List<GroupMetadata>>
+    /** The active account's standing in this group; derived once in [GroupMembershipModel]. */
+    val membershipState: StateFlow<GroupMembershipState> = membershipModel.membershipState
 
-            val pubkey = repo.getPublicKey()
-            val locallyLeft = groupId in leftSet
-            // With an explicit host relay only ITS joined set counts: being in the same-id
-            // group on another relay is membership in a different group.
-            val joined =
-                if (hostRelay != null) {
-                    joinedByRelay.atHostRelay()?.contains(groupId) == true
-                } else {
-                    joinedByRelay.values.any { groupId in it }
-                }
-            val members = membersByGroup[groupId].orEmpty()
-            val admins = adminsByGroup[groupId].orEmpty()
-            // Absent metadata defaults to open (the permissive NIP-29 default), so we don't
-            // wrongly hold a group as pending before its kind:39000 arrives.
-            val meta =
-                if (hostRelay != null) {
-                    byRelay.atHostRelay()?.firstOrNull { it.id == groupId }
-                } else {
-                    allGroups.find { it.id == groupId }
-                }
-            val isOpen = meta?.isOpen ?: true
-            // Outstanding join request: prefer the LOCAL pendingApprovalSince (set on our 9021, cleared
-            // the instant we leave / are approved) — it is the reliable in-session truth. The kind:9021
-            // in the message feed is the fallback that survives a restart, but it is gated on `joined`:
-            // a left group is removed from our joined list, so a stale 9021 still echoed in a re-fetched
-            // feed no longer reads as pending. (`leaveGroup` clears the feed and a re-fetch races, which
-            // is why the feed alone left a left group stuck on "Request pending" until a reload.)
-            val localPendingAt = pendingByGroup[groupId]
-            val ownEvents = messagesByGroup[groupId].orEmpty().asSequence()
-                .filter { it.pubkey == pubkey }
-                .filter { hostRelay == null || it.relayUrl == null || it.relayUrl == hostRelay }
-            val lastJoinReq = ownEvents.filter { it.kind == 9021 }.maxOfOrNull { it.createdAt }
-            val lastLeave = ownEvents.filter { it.kind == 9022 }.maxOfOrNull { it.createdAt }
-            val feedRequestedAt =
-                lastJoinReq?.takeIf { (lastLeave == null || it > lastLeave) && joined }
-            val requestedAt = localPendingAt ?: feedRequestedAt
-
-            val status =
-                deriveMembershipStatus(
-                    pubkey = pubkey,
-                    joined = joined,
-                    isOpen = isOpen,
-                    hasOwnJoinRequest = requestedAt != null,
-                    members = members,
-                    admins = admins,
-                    locallyLeft = locallyLeft,
-                )
-            GroupMembershipState(status, requestedAt)
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, GroupMembershipState())
-
-    /**
-     * Access shape (Private/Closed) for UI labels. Trusts the kind:39000 metadata when present;
-     * otherwise (withheld from a non-member) infers from the relay's restricted signal so an outsider
-     * sees "Private"/"Request to Join" instead of the misleading public/open default. Both UIs read
-     * this for the badges and the Join-vs-Request-to-Join label.
-     */
-    val groupAccess: StateFlow<GroupAccess> =
-        combine(repo.groups, repo.groupsByRelay, repo.restrictedGroups) { groups, byRelay, restricted ->
-            val meta =
-                if (hostRelay != null) {
-                    byRelay.atHostRelay()?.firstOrNull { it.id == groupId }
-                } else {
-                    groups.find { it.id == groupId }
-                }
-            if (meta != null) {
-                GroupAccess(isPrivate = !meta.isPublic, isOpen = meta.isOpen)
-            } else {
-                val restrictedHere = groupId in restricted
-                GroupAccess(isPrivate = restrictedHere, isOpen = !restrictedHere)
-            }
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, GroupAccess())
+    /** Access shape (Private/Closed) for the badges and the Join-vs-Request-to-Join label. */
+    val groupAccess: StateFlow<GroupAccess> = membershipModel.access
 
     /**
      * True when this group is no longer available: the relay it lives on finished serving its group

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -12,11 +12,14 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
+import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.ui.screens.withMinDuration
+import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
@@ -135,6 +138,63 @@ fun canDeleteThreadMessage(
     isAdmin: Boolean,
 ): Boolean = myPubkey != null && (authorPubkey == myPubkey || isAdmin)
 
+/** What the threads list shows when it has no cards to render. */
+enum class ThreadsPlaceholder {
+    /** Still fetching: roots may yet arrive. */
+    LOADING,
+
+    /** Join request sent, no admin answer yet. */
+    PENDING_APPROVAL,
+
+    /** The relay withholds this group's events from you (NIP-29 private group). */
+    PRIVATE,
+
+    /** Readable and genuinely empty: invite the first thread. */
+    EMPTY,
+}
+
+/**
+ * Placeholder for an empty threads list, or null when there are threads to render.
+ *
+ * A private group reads as empty because the relay withholds the events, not because nobody
+ * posted: prompting to "start the first one" there invites a post the relay will reject.
+ * Restriction outranks loading, since the withheld read never settles on its own.
+ * Mirrors the chat gate in MessagesList / the web ChatScreen.
+ */
+fun threadsPlaceholder(
+    hasThreads: Boolean,
+    isLoading: Boolean,
+    isPendingApproval: Boolean,
+    isRestricted: Boolean,
+): ThreadsPlaceholder? = when {
+    hasThreads -> null
+    isPendingApproval -> ThreadsPlaceholder.PENDING_APPROVAL
+    isRestricted -> ThreadsPlaceholder.PRIVATE
+    isLoading -> ThreadsPlaceholder.LOADING
+    else -> ThreadsPlaceholder.EMPTY
+}
+
+/**
+ * Chat messages announcing [rootId] ("Started a thread: ..." carrying its nevent), matched by
+ * decoding the nostr: URIs rather than by string compare - the same root encodes to different
+ * nevents depending on the relay and author hints carried.
+ *
+ * Deleting the thread leaves these pointing at nothing, so they go with it.
+ */
+fun threadAnnouncementsFor(
+    rootId: String,
+    messages: List<NostrGroupClient.NostrMessage>,
+): List<NostrGroupClient.NostrMessage> = messages.filter { msg ->
+    msg.kind == 9 &&
+        Nip27.findReferences(msg.content).any { ref ->
+            when (val entity = ref.entity) {
+                is Nip19.Entity.Nevent -> entity.eventId == rootId
+                is Nip19.Entity.Note -> entity.eventId == rootId
+                else -> false
+            }
+        }
+}
+
 /**
  * Body of the delete confirmation for a thread root or reply. Pass [authorName] only when the
  * content is someone else's: an admin sees the delete action on every message, so moderating
@@ -223,6 +283,9 @@ class ThreadsViewModel(
     fun openThread(rootId: String?) {
         _openRootId.value = rootId
         if (rootId != null) {
+            // Reaching the thread is what clears its notifications: reading the group's chat
+            // never shows a kind:11/1111, so markReadForGroup deliberately skips them.
+            AppModule.notificationHistoryStore.markReadForThread(rootId)
             viewModelScope.launch { repo.fetchThread(groupId, rootId) }
         }
     }
@@ -321,13 +384,16 @@ class ThreadsViewModel(
         targetEventId: String,
         targetPubkey: String,
         emoji: String,
+        /** The thread the target belongs to; defaults to the open one, else the target itself
+         *  (list cards react to the root). Rides along so the reaction's readers can open it. */
+        threadRootId: String? = _openRootId.value ?: targetEventId,
     ) {
         val key = "$targetEventId|$emoji"
         if (key in _pendingReactions.value) return
         _pendingReactions.value = _pendingReactions.value + key
         viewModelScope.launch {
             try {
-                when (val result = repo.sendReaction(groupId, targetEventId, targetPubkey, emoji)) {
+                when (val result = repo.sendReaction(groupId, targetEventId, targetPubkey, emoji, threadRootId)) {
                     is Result.Error -> _reactionError.value = friendlyRelayError(result.error)
                     is Result.Success -> Unit
                 }
@@ -337,24 +403,54 @@ class ThreadsViewModel(
         }
     }
 
-    /**
-     * Whether the signed-in account administers this group, host-relay scoped like
-     * [GroupViewModel.groupAdmins]: a same-id group on another relay must not hand out
-     * moderation rights here. Drives the admin delete affordances on threads.
-     */
-    val isAdmin: StateFlow<Boolean> =
-        (
-            if (hostRelay == null) {
-                repo.groupAdmins
-            } else {
-                combine(repo.groupAdmins, repo.groupAdminsByRelay) { flat, byRelay ->
-                    byRelay.scopedOverFlat(flat, groupId, hostRelay)
-                }
+    /** The relay withholds this group's events until you are a member (NIP-29 private group). */
+    val isRestricted: StateFlow<Boolean> =
+        repo.restrictedGroups
+            .map { groupId in it }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), groupId in repo.restrictedGroups.value)
+
+    /** A join request is in flight and no admin has answered yet. */
+    val isPendingApproval: StateFlow<Boolean> =
+        repo.pendingApprovalSince
+            .map { groupId in it }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), groupId in repo.pendingApprovalSince.value)
+
+    private val membershipModel = GroupMembershipModel(repo, groupId, hostRelay, viewModelScope)
+
+    /** Admin of this group (host-relay scoped): drives the moderation delete affordances. */
+    val isAdmin: StateFlow<Boolean> = membershipModel.isAdmin
+
+    /** Standing in this group, same verdict the chat header uses for its join affordance. */
+    val membershipState: StateFlow<GroupMembershipState> = membershipModel.membershipState
+
+    /** Access shape, for the Join vs Request-to-Join label. */
+    val groupAccess: StateFlow<GroupAccess> = membershipModel.access
+
+    private val _joinError = MutableStateFlow<String?>(null)
+
+    /** Relay refusal of a kind:9021 join (or of the invite code), user-facing. */
+    val joinError: StateFlow<String?> = _joinError
+
+    fun clearJoinError() {
+        _joinError.value = null
+    }
+
+    /** Join (or request to join) without leaving the threads pane. Mirrors GroupViewModel.joinGroup. */
+    fun joinGroup(inviteCode: String? = null) {
+        _joinError.value = null
+        viewModelScope.launch {
+            val result = repo.joinGroup(groupId, inviteCode)
+            if (result is Result.Error) {
+                val reason = (result.error as? AppError.Group.JoinFailed)?.cause?.message
+                _joinError.value =
+                    if (reason.isNullOrBlank()) {
+                        "Could not join the group. Please try again."
+                    } else {
+                        "Could not join: $reason"
+                    }
             }
-            ).map { admins ->
-            val me = repo.getPublicKey()
-            me != null && me in admins[groupId].orEmpty()
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+        }
+    }
 
     private val _deleteError = MutableStateFlow<String?>(null)
 
@@ -372,9 +468,21 @@ class ThreadsViewModel(
     fun deleteThread(rootId: String) {
         viewModelScope.launch {
             when (val result = repo.deleteMessage(groupId, rootId)) {
-                is Result.Error -> _deleteError.value = friendlyRelayError(result.error)
+                is Result.Error -> {
+                    _deleteError.value = friendlyRelayError(result.error)
+                    return@launch
+                }
                 is Result.Success -> Unit
             }
+            // The chat announcement outlives its thread and renders as a dead reference card, so
+            // it goes too - when this account may delete it (its author, or an admin). Failures
+            // stay silent: the thread itself is gone, which is what was asked, and a second error
+            // dialog over a successful delete only confuses.
+            val me = repo.getPublicKey()
+            val admin = isAdmin.value
+            threadAnnouncementsFor(rootId, scoped(repo.messages.value[groupId].orEmpty()))
+                .filter { canDeleteThreadMessage(it.pubkey, me, admin) }
+                .forEach { repo.deleteMessage(groupId, it.id) }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsViewModel.kt
@@ -155,3 +155,19 @@ class NotificationsViewModel(
         const val KEY_UNREAD_ONLY = "notifications_unread_only"
     }
 }
+
+/**
+ * Muted action text for a feed row. Reactions carry their emoji; anything about a forum thread
+ * says so, since the row otherwise reads identically to the chat event it is not. Shared so the
+ * Compose and web feeds cannot word the same entry differently.
+ */
+fun notificationActionLabel(entry: NotificationEntry): String {
+    val inThread = if (entry.threadRootId != null) " in a thread" else ""
+    return when (entry.type) {
+        NotificationType.MENTION -> "mentioned you$inThread"
+        NotificationType.REPLY -> "replied$inThread"
+        NotificationType.MESSAGE -> "posted$inThread"
+        NotificationType.REACTION -> "reacted ${entry.emoji ?: ""}".trim() + inThread
+        NotificationType.GROUP_ADD -> "added you"
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/AuthIdentityTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/AuthIdentityTest.kt
@@ -1,0 +1,26 @@
+package org.nostr.nostrord.network
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AuthIdentityTest {
+    private fun client() = NostrGroupClient("wss://relay.example")
+
+    @Test
+    fun `a socket that never authenticated serves every account`() {
+        // Public relays answer the same for everyone, so they must not be swept on a switch.
+        assertFalse(client().isAuthedAsOther("alice"))
+        assertFalse(client().isAuthedAsOther(null))
+    }
+
+    @Test
+    fun `a socket authed as another account is stale for the new one`() {
+        val c = client()
+        c.notifyAuthCompleted("alice")
+        assertTrue(c.isAuthedAsOther("bob"))
+        // Logged out counts as "not alice" too: nothing may ride alice's socket afterwards.
+        assertTrue(c.isAuthedAsOther(null))
+        assertFalse(c.isAuthedAsOther("alice"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -628,6 +628,7 @@ class FakeNostrRepository : NostrRepositoryApi {
         targetEventId: String,
         targetPubkey: String,
         emoji: String,
+        threadRootId: String?,
     ): Result<Unit> {
         calls += "sendReaction:$groupId:$targetEventId:$emoji"
         return sendReactionResult

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/StaleThreadEventsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/StaleThreadEventsTest.kt
@@ -1,0 +1,153 @@
+package org.nostr.nostrord.network.managers
+
+import org.nostr.nostrord.network.NostrGroupClient
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The EOSE reconciliation that makes a thread deleted on one device disappear on another: the
+ * second device never receives the kind:5/9005, so absence from the relay's answer is the signal.
+ */
+class StaleThreadEventsTest {
+    private fun root(id: String, createdAt: Long) = NostrGroupClient.NostrMessage(
+        id = id,
+        pubkey = "author",
+        content = "c",
+        createdAt = createdAt,
+        kind = 11,
+        tags = emptyList(),
+        relayUrl = "wss://relay.example",
+    )
+
+    @Test
+    fun `a stored root the answer omits is gone`() {
+        val stored = listOf(root("a", 100), root("b", 200), root("c", 300))
+        assertEquals(setOf("b"), staleThreadEventIds(stored, seen = setOf("a", "c")))
+    }
+
+    @Test
+    fun `nothing is dropped when the answer matches what we hold`() {
+        val stored = listOf(root("a", 100), root("b", 200))
+        assertEquals(emptySet(), staleThreadEventIds(stored, seen = setOf("a", "b")))
+    }
+
+    @Test
+    fun `history older than the capped answer survives`() {
+        // The REQ is limit-capped: the relay served only the two newest, so the older ones were
+        // never asked for. Dropping them would wipe history on every EOSE.
+        val stored = listOf(root("old1", 10), root("old2", 20), root("new1", 300), root("new2", 400))
+        assertEquals(emptySet(), staleThreadEventIds(stored, seen = setOf("new1", "new2")))
+    }
+
+    @Test
+    fun `a deletion inside the answered window is caught, older history is not`() {
+        val stored = listOf(root("old", 10), root("deleted", 350), root("new1", 300), root("new2", 400))
+        assertEquals(setOf("deleted"), staleThreadEventIds(stored, seen = setOf("new1", "new2")))
+    }
+
+    @Test
+    fun `an empty answer clears everything we hold for that relay`() {
+        // Every thread was deleted elsewhere. Callers only reconcile a settled, authenticated
+        // sub, so an empty EOSE is a real "there is nothing here".
+        val stored = listOf(root("a", 100), root("b", 200))
+        assertEquals(setOf("a", "b"), staleThreadEventIds(stored, seen = emptySet()))
+    }
+
+    @Test
+    fun `an empty store is a no-op`() {
+        assertEquals(emptySet(), staleThreadEventIds(emptyList(), seen = setOf("a")))
+    }
+}
+
+/** Who a kind:1111 reply notifies, decided from the reply's own NIP-22 tags. */
+class ThreadReplyTargetTest {
+    private val me = "me"
+    private val other = "other"
+    private val hint = "wss://relay.example"
+
+    @Test
+    fun `a top-level reply to my root notifies me through the uppercase P tag`() {
+        // ThreadTags.reply omits the lowercase p when the parent IS the root (relays cap
+        // indexable tags), so P is the only author marker on the most common reply there is.
+        val tags = listOf(
+            listOf("h", "g1"),
+            listOf("E", "root1", hint, me),
+            listOf("K", "11"),
+            listOf("P", me),
+        )
+        assertTrue(threadReplyTargetsMe(tags, me) { null })
+    }
+
+    @Test
+    fun `the E tag author element alone is enough when the root is not in memory`() {
+        val tags = listOf(listOf("E", "root1", hint, me))
+        // findMessageAuthor returns null: the device never loaded the thread.
+        assertTrue(threadReplyTargetsMe(tags, me) { null })
+    }
+
+    @Test
+    fun `a nested reply to my reply notifies me through the lowercase p`() {
+        val tags = listOf(
+            listOf("E", "root1", hint, other),
+            listOf("P", other),
+            listOf("e", "reply1", hint, me),
+            listOf("p", me),
+        )
+        assertTrue(threadReplyTargetsMe(tags, me) { null })
+    }
+
+    @Test
+    fun `a reply between two other people does not notify me`() {
+        val tags = listOf(
+            listOf("E", "root1", hint, other),
+            listOf("P", other),
+        )
+        assertFalse(threadReplyTargetsMe(tags, me) { null })
+    }
+
+    @Test
+    fun `a lean tag set falls back to the local author lookup`() {
+        // No author element, no P: only the local cache can attribute it.
+        val tags = listOf(listOf("E", "root1"))
+        assertTrue(threadReplyTargetsMe(tags, me) { if (it == "root1") me else null })
+        assertFalse(threadReplyTargetsMe(tags, me) { null })
+    }
+}
+
+/** A thread reaction survives a cold start through its cache row. */
+class ThreadReactionCacheTest {
+    private val reaction = NostrGroupClient.NostrReaction(
+        id = "react1",
+        pubkey = "reactor",
+        emoji = ":pepe:",
+        emojiUrl = "https://x/pepe.png",
+        targetEventId = "reply1",
+        createdAt = 42,
+        targetAuthorPubkey = "me",
+        groupId = "g1",
+        threadRootId = "root1",
+    )
+
+    @Test
+    fun `the cached row round-trips back into the same reaction`() {
+        val tags = threadReactionCacheTags(reaction, groupId = "g1", rootId = "root1")
+        val restored = reactionFromCacheRow(reaction.id, reaction.pubkey, reaction.createdAt, reaction.emoji, tags)
+        assertEquals(reaction, restored)
+    }
+
+    @Test
+    fun `a plain reaction keeps its root so the chip and the notification agree`() {
+        val plain = reaction.copy(emojiUrl = null, targetAuthorPubkey = null)
+        val tags = threadReactionCacheTags(plain, groupId = "g1", rootId = "root1")
+        val restored = reactionFromCacheRow(plain.id, plain.pubkey, plain.createdAt, plain.emoji, tags)
+        assertEquals("root1", restored?.threadRootId)
+        assertEquals("reply1", restored?.targetEventId)
+    }
+
+    @Test
+    fun `a row with no target is unusable`() {
+        assertEquals(null, reactionFromCacheRow("r", "p", 1, "+", listOf(listOf("h", "g1"))))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/NotificationRouteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/NotificationRouteTest.kt
@@ -1,0 +1,80 @@
+package org.nostr.nostrord.ui
+
+import org.nostr.nostrord.notifications.NotificationEntry
+import org.nostr.nostrord.notifications.NotificationHistoryStore
+import org.nostr.nostrord.notifications.NotificationType
+import org.nostr.nostrord.ui.navigation.GroupView
+import org.nostr.nostrord.ui.navigation.notificationRoute
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class NotificationRouteTest {
+    @Test
+    fun `a thread notification opens the threads pane at its root`() {
+        val route = notificationRoute(
+            relayUrl = "wss://relay.example",
+            groupId = "g1",
+            messageId = "reply1",
+            threadRootId = "root1",
+        )
+        assertEquals(GroupView.Threads, route.view)
+        assertEquals("root1", route.threadRootId)
+        // The reply stays the scroll/flash target inside the thread.
+        assertEquals("reply1", route.messageId)
+    }
+
+    @Test
+    fun `a chat notification opens the chat at its message`() {
+        val route = notificationRoute(
+            relayUrl = "wss://relay.example",
+            groupId = "g1",
+            messageId = "msg1",
+            threadRootId = null,
+        )
+        assertEquals(GroupView.Chat, route.view)
+        assertNull(route.threadRootId)
+        assertEquals("msg1", route.messageId)
+    }
+}
+
+/**
+ * Reading a group's chat clears its chat notifications, never its thread ones: a kind:1111 is
+ * not in the chat, so opening the chat is no evidence the user saw it.
+ */
+class NotificationReadScopeTest {
+    private fun entry(id: String, groupId: String, threadRootId: String?) = NotificationEntry(
+        id = id,
+        type = NotificationType.REPLY,
+        groupId = groupId,
+        relayUrl = "wss://relay.example",
+        actorPubkey = "other",
+        createdAt = 1,
+        preview = "hi",
+        threadRootId = threadRootId,
+    )
+
+    @Test
+    fun `reading the chat leaves thread entries unread`() {
+        val store = NotificationHistoryStore()
+        store.add(entry("chat1", "g1", threadRootId = null))
+        store.add(entry("thread1", "g1", threadRootId = "root1"))
+
+        store.markReadForGroup("g1")
+
+        assertEquals(true, store.entries.value.first { it.id == "chat1" }.read)
+        assertEquals(false, store.entries.value.first { it.id == "thread1" }.read)
+    }
+
+    @Test
+    fun `opening the thread clears only that thread's entries`() {
+        val store = NotificationHistoryStore()
+        store.add(entry("thread1", "g1", threadRootId = "root1"))
+        store.add(entry("thread2", "g1", threadRootId = "root2"))
+
+        store.markReadForThread("root1")
+
+        assertEquals(true, store.entries.value.first { it.id == "thread1" }.read)
+        assertEquals(false, store.entries.value.first { it.id == "thread2" }.read)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -9,15 +9,19 @@ import kotlinx.coroutines.test.setMain
 import org.nostr.nostrord.network.FakeNostrRepository
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.screens.group.ReactionChip
+import org.nostr.nostrord.ui.screens.group.ThreadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.buildThreadSummaries
 import org.nostr.nostrord.ui.screens.group.canDeleteThreadMessage
 import org.nostr.nostrord.ui.screens.group.deleteThreadConfirmBody
 import org.nostr.nostrord.ui.screens.group.filterMutedReactions
 import org.nostr.nostrord.ui.screens.group.friendlyRelayError
+import org.nostr.nostrord.ui.screens.group.threadAnnouncementsFor
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
+import org.nostr.nostrord.ui.screens.group.threadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
@@ -264,6 +268,56 @@ class ThreadsViewModelTest {
         // A plain member gets no delete on someone else's thread, and logged out none at all.
         assertFalse(canDeleteThreadMessage(other, me, isAdmin = false))
         assertFalse(canDeleteThreadMessage(other, null, isAdmin = true))
+    }
+
+    @Test
+    fun `threadsPlaceholder gates a private group instead of inviting the first thread`() {
+        // Withheld reads look identical to an empty group, so restriction wins over both the
+        // loading spinner (it never settles) and the "start the first one" prompt.
+        assertEquals(
+            ThreadsPlaceholder.PRIVATE,
+            threadsPlaceholder(hasThreads = false, isLoading = true, isPendingApproval = false, isRestricted = true),
+        )
+        assertEquals(
+            ThreadsPlaceholder.PENDING_APPROVAL,
+            threadsPlaceholder(hasThreads = false, isLoading = false, isPendingApproval = true, isRestricted = true),
+        )
+        assertEquals(
+            ThreadsPlaceholder.LOADING,
+            threadsPlaceholder(hasThreads = false, isLoading = true, isPendingApproval = false, isRestricted = false),
+        )
+        assertEquals(
+            ThreadsPlaceholder.EMPTY,
+            threadsPlaceholder(hasThreads = false, isLoading = false, isPendingApproval = false, isRestricted = false),
+        )
+        // Threads already on screen keep rendering even if a restriction marker lands late.
+        assertNull(threadsPlaceholder(hasThreads = true, isLoading = false, isPendingApproval = false, isRestricted = true))
+    }
+
+    @Test
+    fun `threadAnnouncementsFor matches the announcement by decoded nevent`() {
+        val rootId = "a".repeat(64)
+        val otherId = "b".repeat(64)
+        // Hints differ from the ones the announcement was built with: a string compare on the
+        // nevent would miss this, decoding does not.
+        val announcement = NostrGroupClient.NostrMessage(
+            id = "ann1",
+            pubkey = "author",
+            content = "Started a thread: Bla\nnostr:${Nip19.encodeNevent(rootId, relays = listOf("wss://a.example"), kind = 11)}",
+            createdAt = 10,
+            kind = 9,
+            tags = emptyList(),
+        )
+        val unrelated = announcement.copy(
+            id = "ann2",
+            content = "Started a thread: Other\nnostr:${Nip19.encodeNevent(otherId, kind = 11)}",
+        )
+        val plainChat = announcement.copy(id = "chat", content = "just talking")
+        // The root itself is kind:11, never an announcement.
+        val theRoot = announcement.copy(id = rootId, kind = 11)
+
+        val found = threadAnnouncementsFor(rootId, listOf(announcement, unrelated, plainChat, theRoot))
+        assertEquals(listOf("ann1"), found.map { it.id })
     }
 
     @Test

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -70,6 +72,8 @@ fun MessageComposer(
     placeholder: String,
     isSending: Boolean,
     modifier: Modifier = Modifier,
+    // Lets a caller put the caret here (picking Reply focuses the composer to type into).
+    focusRequester: FocusRequester? = null,
 ) {
     var showEmojiPicker by remember { mutableStateOf(false) }
     var isUploadingPaste by remember { mutableStateOf(false) }
@@ -127,6 +131,7 @@ fun MessageComposer(
                 modifier =
                 Modifier
                     .weight(1f)
+                    .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
                     .onPreviewKeyEvent { event ->
                         when {
                             event.type == KeyEventType.KeyDown && event.key == Key.Escape && showEmojiPicker -> {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -1923,7 +1923,9 @@ private fun QuotedEvent(
                         color = NostrordColors.TextMuted,
                     )
                     Text(
-                        text = "Event not found",
+                        // Deleted and unreachable look identical from here (the relay just does
+                        // not serve it), so the copy must not claim either one.
+                        text = "Event removed or unavailable",
                         color = NostrordColors.TextMuted,
                         style = NostrordTypography.Caption,
                     )
@@ -3054,7 +3056,9 @@ private fun AddressableEvent(
                         color = NostrordColors.TextMuted,
                     )
                     Text(
-                        text = "Event not found",
+                        // Deleted and unreachable look identical from here (the relay just does
+                        // not serve it), so the copy must not claim either one.
+                        text = "Event removed or unavailable",
                         color = NostrordColors.TextMuted,
                         style = NostrordTypography.Caption,
                     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt
@@ -1,7 +1,7 @@
 package org.nostr.nostrord.ui.components.chat
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -140,13 +140,20 @@ fun ReplyPreview(
     parentMessage: NostrGroupClient.NostrMessage?,
     parentMetadata: UserMetadata?,
     resolveMetadata: (String) -> UserMetadata? = { null },
-    onReplyClick: () -> Unit = {},
+    // Null when the quote is not tappable (the parent is not in this thread / chat page). Do NOT
+    // pass an empty lambda for that: a no-op clickable still consumes the gesture, so a
+    // long-press on the quote would never reach the row's context-menu detector.
+    onReplyClick: (() -> Unit)? = null,
+    // Keeps the row's context menu reachable from inside the quote: a plain clickable consumes
+    // the long-press, so the tappable quote has to offer the gesture itself.
+    onReplyLongClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     if (parentMessage == null) {
         // Parent message not found - show placeholder
         ReplyPreviewContainer(
             onClick = onReplyClick,
+            onLongClick = onReplyLongClick,
             modifier = modifier,
         ) {
             Text(
@@ -184,6 +191,7 @@ fun ReplyPreview(
 
     ReplyPreviewContainer(
         onClick = onReplyClick,
+        onLongClick = onReplyLongClick,
         modifier = modifier,
     ) {
         Text(
@@ -212,7 +220,8 @@ fun ReplyPreview(
  */
 @Composable
 private fun ReplyPreviewContainer(
-    onClick: () -> Unit,
+    onClick: (() -> Unit)?,
+    onLongClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit,
 ) {
@@ -230,8 +239,15 @@ private fun ReplyPreviewContainer(
                     NostrordColors.BackgroundFloating
                 },
             )
-            .clickable(onClick = onClick)
-            .pointerHoverIcon(PointerIcon.Hand, overrideDescendants = true)
+            .then(
+                if (onClick != null) {
+                    Modifier
+                        .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+                        .pointerHoverIcon(PointerIcon.Hand, overrideDescendants = true)
+                } else {
+                    Modifier
+                },
+            )
             .padding(vertical = Spacing.xs),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -777,7 +777,7 @@ private fun FrameContent(
             is NotificationsRoute ->
                 NotificationsPage(
                     vm = notifVm,
-                    onOpenGroupAtRelay = { gid, _, relay, mid -> onNavigate(GroupRoute(relay, gid, messageId = mid)) },
+                    onOpenRoute = { onNavigate(it) },
                     onOpenDrawer = onOpenDrawer,
                 )
             is SettingsRoute -> {}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -26,10 +26,13 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Forum
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -48,12 +51,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -131,6 +136,11 @@ fun ThreadsScreen(
     val reactionError by vm.reactionError.collectAsState()
     val deleteError by vm.deleteError.collectAsState()
     val isAdmin by vm.isAdmin.collectAsState()
+    val isRestricted by vm.isRestricted.collectAsState()
+    val isPendingApproval by vm.isPendingApproval.collectAsState()
+    val membership by vm.membershipState.collectAsState()
+    val groupAccess by vm.groupAccess.collectAsState()
+    val joinError by vm.joinError.collectAsState()
     val myPubkey = remember { vm.getPublicKey() }
 
     // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
@@ -141,6 +151,14 @@ fun ThreadsScreen(
 
     // Message being answered by the composer (context-menu Reply); null posts top-level.
     var replyingTo by remember { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
+
+    // Picking Reply puts the caret in the composer, ready to type (chat/web parity). Bumped per
+    // pick so replying twice to the same message re-focuses.
+    val composerFocus = remember { FocusRequester() }
+    var replyFocusNonce by remember { mutableStateOf(0) }
+    LaunchedEffect(replyingTo?.id, replyFocusNonce) {
+        if (replyingTo != null) runCatching { composerFocus.requestFocus() }
+    }
 
     // Deep-link target (?e=): the message to scroll to and flash once the thread loads.
     var highlightId by remember { mutableStateOf<String?>(null) }
@@ -153,9 +171,21 @@ fun ThreadsScreen(
             highlightId = null
         }
     }
+    // In-thread jump (tapping a quoted parent). Shares the deep link's scroll + flash, so only
+    // one target is ever pending; the tap wins while it lasts.
+    var jumpTargetId by remember { mutableStateOf<String?>(null) }
+    LaunchedEffect(jumpTargetId) {
+        val target = jumpTargetId ?: return@LaunchedEffect
+        highlightId = target
+        delay(HIGHLIGHT_FLASH_MS)
+        highlightId = null
+        jumpTargetId = null
+    }
+    val scrollTargetId = jumpTargetId ?: route.messageId
+
     val threadScroll = rememberScrollState()
     // Scroll target: the flashed message's y inside the scrolled column, reported on layout.
-    var highlightTargetY by remember(route.messageId) { mutableStateOf<Int?>(null) }
+    var highlightTargetY by remember(scrollTargetId) { mutableStateOf<Int?>(null) }
     LaunchedEffect(highlightTargetY) {
         highlightTargetY?.let { threadScroll.animateScrollTo((it - HIGHLIGHT_SCROLL_MARGIN_PX).coerceAtLeast(0)) }
     }
@@ -282,12 +312,18 @@ fun ThreadsScreen(
                                         .map { it.substringAfter('|') }
                                         .toSet(),
                                     parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
+                                    onJumpToParent = msg.threadParentIdTag()
+                                        ?.takeIf { messagesById.containsKey(it) }
+                                        ?.let { parentId -> { jumpTargetId = parentId } },
                                     highlighted = msg.id == highlightId,
-                                    onPositioned = if (msg.id == route.messageId) ({ y -> highlightTargetY = y }) else null,
+                                    onPositioned = if (msg.id == scrollTargetId) ({ y -> highlightTargetY = y }) else null,
                                     resolveMetadata = { userMetadata[it] },
                                     onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                                     onOpenReactionPicker = { reactingTo = msg.id to msg.pubkey },
-                                    onReply = { replyingTo = msg },
+                                    onReply = {
+                                        replyingTo = msg
+                                        replyFocusNonce++
+                                    },
                                     onShareToChat = { vm.shareThreadToChat(msg) },
                                     onUserClick = { selectedUserPubkey = it },
                                     onDelete = { deleteTarget = msg },
@@ -363,6 +399,7 @@ fun ThreadsScreen(
                         },
                         placeholder = "Write a reply...",
                         isSending = sending,
+                        focusRequester = composerFocus,
                         modifier = Modifier.padding(Spacing.md),
                     )
                 }
@@ -374,6 +411,14 @@ fun ThreadsScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
                 ) {
+                    // Same glyph the sidebar's Threads row uses, so the pane is identifiable
+                    // on mobile where that row is off screen.
+                    Icon(
+                        Icons.Default.Forum,
+                        contentDescription = null,
+                        tint = NostrordColors.TextPrimary,
+                        modifier = Modifier.size(18.dp),
+                    )
                     Text(
                         "Threads",
                         color = NostrordColors.TextPrimary,
@@ -381,19 +426,48 @@ fun ThreadsScreen(
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.weight(1f),
                     )
-                    AppButton(
-                        text = "New thread",
-                        onClick = { showCompose = true },
-                        icon = Icons.Filled.Forum,
-                        size = AppButtonSize.Small,
-                    )
+                    when {
+                        // Outsiders get the same join affordance as the chat header instead of a
+                        // composer the relay would reject.
+                        membership.status == GroupMembership.NONE ->
+                            AppButton(
+                                text = if (groupAccess.isOpen) "Join" else "Request to Join",
+                                onClick = { vm.joinGroup() },
+                                icon = Icons.Default.PersonAdd,
+                                size = AppButtonSize.Small,
+                            )
+                        membership.status == GroupMembership.PENDING ->
+                            Text(
+                                "Request pending",
+                                color = NostrordColors.TextMuted,
+                                fontSize = 13.sp,
+                            )
+                        // No composer while the relay withholds the group: the kind:11 would be rejected.
+                        !isRestricted ->
+                            AppButton(
+                                text = "New thread",
+                                onClick = { showCompose = true },
+                                icon = Icons.Filled.Add,
+                                size = AppButtonSize.Small,
+                            )
+                    }
                 }
                 HorizontalDivider(color = NostrordColors.Divider)
 
-                when {
-                    isLoading && threads.isEmpty() -> EmptyState("Loading threads...")
-                    threads.isEmpty() -> EmptyState("No threads yet. Start the first one.")
-                    else ->
+                when (threadsPlaceholder(threads.isNotEmpty(), isLoading, isPendingApproval, isRestricted)) {
+                    ThreadsPlaceholder.LOADING -> EmptyState("Loading threads...")
+                    ThreadsPlaceholder.PENDING_APPROVAL ->
+                        LockedState(
+                            title = "Awaiting admin approval",
+                            body = "Threads will appear once an admin approves your request.",
+                        )
+                    ThreadsPlaceholder.PRIVATE ->
+                        LockedState(
+                            title = "Private group",
+                            body = "You need an invite code or admin approval to see threads.",
+                        )
+                    ThreadsPlaceholder.EMPTY -> EmptyState("No threads yet. Start the first one.")
+                    null ->
                         LazyColumn(modifier = Modifier.weight(1f), contentPadding = PaddingValues(Spacing.sm)) {
                             items(threads, key = { it.rootId }) { t ->
                                 ThreadCard(
@@ -507,6 +581,17 @@ fun ThreadsScreen(
 
     // Relay rejected the kind:5/9005 delete - show the reason instead of silently swallowing
     // (chat parity: "Could Not Delete Message" + the relay's OK message).
+    joinError?.let { error ->
+        ConfirmDialog(
+            title = "Could Not Join",
+            message = error,
+            confirmLabel = "OK",
+            cancelLabel = null,
+            onConfirm = { vm.clearJoinError() },
+            onDismiss = { vm.clearJoinError() },
+        )
+    }
+
     deleteError?.let { error ->
         ConfirmDialog(
             title = "Could Not Delete Message",
@@ -554,6 +639,22 @@ private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = met
 private fun ColumnScope.EmptyState(text: String) {
     Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
         Text(text, color = NostrordColors.TextMuted, fontSize = 14.sp)
+    }
+}
+
+/** Lock panel for a group the relay withholds; same wording tier as the chat gate. */
+@Composable
+private fun ColumnScope.LockedState(title: String, body: String) {
+    Box(modifier = Modifier.weight(1f).fillMaxWidth(), contentAlignment = Alignment.Center) {
+        Column(
+            modifier = Modifier.padding(Spacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Spacing.sm),
+        ) {
+            Icon(Icons.Default.Lock, contentDescription = null, tint = NostrordColors.TextMuted, modifier = Modifier.size(40.dp))
+            Text(title, color = NostrordColors.TextSecondary, fontSize = 16.sp, textAlign = TextAlign.Center)
+            Text(body, color = NostrordColors.TextMuted, fontSize = 14.sp, textAlign = TextAlign.Center)
+        }
     }
 }
 
@@ -650,6 +751,8 @@ private fun ThreadMessage(
     reactions: Map<String, GroupManager.ReactionInfo>,
     pendingEmojis: Set<String>,
     parentMsg: NostrGroupClient.NostrMessage?,
+    // Scrolls to the quoted parent; null when it is not in this thread (quote stays decoration).
+    onJumpToParent: (() -> Unit)?,
     highlighted: Boolean,
     onPositioned: ((Int) -> Unit)?,
     resolveMetadata: (String) -> UserMetadata?,
@@ -674,7 +777,9 @@ private fun ThreadMessage(
     val rowBackground by animateColorAsState(
         when {
             highlighted -> NostrordColors.Primary.copy(alpha = 0.18f)
-            isHovered -> NostrordColors.MessageHover
+            // The open menu keeps its target tinted, so it is obvious which message the
+            // actions apply to (chat parity: .msg.menu-open).
+            menuVisible || isHovered -> NostrordColors.MessageHover
             else -> Color.Transparent
         },
     )
@@ -769,6 +874,10 @@ private fun ThreadMessage(
                         parentMessage = parentMsg,
                         parentMetadata = parentMsg?.let { resolveMetadata(it.pubkey) },
                         resolveMetadata = resolveMetadata,
+                        onReplyClick = onJumpToParent,
+                        // Without this the tappable quote would swallow the long-press and the
+                        // row's context menu would be unreachable from inside it.
+                        onReplyLongClick = onJumpToParent?.let { { menuVisible = true } },
                     )
                 }
                 Row(verticalAlignment = Alignment.Bottom) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
@@ -43,9 +43,10 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import org.nostr.nostrord.notifications.NotificationEntry
-import org.nostr.nostrord.notifications.NotificationType
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.layout.PageHeader
+import org.nostr.nostrord.ui.navigation.GroupRoute
+import org.nostr.nostrord.ui.navigation.notificationRoute
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.utils.formatTimestamp
@@ -60,7 +61,7 @@ import org.nostr.nostrord.utils.shortNpub
 @Composable
 fun NotificationsPage(
     vm: NotificationsViewModel,
-    onOpenGroupAtRelay: (groupId: String, groupName: String?, relayUrl: String, targetMessageId: String?) -> Unit,
+    onOpenRoute: (GroupRoute) -> Unit,
     modifier: Modifier = Modifier,
     onOpenDrawer: (() -> Unit)? = null,
 ) {
@@ -147,7 +148,7 @@ fun NotificationsPage(
                             groupPicture = groupMeta?.picture,
                             onClick = {
                                 vm.markRead(entry.id)
-                                onOpenGroupAtRelay(entry.groupId, groupName, entry.relayUrl, entry.messageId)
+                                onOpenRoute(notificationRoute(entry.relayUrl, entry.groupId, entry.messageId, entry.threadRootId))
                             },
                         )
                     }
@@ -256,11 +257,4 @@ private fun NotificationRow(
     }
 }
 
-/** Muted action text per type; reactions show the emoji (no dedicated tab). */
-private fun actionLabel(entry: NotificationEntry): String = when (entry.type) {
-    NotificationType.MENTION -> "mentioned you"
-    NotificationType.REPLY -> "replied"
-    NotificationType.MESSAGE -> "posted"
-    NotificationType.REACTION -> "reacted ${entry.emoji ?: ""}".trim()
-    NotificationType.GROUP_ADD -> "added you"
-}
+private fun actionLabel(entry: NotificationEntry): String = notificationActionLabel(entry)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -648,9 +648,7 @@ val AppFrame =
                         NotificationsPage {
                             this.vm = notifVm
                             onOpenDrawer = { setDrawerOpen(true) }
-                            onOpen = { relay, gid, mid ->
-                                pushRoute(GroupRoute(relay, gid, messageId = mid))
-                            }
+                            onOpenRoute = { pushRoute(it) }
                         }
                     r is UserRoute ->
                         ProfilePage {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2675,9 +2675,8 @@ private fun ChildrenBuilder.joinErrorDialog(message: String, onDismiss: () -> Un
     }
 }
 
-/** Error dialog shown when the relay rejects a kind:5. Single OK button —
- *  matches the native AlertDialog at GroupScreen.kt:548-562. */
-internal fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss: () -> Unit) {
+/** Acknowledge-only failure dialog: single OK button, nothing to retry from here. */
+internal fun ChildrenBuilder.errorDialog(title: String, message: String, onDismiss: () -> Unit) {
     div {
         className = ClassName("modal-overlay")
         onClick = { onDismiss() }
@@ -2686,7 +2685,7 @@ internal fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss
             onClick = { it.stopPropagation() }
             div {
                 className = ClassName("modal-title")
-                +"Could Not Delete Message"
+                +title
             }
             div {
                 className = ClassName("modal-subtitle tight")
@@ -2703,6 +2702,10 @@ internal fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss
         }
     }
 }
+
+/** Error dialog shown when the relay rejects a kind:5. Matches the native AlertDialog at
+ *  GroupScreen.kt:548-562. */
+internal fun ChildrenBuilder.deleteMessageErrorDialog(message: String, onDismiss: () -> Unit) = errorDialog("Could Not Delete Message", message, onDismiss)
 
 /** Error dialog shown when a media upload is rejected (too large, unsupported
  *  format, or an auth/server failure). Single OK button — mirrors the native
@@ -3828,7 +3831,7 @@ private val QuotedEvent =
         val quotedTags = local?.tags ?: cachedEv?.tags ?: emptyList()
 
         // Flips true when the event never resolves (e.g. its relay isn't connected), so the card
-        // shows "Event not found" instead of spinning forever — parity with native's 5s give-up.
+        // shows the removed-or-unavailable card instead of spinning forever — parity with native's 5s give-up.
         val (notFound, setNotFound) = useState { false }
         val (menuOpen, setMenuOpen) = useState { false }
 
@@ -3958,7 +3961,9 @@ private val QuotedEvent =
                 }
                 div {
                     className = ClassName("thread-quote-title")
-                    +(threadTitle ?: if (notFound) "Thread not found" else "Loading thread...")
+                    // Deleted and unreachable look identical from here (the relay just does not
+                    // serve it), so the copy must not claim either one.
+                    +(threadTitle ?: if (notFound) "Thread removed or unavailable" else "Loading thread...")
                 }
                 threadSnippet?.let {
                     div {
@@ -4144,7 +4149,7 @@ private val QuotedEvent =
                         icon(Ic.Warning)
                         span {
                             className = ClassName("quoted-event-notfound-label")
-                            +"Event not found"
+                            +"Event removed or unavailable"
                         }
                         button {
                             className = ClassName("quoted-event-retry")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
@@ -2,9 +2,11 @@ package org.nostr.nostrord.web.screens
 
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.notifications.NotificationEntry
-import org.nostr.nostrord.notifications.NotificationType
+import org.nostr.nostrord.ui.navigation.GroupRoute
+import org.nostr.nostrord.ui.navigation.notificationRoute
 import org.nostr.nostrord.ui.screens.notifications.NotifFilter
 import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
+import org.nostr.nostrord.ui.screens.notifications.notificationActionLabel
 import org.nostr.nostrord.utils.formatTimestamp
 import org.nostr.nostrord.utils.shortNpub
 import org.nostr.nostrord.web.bridge.useStateFlow
@@ -23,7 +25,7 @@ import web.cssom.ClassName
 
 external interface NotificationsPageProps : Props {
     var vm: NotificationsViewModel
-    var onOpen: (relayUrl: String, groupId: String, messageId: String?) -> Unit
+    var onOpenRoute: (GroupRoute) -> Unit
     var onOpenDrawer: () -> Unit
 }
 
@@ -102,7 +104,7 @@ val NotificationsPage =
                                     ?: entry.groupId.take(8)
                             notifRow(entry, meta, groupName, groupMeta?.picture) {
                                 vm.markRead(entry.id)
-                                props.onOpen(entry.relayUrl, entry.groupId, entry.messageId)
+                                props.onOpenRoute(notificationRoute(entry.relayUrl, entry.groupId, entry.messageId, entry.threadRootId))
                             }
                         }
                     }
@@ -115,13 +117,7 @@ private fun actorName(meta: UserMetadata?, pubkey: String): String = meta?.displ
     ?: meta?.name?.takeIf { it.isNotBlank() }
     ?: shortNpub(pubkey)
 
-private fun actionLabel(entry: NotificationEntry): String = when (entry.type) {
-    NotificationType.MENTION -> "mentioned you"
-    NotificationType.REPLY -> "replied"
-    NotificationType.MESSAGE -> "posted"
-    NotificationType.REACTION -> "reacted ${entry.emoji ?: ""}".trim()
-    NotificationType.GROUP_ADD -> "added you"
-}
+private fun actionLabel(entry: NotificationEntry): String = notificationActionLabel(entry)
 
 private fun ChildrenBuilder.notifRow(
     entry: NotificationEntry,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -12,16 +12,20 @@ import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.threadShareLink
+import org.nostr.nostrord.ui.screens.group.GroupMembership
+import org.nostr.nostrord.ui.screens.group.ThreadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.canDeleteThreadMessage
 import org.nostr.nostrord.ui.screens.group.deleteThreadConfirmBody
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.threadTitle
+import org.nostr.nostrord.ui.screens.group.threadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.getDateLabel
 import org.nostr.nostrord.utils.shortNpub
+import org.nostr.nostrord.web.bridge.VirtualKeyboard
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
@@ -57,6 +61,22 @@ import web.dom.ElementId
 import web.html.HTMLDivElement
 import web.html.HTMLTextAreaElement
 import kotlin.js.Date
+
+/** Lock panel for a group the relay withholds; same chrome as the chat gate. */
+private fun ChildrenBuilder.threadsLockedState(title: String, body: String) {
+    div {
+        className = ClassName("chat-restricted")
+        icon(Ic.Lock, "chat-restricted-icon")
+        div {
+            className = ClassName("chat-restricted-title")
+            +title
+        }
+        div {
+            className = ClassName("chat-restricted-body")
+            +body
+        }
+    }
+}
 
 // Mirrors ChatScreen.displayName (private there): profile name, else a short npub.
 private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = meta?.displayName?.takeIf { it.isNotBlank() }
@@ -117,6 +137,11 @@ val ThreadsScreen =
         val reactionError = useStateFlow(vm.reactionError)
         val deleteError = useStateFlow(vm.deleteError)
         val isAdmin = useStateFlow(vm.isAdmin)
+        val isRestricted = useStateFlow(vm.isRestricted)
+        val isPendingApproval = useStateFlow(vm.isPendingApproval)
+        val membership = useStateFlow(vm.membershipState)
+        val groupAccess = useStateFlow(vm.groupAccess)
+        val joinError = useStateFlow(vm.joinError)
         val myPubkey = vm.getPublicKey()
 
         // Full-picker target: the (eventId, authorPubkey) of the message being reacted to.
@@ -164,6 +189,14 @@ val ThreadsScreen =
             }
         }
 
+        /** Scroll to a message inside the open thread and flash it (quote tap, chat parity). */
+        fun jumpToMessage(id: String) {
+            val el = document.getElementById("thread-msg-$id") ?: return
+            setHighlightId(id)
+            el.asDynamic().scrollIntoView(js("{ block: 'center', behavior: 'smooth' }"))
+            window.setTimeout({ setHighlightId(null) }, HIGHLIGHT_FLASH_MS)
+        }
+
         // Keep the open thread synced with the URL (#/g/<relay>/<id>/threads/<rootId>).
         useEffect(route.threadRootId) {
             vm.openThread(route.threadRootId)
@@ -177,6 +210,20 @@ val ThreadsScreen =
         val (uploadCount, setUploadCount) = useState { 0 }
         val (uploadError, setUploadError) = useState<String?> { null }
         val composerInputRef = useRef<HTMLTextAreaElement>(null)
+
+        // Picking Reply should leave the caret in the composer, ready to type (chat parity).
+        // Bumped per pick so replying twice to the same message re-focuses.
+        val (replyFocusNonce, setReplyFocusNonce) = useState { 0 }
+        useEffect(replyingTo?.id, replyFocusNonce) {
+            if (replyingTo == null) return@useEffect
+            val ta = composerInputRef.current ?: return@useEffect
+            // Re-focusing an already-focused field does not re-open a keyboard the user
+            // dismissed, so blur first in exactly that case (mirrors ChatScreen).
+            if (!VirtualKeyboard.isOpen && document.asDynamic().activeElement === ta.asDynamic()) {
+                ta.blur()
+            }
+            ta.focus()
+        }
 
         fun isMediaMime(type: String?): Boolean = type != null && (type.startsWith("image/") || type.startsWith("video/") || type.startsWith("audio/"))
 
@@ -260,28 +307,59 @@ val ThreadsScreen =
                         className = ClassName("threads-header")
                         span {
                             className = ClassName("threads-title")
-                            +"Threads"
+                            // Same glyph the sidebar's Threads row uses, so the pane is
+                            // identifiable on mobile where that row is off screen.
+                            icon(Ic.Forum, "threads-title-icon")
+                            span { +"Threads" }
                         }
-                        button {
-                            className = ClassName("btn-primary thread-new-btn")
-                            onClick = { setComposing(true) }
-                            icon(Ic.Forum)
-                            span { +"New thread" }
+                        when {
+                            // Outsiders get the same join affordance as the chat header instead of
+                            // a composer the relay would reject.
+                            membership.status == GroupMembership.NONE ->
+                                button {
+                                    className = ClassName("chat-join-btn")
+                                    onClick = { vm.joinGroup() }
+                                    icon(Ic.PersonAdd)
+                                    span { +(if (groupAccess.isOpen) "Join" else "Request to Join") }
+                                }
+                            membership.status == GroupMembership.PENDING ->
+                                span {
+                                    className = ClassName("chat-pending")
+                                    +"Request pending"
+                                }
+                            // No composer while the relay withholds the group: the kind:11 would be rejected.
+                            !isRestricted ->
+                                button {
+                                    className = ClassName("btn-primary thread-new-btn")
+                                    onClick = { setComposing(true) }
+                                    icon(Ic.Add)
+                                    span { +"New thread" }
+                                }
                         }
                     }
 
-                    when {
-                        isLoading && threads.isEmpty() ->
+                    when (threadsPlaceholder(threads.isNotEmpty(), isLoading, isPendingApproval, isRestricted)) {
+                        ThreadsPlaceholder.LOADING ->
                             div {
                                 className = ClassName("threads-empty")
                                 +"Loading threads..."
                             }
-                        threads.isEmpty() ->
+                        ThreadsPlaceholder.PENDING_APPROVAL ->
+                            threadsLockedState(
+                                "Awaiting admin approval",
+                                "Threads will appear once an admin approves your request.",
+                            )
+                        ThreadsPlaceholder.PRIVATE ->
+                            threadsLockedState(
+                                "Private group",
+                                "You need an invite code or admin approval to see threads.",
+                            )
+                        ThreadsPlaceholder.EMPTY ->
                             div {
                                 className = ClassName("threads-empty")
                                 +"No threads yet. Start the first one."
                             }
-                        else ->
+                        null ->
                             div {
                                 className = ClassName("thread-list")
                                 threads.forEach { t ->
@@ -420,9 +498,14 @@ val ThreadsScreen =
                                 pendingFor(msg.id),
                                 parentMsg = msg.threadParentIdTag()?.let { messagesById[it] },
                                 highlighted = msg.id == highlightId,
+                                menuOpen = ctxMenu?.msg?.id == msg.id,
                                 onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
                                 onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
+                                onCloseMenu = { setCtxMenu(null) },
                                 onUser = { setProfilePubkey(it) },
+                                onJumpToParent = msg.threadParentIdTag()
+                                    ?.takeIf { messagesById.containsKey(it) }
+                                    ?.let { parentId -> { jumpToMessage(parentId) } },
                                 // A group ref in the body opens that group's chat page.
                                 onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
                                 onRetry = { vm.retrySend(msg.id) },
@@ -554,10 +637,9 @@ val ThreadsScreen =
                 div {
                     className = ClassName("ctx-overlay")
                     onClick = { setCtxMenu(null) }
-                    onContextMenu = {
-                        it.preventDefault()
-                        setCtxMenu(null)
-                    }
+                    // No preventDefault: closing is enough, and swallowing it would deny the
+                    // browser menu a right-click outside the row is entitled to (chat parity).
+                    onContextMenu = { setCtxMenu(null) }
                 }
                 div {
                     ref = ctxMenuRef
@@ -588,7 +670,9 @@ val ThreadsScreen =
                     ctxItem(Ic.Reply, "Reply") {
                         setReplyingTo(m.msg)
                         setCtxMenu(null)
-                        composerInputRef.current?.focus()
+                        // Focus rides the effect above, not a call here: this runs before React
+                        // re-renders, so the composer it would focus is the pre-reply one.
+                        setReplyFocusNonce { it + 1 }
                     }
                     // Announce the thread in the group chat (kind:9 with the root's nevent).
                     if (m.msg.kind == 11) {
@@ -668,6 +752,11 @@ val ThreadsScreen =
                     },
                 )
             }
+            // Relay refused the kind:9021 (or the invite code): same acknowledge-only shape as
+            // the delete failure, since there is nothing to retry from here.
+            joinError?.let { err ->
+                errorDialog("Could Not Join", err) { vm.clearJoinError() }
+            }
             // Relay rejected the kind:5/9005 - show the reason (chat parity).
             deleteError?.let { err ->
                 deleteMessageErrorDialog(err) { vm.clearDeleteError() }
@@ -728,9 +817,15 @@ private fun ChildrenBuilder.threadMessage(
     pendingEmojis: List<String>,
     parentMsg: NostrGroupClient.NostrMessage?,
     highlighted: Boolean,
+    // Keeps this row tinted while its context menu is open, so the target of the actions is
+    // unambiguous (chat parity: .msg.menu-open).
+    menuOpen: Boolean,
     onReact: (String) -> Unit,
     onOpenMenu: (Double, Double) -> Unit,
+    onCloseMenu: () -> Unit,
     onUser: (String) -> Unit,
+    // Tapping the quoted parent scrolls to it; null when the parent is not in this thread.
+    onJumpToParent: (() -> Unit)?,
     onGroupRef: (String, String?) -> Unit,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
@@ -739,15 +834,24 @@ private fun ChildrenBuilder.threadMessage(
         id = ElementId("thread-msg-${msg.id}")
         className = ClassName(
             (if (isRoot) "thread-msg thread-msg-root" else "thread-msg") +
-                (if (highlighted) " highlight" else ""),
+                (if (highlighted) " highlight" else "") +
+                (if (menuOpen) " menu-open" else ""),
         )
         // Right-click (desktop) / long-press (mobile browsers) opens the thread context menu.
         // Right-click directly on a hyperlink keeps the browser's native menu (chat parity),
         // so "Copy link address" copies the actual URL.
         onContextMenu = { e ->
-            if (e.target.asDynamic().closest("a") == null) {
-                e.preventDefault()
-                onOpenMenu(e.clientX, e.clientY)
+            when {
+                // On a hyperlink the browser menu wins, so "Copy link address" copies the URL.
+                e.target.asDynamic().closest("a") != null -> onCloseMenu()
+                // First right-click: ours at the cursor, native suppressed.
+                !menuOpen -> {
+                    e.preventDefault()
+                    onOpenMenu(e.clientX, e.clientY)
+                }
+                // Second right-click: the row sits above the overlay, so the event lands here.
+                // Close ours and let the native menu through (no preventDefault).
+                else -> onCloseMenu()
             }
         }
         // Avatar and author name open the user profile modal (chat parity).
@@ -786,7 +890,10 @@ private fun ChildrenBuilder.threadMessage(
             // parent has not loaded), like chat's reply preview.
             if (!isRoot && (parentMsg != null || msg.threadParentIdTag() != null)) {
                 div {
-                    className = ClassName("msg-reply")
+                    // Tappable only when the parent is in this thread; otherwise it is decoration
+                    // and must not swallow the long-press that opens the context menu.
+                    className = ClassName(if (onJumpToParent != null) "msg-reply tappable" else "msg-reply")
+                    if (onJumpToParent != null) onClick = { onJumpToParent() }
                     div { className = ClassName("msg-reply-bar") }
                     div {
                         className = ClassName("msg-reply-content")

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2237,10 +2237,22 @@ body {
 }
 
 .threads-title {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
     flex: 1;
     font-size: 17px;
     font-weight: 700;
     color: var(--color-text-primary);
+}
+
+/* Custom icon classes replace `.ico` (the helper's cls arg is not additive), so they must
+   set fill themselves — `color` alone leaves the SVG on the default black. */
+.threads-title-icon {
+    width: 18px;
+    height: 18px;
+    fill: var(--color-text-primary);
+    flex-shrink: 0;
 }
 
 .thread-new-btn {
@@ -6946,6 +6958,22 @@ body {
     border-radius: 4px;
     cursor: pointer;
 }
+/* Above .ctx-overlay (z-index 50) like .msg.menu-open, so a SECOND right-click lands on the
+   row instead of the overlay - that is what lets the browser's native menu through. */
+.thread-msg.menu-open {
+    position: relative;
+    z-index: 60;
+    background: var(--color-message-hover);
+}
+
+.msg-reply.tappable {
+    cursor: pointer;
+}
+
+.msg-reply.tappable:hover {
+    background: var(--color-hover);
+}
+
 [data-theme="light"] .msg-reply {
     /* Light keeps the floating surface (the contrast fix). */
     background: var(--color-floating);


### PR DESCRIPTION
Stacked on #230 — the base retargets to `main` once that merges.

Follow-ups on top of the admin-delete work, all in the threads pane and the plumbing under it.

**Threads UI**
- Private and pending-approval groups get the chat's lock panel instead of "No threads yet. Start the first one." A withheld read looks identical to an empty group, and the prompt invited a kind:11 the relay would reject. The New thread button and the composer follow the same gate.
- The header carries the sidebar's Forum glyph and the chat's join affordance (Join / Request to Join / Request pending).
- Tapping a quoted parent scrolls to it and flashes it. The quote is clickable only when the parent is in this thread: a no-op clickable still swallows the long-press that opens the context menu, so it offers `onLongClick` too.
- Picking Reply focuses the composer (blur-then-focus, so a dismissed keyboard is not re-opened), the row stays tinted while its context menu is open, and a second right-click falls through to the browser's native menu.

**Shared logic**
- `GroupMembershipModel` derives the roster and the account's standing once for both the chat and the threads screens; `GroupViewModel` delegates to it instead of owning it.

**Cross-device correctness**
- A thread deleted on another device disappears here. The threads REQ answer is authoritative, so stored events it omits are dropped — bounded by the answer's own window, since the REQ is limit-capped and older history was never asked for.
- Deleting a thread also deletes its chat announcement, matched by decoding the `nostr:` URIs rather than comparing nevent strings.
- Thread reactions are cached with their root, so reopening the pane renders the chips from disk instead of waiting on the relay.
- A socket still AUTH'd as a previous account is dropped on switch, and its events are ignored. A relay answers reads under the identity that AUTH'd the socket, so a brand-new account could read a private group only the previous account belonged to. The old sweep only covered the incoming account's joined relays, which is empty for a new account.
- Quoted kind:11 lookups wait for NIP-42 before giving up, and the in-flight guard now expires under the UI's retry window (the Retry button used to be a silent no-op).

**Notifications**
- Thread replies and reactions reach the notification feed, open the threads pane at their root, and clear when that thread is opened — not when the group's chat is read. Kinds 11/1111 ride the chat mux so a reply arrives with the pane closed.

Verified with `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid` and `:composeApp:jvmTest`. New tests cover the reconciliation window, the reply-target rule, the reaction cache round-trip, the notification route and read scoping, the placeholder rule and the announcement match. iOS is untested (no macOS here).