### PR TITLE
fix(desktop): close the app when the OS keychain denies access instead of running ephemeral

### DIFF
--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/KeychainStore.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/KeychainStore.kt
@@ -5,9 +5,26 @@ import com.github.javakeyring.Keyring
 import com.github.javakeyring.PasswordAccessException
 import java.util.Base64
 
+internal sealed interface MasterKeyResult {
+    data class Found(val key: ByteArray) : MasterKeyResult
+
+    data object Absent : MasterKeyResult
+
+    // The OS keyring holds an entry but refused to hand it over (user hit Deny on the
+    // macOS ACL prompt, locked Secret Service collection, ...). Minting a fresh key or
+    // running with an ephemeral one here would orphan every blob encrypted with the
+    // real key — callers must treat this as fatal, never as "no key yet".
+    data object Denied : MasterKeyResult
+}
+
 internal object KeychainStore {
     private const val SERVICE = "org.nostr.nostrord"
     private const val ACCOUNT_MASTER_KEY = "master_encryption_key"
+
+    // java-keyring 1.0.3 signals "entry does not exist" only via this message prefix
+    // (same string in the osx and freedesktop backends); every other failure is an
+    // access/backend error. Message-matching is version-fragile — revisit on upgrade.
+    private const val NOT_FOUND_PREFIX = "No stored credentials match"
 
     private val keyring: Keyring? by lazy {
         // Unit tests must not touch the real OS keyring: java-keyring's Secret Service
@@ -28,15 +45,20 @@ internal object KeychainStore {
 
     fun isAvailable(): Boolean = keyring != null
 
-    fun getMasterKey(): ByteArray? {
-        val ring = keyring ?: return null
+    fun readMasterKey(): MasterKeyResult {
+        val ring = keyring ?: return MasterKeyResult.Absent
         return try {
-            val b64 = ring.getPassword(SERVICE, ACCOUNT_MASTER_KEY) ?: return null
-            Base64.getDecoder().decode(b64)
-        } catch (_: PasswordAccessException) {
-            null
+            val b64 = ring.getPassword(SERVICE, ACCOUNT_MASTER_KEY)
+                ?: return MasterKeyResult.Absent
+            MasterKeyResult.Found(Base64.getDecoder().decode(b64))
+        } catch (e: PasswordAccessException) {
+            if (e.message?.startsWith(NOT_FOUND_PREFIX) == true) {
+                MasterKeyResult.Absent
+            } else {
+                MasterKeyResult.Denied
+            }
         } catch (_: Throwable) {
-            null
+            MasterKeyResult.Denied
         }
     }
 

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/storage/SecureStorage.jvm.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.awt.GraphicsEnvironment
 import java.security.SecureRandom
 import java.util.Base64
 import java.util.prefs.Preferences
@@ -16,6 +17,9 @@ import javax.crypto.SecretKeyFactory
 import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
+import javax.swing.JOptionPane
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
 
 sealed class UnlockState {
     object Initializing : UnlockState()
@@ -93,13 +97,20 @@ actual object SecureStorage {
         }
         legacyKey = loadLegacyKey()
 
-        val existingKeychainKey = KeychainStore.getMasterKey()
-        if (existingKeychainKey != null) {
-            masterKey = SecretKeySpec(existingKeychainKey, "AES")
-            keySource = KeySource.Keychain
-            _unlockState.value = UnlockState.Unlocked
-            migrateLegacyIfNeeded()
-            return
+        when (val result = KeychainStore.readMasterKey()) {
+            is MasterKeyResult.Found -> {
+                masterKey = SecretKeySpec(result.key, "AES")
+                keySource = KeySource.Keychain
+                _unlockState.value = UnlockState.Unlocked
+                migrateLegacyIfNeeded()
+                return
+            }
+            // Denied is fatal: an entry exists but the OS refused it. Continuing would
+            // mint a fresh key over it (orphaning the real one) or run on an ephemeral
+            // key whose writes silently clobber the real key's blobs. Exit instead;
+            // relaunching and allowing access recovers everything.
+            MasterKeyResult.Denied -> exitForDeniedKeychain()
+            MasterKeyResult.Absent -> {}
         }
 
         // Keychain available but empty: adopt it ONLY when no passphrase protects the
@@ -135,6 +146,33 @@ actual object SecureStorage {
                 _unlockState.value = UnlockState.Unlocked
             }
         }
+    }
+
+    private fun exitForDeniedKeychain(): Nothing {
+        val message =
+            "Nostrord was denied access to its entry in the system keychain, so your " +
+                "stored accounts cannot be unlocked.\n\n" +
+                "The app will close to keep that data safe. Reopen it and choose " +
+                "\"Always Allow\" when the system asks for keychain access."
+        System.err.println(message)
+        if (!GraphicsEnvironment.isHeadless()) {
+            val show = {
+                JOptionPane.showMessageDialog(
+                    null,
+                    message,
+                    "Keychain access denied",
+                    JOptionPane.ERROR_MESSAGE,
+                )
+            }
+            try {
+                // First touch of SecureStorage happens during Compose composition, i.e.
+                // ON the AWT event dispatch thread — invokeAndWait would throw there.
+                if (SwingUtilities.isEventDispatchThread()) show() else SwingUtilities.invokeAndWait(show)
+            } catch (_: Throwable) {
+                // Dialog is best-effort; the exit below is what protects the data.
+            }
+        }
+        exitProcess(1)
     }
 
     fun unlockWithPassphrase(passphrase: String): Boolean {


### PR DESCRIPTION
## Problem

`KeychainStore.getMasterKey()` returned `null` both when the keychain entry does not exist and when the OS refused access (user clicked **Deny** on the macOS ACL prompt, locked Secret Service collection on Linux). After a Deny, `SecureStorage` treated the machine as a fresh install:

1. It tried to mint a fresh master key **over the real one** in the keychain (orphaning every blob encrypted with it if the write went through), and
2. it ran unlocked on an **ephemeral key**, so any write during that session silently clobbered the real key's encrypted slots — gradual, unrecoverable data corruption.

## Fix

- `KeychainStore.readMasterKey()` returns `Found / Absent / Denied` instead of `ByteArray?`. java-keyring 1.0.3 signals not-found only via its `"No stored credentials match"` message (same string on the osx and freedesktop backends); everything else is an access/backend error. Commented as version-fragile for the next lib upgrade.
- `Denied` is fatal in `SecureStorage.initialize()`: show a native dialog explaining what happened and how to recover ("reopen and choose Always Allow"), log to stderr for headless runs, then `exitProcess(1)` **before any write can touch the store**. Relaunching and allowing access recovers everything.
- The dialog is EDT-aware: the first touch of `SecureStorage` happens during Compose composition on the AWT event dispatch thread, where `invokeAndWait` throws — that swallowed error previously made the app exit with no message at all.
- `Absent` keeps the exact previous behavior (fresh install → keychain adoption or ephemeral key; Linux without a keyring → passphrase flow unchanged).

## Testing

- `compileKotlinJvm` + `:composeApp:jvmTest` pass.
- Manually on macOS via `:composeApp:run`: **Deny** → error dialog, app closes after OK, keychain entry and encrypted data untouched; relaunch + **Allow** → normal unlocked startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)