### PR TITLE
chore: bump version to 2.5.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.4.0
-app.versionCode=18
+app.version=2.5.0
+app.versionCode=19
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Minor bump for the 61 commits since v2.4.0: the threads pane (moderation, private-group gate, join, notifications, cross-device sync), Blossom / NIP-96 uploads, and the chat reference-card work. No breaking changes.

versionCode 18 → 19.