### PR TITLE
fix(relays): connect the joined relays on a login with no cache

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2784,6 +2784,14 @@ class NostrRepository(
             groupManager.loadRestrictedGroupsFromStorage(pubkey, relays)
         }
         connect(focusedRelay)
+        // This path is the ONLY bootstrap for a login with no local cache: the relay list
+        // arrives with the kind:10009, so the login branch skipped its own
+        // ensureJoinedRelaysConnected (focusedRelay was still blank) and initialize()'s two
+        // call sites never ran either. Without this the whole session holds a single socket,
+        // so every joined group on another relay has no kind:39000 and no chat until the app
+        // is restarted. joinedGroupsByRelay is already populated here: the parser fires
+        // onRelayGroupsUpdated before onRelaysRestored.
+        scope.launch { ensureJoinedRelaysConnected(focusedRelay) }
     }
 
     override suspend fun switchRelay(newRelayUrl: String) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -840,6 +840,10 @@ class OutboxManager(
         }
         _kind10009Relays.value = emptySet()
         _groupTagRelays.value = emptySet()
+        // Per-account, like the relay list above: [restoreGroupOrder] declines to seed over a
+        // non-empty order, so an order surviving the swap would lock the incoming account out
+        // of its own persisted one until its kind:10009 arrived over the network.
+        _groupOrder.value = emptyList()
         kind10009SubId = null
         kind10009Received = false
     }


### PR DESCRIPTION
Two per-account bootstrap gaps, both reachable right after a login.

A login with no local cache learns its relay list only when the kind:10009 lands, so the bootstrap runs through `autoConnectFirstRelay`, which connects `relays.first()` and stops. The login branch had already skipped its own `ensureJoinedRelaysConnected` (`focusedRelay` was still blank at that point) and `initialize()`'s two call sites never ran either, so the whole session held a single socket. Every joined group on another relay had no kind:39000 and no kind:9 until the app was restarted, which is where `initialize()` finally connects the pool: the reported symptom was a rail of groups with no name or avatar that only loaded after a close and reopen.

`ensureJoinedRelaysConnected` is idempotent and already the pattern at the other three call sites. `joinedGroupsByRelay` is populated by the time it runs here: the kind:10009 parser fires `onRelayGroupsUpdated` before `onRelaysRestored`.

Nothing about the rail order changed. #238 only made the gap visible: the rail used to come out in per-relay blocks with the connected relay first, so the starved groups sat at the bottom.

| Path | Connects the secondary relays |
|---|---|
| `initialize()` (restart) | yes, both branches |
| login with a cached relay list | yes, guarded by `focusedRelay.isNotBlank()` |
| login with no cache (before) | no |
| login with no cache (after) | yes |

The second commit is the same class of bug in the rail order #238 added: it is per-account, but `OutboxManager.clear()` (logout and account switch) left it behind, next to the relay list it does clear. `restoreGroupOrder` declines to seed over a non-empty order, so the incoming account never loaded its own persisted one and its rail stayed unsorted until the kind:10009 came back over the network.

Validated on a fresh install on Android, desktop and web: groups on secondary relays load their metadata and chat in the first session. iOS pending.

- 132eb89c fix(relays): connect the joined relays on a login with no cache
- 4c1eb583 fix(rail): clear the group order on logout and account switch