### PR TITLE
chore: bump version to 2.8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.7.0
-app.versionCode=22
+app.version=2.8.0
+app.versionCode=23
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Minor bump: two features landed since 2.7.0 and nothing breaking.

- `6362d50e` NIP-51 private groups on the kind:10009 list (#246)
- `629873da`..`faad1cbe` browserless Google sign-in on Android (#248)

versionCode 22 to 23.