### PR TITLE
fix: stop inline markdown markers from mangling ordinary chat text

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -48,6 +48,7 @@ import org.nostr.nostrord.settings.NotificationSettings
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.CacheStore
 import org.nostr.nostrord.storage.cache.createCacheStore
+import org.nostr.nostrord.ui.text.flattenMarkdownForPreview
 import org.nostr.nostrord.utils.epochSeconds
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
@@ -402,7 +403,7 @@ object AppModule {
                 if (selfPubkey == null || message.pubkey != selfPubkey) {
                     val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
                         ?: groupManager.getRelayForGroup(groupId) ?: ""
-                    val preview = resolveMentionsForNotification(message.content).take(120)
+                    val preview = notificationPreview(message.content)
                     val groupName = groupDisplayName(groupId)
                     val relayName = relayDisplayName(relayUrl)
                     notificationHistoryStore.add(
@@ -451,7 +452,7 @@ object AppModule {
             onReplyNotify = { groupId, message ->
                 val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
                     ?: groupManager.getRelayForGroup(groupId) ?: ""
-                val preview = resolveMentionsForNotification(message.content).take(120)
+                val preview = notificationPreview(message.content)
                 val groupName = groupDisplayName(groupId)
                 val relayName = relayDisplayName(relayUrl)
                 notificationHistoryStore.add(
@@ -493,7 +494,7 @@ object AppModule {
             onThreadReplyNotify = { groupId, reply ->
                 val relayUrl = reply.relayUrl
                     ?: groupManager.getRelayForGroup(groupId) ?: ""
-                val preview = resolveMentionsForNotification(reply.content).take(120)
+                val preview = notificationPreview(reply.content)
                 val groupName = groupDisplayName(groupId)
                 val relayName = relayDisplayName(relayUrl)
                 // The E tag is the thread root; without it the entry would open the chat, where a
@@ -539,7 +540,7 @@ object AppModule {
             onMentionNotify = { groupId, message ->
                 val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
                     ?: groupManager.getRelayForGroup(groupId) ?: ""
-                val preview = resolveMentionsForNotification(message.content).take(120)
+                val preview = notificationPreview(message.content)
                 val groupName = groupDisplayName(groupId)
                 val relayName = relayDisplayName(relayUrl)
                 notificationHistoryStore.add(
@@ -811,6 +812,14 @@ object AppModule {
      * references into a readable summary needs the event itself, which isn't
      * available here.
      */
+    /**
+     * The message text as a notification shows it: mentions resolved to names and
+     * markdown flattened to plain text. Feeds both the in-app feed and the OS
+     * notification body, neither of which renders markers - and the OS body is why
+     * spoilers are masked rather than unwrapped.
+     */
+    private fun notificationPreview(content: String): String = flattenMarkdownForPreview(resolveMentionsForNotification(content)).take(120)
+
     private fun resolveMentionsForNotification(content: String): String {
         val matches = Nip27.findReferenceMatches(content)
         if (matches.isEmpty()) return content

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsViewModel.kt
@@ -15,6 +15,7 @@ import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.notifications.NotificationEntry
 import org.nostr.nostrord.notifications.NotificationType
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.ui.text.flattenMarkdownForPreview
 
 /** Notifications type filter (prototype tabs). Reactions have no tab; they show under [ALL]. */
 enum class NotifFilter { ALL, MENTIONS, REPLIES, MESSAGES }
@@ -86,14 +87,19 @@ class NotificationsViewModel(
         NotifFilter.MESSAGES -> entry.type == NotificationType.MESSAGE
     }
 
-    /** The notifications to render, after the type, group and unread-only filters. */
+    /**
+     * The notifications to render, after the type, group and unread-only filters.
+     * Previews are flattened here rather than in either UI: entries persisted
+     * before previews were flattened still hold raw markers, and neither feed row
+     * renders them. Idempotent, so freshly built previews pass through unchanged.
+     */
     val filtered: StateFlow<List<NotificationEntry>> =
         combine(entries, _typeFilter, _unreadOnly, _groupFilter) { list, type, unread, group ->
             list.filter { e ->
                 matchesType(e, type) &&
                     (group == null || e.groupId == group) &&
                     (!unread || !e.read)
-            }
+            }.map { e -> e.copy(preview = flattenMarkdownForPreview(e.preview)) }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     /** Total unread, for the header pill. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasis.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasis.kt
@@ -1,0 +1,21 @@
+package org.nostr.nostrord.ui.text
+
+/**
+ * Inline emphasis rules shared by the Compose and web message renderers, so the
+ * two render trees can't drift on what counts as a marker.
+ */
+object MarkdownEmphasis {
+    /**
+     * `_italic_`, word-bounded: the markers only emphasize when they sit outside
+     * a word, so identifiers keep their underscores (`nip44_decrypt_batch`,
+     * `snake_case`, `:emoji_shortcode:`). CommonMark draws the same line - only
+     * `*` does intraword emphasis - because code names are underscore-heavy.
+     *
+     * Group 1 is the emphasized text. Kept as a pattern string so it can be
+     * embedded in a larger alternation (the web renderer scans every inline
+     * marker in one pass).
+     */
+    const val ITALIC_UNDERSCORE_PATTERN = "(?<![^\\s])_([^_\\n]+)_(?![^\\s.,!?;:])"
+
+    val italicUnderscoreRegex = Regex(ITALIC_UNDERSCORE_PATTERN)
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasis.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasis.kt
@@ -1,21 +1,81 @@
 package org.nostr.nostrord.ui.text
 
 /**
- * Inline emphasis rules shared by the Compose and web message renderers, so the
- * two render trees can't drift on what counts as a marker.
+ * Inline marker rules shared by the Compose and web message renderers, so the
+ * two render trees can't drift on what counts as formatting.
+ *
+ * Every marker here is a character that also occurs literally in ordinary chat
+ * text - shell globs, operators, arithmetic, code names. Three guards keep those
+ * literal uses intact, matching CommonMark's flanking-delimiter-run rule:
+ *
+ * 1. the opening marker is not followed by whitespace (`1 * 2 * 3` stays plain);
+ * 2. the closing marker is not preceded by whitespace;
+ * 3. the content is at least one character and holds no newline, so a stray
+ *    marker cannot swallow the rest of the message.
+ *
+ * Underscore adds a fourth guard: it only marks emphasis outside a word, so
+ * identifiers keep their underscores (`nip44_decrypt_batch`, `snake_case`,
+ * `:emoji_shortcode:`). CommonMark draws the same line - only `*` does intraword
+ * emphasis - because code names are underscore-heavy.
+ *
+ * `x**2 and y**2` still bolds, as it does under CommonMark: `**` is legal
+ * intraword. Code spans are the escape hatch, and both renderers claim backticks
+ * before reaching any of these patterns.
+ *
+ * Group 1 is the marked-up text. Patterns stay as strings so they can be
+ * embedded in a larger alternation (the web renderer scans every inline marker
+ * in one pass).
  */
 object MarkdownEmphasis {
-    /**
-     * `_italic_`, word-bounded: the markers only emphasize when they sit outside
-     * a word, so identifiers keep their underscores (`nip44_decrypt_batch`,
-     * `snake_case`, `:emoji_shortcode:`). CommonMark draws the same line - only
-     * `*` does intraword emphasis - because code names are underscore-heavy.
-     *
-     * Group 1 is the emphasized text. Kept as a pattern string so it can be
-     * embedded in a larger alternation (the web renderer scans every inline
-     * marker in one pass).
-     */
-    const val ITALIC_UNDERSCORE_PATTERN = "(?<![^\\s])_([^_\\n]+)_(?![^\\s.,!?;:])"
+    /** Opener guard: no whitespace after the marker. */
+    private const val OPEN = "(?!\\s)"
 
+    /** Closer guard: no whitespace before the marker. */
+    private const val CLOSE = "(?<!\\s)"
+
+    /**
+     * Trailing guard: the closing marker sits at an outer boundary. Without it a
+     * lone `*` finds a partner anywhere later in the message - `rm *.kt and *.js`
+     * next to an `x**2` pairs the two survivors and bolds everything between.
+     */
+    private const val AFTER = "(?![^\\s.,!?;:)\\]}])"
+
+    /** Single-line content, at least one character. */
+    private const val TEXT = "([^\\n]+?)"
+
+    /** `*bold*`. Content cannot hold `*`, so `**bold**` is left to the double form. */
+    const val BOLD_PATTERN = "\\*$OPEN([^*\\n]+?)$CLOSE\\*$AFTER"
+
+    /** `**bold**`. No trailing guard: `x**2 and y**2` bolds, as it does in CommonMark. */
+    const val BOLD_DOUBLE_PATTERN = "\\*\\*$OPEN$TEXT$CLOSE\\*\\*"
+
+    /** `_italic_`, additionally word-bounded (see the class doc). */
+    const val ITALIC_UNDERSCORE_PATTERN = "(?<![^\\s])_([^_\\n]+)_$AFTER"
+
+    /** `~~strikethrough~~`. */
+    const val STRIKETHROUGH_PATTERN = "~~$OPEN$TEXT$CLOSE~~"
+
+    /** `||spoiler||`. The guard is what keeps `if (a || b || c)` readable. */
+    const val SPOILER_PATTERN = "\\|\\|$OPEN$TEXT$CLOSE\\|\\|"
+
+    val boldRegex = Regex(BOLD_PATTERN)
+    val boldDoubleRegex = Regex(BOLD_DOUBLE_PATTERN)
     val italicUnderscoreRegex = Regex(ITALIC_UNDERSCORE_PATTERN)
+    val strikethroughRegex = Regex(STRIKETHROUGH_PATTERN)
+    val spoilerRegex = Regex(SPOILER_PATTERN)
+
+    /**
+     * All inline markers in one alternation, longest markers first so `**` wins
+     * over `*` and the doubled `~~` / `||` aren't split into single characters.
+     */
+    val inlineMarkerRegex =
+        Regex(
+            listOf(
+                STRIKETHROUGH_PATTERN,
+                SPOILER_PATTERN,
+                BOLD_DOUBLE_PATTERN,
+                BOLD_PATTERN,
+                ITALIC_UNDERSCORE_PATTERN,
+            ).joinToString("|"),
+        )
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownPreview.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownPreview.kt
@@ -1,0 +1,48 @@
+package org.nostr.nostrord.ui.text
+
+/**
+ * Stands in for spoiler text in a plain-text preview. The chat hides a spoiler
+ * visually and keeps it one tap away; a notification row and an OS notification
+ * body have neither the blur nor the tap, so the content is dropped outright.
+ */
+const val SPOILER_MASK = "▮▮▮"
+
+/** Code fence, with the optional language tag dropped along with the backticks. */
+private val CODE_FENCE_REGEX = Regex("```(?:[A-Za-z0-9_+-]*\n)?([\\s\\S]*?)```")
+
+private val INLINE_CODE_REGEX = Regex("`([^`\n]+)`")
+
+/** Emphasis nests (`**bold with _italic_**`), so unwrapping runs until stable. */
+private const val MAX_UNWRAP_PASSES = 4
+
+/**
+ * Flatten chat markdown to plain text for a notification preview: markers are
+ * dropped and their text kept, except spoilers, which are replaced by
+ * [SPOILER_MASK] so a hidden message never surfaces on a lock screen.
+ *
+ * Idempotent, so it is safe both where the preview is built and where an already
+ * persisted one is rendered.
+ */
+fun flattenMarkdownForPreview(text: String): String {
+    if (text.isEmpty()) return text
+
+    var out = CODE_FENCE_REGEX.replace(text) { it.groupValues[1] }
+    out = INLINE_CODE_REGEX.replace(out) { it.groupValues[1] }
+    // Before unwrapping, so spoiler text is discarded rather than exposed by an
+    // outer marker being stripped first.
+    out = MarkdownEmphasis.spoilerRegex.replace(out, SPOILER_MASK)
+
+    repeat(MAX_UNWRAP_PASSES) {
+        val next = unwrapEmphasis(out)
+        if (next == out) return out
+        out = next
+    }
+    return out
+}
+
+private fun unwrapEmphasis(text: String): String {
+    var out = MarkdownEmphasis.boldDoubleRegex.replace(text) { it.groupValues[1] }
+    out = MarkdownEmphasis.boldRegex.replace(out) { it.groupValues[1] }
+    out = MarkdownEmphasis.strikethroughRegex.replace(out) { it.groupValues[1] }
+    return MarkdownEmphasis.italicUnderscoreRegex.replace(out) { it.groupValues[1] }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasisTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasisTest.kt
@@ -46,4 +46,69 @@ class MarkdownEmphasisTest {
         val found = combined.findAll("*bold* nip44_decrypt_batch _italic_").map { it.value }.toList()
         assertEquals(listOf("*bold*", "_italic_"), found)
     }
+
+    private fun tokens(text: String) = MarkdownEmphasis.inlineMarkerRegex.findAll(text).map { it.value }.toList()
+
+    @Test
+    fun `spoiler markers do not swallow a logical or`() {
+        assertEquals(emptyList(), tokens("if (a || b || c) return"))
+        assertEquals(emptyList(), tokens("cmd || echo fail || true"))
+        assertEquals(listOf("||spoiler||"), tokens("a ||spoiler|| b"))
+        assertEquals(listOf("||two words||"), tokens("||two words|| after"))
+    }
+
+    @Test
+    fun `asterisks around whitespace are arithmetic, not bold`() {
+        assertEquals(emptyList(), tokens("1 * 2 * 3 = 6"))
+        assertEquals(emptyList(), tokens("SELECT * FROM t WHERE a = *"))
+    }
+
+    @Test
+    fun `globs keep their asterisks`() {
+        assertEquals(emptyList(), tokens("rm *.kt and *.js"))
+    }
+
+    @Test
+    fun `a stray asterisk does not pair with a later one`() {
+        // The whole line is literal: every * here is unpaired shell/arithmetic syntax.
+        assertEquals(emptyList(), tokens("if (a || b || c) — 1 * 2 * 3 = 6 — rm *.kt and *.js — x**2"))
+    }
+
+    @Test
+    fun `bold closes against punctuation and brackets`() {
+        assertEquals(listOf("*bold*"), tokens("*bold*."))
+        assertEquals(listOf("*bold*"), tokens("(*bold*)"))
+        assertEquals(listOf("*bold*"), tokens("*bold*, next"))
+        assertEquals(listOf("*a*", "*b*"), tokens("*a* *b*"))
+    }
+
+    @Test
+    fun `a lone double asterisk is not an empty bold`() {
+        assertEquals(emptyList(), tokens("x**2"))
+    }
+
+    @Test
+    fun `markers do not span a newline`() {
+        assertEquals(emptyList(), tokens("* one\n* two"))
+        assertEquals(emptyList(), tokens("~~ one\ntwo ~~"))
+    }
+
+    @Test
+    fun `ordinary formatting still renders`() {
+        assertEquals(listOf("*bold*"), tokens("see *bold* here"))
+        assertEquals(listOf("*b c*"), tokens("a *b c* d"))
+        assertEquals(listOf("**bold**"), tokens("see **bold** here"))
+        assertEquals(listOf("~~gone~~"), tokens("it is ~~gone~~ now"))
+        assertEquals(listOf("_italic_"), tokens("an _italic_ word"))
+    }
+
+    @Test
+    fun `longest marker wins at the same position`() {
+        assertEquals(listOf("**bold**", "~~gone~~", "||hidden||"), tokens("**bold** ~~gone~~ ||hidden||"))
+    }
+
+    @Test
+    fun `intraword double asterisk still bolds, as in CommonMark`() {
+        assertEquals(listOf("**2 and y**"), tokens("x**2 and y**2"))
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasisTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownEmphasisTest.kt
@@ -1,0 +1,49 @@
+package org.nostr.nostrord.ui.text
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MarkdownEmphasisTest {
+    private fun matches(text: String) = MarkdownEmphasis.italicUnderscoreRegex.findAll(text).map { it.groupValues[1] }.toList()
+
+    @Test
+    fun `underscores inside an identifier are not emphasis`() {
+        assertEquals(emptyList(), matches("what is this nip44_decrypt_batch?"))
+        assertEquals(emptyList(), matches("snake_case"))
+        assertEquals(emptyList(), matches("a_b_c_d"))
+    }
+
+    @Test
+    fun `emoji shortcodes keep their underscores`() {
+        assertEquals(emptyList(), matches(":smiling_face_with_tear:"))
+    }
+
+    @Test
+    fun `word-bounded underscores are emphasis`() {
+        assertEquals(listOf("italic"), matches("_italic_"))
+        assertEquals(listOf("italic"), matches("an _italic_ word"))
+        assertEquals(listOf("italic"), matches("ends in punctuation _italic_."))
+    }
+
+    @Test
+    fun `identifiers and emphasis coexist in one message`() {
+        assertEquals(listOf("really"), matches("nip44_decrypt_batch is _really_ a custom method"))
+    }
+
+    @Test
+    fun `a closing marker glued to a word does not emphasize`() {
+        assertEquals(emptyList(), matches("foo _bar_baz_ qux"))
+    }
+
+    @Test
+    fun `emphasis does not span lines`() {
+        assertEquals(emptyList(), matches("_open\nclose_"))
+    }
+
+    @Test
+    fun `pattern embeds in an alternation without changing behavior`() {
+        val combined = Regex("\\*[^*\\n]+?\\*|" + MarkdownEmphasis.ITALIC_UNDERSCORE_PATTERN)
+        val found = combined.findAll("*bold* nip44_decrypt_batch _italic_").map { it.value }.toList()
+        assertEquals(listOf("*bold*", "_italic_"), found)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownPreviewTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownPreviewTest.kt
@@ -1,0 +1,58 @@
+package org.nostr.nostrord.ui.text
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MarkdownPreviewTest {
+    @Test
+    fun `emphasis markers are dropped and their text kept`() {
+        assertEquals("bold", flattenMarkdownForPreview("*bold*"))
+        assertEquals("bold", flattenMarkdownForPreview("**bold**"))
+        assertEquals("italic", flattenMarkdownForPreview("_italic_"))
+        assertEquals("gone", flattenMarkdownForPreview("~~gone~~"))
+        assertEquals("look at this now", flattenMarkdownForPreview("look at *this* now"))
+    }
+
+    @Test
+    fun `spoiler content is masked, never unwrapped`() {
+        assertEquals("vejam $SPOILER_MASK serio", flattenMarkdownForPreview("vejam ||o final do filme|| serio"))
+        assertEquals(SPOILER_MASK, flattenMarkdownForPreview("||the killer is the butler||"))
+    }
+
+    @Test
+    fun `an outer marker does not expose a nested spoiler`() {
+        assertEquals(SPOILER_MASK, flattenMarkdownForPreview("**||secret||**"))
+        assertEquals("see $SPOILER_MASK", flattenMarkdownForPreview("~~see ||secret||~~"))
+    }
+
+    @Test
+    fun `nested emphasis unwraps completely`() {
+        assertEquals("bold with italic", flattenMarkdownForPreview("**bold with _italic_**"))
+    }
+
+    @Test
+    fun `code keeps its text and loses its backticks`() {
+        assertEquals("run npm test now", flattenMarkdownForPreview("run `npm test` now"))
+        assertEquals("val x = 1\n", flattenMarkdownForPreview("```kotlin\nval x = 1\n```"))
+    }
+
+    @Test
+    fun `text without markers is untouched`() {
+        assertEquals("", flattenMarkdownForPreview(""))
+        assertEquals("plain message", flattenMarkdownForPreview("plain message"))
+        assertEquals("@ana hi", flattenMarkdownForPreview("@ana hi"))
+    }
+
+    @Test
+    fun `literal marker characters survive, matching the chat`() {
+        assertEquals("if (a || b || c)", flattenMarkdownForPreview("if (a || b || c)"))
+        assertEquals("1 * 2 * 3 = 6", flattenMarkdownForPreview("1 * 2 * 3 = 6"))
+        assertEquals("nip44_decrypt_batch", flattenMarkdownForPreview("nip44_decrypt_batch"))
+    }
+
+    @Test
+    fun `flattening is idempotent`() {
+        val once = flattenMarkdownForPreview("**bold** and ||secret|| and _it_")
+        assertEquals(once, flattenMarkdownForPreview(once))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui.components.chat
 
 import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.nostr.Nip68
+import org.nostr.nostrord.ui.text.MarkdownEmphasis
 
 /**
  * # Chat Message Content Parser
@@ -742,11 +743,8 @@ object MessageContentParser {
     private val boldDoubleRegex = Regex("\\*\\*([\\s\\S]+?)\\*\\*")
     private val boldRegex = Regex("\\*([\\s\\S]*?)\\*")
 
-    /**
-     * Italic text: _text_ (requires word boundary - space or start/end)
-     * Avoids matching underscores in snake_case or emoji shortcodes
-     */
-    private val italicRegex = Regex("(?:^|(?<=\\s))_([^_]+)_(?=\\s|$|[.,!?;:])")
+    /** Italic text: _text_, word-bounded so snake_case identifiers keep their underscores. */
+    private val italicRegex = MarkdownEmphasis.italicUnderscoreRegex
 
     /**
      * Monospace/inline code: `text` (not triple backticks)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
@@ -736,27 +736,21 @@ object MessageContentParser {
     // ============================================================================
 
     /**
-     * Bold text: **text** (markdown) and *text* (Nostr style). Both render bold — additive, so
-     * existing *bold* keeps working while markdown **bold** is also recognized. The double form is
-     * matched first (see [findFormatting]) so it isn't split into two empty single-asterisk marks.
+     * Inline markers, all guarded against literal use in ordinary text - see [MarkdownEmphasis].
+     * Bold is additive: **text** (markdown) and *text* (Nostr style) both render bold, with the
+     * double form matched first (see [findFormatting]) so it isn't split into two single marks.
      */
-    private val boldDoubleRegex = Regex("\\*\\*([\\s\\S]+?)\\*\\*")
-    private val boldRegex = Regex("\\*([\\s\\S]*?)\\*")
-
-    /** Italic text: _text_, word-bounded so snake_case identifiers keep their underscores. */
+    private val boldDoubleRegex = MarkdownEmphasis.boldDoubleRegex
+    private val boldRegex = MarkdownEmphasis.boldRegex
     private val italicRegex = MarkdownEmphasis.italicUnderscoreRegex
+    private val strikethroughRegex = MarkdownEmphasis.strikethroughRegex
+    private val spoilerRegex = MarkdownEmphasis.spoilerRegex
 
     /**
      * Monospace/inline code: `text` (not triple backticks)
      * Uses simple approach to avoid lookbehind compatibility issues
      */
     private val monospaceRegex = Regex("`([^`]+)`")
-
-    /** Strikethrough: ~~text~~ (non-greedy, at least one char). */
-    private val strikethroughRegex = Regex("~~([\\s\\S]+?)~~")
-
-    /** Spoiler: ||text|| (non-greedy, at least one char). */
-    private val spoilerRegex = Regex("\\|\\|([\\s\\S]+?)\\|\\|")
 
     /**
      * Find text formatting (bold, italic, monospace) in non-covered regions.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/RichText.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/RichText.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.web.components
 
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.text.MarkdownEmphasis
 import react.ChildrenBuilder
 import react.dom.html.ReactHTML.a
 import react.dom.html.ReactHTML.code
@@ -46,7 +47,7 @@ fun aboutMentionPubkeys(text: String): Set<String> = ABOUT_REGEX
 // non-greedy), _italic_ (word-bounded) and `inline code` (opaque: no entities inside).
 private val INLINE_CODE_REGEX = Regex("`([^`]+)`")
 private val BOLD_REGEX = Regex("\\*([\\s\\S]*?)\\*")
-private val ITALIC_REGEX = Regex("(?:^|(?<=\\s))_([^_]+)_(?=\\s|\$|[.,!?;:])")
+private val ITALIC_REGEX = MarkdownEmphasis.italicUnderscoreRegex
 
 /**
  * Render an about / description string with clickable web links, NIP-27 mentions

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/RichText.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/RichText.kt
@@ -43,10 +43,10 @@ fun aboutMentionPubkeys(text: String): Set<String> = ABOUT_REGEX
         }
     }.toSet()
 
-// Markdown subset mirrored from native MessageContentParser: *bold* (any content,
-// non-greedy), _italic_ (word-bounded) and `inline code` (opaque: no entities inside).
+// Markdown subset mirrored from native MessageContentParser: *bold*, _italic_ (both
+// guarded, see MarkdownEmphasis) and `inline code` (opaque: no entities inside).
 private val INLINE_CODE_REGEX = Regex("`([^`]+)`")
-private val BOLD_REGEX = Regex("\\*([\\s\\S]*?)\\*")
+private val BOLD_REGEX = MarkdownEmphasis.boldRegex
 private val ITALIC_REGEX = MarkdownEmphasis.italicUnderscoreRegex
 
 /**

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -34,6 +34,7 @@ import org.nostr.nostrord.ui.screens.group.classifyReactionError
 import org.nostr.nostrord.ui.screens.group.pluralizeSystemAction
 import org.nostr.nostrord.ui.scroll.ChatScrollPolicy
 import org.nostr.nostrord.ui.scroll.JumpPillTarget
+import org.nostr.nostrord.ui.text.MarkdownEmphasis
 import org.nostr.nostrord.utils.ChatSearch
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
@@ -3746,9 +3747,13 @@ private fun ChildrenBuilder.renderEntities(
 
 // Inline formatting tokens, longest markers first so **bold** wins over *bold* and ~~/|| aren't
 // split. Mirrors native MessageContentParser: * and ** are bold (additive), _ italic, ~~ strike,
-// || spoiler.
+// || spoiler. The _ arm is word-bounded (shared with native) so identifiers such as
+// nip44_decrypt_batch keep their underscores instead of italicizing the middle.
 private val INLINE_FORMAT_REGEX =
-    Regex("~~[\\s\\S]+?~~|\\|\\|[\\s\\S]+?\\|\\||\\*\\*[\\s\\S]+?\\*\\*|\\*[^*\\n]+?\\*|_[^_\\n]+?_")
+    Regex(
+        "~~[\\s\\S]+?~~|\\|\\|[\\s\\S]+?\\|\\||\\*\\*[\\s\\S]+?\\*\\*|\\*[^*\\n]+?\\*|" +
+            MarkdownEmphasis.ITALIC_UNDERSCORE_PATTERN,
+    )
 
 /**
  * Render inline *bold* / **bold**, _italic_, ~~strikethrough~~ and ||spoiler|| in a non-URL text

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -3745,15 +3745,9 @@ private fun ChildrenBuilder.renderEntities(
     if (last < content.length) renderFormattedText(content.substring(last), emojiMap)
 }
 
-// Inline formatting tokens, longest markers first so **bold** wins over *bold* and ~~/|| aren't
-// split. Mirrors native MessageContentParser: * and ** are bold (additive), _ italic, ~~ strike,
-// || spoiler. The _ arm is word-bounded (shared with native) so identifiers such as
-// nip44_decrypt_batch keep their underscores instead of italicizing the middle.
-private val INLINE_FORMAT_REGEX =
-    Regex(
-        "~~[\\s\\S]+?~~|\\|\\|[\\s\\S]+?\\|\\||\\*\\*[\\s\\S]+?\\*\\*|\\*[^*\\n]+?\\*|" +
-            MarkdownEmphasis.ITALIC_UNDERSCORE_PATTERN,
-    )
+// Inline formatting tokens: * and ** bold (additive), _ italic, ~~ strike, || spoiler. Shared
+// with native MessageContentParser, guards included - see MarkdownEmphasis.
+private val INLINE_FORMAT_REGEX = MarkdownEmphasis.inlineMarkerRegex
 
 /**
  * Render inline *bold* / **bold**, _italic_, ~~strikethrough~~ and ||spoiler|| in a non-URL text


### PR DESCRIPTION
A user reported `nip44_decrypt_batch` arriving as `nip44decryptbatch`: the web chat matched `_..._` with no word-boundary guard, so the identifier lost its underscores and italicized its middle. Native and the bio renderer each carried their own guarded copy of the same rule, which is how the third one drifted, so the rule now lives once in `commonMain/ui/text/MarkdownEmphasis.kt` and all three renderers point at it.

Auditing the other markers found the same class of bug in every one of them: each is a character that also occurs literally in chat text, and none had a guard. They now follow CommonMark's flanking rule (no whitespace after an opener, none before a closer, content non-empty and single-line), and the single-`*` and `_` arms additionally require the closer to sit at an outer boundary, which is what stops a stray asterisk from pairing with another one later in the line. `**` keeps no trailing guard, so `x**2 and y**2` bolds as it does in CommonMark; backticks remain the escape hatch, since both renderers claim code spans first.

The notification preview was a separate leak. It is a plain string rendered raw by both feeds, and the same string is the OS notification body, so a `||spoiler||` reached the lock screen with its content intact. It is now flattened in commonMain: markers dropped, their text kept, spoiler replaced by a block mask.

| Input | Before | After |
|---|---|---|
| `nip44_decrypt_batch` | `nip44decryptbatch` | literal |
| `if (a \|\| b \|\| c)` | ` b ` hidden behind a spoiler | literal |
| `1 * 2 * 3 = 6` | ` 2 ` bolded | literal |
| `rm *.kt and *.js — x**2` | `.js — x` bolded, an asterisk eaten | literal |
| `x**2` (native) | rendered `x2`, empty bold ate the pair | literal |
| `* one` / `* two` (two lines, native) | bolded across the newline | literal |
| notification of `\|\|secret\|\|` | secret shown in-app and on the lock screen | `▮▮▮` |
| `*bold*`, `**bold**`, `_italic_`, `~~gone~~`, `\|\|spoiler\|\|` | working | unchanged |

23 cases in `MarkdownEmphasisTest` and 8 in `MarkdownPreviewTest`, both in commonTest so they cover Compose and web at once. `MessageContentParserTest`'s 85 cases pass unchanged. Device-validated on web, Android, and the iOS simulator (iPhone 17 Pro): the chat matrix renders as specified on all three — formatted message formats, literal message stays literal, and the boundary cases (`foo _bar_baz_ qux` literal, `x**2 and y**2` bolding per CommonMark) behave identically to Android. The notification check (`**importante** vejam ||o resultado|| ~~ontem~~` → `importante vejam ▮▮▮ ontem`) ran on web and Android; iOS notification previews share the same commonMain flattening.

- 492ec706 fix(chat): keep intraword underscores literal in web messages
- 4f898158 fix(chat): guard the remaining inline markers against literal text
- 6901a6be fix(notifications): flatten markdown in previews and mask spoilers

