### PR TITLE
feat(pomegranate): browserless Google sign-in on Android

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -82,8 +82,13 @@ kotlin {
         androidMain.dependencies {
             implementation("io.github.nostrord:pomegranate-dealer:0.1.0")
             implementation(compose.preview)
-            // Chrome Custom Tabs for the pomegranate Google sign-in (system browser, not WebView).
+            // Chrome Custom Tabs: pomegranate Google sign-in fallback when the account picker
+            // below has nothing to offer (no Play services, no Google account, unregistered build).
             implementation("androidx.browser:browser:1.8.0")
+            // Credential Manager: browserless Google sign-in for pomegranate.
+            implementation("androidx.credentials:credentials:1.6.0")
+            implementation("androidx.credentials:credentials-play-services-auth:1.6.0")
+            implementation("com.google.android.libraries.identity.googleid:googleid:1.2.0")
             implementation(libs.androidx.activity.compose)
             implementation("io.ktor:ktor-client-okhttp:3.4.2")
             implementation("fr.acinq.secp256k1:secp256k1-kmp-jni-android:0.14.0")

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/MainActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import org.nostr.nostrord.auth.pomegranate.PomegranateGoogleSignIn
 import org.nostr.nostrord.network.livekit.AvMediaBridge
 import org.nostr.nostrord.network.upload.ShareMediaQueue
 import org.nostr.nostrord.nostr.Nip55AndroidBridge
@@ -45,6 +46,8 @@ class MainActivity : ComponentActivity() {
         Nip55AndroidBridge.register(this)
         // Mic / camera grants for NIP-29 AV spaces round-trip through this activity too.
         AvMediaBridge.register(this)
+        // The pomegranate Google account picker draws on this activity.
+        PomegranateGoogleSignIn.register(this)
         handleDeepLink(intent)
         handleShareIntent(intent)
         setContent {

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
@@ -21,6 +21,9 @@ import java.lang.ref.WeakReference
  * Cloud project (Play services refuses the token in that case).
  */
 internal actual object PomegranateNativeGoogle {
+    /** Play services status code prefix, e.g. "[16] Account reauth failed.". */
+    private val GMS_STATUS_CODE = Regex("""\[\d+]""")
+
     actual val isAvailable: Boolean get() = PomegranateGoogleSignIn.activity != null
 
     actual suspend fun requestIdToken(serverClientId: String): String? {
@@ -36,7 +39,16 @@ internal actual object PomegranateNativeGoogle {
         val response =
             try {
                 CredentialManager.create(activity).getCredential(activity, request)
-            } catch (_: GetCredentialCancellationException) {
+            } catch (e: GetCredentialCancellationException) {
+                // Play services reports its own failures as a user cancel as well, tagged with a
+                // status code: an app whose package + fingerprint is not registered in the
+                // central's Google Cloud project closes the chooser with "[16] Account reauth
+                // failed.". A real dismissal carries no such code, and only that is a cancel.
+                val detail = e.errorMessage?.toString().orEmpty()
+                if (GMS_STATUS_CODE.containsMatchIn(detail)) {
+                    println("[Pomegranate] native sign-in unavailable: $detail")
+                    return null
+                }
                 throw PomegranatePopupClosedException()
             } catch (e: CancellationException) {
                 throw e

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
@@ -5,11 +5,11 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.CustomCredential
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.exceptions.GetCredentialCancellationException
-import androidx.credentials.exceptions.GetCredentialException
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import kotlinx.coroutines.CancellationException
 import java.lang.ref.WeakReference
 
 /**
@@ -38,18 +38,26 @@ internal actual object PomegranateNativeGoogle {
                 CredentialManager.create(activity).getCredential(activity, request)
             } catch (_: GetCredentialCancellationException) {
                 throw PomegranatePopupClosedException()
-            } catch (_: GetCredentialException) {
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Throwable) {
+                // Play services also reports an unregistered package / signing fingerprint here,
+                // and not always as a GetCredentialException, so anything that is not a user
+                // cancel hands the sign-in back to the browser flow.
+                println("[Pomegranate] native sign-in unavailable: ${e::class.simpleName}: ${e.message}")
                 return null
             }
         val credential = response.credential
         if (credential !is CustomCredential ||
             credential.type != GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
         ) {
+            println("[Pomegranate] native sign-in returned ${credential.type}, not a Google ID token")
             return null
         }
         return try {
             GoogleIdTokenCredential.createFrom(credential.data).idToken
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            println("[Pomegranate] native sign-in token unreadable: ${e.message}")
             null
         }
     }

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
@@ -1,0 +1,83 @@
+package org.nostr.nostrord.auth.pomegranate
+
+import androidx.activity.ComponentActivity
+import androidx.credentials.CredentialManager
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import java.lang.ref.WeakReference
+
+/**
+ * Android sign-in without a browser: the system account picker (Credential Manager over Play
+ * services) returns a Google ID token addressed to the central's web client, which the central
+ * verifies at `POST /login/google/android`. Falls back to null on anything the browser flow can
+ * still handle: no Play services, no Google account on the device, or an app build whose package
+ * and signing fingerprint are not registered as an Android OAuth client in the central's Google
+ * Cloud project (Play services refuses the token in that case).
+ */
+internal actual object PomegranateNativeGoogle {
+    actual val isAvailable: Boolean get() = PomegranateGoogleSignIn.activity != null
+
+    actual suspend fun requestIdToken(serverClientId: String): String? {
+        val activity = PomegranateGoogleSignIn.activity ?: return null
+        val request =
+            GetCredentialRequest
+                .Builder()
+                .addCredentialOption(
+                    GetGoogleIdOption
+                        .Builder()
+                        .setServerClientId(serverClientId)
+                        // Login screen: offer every Google account on the device, not just the
+                        // ones already linked to this app, and always let the user pick.
+                        .setFilterByAuthorizedAccounts(false)
+                        .setAutoSelectEnabled(false)
+                        .build(),
+                ).build()
+        val response =
+            try {
+                CredentialManager.create(activity).getCredential(activity, request)
+            } catch (_: GetCredentialCancellationException) {
+                throw PomegranatePopupClosedException()
+            } catch (_: GetCredentialException) {
+                return null
+            }
+        val credential = response.credential
+        if (credential !is CustomCredential ||
+            credential.type != GoogleIdTokenCredential.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+        ) {
+            return null
+        }
+        return try {
+            GoogleIdTokenCredential.createFrom(credential.data).idToken
+        } catch (_: Exception) {
+            null
+        }
+    }
+}
+
+/**
+ * Holds the foreground activity the account picker needs to draw on. [MainActivity] registers
+ * itself in onCreate; the reference is weak and cleared on destroy so a rotated-away activity
+ * is not retained.
+ */
+object PomegranateGoogleSignIn {
+    private var ref: WeakReference<ComponentActivity>? = null
+
+    internal val activity: ComponentActivity? get() = ref?.get()
+
+    fun register(activity: ComponentActivity) {
+        ref = WeakReference(activity)
+        activity.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    if (ref?.get() === activity) ref = null
+                }
+            },
+        )
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.android.kt
@@ -8,7 +8,7 @@ import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.credentials.exceptions.GetCredentialException
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import java.lang.ref.WeakReference
 
@@ -28,16 +28,11 @@ internal actual object PomegranateNativeGoogle {
         val request =
             GetCredentialRequest
                 .Builder()
-                .addCredentialOption(
-                    GetGoogleIdOption
-                        .Builder()
-                        .setServerClientId(serverClientId)
-                        // Login screen: offer every Google account on the device, not just the
-                        // ones already linked to this app, and always let the user pick.
-                        .setFilterByAuthorizedAccounts(false)
-                        .setAutoSelectEnabled(false)
-                        .build(),
-                ).build()
+                // Button-initiated flow, not One Tap: the account chooser always opens. One Tap
+                // goes quiet for 24h once a user dismisses it a few times, which here would read
+                // as the native path silently reverting to the browser.
+                .addCredentialOption(GetSignInWithGoogleOption.Builder(serverClientId).build())
+                .build()
         val response =
             try {
                 CredentialManager.create(activity).getCredential(activity, request)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/Pomegranate.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/Pomegranate.kt
@@ -17,6 +17,15 @@ object PomegranateConfig {
     const val CENTRAL_URL = "https://auth.njump.me"
 
     /**
+     * The central's Google OAuth web client, public (it rides the redirect to accounts.google.com).
+     * The Android account picker mints ID tokens with this as their audience, which is exactly what
+     * the central checks at `POST /login/google/android`. Play services only hands out such a token
+     * to an app whose package + signing fingerprint is registered as an Android OAuth client in the
+     * same Google Cloud project, so this stays inert until the central's operator adds ours.
+     */
+    const val GOOGLE_WEB_CLIENT_ID = "300561989816-7nv10jo4vdn0d6p9knf12g7rq4fcusnc.apps.googleusercontent.com"
+
+    /**
      * Recommended shard operators (the public promenade instances). Any of them can be
      * offline at a given moment, so the setup step probes them and registration tolerates
      * the ones that fail.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranatePlatform.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranatePlatform.kt
@@ -21,6 +21,24 @@ internal expect object PomegranatePopups {
     ): String
 }
 
+/**
+ * Browserless Google sign-in. Real only on Android, where the platform account picker
+ * (Credential Manager over Play services) mints a Google ID token the central exchanges at
+ * `POST /login/google/android`. Every other target reports unavailable and the flow keeps
+ * its browser popup.
+ */
+internal expect object PomegranateNativeGoogle {
+    val isAvailable: Boolean
+
+    /**
+     * Google ID token with [serverClientId] as its audience, or null when no native
+     * credential can be obtained (no Google account, no Play services, app not registered
+     * in the central's Google Cloud project) so the caller falls back to the browser.
+     * Throws [PomegranatePopupClosedException] when the user dismisses the picker.
+     */
+    suspend fun requestIdToken(serverClientId: String): String?
+}
+
 /** FROST trusted dealer, backed by the JS-only npm lib `@fiatjaf/promenade-trusted-dealer`. */
 internal expect object PomegranateDealer {
     /** Splits the key into [count] shards with signing threshold [threshold]. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateService.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateService.kt
@@ -237,11 +237,16 @@ class PomegranateService {
                         contentType(ContentType.Application.Json)
                         setBody(buildJsonObject { put("id_token", idToken) }.toString())
                     }
-                if (!res.status.isSuccess()) return null
-                res.bodyAsText()
+                val text = res.bodyAsText()
+                if (!res.status.isSuccess()) {
+                    println("[Pomegranate] central rejected the ID token (${res.status}): $text")
+                    return null
+                }
+                text
             } catch (e: CancellationException) {
                 throw e
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                println("[Pomegranate] ID token exchange failed: ${e.message}")
                 return null
             }
         val raw = parseAndroidLoginToken(body) ?: return null

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateService.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateService.kt
@@ -23,8 +23,10 @@ import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.longOrNull
+import kotlinx.serialization.json.put
 import org.nostr.nostrord.network.createHttpClient
 import org.nostr.nostrord.nostr.Crypto
 import org.nostr.nostrord.nostr.Event
@@ -214,8 +216,40 @@ class PomegranateService {
     // --- internal -------------------------------------------------------------
 
     private suspend fun authenticateWithGoogle(central: String): GoogleToken {
+        nativeGoogleToken(central)?.let { return it }
         val raw = PomegranatePopups.awaitTokenFromPopup("$central/login/google", central)
         return decodeGoogleToken(raw)
+    }
+
+    /**
+     * Browserless sign-in: the platform account picker mints a Google ID token and the central
+     * exchanges it for its own token at `POST /login/google/android`, skipping the OAuth redirect
+     * dance entirely. Null on any platform or configuration where that is not possible, so the
+     * caller opens the browser flow instead; a user-dismissed picker propagates as a cancel.
+     */
+    private suspend fun nativeGoogleToken(central: String): GoogleToken? {
+        if (!PomegranateNativeGoogle.isAvailable) return null
+        val idToken = PomegranateNativeGoogle.requestIdToken(PomegranateConfig.GOOGLE_WEB_CLIENT_ID) ?: return null
+        val body =
+            try {
+                val res =
+                    http.post("$central/login/google/android") {
+                        contentType(ContentType.Application.Json)
+                        setBody(buildJsonObject { put("id_token", idToken) }.toString())
+                    }
+                if (!res.status.isSuccess()) return null
+                res.bodyAsText()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                return null
+            }
+        val raw = parseAndroidLoginToken(body) ?: return null
+        return try {
+            decodeGoogleToken(raw)
+        } catch (_: Exception) {
+            null
+        }
     }
 
     /** GET /account — the account, or null when this Google login has none yet. */
@@ -400,6 +434,13 @@ class PomegranateService {
         session: String,
         operatorUrl: String,
     ): String = Crypto.sha256("$session:$operatorUrl").toHexString()
+
+    /** Pulls the central token out of the `POST /login/google/android` reply (`{"token": "..."}`). */
+    internal fun parseAndroidLoginToken(body: String): String? = try {
+        (json.parseToJsonElement(body).jsonObject["token"] as? JsonPrimitive)?.content?.takeIf { it.isNotBlank() }
+    } catch (_: Exception) {
+        null
+    }
 
     /** Decodes the base64 token the central popup posts; rejects expired/garbled ones. */
     @OptIn(ExperimentalEncodingApi::class)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateServiceTest.kt
@@ -6,6 +6,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 @OptIn(ExperimentalEncodingApi::class)
 class PomegranateServiceTest {
@@ -58,5 +59,18 @@ class PomegranateServiceTest {
     fun decodeGoogleTokenRejectsGarbage() {
         assertFailsWith<Exception> { service.decodeGoogleToken("not-base64!!") }
         assertFailsWith<Exception> { service.decodeGoogleToken(Base64.encode("[1,2]".encodeToByteArray())) }
+    }
+
+    @Test
+    fun parseAndroidLoginTokenReadsTheTokenField() {
+        assertEquals("abc123", service.parseAndroidLoginToken("""{"token":"abc123"}"""))
+    }
+
+    @Test
+    fun parseAndroidLoginTokenReturnsNullOnUnusableReplies() {
+        // An error page or an empty token must fall back to the browser flow, not log in blank.
+        assertNull(service.parseAndroidLoginToken("invalid google token audience"))
+        assertNull(service.parseAndroidLoginToken("""{"error":"nope"}"""))
+        assertNull(service.parseAndroidLoginToken("""{"token":""}"""))
     }
 }

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.ios.kt
@@ -1,0 +1,11 @@
+package org.nostr.nostrord.auth.pomegranate
+
+/**
+ * iOS signs in through SFSafariViewController + loopback. A browserless path would mean the
+ * Google Sign-In SDK, which is not linked here.
+ */
+internal actual object PomegranateNativeGoogle {
+    actual val isAvailable: Boolean = false
+
+    actual suspend fun requestIdToken(serverClientId: String): String? = null
+}

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.js.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.auth.pomegranate
+
+/** The web already runs the sign-in in a popup on the central's own origin. */
+internal actual object PomegranateNativeGoogle {
+    actual val isAvailable: Boolean = false
+
+    actual suspend fun requestIdToken(serverClientId: String): String? = null
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/auth/pomegranate/PomegranateNativeGoogle.jvm.kt
@@ -1,0 +1,8 @@
+package org.nostr.nostrord.auth.pomegranate
+
+/** Desktop has no system account picker; sign-in goes through the loopback browser flow. */
+internal actual object PomegranateNativeGoogle {
+    actual val isAvailable: Boolean = false
+
+    actual suspend fun requestIdToken(serverClientId: String): String? = null
+}


### PR DESCRIPTION
Android signs in with Google through the system account picker (Credential Manager over Play services) instead of opening Chrome Custom Tabs. The central already exchanges a Google ID token for its own token at `POST /login/google/android`, so this needs no protocol work: the picker mints the ID token, the central answers with the same token the popup would have posted, and the rest of the flow (register / account / profiles / `bunker://`) is untouched. All three entry points go through `authenticateWithGoogle`, so nsec export and disconnect get it too.

The picker is tried first and hands the sign-in back to the existing loopback browser flow whenever it cannot produce a token. Closing the picker cancels the login instead of falling back, which is the one case the browser must not open.

Not live yet: Play services only mints an ID token addressed to the central web client for an app registered as an Android OAuth client in the same Google Cloud project, which only the central operator can add. Until then every attempt falls back and the behavior is exactly what ships today. The native happy path is therefore still unexercised; the fallback path is verified.

| Case | Result |
|---|---|
| Package + fingerprint registered | account picker, no browser |
| Not registered, no Play services, no Google account | loopback browser flow, as today |
| Central rejects the exchange or answers without a token | loopback browser flow |
| User closes the picker | login cancelled, nothing opens |

A trap worth knowing: an unregistered app does not fail with a plain `GetCredentialException`. The chooser opens, lists the accounts, and on selection Play services throws `TYPE_USER_CANCELED` with `[16] Account reauth failed.`. Reading that as a user cancel ended the login silently, so a cancel carrying a status code is now treated as a platform failure.

- `e635f2dc` feat(pomegranate): browserless Google sign-in on Android
- `2d1e5edb` fix(pomegranate): use the button sign-in option, not One Tap
- `c87ac00f` fix(pomegranate): fall back to the browser on any non-cancel picker failure
- `596ce8ec` fix(pomegranate): treat a coded picker cancel as a platform failure