### PR TITLE
refactor(home): drop the Joined badge from My groups cards

### DIFF
--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
@@ -347,7 +347,9 @@ fun HomePageScreen(
                                                 hasMetadata = group.hasMetadata,
                                                 relayUrl = group.relayUrl,
                                                 relayIconUrl = relayMetadata[group.relayUrl]?.icon,
-                                                isJoined = joinedGroupsByRelay.isJoinedOn(group.relayUrl, group.meta.id),
+                                                // Every card in My groups is joined; the badge
+                                                // earns its place only in the mixed lists.
+                                                isJoined = false,
                                                 onRelayClick = { onOpenRelay(group.relayUrl) },
                                                 onClick = { onOpenGroup(JoinedGroup(group.relayUrl, group.meta)) },
                                             )

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
@@ -220,7 +220,9 @@ val HomePage =
                                     div {
                                         className = ClassName("card-grid")
                                         myGroups.forEach { group ->
-                                            discoverGroupCard(group, relayMeta[group.relayUrl]?.icon, joinedByRelay.isJoinedOn(group.relayUrl, group.meta.id)) {
+                                            // Every card here is joined; the badge earns its
+                                            // place only in the mixed lists.
+                                            discoverGroupCard(group, relayMeta[group.relayUrl]?.icon, isJoined = false) {
                                                 props.onOpenGroup(JoinedGroup(group.relayUrl, group.meta))
                                             }
                                         }


### PR DESCRIPTION
Every card in the My groups tab is joined by definition, so the badge sat on all of them and carried no information. It still marks membership in the mixed From friends and Recommended lists, where some cards are joined and some are not.

| Area | Change |
|---|---|
| `HomePage.kt` (web) | My groups cards pass `isJoined = false` |
| `HomePageScreen.kt` (Compose) | same for the `GroupCard` grid |

Validated with `compileKotlinJvm`, `compileKotlinJs` and `spotlessApply`.

- f9c668f3 refactor(home): drop the Joined badge from My groups cards