### PR TITLE
chore: bump version to 2.5.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.5.0
-app.versionCode=19
+app.version=2.5.1
+app.versionCode=20
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Patch release for the desktop packaging fix in #235 (`jdk.httpserver` missing from the jlink image broke Google login in the packaged app).

| | |
|---|---|
| app.version | 2.5.0 → 2.5.1 |
| app.versionCode | 19 → 20 |

- chore: bump version to 2.5.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)