### PR TITLE
ci: build livekit-kmp for the Arch package job too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,18 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      # Same reason as desktop-release: this job compiles the JVM target, which resolves
+      # livekit-kmp from mavenLocal. Keep the ref in step with ci.yml and desktop-release.
+      - name: Checkout livekit-kmp
+        uses: actions/checkout@v5
+        with:
+          repository: nostrord/livekit-kmp
+          ref: 37095f807922b8ecf3d88c8ae931a824a7b8661f
+          path: livekit-kmp
+
+      - name: Publish livekit-kmp to mavenLocal
+        run: cd livekit-kmp && ./gradlew publishToMavenLocal -q
+
       - name: Build .deb
         run: ./gradlew :composeApp:fixDebPackage --no-daemon
 


### PR DESCRIPTION
`arch-pkg` runs `:composeApp:fixDebPackage`, so it compiles the JVM target and needs `livekit-kmp` in mavenLocal exactly like `desktop-release`. #243 added the step to `desktop-release` only, which the v2.7.0 run is proving right now: every other job builds, that one cannot resolve the dependency.

Same pinned ref as `ci.yml` and `desktop-release`; all three move together when the library changes.

Unrelated, for the record: the v2.6.0 release failed only on "Publish to AUR", and the log says `The AUR is down due to maintenance`. Nothing to fix there.