### PR TITLE
fix(desktop): bundle jdk.httpserver in the packaged runtime

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -361,7 +361,10 @@ compose.desktop {
             // provides sun.misc.Unsafe for jnr-ffi (dbus-java transport); without it
             // Keyring.create() throws BackendNotSupportedException and the packaged app
             // falls back to the passphrase gate even with a Secret Service running.
-            modules("java.sql", "jdk.unsupported")
+            // jdk.httpserver provides com.sun.net.httpserver.HttpServer, which the Google
+            // login flow binds on localhost to catch the OAuth redirect; without it the
+            // sign-in dialog dies with NoClassDefFoundError in the packaged app.
+            modules("java.sql", "jdk.unsupported", "jdk.httpserver")
 
             linux {
                 iconFile.set(project.file("src/jvmMain/resources/icon-512.png"))


### PR DESCRIPTION
Google login on the packaged desktop app died with `NoClassDefFoundError: com/sun/net/httpserver/HttpServer`. The sign-in flow binds a loopback `HttpServer` to catch the OAuth redirect, but jpackage builds a minimal jlink image and `jdk.httpserver` was not in the module list, so the class only existed when running from a full JDK (`./gradlew run`). Same class of bug as #165 with `java.sql`.

| | |
|---|---|
| Fix | add `jdk.httpserver` to `nativeDistributions.modules` |
| Verified | runtime image `release` file lists the module; .deb built and Google login opens correctly |
| Platforms | desktop packaging only |

- fix(desktop): bundle jdk.httpserver in the packaged runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)