### PR TITLE
chore: bump version to 2.6.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.5.1
-app.versionCode=20
+app.version=2.6.0
+app.versionCode=21
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Minor bump: the rail now orders groups by the kind:10009 tag sequence and lets you drag to reorder it on every platform (#238), which is user-facing behavior rather than a fix. Also carries the desktop keychain fix (#237) and the My groups badge cleanup (#239).

| Key | From | To |
|---|---|---|
| `app.version` | 2.5.1 | 2.6.0 |
| `app.versionCode` | 20 | 21 |

- 71caecac chore: bump version to 2.6.0