### PR TITLE
chore: bump version to 2.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,19 @@ jobs:
         if: matrix.ext == 'rpm'
         run: sudo apt-get update && sudo apt-get install -y rpm
 
+      # livekit-kmp (desktop AV) is not on Maven Central yet; the JVM target resolves it
+      # from mavenLocal, so build it first. Same pinned ref as ci.yml — bump both together.
+      - name: Checkout livekit-kmp
+        uses: actions/checkout@v5
+        with:
+          repository: nostrord/livekit-kmp
+          ref: 37095f807922b8ecf3d88c8ae931a824a7b8661f
+          path: livekit-kmp
+
+      - name: Publish livekit-kmp to mavenLocal
+        shell: bash
+        run: cd livekit-kmp && ./gradlew publishToMavenLocal -q
+
       - name: Build installer
         run: ./gradlew ${{ matrix.task }} --no-daemon
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.6.0
-app.versionCode=21
+app.version=2.7.0
+app.versionCode=22
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Prepares the 2.7.0 release, whose headline is the NIP-29 AV spaces merged in #224.

The bump rides with a release-pipeline fix it depends on: the desktop installers resolve `livekit-kmp` from mavenLocal, and only `ci.yml` had the step that builds it. A tag on today's `main` would have produced a signed APK and three failed installers. `release.yml` now checks out and publishes the library in `desktop-release`, pinned to the same ref as `ci.yml`. The Android job needs nothing: `livekit-kmp` is declared in `jvmMain` only, and Android gets its media from `io.livekit:livekit-android`.

| File | Change |
|---|---|
| `.github/workflows/release.yml` | checkout + `publishToMavenLocal` for `nostrord/livekit-kmp` in `desktop-release`, `shell: bash` so the Windows runner agrees |
| `gradle.properties` | `app.version` 2.6.0 -> 2.7.0, `app.versionCode` 21 -> 22 |

The versionCode matters as much as the name: zsp reads both from the APK manifest, not from the git tag, and dedups a release that looks unchanged.

- 6acabd65 ci: publish livekit-kmp before the desktop release build
- a5072b64 chore: bump version to 2.7.0