### PR TITLE
feat(dm): address NIP-4e encryption keys when sending DMs

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -61,6 +61,7 @@ import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip4e
 import org.nostr.nostrord.nostr.Nip78
 import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.startup.StartupResolver
@@ -72,6 +73,7 @@ import org.nostr.nostrord.storage.getLastActiveAt
 import org.nostr.nostrord.storage.isDmCacheMigratedFor
 import org.nostr.nostrord.storage.isGroupFetchLazy
 import org.nostr.nostrord.storage.isKind10009RepublishPendingFor
+import org.nostr.nostrord.storage.loadDmEncKeys
 import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
@@ -85,6 +87,7 @@ import org.nostr.nostrord.storage.loadKind30078TimestampFor
 import org.nostr.nostrord.storage.loadMuteListSnapshotFor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
+import org.nostr.nostrord.storage.saveDmEncKeys
 import org.nostr.nostrord.storage.saveDmLastRead
 import org.nostr.nostrord.storage.saveDmProcessedWrapIds
 import org.nostr.nostrord.storage.saveDmSeenRelays
@@ -1969,7 +1972,19 @@ class NostrRepository(
         val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
         return try {
             val rumor = Nip17.buildRumor(myPub, recipientPubkey, content)
-            val recipientWrap = Nip17.wrap(rumor, recipientPubkey, signer)
+            // NIP-4e: a recipient who announced an encryption key gets both NIP-44 layers addressed
+            // to it, tagged with the key they must ECDH the seal against. We hold no encryption key
+            // of our own yet, so that key is our identity pubkey, which is what makes this readable
+            // and verified by adopters without us publishing any state.
+            val recipientEncKey = dmManager.encryptionKeyFor(recipientPubkey)
+            val recipientWrap =
+                if (recipientEncKey != null) {
+                    Nip17.wrap(rumor, recipientPubkey, signer, encryptTo = recipientEncKey, senderEncTag = myPub)
+                } else {
+                    Nip17.wrap(rumor, recipientPubkey, signer)
+                }
+            // The self-copy stays identity-addressed: our own inbox path is unchanged and other
+            // devices on this account read it exactly as before.
             val selfWrap = Nip17.wrap(rumor, myPub, signer)
             dmManager.addOptimistic(rumor, recipientPubkey, myPub)
             val rumorId = rumor.id ?: return Result.Error(AppError.Unknown("Failed to build the message"))
@@ -2309,6 +2324,7 @@ class NostrRepository(
             SecureStorage.loadDmLastRead(myPub),
             SecureStorage.loadDmSeenRelays(myPub),
             SecureStorage.loadDmWrapRumor(myPub),
+            SecureStorage.loadDmEncKeys(myPub),
         )
         return cached.size
     }
@@ -2346,15 +2362,18 @@ class NostrRepository(
                 }
             }
         // Persist the "seen on" relay map (debounced) so View source keeps it across restarts.
-        dmManager.onSeenRelaysChanged = { scheduleSaveSeenRelays(myPub) }
+        dmManager.onSeenRelaysChanged = { scheduleSaveDmMaps(myPub) }
+        // Peer encryption keys ride the same debounce: both are small maps written on arrival.
+        dmManager.onEncKeysChanged = { scheduleSaveDmMaps(myPub) }
     }
 
-    private fun scheduleSaveSeenRelays(myPub: String) {
+    private fun scheduleSaveDmMaps(myPub: String) {
         dmSeenRelaysSaveJob?.cancel()
         dmSeenRelaysSaveJob = scope.launch {
             delay(2_000)
             SecureStorage.saveDmSeenRelays(myPub, dmManager.seenRelaysSnapshot())
             SecureStorage.saveDmWrapRumor(myPub, dmManager.wrapToRumorSnapshot())
+            SecureStorage.saveDmEncKeys(myPub, dmManager.encKeysSnapshot())
         }
     }
 
@@ -2469,14 +2488,19 @@ class NostrRepository(
     }
 
     /**
-     * One-shot fetch of [pubkey]'s kind:10050 DM relay list. Queries the user's NIP-65 write relays
-     * and bootstrap relays (where the replaceable list is published, see publishDmRelayList) plus the
-     * defaults, so an existing list is actually found instead of falsely read as absent.
+     * One-shot fetch of [pubkey]'s kind:10050 DM relay list and kind:10044 NIP-4e encryption key.
+     * Queries the user's NIP-65 write relays and bootstrap relays (where the replaceable lists are
+     * published, see publishDmRelayList) plus the defaults, so an existing list is actually found
+     * instead of falsely read as absent. Both replaceables ride one REQ: they are published to the
+     * same relay set and both are needed before the first send to this peer.
      */
     private suspend fun fetchDmRelays(pubkey: String) {
         val filter =
             buildJsonObject {
-                putJsonArray("kinds") { add(Nip17.KIND_DM_RELAYS) }
+                putJsonArray("kinds") {
+                    add(Nip17.KIND_DM_RELAYS)
+                    add(Nip4e.KIND_ENCRYPTION_KEY)
+                }
                 putJsonArray("authors") { add(pubkey) }
             }
         val req =
@@ -5127,6 +5151,15 @@ class NostrRepository(
                     } finally {
                         if (wrapId != null) dmInFlightWrapIds = dmInFlightWrapIds - wrapId
                     }
+                }
+                return
+            }
+            // A user's NIP-4e encryption key announcement (kind:10044). Sending only: we announce
+            // no key of our own here, so nothing changes about how our inbox is read.
+            if (kind == Nip4e.KIND_ENCRYPTION_KEY) {
+                if (!AppModule.dmSettings.dmEnabled.value) return
+                runCatching { parseSignedEventJson(event.toString()) }.getOrNull()?.let {
+                    dmManager.ingestEncryptionKey(it)
                 }
                 return
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.Serializable
 import org.nostr.nostrord.auth.NostrSigner
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip17
+import org.nostr.nostrord.nostr.Nip4e
 
 /** One decrypted NIP-17 chat message, scoped to a conversation with [peerPubkey]. */
 @Serializable
@@ -42,6 +43,17 @@ data class PendingDmWrap(
     val wrapId: String,
     val wrapJson: String,
     val relays: List<String>,
+    val createdAt: Long,
+)
+
+/**
+ * A peer's announced NIP-4e encryption key (kind:10044). [key] is null when their latest
+ * announcement carries none, which withdraws it and puts them back on identity-addressed
+ * encryption. [createdAt] keeps replaceable latest-wins across relays.
+ */
+@Serializable
+data class DmEncKey(
+    val key: String?,
     val createdAt: Long,
 )
 
@@ -111,6 +123,11 @@ class DmManager(
     // Recipient/own DM relay lists from kind:10050, keyed by pubkey.
     private val _dmRelaysByPubkey = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = _dmRelaysByPubkey.asStateFlow()
+
+    // NIP-4e encryption keys announced by peers (kind:10044), keyed by identity pubkey. created_at
+    // is kept so a copy of an older announcement arriving from a slower relay cannot regress a
+    // newer key; a record with a null key is a withdrawal, which must also win by created_at.
+    private val _encKeyByPubkey = MutableStateFlow<Map<String, DmEncKey>>(emptyMap())
 
     // Send status of our own optimistic messages, keyed by rumor id (in-memory, like GroupManager).
     // Sending until a relay OKs the wrap or the self-copy echoes back; then Delivered. Reuses the
@@ -234,6 +251,9 @@ class DmManager(
     /** Set by NostrRepository to persist the seen-on + wrap-to-rumor maps when they grow. */
     var onSeenRelaysChanged: (() -> Unit)? = null
 
+    /** Set by NostrRepository to persist the peer encryption-key cache when it changes. */
+    var onEncKeysChanged: (() -> Unit)? = null
+
     /** Record that [wrapId] was delivered by [relayUrl] (normalized). Safe pre-decrypt. */
     fun recordWrapRelay(wrapId: String, relayUrl: String) {
         if (relayUrl.isBlank()) return
@@ -303,7 +323,11 @@ class DmManager(
         lastRead: Map<String, Long>,
         seenRelays: Map<String, List<String>> = emptyMap(),
         wrapToRumor: Map<String, String> = emptyMap(),
+        encKeys: Map<String, DmEncKey> = emptyMap(),
     ) {
+        // Restored before the first send so a cold-start message to a NIP-4e peer is addressed to
+        // their encryption key instead of racing the kind:10044 fetch and falling back to identity.
+        if (encKeys.isNotEmpty()) _encKeyByPubkey.update { it + encKeys }
         relaysByRumor.update { it + seenRelays.mapValues { (_, relays) -> relays.toSet() } }
         // Restore the wrap->rumor links so a re-streamed, already-processed wrap can attach its
         // relay on the decrypt-skip path (recordWrapRelay) instead of being dropped.
@@ -339,6 +363,27 @@ class DmManager(
 
     fun dmRelaysFor(pubkey: String): List<String> = _dmRelaysByPubkey.value[pubkey].orEmpty()
 
+    /**
+     * Parse a kind:10044 into the author's NIP-4e encryption key. Replaceable latest-wins; an
+     * announcement without a valid `n` tag withdraws the key, so the author goes back to
+     * identity-addressed encryption.
+     */
+    fun ingestEncryptionKey(event: Event) {
+        if (event.kind != Nip4e.KIND_ENCRYPTION_KEY) return
+        val known = _encKeyByPubkey.value[event.pubkey]
+        if (known != null && known.createdAt >= event.createdAt) return
+        val record = DmEncKey(key = Nip4e.encryptionKeyFrom(event), createdAt = event.createdAt)
+        _encKeyByPubkey.update { it + (event.pubkey to record) }
+        // A re-announcement of the same key only refreshes created_at; nothing to rewrite on disk.
+        if (known?.key != record.key) onEncKeysChanged?.invoke()
+    }
+
+    /** [pubkey]'s announced encryption key, or null when they have not announced one. */
+    fun encryptionKeyFor(pubkey: String): String? = _encKeyByPubkey.value[pubkey]?.key
+
+    /** Snapshot of the peer encryption-key cache, for persistence. */
+    fun encKeysSnapshot(): Map<String, DmEncKey> = _encKeyByPubkey.value
+
     /** Drop all state on account switch. */
     fun clear() {
         seenRumorIds.value = emptySet()
@@ -349,6 +394,7 @@ class DmManager(
         _messageStatus.value = emptyMap()
         _messagesByPeer.value = emptyMap()
         _dmRelaysByPubkey.value = emptyMap()
+        _encKeyByPubkey.value = emptyMap()
         _lastReadByPeer.value = emptyMap()
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
@@ -18,9 +18,13 @@ import kotlin.random.Random
  *   -> gift wrap (kind 1059, ephemeral-signed, NIP-44 to the recipient, randomized timestamp)
  *
  * The seal is encrypted/decrypted with the account's identity key through [NostrSigner.nip44Encrypt]
- * / [nip44Decrypt] so remote signers can plug in later; the gift wrap is encrypted under a throwaway
- * key we generate and own. This is the standard, interoperable NIP-17 (single `p` tag = recipient
- * identity), not a client-specific scheme.
+ * / [nip44Decrypt] so remote signers can plug in; the gift wrap is encrypted under a throwaway key
+ * we generate and own.
+ *
+ * Both layers address the recipient's identity key by default (standard, interoperable NIP-17,
+ * single `p` tag). A recipient who announced a NIP-4e encryption key is addressed at that key
+ * instead: see [Nip4e] and the `encryptTo` parameters. Only the ECDH peer changes; authorship,
+ * signatures and `p` routing stay on identity keys.
  */
 object Nip17 {
     const val KIND_CHAT = 14
@@ -56,43 +60,62 @@ object Nip17 {
     }
 
     /**
-     * Seal a [rumor] (kind:13): NIP-44 encrypt it to [recipientPubkey] with the account key via
-     * [signer] and identity-sign, so `seal.pubkey == rumor.pubkey`.
+     * Seal a [rumor] (kind:13): NIP-44 encrypt it to [encryptTo] with the account key via [signer]
+     * and identity-sign, so `seal.pubkey == rumor.pubkey`.
+     *
+     * [encryptTo] is the NIP-44 ECDH peer, which is the recipient's identity key by default and
+     * their NIP-4e encryption key when they announced one. [senderEncTag] names the key the
+     * recipient must ECDH this seal against (`["n", ...]`, NIP-4e); pass it whenever [encryptTo]
+     * is not the recipient's identity key, or readers fall back to a kind:10044 lookup.
      */
     suspend fun seal(
         rumor: Event,
         recipientPubkey: String,
         signer: NostrSigner,
         createdAt: Long = rumor.createdAt,
+        encryptTo: String = recipientPubkey,
+        senderEncTag: String? = null,
     ): Event {
-        val encrypted = signer.nip44Encrypt(recipientPubkey, rumor.toJsonString())
+        val encrypted = signer.nip44Encrypt(encryptTo, rumor.toJsonString())
         val unsigned =
             Event(
                 pubkey = signer.pubkey,
                 createdAt = createdAt,
                 kind = KIND_SEAL,
+                tags = senderEncTag?.let { listOf(listOf(Nip4e.TAG_ENCRYPTION_PUBKEY, it)) } ?: emptyList(),
                 content = encrypted,
             )
         return signer.signEvent(unsigned)
     }
 
     /**
-     * Gift-wrap a [seal] (kind:1059): NIP-44 encrypt it to [recipientPubkey] under a throwaway key,
+     * Gift-wrap a [seal] (kind:1059): NIP-44 encrypt it to [encryptTo] under a throwaway key,
      * `p`-tag the recipient, randomize the timestamp, and sign with the throwaway key.
+     *
+     * The `p` tags always include [recipientPubkey], the identity key: that is what relays route on
+     * and what every inbox REQ filters by. When [encryptTo] is a NIP-4e encryption key it leads the
+     * list, because deployed readers take `p[0]` as the key the wrap is encrypted to.
      */
     fun giftWrap(
         seal: Event,
         recipientPubkey: String,
         createdAt: Long = randomizedWrapTime(),
+        encryptTo: String = recipientPubkey,
     ): Event {
         val ephemeral = KeyPair.generate()
-        val encrypted = Nip44.encrypt(seal.toJsonString(), ephemeral.privateKeyHex, recipientPubkey)
+        val encrypted = Nip44.encrypt(seal.toJsonString(), ephemeral.privateKeyHex, encryptTo)
+        val tags =
+            if (encryptTo == recipientPubkey) {
+                listOf(listOf("p", recipientPubkey))
+            } else {
+                listOf(listOf("p", encryptTo), listOf("p", recipientPubkey))
+            }
         val unsigned =
             Event(
                 pubkey = ephemeral.publicKeyHex,
                 createdAt = createdAt,
                 kind = KIND_GIFT_WRAP,
-                tags = listOf(listOf("p", recipientPubkey)),
+                tags = tags,
                 content = encrypted,
             )
         return unsigned.sign(ephemeral)
@@ -101,6 +124,7 @@ object Nip17 {
     /**
      * End-to-end: build the seal for [rumor] (identity-signed via [signer]) and wrap it for
      * [recipientPubkey]. Returns the kind:1059 ready to publish to the recipient's DM relays.
+     * Defaults produce classic NIP-17; pass [encryptTo]/[senderEncTag] for a NIP-4e recipient.
      */
     suspend fun wrap(
         rumor: Event,
@@ -108,7 +132,14 @@ object Nip17 {
         signer: NostrSigner,
         sealCreatedAt: Long = rumor.createdAt,
         wrapCreatedAt: Long = randomizedWrapTime(),
-    ): Event = giftWrap(seal(rumor, recipientPubkey, signer, sealCreatedAt), recipientPubkey, wrapCreatedAt)
+        encryptTo: String = recipientPubkey,
+        senderEncTag: String? = null,
+    ): Event = giftWrap(
+        seal(rumor, recipientPubkey, signer, sealCreatedAt, encryptTo, senderEncTag),
+        recipientPubkey,
+        wrapCreatedAt,
+        encryptTo,
+    )
 
     data class Unwrapped(
         val rumor: Event,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip4e.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip4e.kt
@@ -1,0 +1,61 @@
+package org.nostr.nostrord.nostr
+
+/**
+ * NIP-4e: encryption decoupled from identity.
+ *
+ * A user announces a dedicated encryption pubkey `E` in a replaceable kind:10044 signed by their
+ * identity key `A`. Senders then derive the NIP-44 conversation key against `E` (`ecdh(b, E)`)
+ * instead of `A`, on BOTH NIP-17 layers, so a recipient holding `e` locally decrypts without a
+ * remote signer. Identity is untouched: `p` tags, seal signatures and event authorship stay on `A`.
+ *
+ * This is the ONLY place that knows nip4e wire constants. The proposal
+ * (nostr-protocol/nips#1647) is an open, contested draft and the deployed clients already
+ * diverge from it, so kinds and tag names are expected to move; keep every format detail here.
+ *
+ * Divergence from the PR text, taken from the deployed Jumble implementation (authoritative for
+ * interop): the `n` tag also appears on the kind:13 seal, naming the encryption key the recipient
+ * must ECDH the seal content against, so no kind:10044 lookup is needed to read a message.
+ */
+object Nip4e {
+    /** Replaceable announcement carrying the account's encryption pubkey. */
+    const val KIND_ENCRYPTION_KEY = 10044
+
+    /** Names an encryption pubkey. On kind:10044 it is the announcement; on a seal, the sender's. */
+    const val TAG_ENCRYPTION_PUBKEY = "n"
+
+    /**
+     * The encryption pubkey [event] announces, or null when it announces none. A kind:10044 with
+     * no valid `n` tag is a withdrawal: the author is back to identity-addressed encryption.
+     */
+    fun encryptionKeyFrom(event: Event): String? {
+        if (event.kind != KIND_ENCRYPTION_KEY) return null
+        return encryptionKeyFromTags(event.tags)
+    }
+
+    /** The `n` value carried by a seal (or any event's tags), validated. Null when absent. */
+    fun encryptionKeyFromTags(tags: List<List<String>>): String? = tags
+        .firstOrNull { it.firstOrNull() == TAG_ENCRYPTION_PUBKEY && isPubkey(it.getOrNull(1)) }
+        ?.get(1)
+
+    /**
+     * Unsigned kind:10044 announcing [encPubkeyHex] for [identityPubkey]. A null key builds the
+     * withdrawal shape (no `n` tag); replaceable latest-wins then retires the previous key for
+     * senders. Withdrawing never means deleting the private key: messages already addressed to it
+     * only ever open with it.
+     */
+    fun buildAnnouncement(
+        identityPubkey: String,
+        encPubkeyHex: String?,
+        createdAt: Long,
+    ): Event = Event(
+        pubkey = identityPubkey,
+        createdAt = createdAt,
+        kind = KIND_ENCRYPTION_KEY,
+        tags = encPubkeyHex?.takeIf { isPubkey(it) }?.let { listOf(listOf(TAG_ENCRYPTION_PUBKEY, it)) } ?: emptyList(),
+        content = "",
+    )
+
+    private fun isPubkey(value: String?): Boolean = value != null && value.length == 64 && value.all { it.isHexDigit() }
+
+    private fun Char.isHexDigit(): Boolean = this in '0'..'9' || this in 'a'..'f' || this in 'A'..'F'
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1160,6 +1160,30 @@ fun SecureStorage.saveDmWrapRumor(
     }
 }
 
+// Peer NIP-4e encryption keys (kind:10044), so the first send after a cold start addresses a
+// peer's encryption key instead of racing the announcement fetch and falling back to identity.
+private fun dmEncKeysKey(pubkey: String): String = "dm_enc_keys_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.loadDmEncKeys(pubkey: String): Map<String, org.nostr.nostrord.network.managers.DmEncKey> {
+    if (pubkey.isBlank()) return emptyMap()
+    val raw = getStringPref(dmEncKeysKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return emptyMap()
+    return runCatching {
+        Json.decodeFromString<Map<String, org.nostr.nostrord.network.managers.DmEncKey>>(raw)
+    }.getOrDefault(emptyMap())
+}
+
+fun SecureStorage.saveDmEncKeys(
+    pubkey: String,
+    keys: Map<String, org.nostr.nostrord.network.managers.DmEncKey>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(dmEncKeysKey(pubkey), Json.encodeToString(keys))
+    } catch (_: Exception) {
+    }
+}
+
 // Notification history — persisted feed of cross-relay notifications shown in
 // the notification center. Scoped by pubkey so multi-account devices stay isolated.
 private fun notificationHistoryKey(pubkey: String): String = "notification_history_${pubkeyDigest(pubkey)}"

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
@@ -13,6 +13,59 @@ import kotlin.test.assertTrue
 class DmManagerTest {
     private fun signer() = NostrSigner.Local(KeyPair.generate())
 
+    private fun announcement(author: String, key: String?, createdAt: Long) = org.nostr.nostrord.nostr.Nip4e.buildAnnouncement(author, key, createdAt)
+
+    @Test
+    fun `an announced encryption key is used for that peer`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val peer = signer().pubkey
+        val key = "b".repeat(64)
+        assertEquals(null, dm.encryptionKeyFor(peer))
+
+        dm.ingestEncryptionKey(announcement(peer, key, createdAt = 10L))
+        assertEquals(key, dm.encryptionKeyFor(peer))
+    }
+
+    @Test
+    fun `an older announcement cannot regress a newer key`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val peer = signer().pubkey
+        val newer = "b".repeat(64)
+        val older = "c".repeat(64)
+
+        dm.ingestEncryptionKey(announcement(peer, newer, createdAt = 20L))
+        // Same replaceable arriving from a slower relay, stale copy.
+        dm.ingestEncryptionKey(announcement(peer, older, createdAt = 10L))
+        assertEquals(newer, dm.encryptionKeyFor(peer))
+    }
+
+    @Test
+    fun `a withdrawal puts the peer back on identity encryption`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val peer = signer().pubkey
+        dm.ingestEncryptionKey(announcement(peer, "b".repeat(64), createdAt = 10L))
+        dm.ingestEncryptionKey(announcement(peer, null, createdAt = 20L))
+        assertEquals(null, dm.encryptionKeyFor(peer))
+    }
+
+    @Test
+    fun `encryption keys are dropped on account switch`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val peer = signer().pubkey
+        dm.ingestEncryptionKey(announcement(peer, "b".repeat(64), createdAt = 10L))
+        dm.clear()
+        assertEquals(null, dm.encryptionKeyFor(peer))
+    }
+
+    @Test
+    fun `hydrated encryption keys survive a cold start`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val peer = signer().pubkey
+        val key = "b".repeat(64)
+        dm.hydrate(emptyList(), emptyMap(), encKeys = mapOf(peer to DmEncKey(key, 10L)))
+        assertEquals(key, dm.encryptionKeyFor(peer))
+    }
+
     @Test
     fun `received message lands under the sender as the conversation peer`() = runTest {
         val dm = DmManager(backgroundScope)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip17Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip17Test.kt
@@ -90,6 +90,78 @@ class Nip17Test {
     }
 
     @Test
+    fun `classic wrap keeps a single p tag and no n tag`() = runTest {
+        val alice = signer()
+        val bob = signer()
+        val rumor = Nip17.buildRumor(alice.pubkey, bob.pubkey, "x")
+        val seal = Nip17.seal(rumor, bob.pubkey, alice)
+        val wrap = Nip17.giftWrap(seal, bob.pubkey)
+
+        assertTrue(seal.tags.isEmpty(), "classic seal carries no NIP-4e n tag")
+        assertEquals(listOf(listOf("p", bob.pubkey)), wrap.tags)
+    }
+
+    @Test
+    fun `NIP-4e wrap addresses the encryption key and round-trips with it`() = runTest {
+        val alice = signer()
+        val bob = signer()
+        // Bob announced this key; only he holds its private half.
+        val bobEnc = KeyPair.generate()
+        val rumor = Nip17.buildRumor(alice.pubkey, bob.pubkey, "hi via nip4e")
+        val wrap =
+            Nip17.wrap(
+                rumor,
+                bob.pubkey,
+                alice,
+                encryptTo = bobEnc.publicKeyHex,
+                senderEncTag = alice.pubkey,
+            )
+
+        // Encryption key leads so readers taking p[0] find it; the identity p tag must remain,
+        // because that is what relays route on and what every inbox REQ filters by.
+        assertEquals(listOf(listOf("p", bobEnc.publicKeyHex), listOf("p", bob.pubkey)), wrap.tags)
+
+        val out = Nip17.unwrap(wrap, NostrSigner.Local(bobEnc))
+        assertNotNull(out)
+        assertEquals("hi via nip4e", out.rumor.content)
+        assertEquals(alice.pubkey, out.senderPubkey, "sender is still the identity that signed the seal")
+    }
+
+    @Test
+    fun `NIP-4e seal names the key it was encrypted against`() = runTest {
+        val alice = signer()
+        val bob = signer()
+        val bobEnc = KeyPair.generate()
+        val seal =
+            Nip17.seal(
+                Nip17.buildRumor(alice.pubkey, bob.pubkey, "x"),
+                bob.pubkey,
+                alice,
+                encryptTo = bobEnc.publicKeyHex,
+                senderEncTag = alice.pubkey,
+            )
+        // Without this tag a reader falls back to a kind:10044 lookup and flags us unverified.
+        assertEquals(alice.pubkey, Nip4e.encryptionKeyFromTags(seal.tags))
+        assertEquals(alice.pubkey, seal.pubkey, "the seal is still identity-signed")
+    }
+
+    @Test
+    fun `an encryption-key-addressed wrap does not open with the identity key alone`() = runTest {
+        val alice = signer()
+        val bob = signer()
+        val bobEnc = KeyPair.generate()
+        val wrap =
+            Nip17.wrap(
+                Nip17.buildRumor(alice.pubkey, bob.pubkey, "secret"),
+                bob.pubkey,
+                alice,
+                encryptTo = bobEnc.publicKeyHex,
+                senderEncTag = alice.pubkey,
+            )
+        assertNull(Nip17.unwrap(wrap, bob))
+    }
+
+    @Test
     fun `a signer without NIP-44 support rejects encryption`() = runTest {
         val stub =
             object : NostrSigner {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip4eTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip4eTest.kt
@@ -1,0 +1,66 @@
+package org.nostr.nostrord.nostr
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class Nip4eTest {
+    private val identity = "a".repeat(64)
+    private val encKey = "b".repeat(64)
+
+    private fun announcement(tags: List<List<String>>, kind: Int = Nip4e.KIND_ENCRYPTION_KEY) = Event(pubkey = identity, createdAt = 1L, kind = kind, tags = tags, content = "")
+
+    @Test
+    fun `reads the announced encryption key`() {
+        assertEquals(encKey, Nip4e.encryptionKeyFrom(announcement(listOf(listOf("n", encKey)))))
+    }
+
+    @Test
+    fun `an announcement without an n tag announces no key`() {
+        // The withdrawal shape: the author is back to identity-addressed encryption.
+        assertNull(Nip4e.encryptionKeyFrom(announcement(emptyList())))
+        assertNull(Nip4e.encryptionKeyFrom(announcement(listOf(listOf("relay", "wss://x")))))
+    }
+
+    @Test
+    fun `malformed keys are ignored rather than sent to`() {
+        assertNull(Nip4e.encryptionKeyFrom(announcement(listOf(listOf("n")))))
+        assertNull(Nip4e.encryptionKeyFrom(announcement(listOf(listOf("n", "")))))
+        assertNull(Nip4e.encryptionKeyFrom(announcement(listOf(listOf("n", "tooshort")))))
+        assertNull(Nip4e.encryptionKeyFrom(announcement(listOf(listOf("n", "z".repeat(64))))))
+    }
+
+    @Test
+    fun `the first valid n tag wins`() {
+        val event = announcement(listOf(listOf("n", "nothex"), listOf("n", encKey)))
+        assertEquals(encKey, Nip4e.encryptionKeyFrom(event))
+    }
+
+    @Test
+    fun `another kind carrying an n tag is not an announcement`() {
+        assertNull(Nip4e.encryptionKeyFrom(announcement(listOf(listOf("n", encKey)), kind = 10050)))
+    }
+
+    @Test
+    fun `announcement round-trips`() {
+        val built = Nip4e.buildAnnouncement(identity, encKey, createdAt = 42L)
+        assertEquals(Nip4e.KIND_ENCRYPTION_KEY, built.kind)
+        assertEquals(identity, built.pubkey)
+        assertEquals(42L, built.createdAt)
+        assertEquals(encKey, Nip4e.encryptionKeyFrom(built))
+    }
+
+    @Test
+    fun `a null key builds the withdrawal shape`() {
+        val built = Nip4e.buildAnnouncement(identity, null, createdAt = 42L)
+        assertTrue(built.tags.none { it.firstOrNull() == Nip4e.TAG_ENCRYPTION_PUBKEY })
+        assertNull(Nip4e.encryptionKeyFrom(built))
+    }
+
+    @Test
+    fun `seal n tags are read from tags directly`() {
+        assertEquals(encKey, Nip4e.encryptionKeyFromTags(listOf(listOf("n", encKey))))
+        assertNull(Nip4e.encryptionKeyFromTags(listOf(listOf("p", identity))))
+    }
+}


### PR DESCRIPTION
First of four PRs implementing NIP-4e ([nips#1647](https://github.com/nostr-protocol/nips/pull/1647)). This one is send-side only and publishes no state of ours, so it is inert until someone we message has announced a key.

## Why

Reading NIP-17 DMs through a remote signer costs two round-trips per message: the gift wrap is encrypted from a fresh ephemeral key and the seal from the sender's key, so neither conversation key can be cached. NIP-4e fixes it at the root by letting a user announce a dedicated encryption key that their client holds locally. Both layers then decrypt in-process.

## What this does

When sending, resolve the recipient's kind:10044. If they announced a key, address both NIP-44 layers to it; if not, take the classic path unchanged.

| | |
|---|---|
| `nostr/Nip4e.kt` (new) | the only file that knows the wire format: kind, `n` tag, announcement parse/build |
| `nostr/Nip17.kt` | `encryptTo` and `senderEncTag` on `seal`/`giftWrap`/`wrap`; defaults reproduce today's bytes |
| `network/managers/DmManager.kt` | peer key cache, replaceable latest-wins by `created_at`, withdrawal removes |
| `network/NostrRepository.kt` | 10044 rides the existing 10050 REQ; handler; `sendDm` addressing; debounced persistence |
| `storage/SecureStorage.kt` | per-account cache slot so the first send after a cold start does not race the fetch |

## Wire format notes

The spec is behind the deployed clients, so the format follows the Jumble source where they disagree, flagged in the code:

- the `n` tag also appears on the kind:13 seal, naming the key to ECDH the seal content against, so a reader needs no announcement lookup. Without it Jumble falls into its legacy branch and flags us unverified;
- the gift wrap carries two `p` tags, `[encryption key, identity]`. The identity one is mandatory (relays route on it, and every inbox REQ filters by it); the encryption key leads because deployed readers take `p[0]` as the encryption target.

Non-adopting clients are unaffected by construction. Verified against the Armada source: it filters `{kinds:[1059], "#p":[identity]}` and publishes no 10044, so we keep taking the classic path with it.

## Tests

`Nip4eTest` (8) announcement parse/build, withdrawal, malformed keys. `Nip17Test` (+4) round-trip through an encryption key, `n` tag content, `p` tag order, classic byte-compat, and that an encryption-addressed wrap does not open with the identity key alone. `DmManagerTest` (+5) latest-wins, withdrawal, account switch, hydration.

`spotlessCheck`, `detekt`, `compileKotlinJvm`, `compileKotlinJs`, `:composeApp:jvmTest` all green.

- 797750b6 feat(dm): address NIP-4e encryption keys when sending DMs