### PR TITLE
feat(rail): order groups by the kind:10009 tag sequence

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -537,6 +537,7 @@ class NostrRepository(
         }.stateIn(scope, SharingStarted.Eagerly, emptySet())
     override val kind10009Relays: StateFlow<Set<String>> = outboxManager.kind10009Relays
     override val groupTagRelays: StateFlow<Set<String>> = outboxManager.groupTagRelays
+    override val groupOrder: StateFlow<List<Pair<String, String>>> = outboxManager.groupOrder
 
     // Public kind:10009 group lists of OTHER users (profile pages). Newest event
     // wins per pubkey; the active account's own list never lands here.
@@ -1089,6 +1090,7 @@ class NostrRepository(
                             groupManager.loadAllJoinedGroupsFromStorage(pubkey, restoredRelays)
                             groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, restoredRelays)
                             groupManager.restoreGroupMembershipFromStorage(pubkey)
+                            outboxManager.restoreGroupOrder(pubkey)
                             groupManager.migrateMessageBlobsToCache(pubkey)
                             // Arm catch-up right before connect (fresh TTL) so the
                             // first mux refresh replays the closed-app backlog.
@@ -1128,6 +1130,7 @@ class NostrRepository(
                 groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
                 groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
                 groupManager.restoreGroupMembershipFromStorage(pubkey)
+                outboxManager.restoreGroupOrder(pubkey)
                 groupManager.migrateMessageBlobsToCache(pubkey)
                 unreadManager.initialize(pubkey)
                 notificationSettings?.initialize(pubkey)
@@ -1485,6 +1488,7 @@ class NostrRepository(
                 groupManager.loadAllJoinedGroupsFromStorage(newPubkey, allRelays)
                 groupManager.restoreJoinedGroupMetadataFromStorage(newPubkey, allRelays)
                 groupManager.restoreGroupMembershipFromStorage(newPubkey)
+                outboxManager.restoreGroupOrder(newPubkey)
                 groupManager.migrateMessageBlobsToCache(newPubkey)
             }
             unreadManager.initialize(newPubkey)
@@ -2297,6 +2301,7 @@ class NostrRepository(
             groupManager.loadAllJoinedGroupsFromStorage(pubkey, allRelays)
             groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, allRelays)
             groupManager.restoreGroupMembershipFromStorage(pubkey)
+            outboxManager.restoreGroupOrder(pubkey)
             groupManager.migrateMessageBlobsToCache(pubkey)
             groupManager.loadRestrictedGroupsFromStorage(pubkey, allRelays)
             // Point GroupManager's current-relay flow at the new focused so the
@@ -2774,6 +2779,7 @@ class NostrRepository(
             groupManager.loadAllJoinedGroupsFromStorage(pubkey, relays)
             groupManager.restoreJoinedGroupMetadataFromStorage(pubkey, relays)
             groupManager.restoreGroupMembershipFromStorage(pubkey)
+            outboxManager.restoreGroupOrder(pubkey)
             groupManager.migrateMessageBlobsToCache(pubkey)
             groupManager.loadRestrictedGroupsFromStorage(pubkey, relays)
         }
@@ -4432,6 +4438,7 @@ class NostrRepository(
     private suspend fun publishJoinedGroupsListWith(
         pubKey: String,
         nip29Relays: List<String> = outboxManager.kind10009Relays.value.toList(),
+        orderOverride: List<Pair<String, String>>? = null,
     ): Result<Unit> {
         // The in-memory map can be partial early in a session (the storage restore and
         // the kind:10009 fetch are async). An event published from a partial map drops
@@ -4454,7 +4461,18 @@ class NostrRepository(
             nip29Relays = nip29Relays,
             signEvent = { sessionManager.signEvent(it) },
             messageHandler = { msg, client -> handleRelayMessage(msg, client) },
+            orderOverride = orderOverride,
         )
+    }
+
+    override suspend fun reorderGroups(order: List<Pair<String, String>>): Result<Unit> {
+        val pubKey = sessionManager.getPublicKey()
+            ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        // Membership is not derived from [order]: the publish emits only groups in the
+        // joined superset, so an entry here that is not joined is a no-op, and a joined
+        // group missing from it falls to the end. A reorder can never add a group.
+        val normalized = order.map { (relay, id) -> relay.normalizeRelayUrl() to id }.distinct()
+        return publishJoinedGroupsListWith(pubKey, orderOverride = normalized)
     }
 
     // Groups whose subscriptions the relay CLOSED (typically auth-required).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -214,6 +214,13 @@ interface NostrRepositoryApi {
     val groupTagRelays: StateFlow<Set<String>>
 
     /**
+     * Rail order: (relayUrl, groupId) in the tag order of the account's kind:10009, the
+     * order the user controls by dragging. Purely a sort key: an entry here whose group is
+     * not joined is ignored, never a source of membership.
+     */
+    val groupOrder: StateFlow<List<Pair<String, String>>>
+
+    /**
      * Public NIP-29 group lists (kind:10009) of OTHER users, keyed by pubkey, as
      * (relayUrl, groupId) refs. Filled by [requestUserGroupList]; the active
      * account's own list keeps flowing through the joined-groups state instead.
@@ -450,6 +457,14 @@ interface NostrRepositoryApi {
         groupId: String,
         orderedIds: List<String>,
     ): Result<Unit>
+
+    /**
+     * Reorder the rail by republishing kind:10009 with the `group` tags in [order].
+     * Membership is untouched: entries not currently joined are dropped and joined groups
+     * missing from [order] keep their slot at the end, so a reorder can never add a group
+     * to the published list.
+     */
+    suspend fun reorderGroups(order: List<Pair<String, String>>): Result<Unit>
 
     fun isGroupJoined(groupId: String): Boolean
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -15,8 +15,10 @@ import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.loadGroupOrderFor
 import org.nostr.nostrord.storage.loadKind10009Timestamp
 import org.nostr.nostrord.storage.loadRelayListFor
+import org.nostr.nostrord.storage.saveGroupOrderFor
 import org.nostr.nostrord.storage.saveKind10009RepublishPendingFor
 import org.nostr.nostrord.storage.saveKind10009Timestamp
 import org.nostr.nostrord.storage.saveRelayListFor
@@ -66,6 +68,40 @@ class OutboxManager(
 
     private val _kind10009Relays = MutableStateFlow<Set<String>>(emptySet())
     val kind10009Relays: StateFlow<Set<String>> = _kind10009Relays.asStateFlow()
+
+    /**
+     * Rail order: (relay, groupId) in the tag order of the authoritative kind:10009, which is
+     * the only order the user actually controls (and the one a drag-reorder republishes).
+     * A sort key only: an entry whose group is not joined is ignored downstream, never
+     * re-added. Stale versions never touch it — a superseded list must not reorder the rail.
+     */
+    private val _groupOrder = MutableStateFlow<List<Pair<String, String>>>(emptyList())
+    val groupOrder: StateFlow<List<Pair<String, String>>> = _groupOrder.asStateFlow()
+
+    /** Publish the tag order and persist it, so the next cold start sorts before the event lands. */
+    private fun applyGroupOrder(
+        pubKey: String,
+        order: List<Pair<String, String>>,
+    ) {
+        if (order == _groupOrder.value) return
+        _groupOrder.value = order
+        try {
+            SecureStorage.saveGroupOrderFor(pubKey, order)
+        } catch (_: Exception) {
+        }
+    }
+
+    /** Seed the order from storage at boot. Never overwrites an order already applied from an event. */
+    fun restoreGroupOrder(pubKey: String) {
+        if (_groupOrder.value.isNotEmpty()) return
+        val stored =
+            try {
+                SecureStorage.loadGroupOrderFor(pubKey)
+            } catch (_: Exception) {
+                emptyList()
+            }
+        if (stored.isNotEmpty()) _groupOrder.value = stored
+    }
 
     /** Relay URLs that appear in "group" tags but NOT in "r" tags.
      *  These are implicit/temporary — shown in the rail but never persisted. */
@@ -310,8 +346,10 @@ class OutboxManager(
         nip29Relays: List<String>,
         signEvent: suspend (Event) -> Event,
         messageHandler: (String, NostrGroupClient) -> Unit,
+        orderOverride: List<Pair<String, String>>? = null,
     ): Result<Unit> {
         return try {
+            var publishedOrder: List<Pair<String, String>> = emptyList()
             val tags =
                 groupsMutex.withLock {
                     // Normalize and deduplicate relay URLs before publishing
@@ -322,11 +360,11 @@ class OutboxManager(
                     }
                     allRelayGroups = normalizedGroups.mapValues { it.value.toSet() }
 
+                    publishedOrder = orderJoinedGroups(allRelayGroups, orderOverride ?: _groupOrder.value)
+
                     val tagsList = mutableListOf<List<String>>()
-                    allRelayGroups.forEach { (relayUrl, groupIds) ->
-                        groupIds.forEach { groupId ->
-                            tagsList.add(listOf("group", groupId, relayUrl))
-                        }
+                    publishedOrder.forEach { (relayUrl, groupId) ->
+                        tagsList.add(listOf("group", groupId, relayUrl))
                     }
                     val distinctRelays = nip29Relays.map { it.normalizeRelayUrl() }.filter { it.isNotBlank() }.distinct()
                     distinctRelays.forEach { relayUrl ->
@@ -335,6 +373,9 @@ class OutboxManager(
 
                     tagsList
                 }
+            // Own publish is authoritative for order too: the event we are about to sign is
+            // exactly what the rail must show, including a drag that moved a chip.
+            applyGroupOrder(pubKey, publishedOrder)
 
             val event =
                 Event(
@@ -490,6 +531,8 @@ class OutboxManager(
 
         val newRelayGroups = mutableMapOf<String, MutableSet<String>>()
         val explicitNip29Relays = mutableListOf<String>()
+        // Tag sequence, preserved: bucketing by relay alone loses the only order the user has.
+        val taggedOrder = mutableListOf<Pair<String, String>>()
 
         tags.forEach { tag ->
             val tagArray = tag.jsonArray
@@ -498,7 +541,9 @@ class OutboxManager(
                 "group" -> {
                     val groupId = tagArray.getOrNull(1)?.jsonPrimitive?.content ?: return@forEach
                     val relayUrl = (tagArray.getOrNull(2)?.jsonPrimitive?.content ?: currentRelayUrl).normalizeRelayUrl()
-                    newRelayGroups.getOrPut(relayUrl) { mutableSetOf() }.add(groupId)
+                    if (newRelayGroups.getOrPut(relayUrl) { mutableSetOf() }.add(groupId)) {
+                        taggedOrder.add(relayUrl to groupId)
+                    }
                 }
                 "r" -> {
                     val relayUrl =
@@ -569,6 +614,9 @@ class OutboxManager(
             contentUnchanged = allRelayGroups == immutableRelayGroups
             allRelayGroups = immutableRelayGroups
         }
+        // Ahead of the contentUnchanged short-circuit below: a reorder published from another
+        // device changes only the tag sequence, and would otherwise never reach the rail.
+        applyGroupOrder(pubKey, taggedOrder)
         // Every connected relay re-delivers the applied event on each fetch (and
         // equal-createdAt now re-applies): identical content with the relay set already
         // in place changes nothing — skip the storage rewrites and callback refires.
@@ -795,4 +843,20 @@ class OutboxManager(
         kind10009SubId = null
         kind10009Received = false
     }
+}
+
+/**
+ * The `group` tags of a kind:10009 publish, in rail order: every entry of [joinedByRelay]
+ * exactly once, sorted by its position in [order], with the unpositioned ones (a fresh
+ * join) appended in map order. [order] only ranks — an entry of it that is not joined
+ * emits nothing, so a publish can never add a group the user did not join.
+ */
+fun orderJoinedGroups(
+    joinedByRelay: Map<String, Set<String>>,
+    order: List<Pair<String, String>>,
+): List<Pair<String, String>> {
+    val positions = order.withIndex().associate { (index, entry) -> entry to index }
+    return joinedByRelay
+        .flatMap { (relayUrl, groupIds) -> groupIds.map { relayUrl to it } }
+        .sortedBy { positions[it] ?: Int.MAX_VALUE }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -382,6 +382,42 @@ private const val RELAY_LIST_MIGRATION_DONE_KEY = "relay_list_legacy_migrated"
 
 private const val NOSTRCONNECT_RELAYS_KEY = "nostrconnect_relays"
 
+private fun groupOrderForAccountKey(pubkey: String) = "group_order_${pubkeyDigest(pubkey)}"
+
+/**
+ * Rail order: `relay|id` entries in the tag order of the account's kind:10009. A sort key
+ * only — an entry whose group is not joined is ignored, never a source of membership.
+ * Persisted so a cold start orders the rail before the event lands.
+ */
+fun SecureStorage.saveGroupOrderFor(
+    pubkey: String,
+    order: List<Pair<String, String>>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(
+            groupOrderForAccountKey(pubkey),
+            Json.encodeToString<List<String>>(order.map { (relay, id) -> "$relay|$id" }),
+        )
+    } catch (_: Exception) {
+    }
+}
+
+fun SecureStorage.loadGroupOrderFor(pubkey: String): List<Pair<String, String>> {
+    if (pubkey.isBlank()) return emptyList()
+    val raw = getStringPref(groupOrderForAccountKey(pubkey), "")
+    if (raw.isBlank()) return emptyList()
+    return try {
+        Json.decodeFromString<List<String>>(raw).mapNotNull { entry ->
+            // Relay URLs carry no "|", so the first separator splits it; a group id may.
+            val sep = entry.indexOf('|')
+            if (sep <= 0 || sep == entry.lastIndex) null else entry.substring(0, sep) to entry.substring(sep + 1)
+        }
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
 /**
  * NIP-46 nostrconnect:// QR-login relays the user customized. Global (pre-login)
  * — not per-account, since they are chosen before any account exists.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
@@ -34,6 +34,22 @@ import org.nostr.nostrord.ui.screens.group.aggregateUnread
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
+ * Rail identity as a single string, for drag-reorder helpers that work on `List<String>`.
+ * The pair (relay, id) is the identity; the bare id is not, since the same id on two
+ * relays is two groups. Relay URLs carry no "|", so the first separator splits it back.
+ */
+fun railKey(
+    relayUrl: String,
+    groupId: String,
+): String = "$relayUrl|$groupId"
+
+fun parseRailKey(key: String): Pair<String, String>? {
+    val sep = key.indexOf('|')
+    if (sep <= 0 || sep == key.lastIndex) return null
+    return key.substring(0, sep) to key.substring(sep + 1)
+}
+
+/**
  * Curator whose public group list (kind:10009) seeds the "Recommended" tab: the
  * groups we hand-pick are simply the ones this account joins.
  */
@@ -194,6 +210,7 @@ class HomePageViewModel(
                 repo.userMetadata,
                 _membersResolved,
                 repo.groupMembersByRelay,
+                repo.groupOrder,
             ),
         ) { arr ->
             val groupsByRelay = arr[0] as Map<String, List<GroupMetadata>>
@@ -203,6 +220,10 @@ class HomePageViewModel(
             val meta = arr[4] as Map<String, UserMetadata>
             val resolved = arr[5] as Set<String>
             val membersByRelay = arr[6] as Map<String, Map<String, List<String>>>
+
+            @Suppress("UNCHECKED_CAST")
+            val order = arr[7] as List<Pair<String, String>>
+            val orderIndex = order.withIndex().associate { (index, entry) -> entry to index }
             joinedByRelay
                 .flatMap { (relay, ids) ->
                     val metas = groupsByRelay[relay].orEmpty().associateBy { it.id }
@@ -239,6 +260,13 @@ class HomePageViewModel(
                 }
                 // Dedup by (relay, id): the same id on two relays is two independent groups.
                 .distinctBy { it.relayUrl to it.meta.id }
+                // The kind:10009 tag order is the user's own order and the only stable one:
+                // the map above is keyed by relay, so its iteration order is whichever relay
+                // loaded first (the focused relay is seeded ahead of the rest), which
+                // reshuffled the rail between reloads. Stable sort, so a group with no
+                // position yet (fresh join, pending invite, orphan pin) sits at the end in
+                // arrival order and settles once the list is published.
+                .sortedBy { orderIndex[it.relayUrl to it.meta.id] ?: Int.MAX_VALUE }
             // Off Main: the previewPeople / associateBy / distinctBy transform is O(groups x members)
             // and re-runs for each of the ~50 metadata events that arrive in waves on home open;
             // running it on viewModelScope's Main dispatcher made it compete with composition. The
@@ -263,6 +291,21 @@ class HomePageViewModel(
      * stays (it would be unreachable otherwise). [railGroups] remains the unfiltered
      * joined list for non-rail consumers (restore validation, history labels).
      */
+    /**
+     * Persist a rail reorder: republish kind:10009 with the `group` tags in [orderedKeys]
+     * (rail order, [railKey] encoding). Entries the rail never renders (channels) follow,
+     * keeping their current relative order. Membership is untouched — the publish emits
+     * only joined groups, so a reorder can neither add nor drop one.
+     */
+    fun reorderRail(orderedKeys: List<String>) {
+        val moved = orderedKeys.mapNotNull(::parseRailKey)
+        if (moved.isEmpty()) return
+        viewModelScope.launch {
+            val movedSet = moved.toSet()
+            repo.reorderGroups(moved + repo.groupOrder.value.filterNot { it in movedSet })
+        }
+    }
+
     val railRootGroups: StateFlow<List<DiscoverGroup>> =
         railGroups
             .map { list ->

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -358,6 +358,11 @@ class FakeNostrRepository : NostrRepositoryApi {
         orderedIds: List<String>,
     ): Result<Unit> = Result.Success(Unit)
 
+    override suspend fun reorderGroups(order: List<Pair<String, String>>): Result<Unit> {
+        groupOrderFlow.value = order
+        return Result.Success(Unit)
+    }
+
     override fun isGroupJoined(groupId: String): Boolean = joinedGroups.value.contains(groupId)
 
     override suspend fun requestGroupMessages(
@@ -665,6 +670,9 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val restrictedRelays: StateFlow<Map<String, String>> = MutableStateFlow(emptyMap())
     override val kind10009Relays: StateFlow<Set<String>> = MutableStateFlow(emptySet())
     override val groupTagRelays: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+
+    val groupOrderFlow = MutableStateFlow<List<Pair<String, String>>>(emptyList())
+    override val groupOrder: StateFlow<List<Pair<String, String>>> = groupOrderFlow
 
     override suspend fun fetchGroupPreview(
         groupId: String,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/GroupOrderTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/GroupOrderTest.kt
@@ -1,0 +1,66 @@
+package org.nostr.nostrord.network
+
+import org.nostr.nostrord.network.managers.orderJoinedGroups
+import org.nostr.nostrord.ui.screens.home.parseRailKey
+import org.nostr.nostrord.ui.screens.home.railKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Rail order comes from the kind:10009 tag sequence: the publish must carry it forward
+ * (a join must not reshuffle the rail) and must never turn a position into membership.
+ */
+class GroupOrderTest {
+    @Test
+    fun `publish keeps the current tag order`() {
+        val joined = mapOf("wss://a" to setOf("g1", "g2"), "wss://b" to setOf("g3"))
+        val order = listOf("wss://b" to "g3", "wss://a" to "g2", "wss://a" to "g1")
+
+        assertEquals(order, orderJoinedGroups(joined, order))
+    }
+
+    @Test
+    fun `a newly joined group is appended, leaving the rest in place`() {
+        val joined = mapOf("wss://a" to setOf("g1", "g2", "fresh"))
+        val order = listOf("wss://a" to "g2", "wss://a" to "g1")
+
+        assertEquals(
+            listOf("wss://a" to "g2", "wss://a" to "g1", "wss://a" to "fresh"),
+            orderJoinedGroups(joined, order),
+        )
+    }
+
+    @Test
+    fun `an ordered entry that is not joined emits no tag`() {
+        val joined = mapOf("wss://a" to setOf("g1"))
+        val order = listOf("wss://a" to "left-on-another-device", "wss://a" to "g1")
+
+        assertEquals(listOf("wss://a" to "g1"), orderJoinedGroups(joined, order))
+    }
+
+    @Test
+    fun `the same id on two relays keeps two independent positions`() {
+        val joined = mapOf("wss://a" to setOf("dup"), "wss://b" to setOf("dup"))
+        val order = listOf("wss://b" to "dup", "wss://a" to "dup")
+
+        assertEquals(order, orderJoinedGroups(joined, order))
+    }
+
+    @Test
+    fun `publishing twice is order-idempotent`() {
+        val joined = mapOf("wss://a" to setOf("g1", "g2"), "wss://b" to setOf("g3"))
+        val first = orderJoinedGroups(joined, emptyList())
+
+        assertEquals(first, orderJoinedGroups(joined, first))
+    }
+
+    @Test
+    fun `rail keys round-trip`() {
+        val key = railKey("wss://relay.example.com", "group-1")
+
+        assertEquals("wss://relay.example.com" to "group-1", parseRailKey(key))
+        assertNull(parseRailKey("no-separator"))
+        assertNull(parseRailKey("wss://a|"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
@@ -13,6 +13,7 @@ import org.nostr.nostrord.notifications.NotificationHistoryStore
 import org.nostr.nostrord.notifications.NotificationType
 import org.nostr.nostrord.ui.screens.home.Friend
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
+import org.nostr.nostrord.ui.screens.home.railKey
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -580,5 +581,69 @@ class HomePageViewModelTest {
         store.markRead("n1")
         testDispatcher.scheduler.advanceUntilIdle()
         assertEquals(1, vm.notificationUnread.value)
+    }
+
+    @Test
+    fun `myGroups follows the kind10009 tag order, not relay load order`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._groupsByRelay.value =
+            mapOf(
+                "wss://a" to listOf(meta("g1", "Alpha"), meta("g2", "Beta")),
+                "wss://b" to listOf(meta("g3", "Gamma")),
+            )
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("g1", "g2"), "wss://b" to setOf("g3"))
+        // Tag order interleaves the relays; the per-relay map cannot express it.
+        fake.groupOrderFlow.value = listOf("wss://a" to "g2", "wss://b" to "g3", "wss://a" to "g1")
+        val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("g2", "g3", "g1"), vm.myGroups.value.map { it.meta.id })
+    }
+
+    @Test
+    fun `a group with no tag position yet sits at the end`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._groupsByRelay.value = mapOf("wss://a" to listOf(meta("g1", "Alpha"), meta("fresh", "Fresh")))
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("fresh", "g1"))
+        fake.groupOrderFlow.value = listOf("wss://a" to "g1")
+        val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("g1", "fresh"), vm.myGroups.value.map { it.meta.id })
+    }
+
+    @Test
+    fun `order entries are matched per relay, so a same-id group elsewhere keeps its own slot`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._groupsByRelay.value =
+            mapOf(
+                "wss://a" to listOf(meta("dup", "On A")),
+                "wss://b" to listOf(meta("dup", "On B")),
+            )
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("dup"), "wss://b" to setOf("dup"))
+        fake.groupOrderFlow.value = listOf("wss://b" to "dup", "wss://a" to "dup")
+        val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("wss://b", "wss://a"), vm.myGroups.value.map { it.relayUrl })
+    }
+
+    @Test
+    fun `reorderRail republishes the rail order and keeps unlisted entries after it`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._groupsByRelay.value = mapOf("wss://a" to listOf(meta("g1", "Alpha"), meta("g2", "Beta")))
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("g1", "g2"))
+        // A channel lives in the list too, but never on the rail.
+        fake.groupOrderFlow.value = listOf("wss://a" to "g1", "wss://a" to "chan", "wss://a" to "g2")
+        val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.reorderRail(listOf(railKey("wss://a", "g2"), railKey("wss://a", "g1")))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(
+            listOf("wss://a" to "g2", "wss://a" to "g1", "wss://a" to "chan"),
+            fake.groupOrderFlow.value,
+        )
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -3,6 +3,8 @@ package org.nostr.nostrord.ui.components.layout
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -64,10 +66,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.withFrameNanos
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.key.Key
@@ -76,6 +84,8 @@ import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -93,6 +103,7 @@ import androidx.compose.ui.window.PopupProperties
 import androidx.lifecycle.viewmodel.compose.viewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.nostr.nostrord.auth.removeAccountBusyLabel
@@ -142,10 +153,12 @@ import org.nostr.nostrord.ui.screens.group.components.AddGroupModal
 import org.nostr.nostrord.ui.screens.group.components.CreateGroupModal
 import org.nostr.nostrord.ui.screens.group.components.JoinGroupModal
 import org.nostr.nostrord.ui.screens.group.components.UserProfileModal
+import org.nostr.nostrord.ui.screens.group.moveChannelBefore
 import org.nostr.nostrord.ui.screens.group.rootGroupId
 import org.nostr.nostrord.ui.screens.home.Friend
 import org.nostr.nostrord.ui.screens.home.HomePageScreen
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
+import org.nostr.nostrord.ui.screens.home.railKey
 import org.nostr.nostrord.ui.screens.notifications.NotificationsPage
 import org.nostr.nostrord.ui.screens.notifications.NotificationsSidebar
 import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
@@ -160,6 +173,7 @@ import org.nostr.nostrord.ui.window.onBackForwardMouseButtons
 import org.nostr.nostrord.utils.accountDisplayLabel
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.rememberClipboardWriter
+import kotlin.math.roundToInt
 
 /**
  * New-design logged-in frame (prototype AppShell): the 72px groups rail (home,
@@ -188,6 +202,64 @@ fun AppFrame() {
     val dmUnread by AppModule.nostrRepository.totalDmUnread.collectAsState()
     val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     var addGroupStep by remember { mutableStateOf<AddGroupStep?>(null) }
+
+    // Rail drag reorder (long-press to pick a chip up, so a tap still opens the group).
+    // Index railRoots.size is the slot after the last chip. No optimistic copy:
+    // reorderRail updates the shared order flow before the publish leaves.
+    var railDragKey by remember { mutableStateOf<String?>(null) }
+    var railDragDelta by remember { mutableStateOf(0f) }
+    var railChipHeightPx by remember { mutableStateOf(0) }
+    var railScrollAtDragStart by remember { mutableStateOf(0) }
+    val railScroll = rememberScrollState()
+    val railKeys = railRoots.map { railKey(it.relayUrl, it.meta.id) }
+    val railDragFromIndex = railKeys.indexOf(railDragKey)
+    val railPitchPx = railChipHeightPx + with(LocalDensity.current) { 8.dp.roundToPx() }
+    // Travel counts auto-scroll, not just pointer movement: on a rail taller than its
+    // viewport, a pointer-only offset would need the cursor to move the full content
+    // height (off-screen) to reach the last slot. Holding at the edge now advances the
+    // target as the content scrolls under it.
+    val railDragTravel = railDragDelta + (railScroll.value - railScrollAtDragStart)
+    val railDragOverIndex =
+        if (railDragKey != null && railDragFromIndex >= 0 && railPitchPx > 0) {
+            (railDragFromIndex + (railDragTravel / railPitchPx).roundToInt()).coerceIn(0, railKeys.size)
+        } else {
+            -1
+        }
+
+    // Edge auto-scroll while a chip is held: keeps the aimed-at slot on screen and, with
+    // the travel above, is what carries the target to the ends of a long rail. Per frame,
+    // so holding still at an edge keeps going.
+    LaunchedEffect(railDragKey) {
+        if (railDragKey == null) return@LaunchedEffect
+        val edge = railPitchPx.toFloat()
+        while (isActive && railPitchPx > 0) {
+            // Recomputed per frame from state: the composition-scope value above is
+            // captured once and would freeze at the offset the drag started with.
+            val chipTop =
+                railDragFromIndex * railPitchPx + railDragDelta + (railScroll.value - railScrollAtDragStart)
+            val viewTop = railScroll.value.toFloat()
+            val viewBottom = viewTop + railScroll.viewportSize
+            val step =
+                when {
+                    chipTop < viewTop + edge -> -edge / 4f
+                    chipTop + railChipHeightPx > viewBottom - edge -> edge / 4f
+                    else -> 0f
+                }
+            if (step != 0f) railScroll.scrollBy(step)
+            withFrameNanos { }
+        }
+    }
+
+    fun endRailDrag(commit: Boolean) {
+        val key = railDragKey
+        val over = railDragOverIndex
+        val from = railDragFromIndex
+        railDragKey = null
+        railDragDelta = 0f
+        if (!commit || key == null || over < 0 || over == from) return
+        val newOrder = moveChannelBefore(railKeys, key, railKeys.getOrNull(over))
+        if (newOrder != railKeys) vm.reorderRail(newOrder)
+    }
     // Friend tapped in the home sidebar: open the quick profile modal first (no
     // chat composer around, so no Mention action), with "View profile" inside it
     // for the full page.
@@ -367,7 +439,7 @@ fun AppFrame() {
                     modifier =
                     Modifier
                         .weight(1f, fill = false)
-                        .verticalScroll(rememberScrollState()),
+                        .verticalScroll(railScroll),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
@@ -377,7 +449,8 @@ fun AppFrame() {
                     // different chip and must not light up too.
                     val activeRootId = groupRoute?.groupId?.let { open -> rootGroupId(open) { groupParents[it] } }
                     val activeRelay = groupRoute?.relayUrl?.normalizeRelayUrl()
-                    railRoots.forEach { group ->
+                    railRoots.forEachIndexed { index, group ->
+                        val rkey = railKey(group.relayUrl, group.meta.id)
                         RailGroupButton(
                             name = group.meta.name ?: group.meta.id,
                             picture = group.meta.picture,
@@ -386,10 +459,37 @@ fun AppFrame() {
                             active = activeRootId == group.meta.id &&
                                 activeRelay == group.relayUrl.normalizeRelayUrl() &&
                                 !showNotifications,
+                            dragging = railDragKey == rkey,
+                            dropIndicator = index == railDragOverIndex && index != railDragFromIndex,
+                            onDragStart = {
+                                railDragKey = rkey
+                                railDragDelta = 0f
+                                railScrollAtDragStart = railScroll.value
+                            },
+                            onDrag = { dy -> railDragDelta += dy },
+                            onDragEnd = { endRailDrag(commit = true) },
+                            onDragCancel = { endRailDrag(commit = false) },
+                            onHeight = { railChipHeightPx = it },
                         ) {
                             history.navigate(GroupRoute(group.relayUrl, group.meta.id))
                             closeDrawer()
                         }
+                    }
+                    // End drop indicator: the slot after the last chip (a chip target always
+                    // inserts BEFORE it, so this is how a group lands last). Not for the last
+                    // chip itself, which is already there.
+                    if (railDragKey != null &&
+                        railDragOverIndex == railKeys.size &&
+                        railDragFromIndex != railKeys.lastIndex
+                    ) {
+                        Box(
+                            modifier =
+                            Modifier
+                                .width(48.dp)
+                                .height(2.dp)
+                                .clip(NostrordShapes.shapeSmall)
+                                .background(NostrordColors.Primary),
+                        )
                     }
                     // Add-group is the last scrollable item (after the groups) so the group
                     // list keeps all the rail space and scrolls together with it.
@@ -870,9 +970,24 @@ private fun RailGroupButton(
     groupId: String,
     unread: Int,
     active: Boolean = false,
+    dragging: Boolean = false,
+    dropIndicator: Boolean = false,
+    onDragStart: () -> Unit = {},
+    onDrag: (Float) -> Unit = {},
+    onDragEnd: () -> Unit = {},
+    onDragCancel: () -> Unit = {},
+    onHeight: (Int) -> Unit = {},
     onClick: () -> Unit,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    // pointerInput captures its lambdas once; the drop math lives in callbacks the rail
+    // recreates on every recomposition (they close over the current drag indexes). Route
+    // through rememberUpdatedState or the drop commits against first-composition state.
+    val currentOnDragStart by rememberUpdatedState(onDragStart)
+    val currentOnDrag by rememberUpdatedState(onDrag)
+    val currentOnDragEnd by rememberUpdatedState(onDragEnd)
+    val currentOnDragCancel by rememberUpdatedState(onDragCancel)
+    val indicatorColor = NostrordColors.Primary
     val isHovered by interactionSource.collectIsHoveredAsState()
     val highlighted = active || isHovered
     // Smoothly morph the corner radius (16dp -> 12dp) rather than snapping the shape,
@@ -885,7 +1000,37 @@ private fun RailGroupButton(
     val shape = RoundedCornerShape(cornerRadius)
     // Span the full rail width so the active pill can sit on the left edge while
     // the icon stays centered.
-    Box(modifier = Modifier.width(72.dp), contentAlignment = Alignment.Center) {
+    Box(
+        modifier =
+        Modifier
+            .width(72.dp)
+            .onSizeChanged { onHeight(it.height) }
+            .alpha(if (dragging) 0.4f else 1f)
+            // Drop target line at the top edge (drop = insert before this chip).
+            .drawBehind {
+                if (dropIndicator) {
+                    drawRoundRect(
+                        color = indicatorColor,
+                        size = Size(size.width, 2.dp.toPx()),
+                        cornerRadius = CornerRadius(1.dp.toPx()),
+                    )
+                }
+            }
+            // Long press, not plain drag: a tap must still open the group, and the chip
+            // has no separate handle to grab.
+            .pointerInput(groupId) {
+                detectDragGesturesAfterLongPress(
+                    onDragStart = { currentOnDragStart() },
+                    onDrag = { change, amount ->
+                        change.consume()
+                        currentOnDrag(amount.y)
+                    },
+                    onDragEnd = { currentOnDragEnd() },
+                    onDragCancel = { currentOnDragCancel() },
+                )
+            },
+        contentAlignment = Alignment.Center,
+    ) {
         // Left pill marker: grows from 0 to 20dp on hover and 36dp when active (web .rail-item::before).
         val pillHeight by animateDpAsState(
             targetValue = if (active) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.web
 
+import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.awaitCancellation
 import org.nostr.nostrord.auth.removeAccountBusyLabel
@@ -19,8 +20,10 @@ import org.nostr.nostrord.ui.navigation.NotificationsRoute
 import org.nostr.nostrord.ui.navigation.RelayRoute
 import org.nostr.nostrord.ui.navigation.SettingsRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
+import org.nostr.nostrord.ui.screens.group.moveChannelBefore
 import org.nostr.nostrord.ui.screens.group.rootGroupId
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
+import org.nostr.nostrord.ui.screens.home.railKey
 import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
 import org.nostr.nostrord.utils.accountDisplayLabel
 import org.nostr.nostrord.utils.normalizeRelayUrl
@@ -69,6 +72,19 @@ import react.useRef
 import react.useState
 import web.cssom.ClassName
 
+/** Squared pointer travel (px) past which a rail press is a drag, not a tap. */
+private const val DRAG_SLOP_SQ = 36.0
+
+/** Hold this long to pick a rail chip up by touch (matches the native rail's long press). */
+private const val RAIL_LONG_PRESS_MS = 400
+
+/** Hit-test id of the strip below the last rail chip: drop there to land last. */
+private const val RAIL_END_DROP = "__rail_end__"
+
+/** Distance from a rail edge where a drag starts auto-scrolling, and its minimum speed (px/frame). */
+private const val RAIL_EDGE_PX = 56.0
+private const val RAIL_SCROLL_STEP = 3.0
+
 /**
  * New-design logged-in frame (prototype AppShell): the 72px groups rail (home,
  * joined groups with unread badges, add, DMs and notifications) plus the 240px
@@ -113,6 +129,130 @@ val AppFrame =
         val (logoutBusy, setLogoutBusy) = useState { false }
         // Which step of the rail "+" add-group flow is open: "chooser" / "create" / "join".
         val (addGroupStep, setAddGroupStep) = useState<String?> { null }
+        // Rail drag-reorder, same pointer hit-testing as the channel sidebar: chips are
+        // found via elementFromPoint + data-rkey, and the drop inserts the dragged chip
+        // before the hovered one. No optimistic override — reorderRail applies the new
+        // order to the shared flow before the publish leaves, so the rail re-sorts at once.
+        val (dragKey, setDragKey) = useState<String?> { null }
+        val (overKey, setOverKey) = useState<String?> { null }
+
+        // Set while a drag actually moved, so the pointerup's click navigates nowhere.
+        val railDraggedRef = useRef<Boolean>(null)
+
+        fun startRailDrag(
+            key: String,
+            e: react.dom.events.PointerEvent<*>,
+        ) {
+            // No preventDefault: the chip is a real button that must keep taking focus and
+            // must let the mobile keyboard close when it navigates away from a chat.
+            val startX = e.clientX
+            val startY = e.clientY
+            // Mouse picks the chip up as soon as it travels past the slop. Touch cannot:
+            // the same early movement is how the rail scrolls, so it waits for a long
+            // press, like the native rail. Until then the browser owns the gesture.
+            val touch = e.pointerType.toString() != "mouse"
+            railDraggedRef.current = false
+            val currentOrder = railRoots.map { railKey(it.relayUrl, it.meta.id) }
+            fun targetAt(
+                x: Double,
+                y: Double,
+            ): String? = document.asDynamic().elementFromPoint(x, y)?.closest("[data-rkey]")?.getAttribute("data-rkey") as String?
+
+            var cleanup: (() -> Unit)? = null
+            var pressTimer: Int? = null
+            var autoScrollFrame: Int? = null
+            var pointerX = startX
+            var pointerY = startY
+
+            // Edge auto-scroll: the drop target is whatever sits under the pointer, so a chip
+            // at the bottom could never reach the top of a scrolled rail without this. Runs
+            // per frame (not per pointermove) so holding still at the edge keeps scrolling.
+            fun autoScrollStep() {
+                val rail = document.querySelector(".rail-scroll")
+                if (rail == null || railDraggedRef.current != true) {
+                    autoScrollFrame = null
+                    return
+                }
+                val rect = rail.getBoundingClientRect()
+                val speed =
+                    when {
+                        pointerY < rect.top + RAIL_EDGE_PX ->
+                            -RAIL_SCROLL_STEP.coerceAtLeast((rect.top + RAIL_EDGE_PX - pointerY) / 4)
+                        pointerY > rect.bottom - RAIL_EDGE_PX ->
+                            RAIL_SCROLL_STEP.coerceAtLeast((pointerY - (rect.bottom - RAIL_EDGE_PX)) / 4)
+                        else -> 0.0
+                    }
+                if (speed != 0.0) {
+                    rail.asDynamic().scrollTop = rail.asDynamic().scrollTop as Double + speed
+                    // Chips moved under a still pointer: re-read the hovered one.
+                    setOverKey(targetAt(pointerX, pointerY))
+                }
+                autoScrollFrame = window.requestAnimationFrame { autoScrollStep() }
+            }
+
+            fun engage() {
+                pressTimer = null
+                railDraggedRef.current = true
+                setDragKey(key)
+                setOverKey(key)
+                if (autoScrollFrame == null) autoScrollFrame = window.requestAnimationFrame { autoScrollStep() }
+            }
+            // Non-passive: once the chip is picked up, this is the only thing that stops
+            // the rail from scrolling under the finger for the rest of the drag.
+            val onTouchMove: (dynamic) -> Unit = { ev ->
+                if (railDraggedRef.current == true) ev.preventDefault()
+            }
+            val onMove: (dynamic) -> Unit = { ev ->
+                pointerX = ev.clientX as Double
+                pointerY = ev.clientY as Double
+                val dx = pointerX - startX
+                val dy = pointerY - startY
+                val movedPastSlop = dx * dx + dy * dy > DRAG_SLOP_SQ
+                if (railDraggedRef.current != true && movedPastSlop) {
+                    if (touch) {
+                        // Moved before the press landed: this is a scroll, so drop the gesture.
+                        pressTimer?.let { window.clearTimeout(it) }
+                        cleanup?.invoke()
+                    } else {
+                        engage()
+                    }
+                }
+                if (railDraggedRef.current == true) setOverKey(targetAt(ev.clientX as Double, ev.clientY as Double))
+            }
+            val onUp: (dynamic) -> Unit = { ev ->
+                if (railDraggedRef.current == true) {
+                    val target = targetAt(ev.clientX as Double, ev.clientY as Double)
+                    if (target != null && target != key) {
+                        // The end strip maps to a null target: drop after the last chip.
+                        val newOrder = moveChannelBefore(currentOrder, key, target.takeIf { it != RAIL_END_DROP })
+                        if (newOrder != currentOrder) vm.reorderRail(newOrder)
+                    }
+                }
+                cleanup?.invoke()
+            }
+            val onCancel: (dynamic) -> Unit = { _ -> cleanup?.invoke() }
+
+            cleanup = {
+                pressTimer?.let { window.clearTimeout(it) }
+                pressTimer = null
+                autoScrollFrame?.let { window.cancelAnimationFrame(it) }
+                autoScrollFrame = null
+                setDragKey(null)
+                setOverKey(null)
+                window.asDynamic().removeEventListener("pointermove", onMove)
+                window.asDynamic().removeEventListener("pointerup", onUp)
+                window.asDynamic().removeEventListener("pointercancel", onCancel)
+                window.asDynamic().removeEventListener("touchmove", onTouchMove)
+            }
+
+            window.asDynamic().addEventListener("pointermove", onMove)
+            window.asDynamic().addEventListener("pointerup", onUp)
+            window.asDynamic().addEventListener("pointercancel", onCancel)
+            if (touch) {
+                window.asDynamic().addEventListener("touchmove", onTouchMove, js("({ passive: false })"))
+                pressTimer = window.setTimeout({ engage() }, RAIL_LONG_PRESS_MS)
+            }
+        }
         // Friend tapped in the home sidebar: open the quick profile modal first (no
         // chat composer around, so no Mention action), with "View profile" inside it
         // for the full page.
@@ -297,9 +437,21 @@ val AppFrame =
                         val activeRelay = groupRoute?.relayUrl?.normalizeRelayUrl()
                         railRoots.forEach { group ->
                             val name = group.meta.name ?: group.meta.id
+                            val rkey = railKey(group.relayUrl, group.meta.id)
                             div {
                                 key = "${group.relayUrl}/${group.meta.id}"
-                                className = ClassName("rail-group")
+                                className =
+                                    ClassName(
+                                        buildString {
+                                            append("rail-group")
+                                            if (dragKey == rkey) append(" dragging")
+                                            if (overKey == rkey && dragKey != null && dragKey != rkey) append(" drag-over")
+                                        },
+                                    )
+                                asDynamic()["data-rkey"] = rkey
+                                // Kill any native HTML drag started inside the chip; it would
+                                // take over the pointer stream the reorder needs.
+                                onDragStart = { it.preventDefault() }
                                 button {
                                     className =
                                         ClassName(
@@ -313,7 +465,12 @@ val AppFrame =
                                             },
                                         )
                                     title = name
-                                    onClick = { pushRoute(GroupRoute(group.relayUrl, group.meta.id)) }
+                                    // Long-press-free: the chip drags from its own pointer down, and
+                                    // a plain click still navigates (no move => no reorder).
+                                    onPointerDown = { e -> startRailDrag(rkey, e) }
+                                    onClick = {
+                                        if (railDraggedRef.current != true) pushRoute(GroupRoute(group.relayUrl, group.meta.id))
+                                    }
                                     WebAvatar {
                                         url = group.meta.picture
                                         seed = group.meta.id
@@ -329,6 +486,16 @@ val AppFrame =
                                         +(if (unread > 99) "99+" else "$unread")
                                     }
                                 }
+                            }
+                        }
+                        // End drop strip, only while dragging: a chip target always inserts
+                        // BEFORE it, so this is the only way to land after the last group.
+                        // Hidden for the last chip itself, which is already there.
+                        val lastRailKey = railRoots.lastOrNull()?.let { railKey(it.relayUrl, it.meta.id) }
+                        if (dragKey != null && dragKey != lastRailKey) {
+                            div {
+                                className = ClassName(if (overKey == RAIL_END_DROP) "rail-drop-end drag-over" else "rail-drop-end")
+                                asDynamic()["data-rkey"] = RAIL_END_DROP
                             }
                         }
                         // Add-group is the last scrollable item (after the groups) so the

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/WebAvatar.kt
@@ -168,6 +168,9 @@ val WebAvatar =
                     className = ClassName((if (loaded) "avatar-photo loaded" else "avatar-photo") + whiteBg)
                     src = url
                     alt = props.name
+                    // The browser's native image drag would swallow the pointer stream an
+                    // avatar sits in (rail chip reorder), leaving a ghost image instead.
+                    draggable = false
                     onLoad = {
                         setErrored(false)
                         setLoaded(true)

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -1825,6 +1825,58 @@ body {
     height: 36px;
 }
 
+/* Drag reorder: the dragged chip dims, the chip under the pointer shows a drop line
+   above it (the dragged chip lands before it). Mirrors .group-side-row's states.
+   The chip owns the whole pointer stream: no text selection, and no native image drag
+   from the avatar inside (Safari needs -webkit-user-drag, the attribute is not enough). */
+.rail-group {
+    user-select: none;
+    -webkit-user-select: none;
+}
+
+.rail-group img,
+.rail-group svg,
+.rail-group canvas {
+    -webkit-user-drag: none;
+    pointer-events: none;
+}
+
+.rail-group.dragging {
+    opacity: 0.4;
+}
+
+.rail-group.drag-over::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: -4px;
+    height: 2px;
+    border-radius: var(--radius-full);
+    background: var(--color-primary);
+}
+
+/* End drop strip, rendered only while dragging: the slot after the last chip.
+   align-self overrides the rail's align-items:center — an empty div would otherwise be
+   0px wide and hit-test as nothing, reserving the space but never taking the drop. */
+.rail-drop-end {
+    position: relative;
+    align-self: stretch;
+    height: 24px;
+    flex-shrink: 0;
+}
+
+.rail-drop-end.drag-over::before {
+    content: "";
+    position: absolute;
+    top: 8px;
+    right: 0;
+    left: 0;
+    height: 2px;
+    border-radius: var(--radius-full);
+    background: var(--color-primary);
+}
+
 .rail-group-btn .group-card-avatar {
     width: 48px;
     height: 48px;


### PR DESCRIPTION
The left rail had no sort. `myGroups` flat-mapped `joinedGroupsByRelay`, so the rail was a concatenation of per-relay blocks in map insertion order, and the focused relay is seeded alone and first at boot (`NostrRepository.kt:1088`). The last relay you opened took the top of the rail, and the whole list reshuffled between reloads.

The kind:10009 tag sequence is a global order the user already publishes, but `handleKind10009Event` bucketed every `group` tag into a per-relay map and lost it. This captures that sequence, persists it per account, sorts `myGroups` by it, and carries it through every publish. Dragging a chip republishes the list with the tags swapped, so a reorder syncs to the account's other devices.

The index only ranks. An entry whose group is not joined emits no tag, and a joined group missing from it falls to the end, so a reorder can neither add nor drop a group from the published list.

| Area | Change |
|---|---|
| `OutboxManager` | capture the tag order, `groupOrder` flow, persist/restore, order-preserving publish, `orderJoinedGroups` |
| `SecureStorage` | per-account `saveGroupOrderFor` / `loadGroupOrderFor` |
| `NostrRepository(Api)` | `groupOrder` flow, `reorderGroups`, restore at the session-start sites |
| `HomePageViewModel` | sort in `myGroups`, `reorderRail`, `railKey` / `parseRailKey` |
| Web rail | pointer drag with slop / long press, edge auto-scroll, end drop slot, non-draggable avatars |
| Compose rail | long-press drag, edge auto-scroll counting scroll as travel, drop indicators |
| Tests | 10 in `commonTest` covering ranking, membership safety and the rail sort |

Only the authoritative version sets the order: a relay serving a superseded kind:10009 alongside the newest one cannot reorder the rail. The publish is order-idempotent, so a join appends rather than reshuffles.

Pick-up gesture follows the input device, not the platform. Mouse engages past a 6px slop; touch and Compose wait for a long press, because early touch movement is how the rail scrolls. Web touch needs a non-passive `touchmove` `preventDefault` once engaged, plus a `pointercancel` teardown. Both rails auto-scroll near the edges; Compose also counts that scroll as drag travel, or the cursor would have to leave the window to reach the last slot on a long rail.

Validated with `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid`, `:composeApp:jvmTest` and `spotlessApply`. iOS shares `uiComposeMain` and is covered by the same code, but cannot be compiled on this machine.

- f75f80c5 feat(rail): order groups by the kind:10009 tag sequence