### PR TITLE
feat: mute groups, synced across devices over NIP-78

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -984,8 +984,18 @@ class NostrGroupClient(
      * Its own REQ rather than a filter on the contact-list one: this is re-issued
      * whenever the window regains focus, which must not drag a kind:3 re-fetch along
      * with it. Re-using the same subId replaces the previous subscription in place.
+     *
+     * Two filters, because one cannot mean both things. The `limit` one fetches the
+     * current value; a relay is free to treat a limited filter as a finished query and
+     * stop there, which is what left the other device waiting for the next poll. The
+     * `since` one carries no limit, so it is unambiguously a live subscription and new
+     * events push straight through. Overlap is harmless: a re-delivered event exits on
+     * the created_at floor before it costs a decrypt.
      */
-    suspend fun requestNotificationPrefs(pubkey: String): String {
+    suspend fun requestNotificationPrefs(
+        pubkey: String,
+        liveSince: Long,
+    ): String {
         val subId = "notifprefs_${pubkey.take(8)}"
         trySendClose(subId)
         val req = buildJsonArray {
@@ -997,6 +1007,14 @@ class NostrGroupClient(
                     putJsonArray("authors") { add(pubkey) }
                     putJsonArray("#d") { add("nostrord.notifications.v1") }
                     put("limit", 1)
+                },
+            )
+            add(
+                buildJsonObject {
+                    putJsonArray("kinds") { add(30078) }
+                    putJsonArray("authors") { add(pubkey) }
+                    putJsonArray("#d") { add("nostrord.notifications.v1") }
+                    put("since", liveSince)
                 },
             )
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -973,8 +973,24 @@ class NostrGroupClient(
                     put("limit", 1)
                 },
             )
-            // NIP-78 per-group notification levels, on the same REQ for the same reason:
-            // one more own-authored replaceable event, no extra subscription.
+        }
+        sendJson(req)
+        return subId
+    }
+
+    /**
+     * NIP-78 per-group notification levels (kind:30078) for our own pubkey.
+     *
+     * Its own REQ rather than a filter on the contact-list one: this is re-issued
+     * whenever the window regains focus, which must not drag a kind:3 re-fetch along
+     * with it. Re-using the same subId replaces the previous subscription in place.
+     */
+    suspend fun requestNotificationPrefs(pubkey: String): String {
+        val subId = "notifprefs_${pubkey.take(8)}"
+        trySendClose(subId)
+        val req = buildJsonArray {
+            add("REQ")
+            add(subId)
             add(
                 buildJsonObject {
                     putJsonArray("kinds") { add(30078) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -973,6 +973,16 @@ class NostrGroupClient(
                     put("limit", 1)
                 },
             )
+            // NIP-78 per-group notification levels, on the same REQ for the same reason:
+            // one more own-authored replaceable event, no extra subscription.
+            add(
+                buildJsonObject {
+                    putJsonArray("kinds") { add(30078) }
+                    putJsonArray("authors") { add(pubkey) }
+                    putJsonArray("#d") { add("nostrord.notifications.v1") }
+                    put("limit", 1)
+                },
+            )
         }
         sendJson(req)
         return subId

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -61,6 +61,7 @@ import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip78
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.DM_CACHE_KIND
@@ -79,6 +80,7 @@ import org.nostr.nostrord.storage.loadDmSyncCursor
 import org.nostr.nostrord.storage.loadDmWrapRumor
 import org.nostr.nostrord.storage.loadFollowingCacheFor
 import org.nostr.nostrord.storage.loadKind10000TimestampFor
+import org.nostr.nostrord.storage.loadKind30078TimestampFor
 import org.nostr.nostrord.storage.loadMuteListSnapshotFor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
@@ -91,6 +93,7 @@ import org.nostr.nostrord.storage.saveDmWrapRumor
 import org.nostr.nostrord.storage.saveFollowingCacheFor
 import org.nostr.nostrord.storage.saveGroupFetchLazy
 import org.nostr.nostrord.storage.saveKind10000TimestampFor
+import org.nostr.nostrord.storage.saveKind30078TimestampFor
 import org.nostr.nostrord.storage.saveMuteListSnapshotFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
@@ -115,6 +118,9 @@ private const val GIFT_WRAP_BACKDATE_SECONDS = 2L * 24 * 60 * 60
 // Min frame silence before a foreground return probes a socket. A frame in the
 // last minute proves the socket is alive; below this, probing is pure overhead.
 private const val FOREGROUND_PROBE_MIN_SILENCE_MS = 60_000L
+
+/** Coalescing window for kind:30078 notification-prefs publishes: a burst of toggles is one event. */
+private const val NOTIF_PREFS_PUBLISH_DEBOUNCE_MS = 3_000L
 
 /**
  * Repository for Nostr operations.
@@ -765,6 +771,169 @@ class NostrRepository(
         }
     }
 
+    // ===== NIP-78 notification preferences (kind:30078) =====
+    // Per-group notification levels follow the account across devices. The payload is
+    // NIP-44 self-encrypted: it is a list of NIP-29 group ids, which in plaintext would
+    // hand any relay the account's group membership.
+
+    private var notifPrefsCreatedAt = 0L
+
+    /** True while a relay's payload is being written into the settings, so the echo doesn't republish it. */
+    private var notifPrefsApplyingRemote = false
+
+    private var notifPrefsPublishJob: Job? = null
+    private var notifPrefsWatchJob: Job? = null
+
+    /**
+     * Starts mirroring the account's per-group notification levels to kind:30078.
+     * Re-armed per account: the previous account's watcher is cancelled first, so a
+     * switch can never publish account A's prefs under account B.
+     */
+    private fun startNotificationPrefsSync(pubkey: String) {
+        val settings = notificationSettings ?: return
+        notifPrefsWatchJob?.cancel()
+        notifPrefsPublishJob?.cancel()
+        notifPrefsCreatedAt = SecureStorage.loadKind30078TimestampFor(pubkey, Nip78.D_NOTIFICATIONS)
+        notifPrefsWatchJob = scope.launch {
+            // drop(1): the current value is what initialize() just loaded from disk, not a change.
+            settings.muteState.drop(1).collect {
+                if (notifPrefsApplyingRemote) return@collect
+                schedulePublishNotificationPrefs()
+            }
+        }
+    }
+
+    private fun stopNotificationPrefsSync() {
+        notifPrefsWatchJob?.cancel()
+        notifPrefsWatchJob = null
+        notifPrefsPublishJob?.cancel()
+        notifPrefsPublishJob = null
+        notifPrefsCreatedAt = 0L
+    }
+
+    /**
+     * Coalesces a burst of level changes into one event. Toggling three groups in a row
+     * is one publish, not three replaceable events racing each other at the relay.
+     */
+    private fun schedulePublishNotificationPrefs() {
+        notifPrefsPublishJob?.cancel()
+        notifPrefsPublishJob = scope.launch {
+            delay(NOTIF_PREFS_PUBLISH_DEBOUNCE_MS)
+            publishNotificationPrefs()
+        }
+    }
+
+    private suspend fun publishNotificationPrefs() {
+        val settings = notificationSettings ?: return
+        val pubKey = sessionManager.getPublicKey() ?: return
+        val signer = ActiveAccountManager.session.value?.signer ?: return
+        val state = settings.muteState.value
+        try {
+            val content = signer.nip44Encrypt(
+                pubKey,
+                Nip78.encodeNotifications(state.defaultLevel, state.overrides),
+            )
+            val event = Event(
+                pubkey = pubKey,
+                createdAt = epochSeconds(),
+                kind = Nip78.KIND_APP_DATA,
+                tags = listOf(listOf("d", Nip78.D_NOTIFICATIONS)),
+                content = content,
+            )
+            val signedEvent = sessionManager.signEvent(event)
+            val eventId = signedEvent.id ?: return
+            val message = buildJsonArray {
+                add("EVENT")
+                add(signedEvent.toJsonObject())
+            }.toString()
+            if (publishToGeneralPurposeRelays(message, eventId) is Result.Success) {
+                notifPrefsCreatedAt = signedEvent.createdAt
+                SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, signedEvent.createdAt)
+            }
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+            // A signer without NIP-44 encryption, or a dead relay set: the levels stay
+            // local and the next change retries. Never fatal to muting itself.
+        }
+    }
+
+    /**
+     * Ingests the account's own kind:30078 notification prefs. Last write wins on
+     * created_at and replaces the whole map, which is what a replaceable event means:
+     * a union-merge would resurrect a group unmuted on another device.
+     */
+    private fun handleKind30078Event(event: JsonObject) {
+        val settings = notificationSettings ?: return
+        val pubKey = sessionManager.getPublicKey() ?: return
+        if (event["pubkey"]?.jsonPrimitive?.contentOrNull != pubKey) return
+        val tags = event["tags"]?.jsonArray.orEmpty().map { tag ->
+            tag.jsonArray.mapNotNull { it.jsonPrimitive.contentOrNull }
+        }
+        val dTag = tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1)
+        if (dTag != Nip78.D_NOTIFICATIONS) return
+        val createdAt = event["created_at"]?.jsonPrimitive?.longOrNull ?: 0L
+        // <=, not <: a same-second replay carries no new information, and applying it
+        // would fight a local change made in that same second.
+        if (createdAt <= notifPrefsCreatedAt) return
+        val content = event["content"]?.jsonPrimitive?.contentOrNull ?: return
+        if (content.isBlank()) return
+        // Decrypt off the ingest path: a bunker signer is a remote round-trip.
+        scope.launch {
+            val signer = ActiveAccountManager.session.value?.signer ?: return@launch
+            val plaintext =
+                try {
+                    signer.nip44Decrypt(pubKey, content)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (_: Throwable) {
+                    return@launch
+                }
+            val decoded = Nip78.decodeNotifications(plaintext) ?: return@launch
+            // Superseded while decrypting (newer event, account switch): drop it.
+            if (createdAt <= notifPrefsCreatedAt) return@launch
+            if (sessionManager.getPublicKey() != pubKey) return@launch
+            notifPrefsCreatedAt = createdAt
+            SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, createdAt)
+            notifPrefsApplyingRemote = true
+            try {
+                settings.applyRemoteGroupLevels(decoded.groupLevels)
+            } finally {
+                notifPrefsApplyingRemote = false
+            }
+        }
+    }
+
+    /**
+     * Publishes a signed replaceable event to the account's general-purpose relays.
+     *
+     * Same routing as kind:3: write + bootstrap relays, never the NIP-29 relays (they
+     * don't serve replaceable lists back). Succeeds if any one relay accepts.
+     */
+    private suspend fun publishToGeneralPurposeRelays(
+        message: String,
+        eventId: String,
+    ): Result<Unit> {
+        val nip29Relays = outboxManager.kind10009Relays.value + connectionManager.currentRelayUrl.value
+        val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays)
+            .distinct()
+            .filter { it !in nip29Relays }
+        val clients = targets.mapNotNull { relayUrl ->
+            connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }
+                ?: connectionManager.getOrConnectRelay(relayUrl, metadataMessageHandler)?.takeIf { it.isConnected() }
+        }
+        if (clients.isEmpty()) {
+            return Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
+        }
+        val results = clients.map { client ->
+            scope.async { client.sendAndAwaitOkOrError(message, eventId) }
+        }.awaitAll()
+        if (results.none { it is PublishResult.Success }) {
+            return Result.Error(AppError.Network.PublishRejected(results.summarizeFailures()))
+        }
+        return Result.Success(Unit)
+    }
+
     /** Seed the mute state from the per-account snapshot so filtering works before the network answers. */
     private fun hydrateMuteListFromCache(pubkey: String) {
         muteListCreatedAt = SecureStorage.loadKind10000TimestampFor(pubkey)
@@ -1066,6 +1235,7 @@ class NostrRepository(
                 if (pubkey != null) {
                     unreadManager.initialize(pubkey)
                     notificationSettings?.initialize(pubkey)
+                    startNotificationPrefsSync(pubkey)
                     notificationHistoryStore?.initialize(pubkey)
                     hydrateMuteListFromCache(pubkey)
                     initializeOutboxModel()
@@ -1133,6 +1303,7 @@ class NostrRepository(
                 groupManager.migrateMessageBlobsToCache(pubkey)
                 unreadManager.initialize(pubkey)
                 notificationSettings?.initialize(pubkey)
+                startNotificationPrefsSync(pubkey)
                 notificationHistoryStore?.initialize(pubkey)
                 hydrateMuteListFromCache(pubkey)
                 // Arm catch-up so the first mux refresh after connect replays
@@ -1492,6 +1663,7 @@ class NostrRepository(
             }
             unreadManager.initialize(newPubkey)
             notificationSettings?.initialize(newPubkey)
+            startNotificationPrefsSync(newPubkey)
             notificationHistoryStore?.initialize(newPubkey)
             hydrateMuteListFromCache(newPubkey)
             // Arm catch-up so the first mux refresh after connect() replays the
@@ -1546,6 +1718,7 @@ class NostrRepository(
         groupManager.clear()
         unreadManager.clear()
         notificationSettings?.clear()
+        stopNotificationPrefsSync()
         notificationHistoryStore?.clear()
         liveCursorStore?.clear()
         relayPipelines.values.forEach { (_, pipeline) -> pipeline.close() }
@@ -4096,25 +4269,8 @@ class NostrRepository(
                     add(signedEvent.toJsonObject())
                 }.toString()
 
-                // Same routing as kind:3: general-purpose relays only, never NIP-29 relays
-                // (they don't serve replaceable lists back).
-                val nip29Relays = outboxManager.kind10009Relays.value + connectionManager.currentRelayUrl.value
-                val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays)
-                    .distinct()
-                    .filter { it !in nip29Relays }
-                val clients = targets.mapNotNull { relayUrl ->
-                    connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }
-                        ?: connectionManager.getOrConnectRelay(relayUrl, metadataMessageHandler)?.takeIf { it.isConnected() }
-                }
-                if (clients.isEmpty()) {
-                    return@withLock Result.Error(AppError.Network.Disconnected(connectionManager.currentRelayUrl.value))
-                }
-                val results = clients.map { client ->
-                    scope.async { client.sendAndAwaitOkOrError(message, eventId) }
-                }.awaitAll()
-                if (results.none { it is PublishResult.Success }) {
-                    return@withLock Result.Error(AppError.Network.PublishRejected(results.summarizeFailures()))
-                }
+                val publish = publishToGeneralPurposeRelays(message, eventId)
+                if (publish is Result.Error) return@withLock publish
 
                 muteListCreatedAt = signedEvent.createdAt
                 muteListPublicTags = newPublicTags
@@ -4711,6 +4867,10 @@ class NostrRepository(
             }
             if (kind == org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST) {
                 handleKind10000Event(event)
+                return
+            }
+            if (kind == Nip78.KIND_APP_DATA) {
+                handleKind30078Event(event)
                 return
             }
             // NIP-17 DM gift wrap addressed to us: decrypt with the active signer.
@@ -5394,6 +5554,12 @@ class NostrRepository(
                 // Handle kind:10000 (NIP-51 mute list) for the active account
                 if (kind == org.nostr.nostrord.nostr.Nip51.KIND_MUTE_LIST) {
                     handleKind10000Event(event)
+                    return
+                }
+
+                // NIP-78 per-group notification levels from another device.
+                if (kind == Nip78.KIND_APP_DATA) {
+                    handleKind30078Event(event)
                     return
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -71,6 +71,7 @@ import org.nostr.nostrord.storage.getLastActiveAt
 import org.nostr.nostrord.storage.isDmCacheMigratedFor
 import org.nostr.nostrord.storage.isGroupFetchLazy
 import org.nostr.nostrord.storage.isKind10009RepublishPendingFor
+import org.nostr.nostrord.storage.isNotifPrefsPendingFor
 import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
@@ -95,6 +96,7 @@ import org.nostr.nostrord.storage.saveGroupFetchLazy
 import org.nostr.nostrord.storage.saveKind10000TimestampFor
 import org.nostr.nostrord.storage.saveKind30078TimestampFor
 import org.nostr.nostrord.storage.saveMuteListSnapshotFor
+import org.nostr.nostrord.storage.saveNotifPrefsPendingFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
 import org.nostr.nostrord.utils.AppError
@@ -119,8 +121,12 @@ private const val GIFT_WRAP_BACKDATE_SECONDS = 2L * 24 * 60 * 60
 // last minute proves the socket is alive; below this, probing is pure overhead.
 private const val FOREGROUND_PROBE_MIN_SILENCE_MS = 60_000L
 
-/** Coalescing window for kind:30078 notification-prefs publishes: a burst of toggles is one event. */
-private const val NOTIF_PREFS_PUBLISH_DEBOUNCE_MS = 3_000L
+/**
+ * Coalescing window for kind:30078 notification-prefs publishes: a burst of toggles is
+ * one event. Short on purpose — with a NIP-07 or bunker signer this is the delay before
+ * the signing prompt appears, and anything longer reads as a popup out of nowhere.
+ */
+private const val NOTIF_PREFS_PUBLISH_DEBOUNCE_MS = 600L
 
 /**
  * Repository for Nostr operations.
@@ -781,6 +787,15 @@ class NostrRepository(
     /** True while a relay's payload is being written into the settings, so the echo doesn't republish it. */
     private var notifPrefsApplyingRemote = false
 
+    /**
+     * A local change that has not reached a relay: the signer declined, was unavailable,
+     * or every relay rejected. Muting is a local preference first, so the change stands
+     * either way, but while this is set an incoming remote event must NOT overwrite it
+     * (the other device's list is older than what the user just did here) and the next
+     * opportunity retries the publish.
+     */
+    private var notifPrefsUnpublished = false
+
     private var notifPrefsPublishJob: Job? = null
     private var notifPrefsWatchJob: Job? = null
 
@@ -794,13 +809,18 @@ class NostrRepository(
         notifPrefsWatchJob?.cancel()
         notifPrefsPublishJob?.cancel()
         notifPrefsCreatedAt = SecureStorage.loadKind30078TimestampFor(pubkey, Nip78.D_NOTIFICATIONS)
+        notifPrefsUnpublished = SecureStorage.isNotifPrefsPendingFor(pubkey)
         notifPrefsWatchJob = scope.launch {
             // drop(1): the current value is what initialize() just loaded from disk, not a change.
             settings.muteState.drop(1).collect {
                 if (notifPrefsApplyingRemote) return@collect
+                markNotifPrefsUnpublished(pubkey)
                 schedulePublishNotificationPrefs()
             }
         }
+        // A change from a previous session never made it out (declined prompt, offline):
+        // retry once the session is up rather than leaving it device-local forever.
+        if (notifPrefsUnpublished) schedulePublishNotificationPrefs()
     }
 
     private fun stopNotificationPrefsSync() {
@@ -809,11 +829,19 @@ class NostrRepository(
         notifPrefsPublishJob?.cancel()
         notifPrefsPublishJob = null
         notifPrefsCreatedAt = 0L
+        notifPrefsUnpublished = false
+    }
+
+    private fun markNotifPrefsUnpublished(pubkey: String) {
+        notifPrefsUnpublished = true
+        SecureStorage.saveNotifPrefsPendingFor(pubkey, true)
     }
 
     /**
-     * Coalesces a burst of level changes into one event. Toggling three groups in a row
-     * is one publish, not three replaceable events racing each other at the relay.
+     * Coalesces a burst of level changes into one event, so toggling three groups in a
+     * row is one signature prompt and one replaceable event rather than three racing at
+     * the relay. Kept short: with a NIP-07 or bunker signer this delay is the gap between
+     * the click and the extension's prompt, and a long one reads as an unprompted popup.
      */
     private fun schedulePublishNotificationPrefs() {
         notifPrefsPublishJob?.cancel()
@@ -849,12 +877,20 @@ class NostrRepository(
             if (publishToGeneralPurposeRelays(message, eventId) is Result.Success) {
                 notifPrefsCreatedAt = signedEvent.createdAt
                 SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, signedEvent.createdAt)
+                notifPrefsUnpublished = false
+                SecureStorage.saveNotifPrefsPendingFor(pubKey, false)
+            } else {
+                markNotifPrefsUnpublished(pubKey)
+                AppModule.postSystemMessage("Mute saved on this device. Could not reach a relay to sync it.")
             }
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (_: Throwable) {
-            // A signer without NIP-44 encryption, or a dead relay set: the levels stay
-            // local and the next change retries. Never fatal to muting itself.
+            // Declined prompt, a signer without NIP-44, or a dead relay set. The levels
+            // stand locally; say so instead of failing silently, and retry on the next
+            // change or the next session.
+            markNotifPrefsUnpublished(pubKey)
+            AppModule.postSystemMessage("Mute saved on this device only. Approve the signing request to sync it.")
         }
     }
 
@@ -872,6 +908,10 @@ class NostrRepository(
         }
         val dTag = tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1)
         if (dTag != Nip78.D_NOTIFICATIONS) return
+        // A local change is still waiting to be signed/published: it is newer than
+        // anything a relay can hand back, so applying this would undo the mute the user
+        // just made. Keep ours; the pending publish supersedes the event.
+        if (notifPrefsUnpublished) return
         val createdAt = event["created_at"]?.jsonPrimitive?.longOrNull ?: 0L
         // <=, not <: a same-second replay carries no new information, and applying it
         // would fight a local change made in that same second.
@@ -890,8 +930,9 @@ class NostrRepository(
                     return@launch
                 }
             val decoded = Nip78.decodeNotifications(plaintext) ?: return@launch
-            // Superseded while decrypting (newer event, account switch): drop it.
+            // Superseded while decrypting (newer event, local change, account switch).
             if (createdAt <= notifPrefsCreatedAt) return@launch
+            if (notifPrefsUnpublished) return@launch
             if (sessionManager.getPublicKey() != pubKey) return@launch
             notifPrefsCreatedAt = createdAt
             SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, createdAt)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -128,15 +128,18 @@ private const val FOREGROUND_PROBE_MIN_SILENCE_MS = 60_000L
 private const val NOTIF_PREFS_PUBLISH_DEBOUNCE_MS = 600L
 
 /** Floor between focus-driven kind:30078 re-fetches, so window flipping can't spam relays. */
-private const val NOTIF_PREFS_FETCH_MIN_INTERVAL_S = 10L
+private const val NOTIF_PREFS_FETCH_MIN_INTERVAL_S = 3L
+
+/** How far back the live kind:30078 filter reaches, to absorb clock skew between devices. */
+private const val NOTIF_PREFS_LIVE_SLACK_S = 300L
 
 /**
- * Safety-net poll for kind:30078 while the app is focused. The standing REQ carries a
- * `limit`, and not every relay keeps pushing new matches on such a filter; desktop also
- * reports no window-focus change when the user clicks over to a browser beside it. One
- * small REQ a minute makes both devices converge regardless.
+ * Backstop poll for kind:30078 while the app is focused. The subscription's `since`
+ * filter is what should deliver a change within a second; this only covers a relay that
+ * drops the subscription, or a desktop window that reports no focus change because the
+ * user clicked over to a browser sitting beside it.
  */
-private const val NOTIF_PREFS_TICK_MS = 60_000L
+private const val NOTIF_PREFS_TICK_MS = 30_000L
 
 /**
  * Repository for Nostr operations.
@@ -887,7 +890,10 @@ class NostrRepository(
             runCatching {
                 val client = connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }
                     ?: connectionManager.getOrConnectRelay(relayUrl, metadataMessageHandler)
-                client?.takeIf { it.isConnected() }?.requestNotificationPrefs(pubKey)
+                // Slack on the live window: the publishing device's clock may sit slightly
+                // behind ours, and an event stamped a few seconds "ago" must not fall
+                // outside the subscription that is supposed to catch it.
+                client?.takeIf { it.isConnected() }?.requestNotificationPrefs(pubKey, now - NOTIF_PREFS_LIVE_SLACK_S)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -872,8 +872,16 @@ class NostrRepository(
     private suspend fun publishNotificationPrefs() {
         val settings = notificationSettings ?: return
         val pubKey = sessionManager.getPublicKey() ?: return
-        val signer = ActiveAccountManager.session.value?.signer ?: return
         val state = settings.muteState.value
+        // No signer yet (session still activating, bunker reconnecting): leave the change
+        // marked pending so the next change or session start retries, and say so rather
+        // than returning silently — a mute that never reached a relay looked identical to
+        // a synced one.
+        val signer = ActiveAccountManager.session.value?.signer ?: run {
+            markNotifPrefsUnpublished(pubKey)
+            AppModule.postSystemMessage("Mute saved on this device. No signer available to sync it yet.")
+            return
+        }
         try {
             val content = signer.nip44Encrypt(
                 pubKey,
@@ -887,7 +895,10 @@ class NostrRepository(
                 content = content,
             )
             val signedEvent = sessionManager.signEvent(event)
-            val eventId = signedEvent.id ?: return
+            val eventId = signedEvent.id ?: run {
+                markNotifPrefsUnpublished(pubKey)
+                return
+            }
             val message = buildJsonArray {
                 add("EVENT")
                 add(signedEvent.toJsonObject())
@@ -2505,6 +2516,10 @@ class NostrRepository(
         // Re-seed the incoming account's mutes so filtering holds through the swap;
         // the network refresh rides the requestContactList() below.
         hydrateMuteListFromCache(pubkey)
+        // Re-arm on the incoming account. A warm swap initializes notificationSettings
+        // from AppModule, not from here, so without this the watcher stays bound to the
+        // previous pubkey and files B's changes under A.
+        startNotificationPrefsSync(pubkey)
         // Same session-cache teardown the full-logout path runs, so a warm swap does not
         // leak account A's restricted-relay / dedup state into account B (which otherwise
         // left B's groups dark until an app restart). Runs BEFORE B's re-derive below.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -72,7 +72,6 @@ import org.nostr.nostrord.storage.getLastActiveAt
 import org.nostr.nostrord.storage.isDmCacheMigratedFor
 import org.nostr.nostrord.storage.isGroupFetchLazy
 import org.nostr.nostrord.storage.isKind10009RepublishPendingFor
-import org.nostr.nostrord.storage.isNotifPrefsPendingFor
 import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
@@ -97,7 +96,6 @@ import org.nostr.nostrord.storage.saveGroupFetchLazy
 import org.nostr.nostrord.storage.saveKind10000TimestampFor
 import org.nostr.nostrord.storage.saveKind30078TimestampFor
 import org.nostr.nostrord.storage.saveMuteListSnapshotFor
-import org.nostr.nostrord.storage.saveNotifPrefsPendingFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
 import org.nostr.nostrord.utils.AppError
@@ -801,14 +799,8 @@ class NostrRepository(
      */
     private var notifPrefsSynced: Map<String, NotificationLevel>? = null
 
-    /**
-     * A local change that has not reached a relay: the signer declined, was unavailable,
-     * or every relay rejected. Muting is a local preference first, so the change stands
-     * either way, but while this is set an incoming remote event must NOT overwrite it
-     * (the other device's list is older than what the user just did here) and the next
-     * opportunity retries the publish.
-     */
-    private var notifPrefsUnpublished = false
+    /** True while a publish is in flight, so an arriving remote event doesn't race it. */
+    private var notifPrefsPublishing = false
 
     private var notifPrefsPublishJob: Job? = null
     private var notifPrefsWatchJob: Job? = null
@@ -822,22 +814,18 @@ class NostrRepository(
         val settings = notificationSettings ?: return
         notifPrefsWatchJob?.cancel()
         notifPrefsPublishJob?.cancel()
+        notifPrefsPublishing = false
         notifPrefsCreatedAt = SecureStorage.loadKind30078TimestampFor(pubkey, Nip78.D_NOTIFICATIONS)
-        notifPrefsUnpublished = SecureStorage.isNotifPrefsPendingFor(pubkey)
-        // What's on disk is what the last session left in agreement with the network,
-        // unless it left a change pending — then nothing is known to be synced.
-        notifPrefsSynced = if (notifPrefsUnpublished) null else settings.muteState.value.overrides
+        // A change only survives once it is published, so whatever is on disk is by
+        // definition the last state that reached the network.
+        notifPrefsSynced = settings.muteState.value.overrides
         notifPrefsWatchJob = scope.launch {
             // drop(1): the current value is what initialize() just loaded from disk, not a change.
             settings.muteState.drop(1).collect { state ->
                 if (state.overrides == notifPrefsSynced) return@collect
-                markNotifPrefsUnpublished(pubkey)
                 schedulePublishNotificationPrefs()
             }
         }
-        // A change from a previous session never made it out (declined prompt, offline):
-        // retry once the session is up rather than leaving it device-local forever.
-        if (notifPrefsUnpublished) schedulePublishNotificationPrefs()
     }
 
     private fun stopNotificationPrefsSync() {
@@ -845,14 +833,22 @@ class NostrRepository(
         notifPrefsWatchJob = null
         notifPrefsPublishJob?.cancel()
         notifPrefsPublishJob = null
+        notifPrefsPublishing = false
         notifPrefsCreatedAt = 0L
-        notifPrefsUnpublished = false
         notifPrefsSynced = null
     }
 
-    private fun markNotifPrefsUnpublished(pubkey: String) {
-        notifPrefsUnpublished = true
-        SecureStorage.saveNotifPrefsPendingFor(pubkey, true)
+    /**
+     * Puts the levels back to the last state that reached the network, after a change
+     * failed to publish. [notifPrefsSynced] already holds that state, so the watcher
+     * sees the restored value as agreed and does not try to publish the undo.
+     */
+    private fun revertNotificationPrefs(reason: String) {
+        val settings = notificationSettings ?: return
+        val synced = notifPrefsSynced ?: return
+        if (settings.muteState.value.overrides == synced) return
+        settings.applyRemoteGroupLevels(synced)
+        AppModule.postSystemMessage(reason)
     }
 
     /**
@@ -869,19 +865,21 @@ class NostrRepository(
         }
     }
 
+    /**
+     * A level change only stands once its kind:30078 is signed and accepted by a relay;
+     * anything else puts the levels back. That is the user's chosen contract: declining
+     * the signing prompt must not leave the app acting on a change it was told not to
+     * make. The cost is that muting with no signer or no reachable relay fails too,
+     * because NIP-07 surfaces a refusal and an error the same way.
+     */
     private suspend fun publishNotificationPrefs() {
         val settings = notificationSettings ?: return
-        val pubKey = sessionManager.getPublicKey() ?: return
+        val pubKey = sessionManager.getPublicKey()
+            ?: return revertNotificationPrefs("Mute undone: not signed in.")
         val state = settings.muteState.value
-        // No signer yet (session still activating, bunker reconnecting): leave the change
-        // marked pending so the next change or session start retries, and say so rather
-        // than returning silently — a mute that never reached a relay looked identical to
-        // a synced one.
-        val signer = ActiveAccountManager.session.value?.signer ?: run {
-            markNotifPrefsUnpublished(pubKey)
-            AppModule.postSystemMessage("Mute saved on this device. No signer available to sync it yet.")
-            return
-        }
+        val signer = ActiveAccountManager.session.value?.signer
+            ?: return revertNotificationPrefs("Mute undone: no signer available to sync it.")
+        notifPrefsPublishing = true
         try {
             val content = signer.nip44Encrypt(
                 pubKey,
@@ -895,10 +893,8 @@ class NostrRepository(
                 content = content,
             )
             val signedEvent = sessionManager.signEvent(event)
-            val eventId = signedEvent.id ?: run {
-                markNotifPrefsUnpublished(pubKey)
-                return
-            }
+            val eventId = signedEvent.id
+                ?: return revertNotificationPrefs("Mute undone: the event could not be signed.")
             val message = buildJsonArray {
                 add("EVENT")
                 add(signedEvent.toJsonObject())
@@ -908,20 +904,17 @@ class NostrRepository(
                 SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, signedEvent.createdAt)
                 // Exactly the snapshot that went out, so our own relay echo is a no-op.
                 notifPrefsSynced = state.overrides
-                notifPrefsUnpublished = false
-                SecureStorage.saveNotifPrefsPendingFor(pubKey, false)
             } else {
-                markNotifPrefsUnpublished(pubKey)
-                AppModule.postSystemMessage("Mute saved on this device. Could not reach a relay to sync it.")
+                revertNotificationPrefs("Mute undone: no relay accepted the change.")
             }
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
         } catch (_: Throwable) {
-            // Declined prompt, a signer without NIP-44, or a dead relay set. The levels
-            // stand locally; say so instead of failing silently, and retry on the next
-            // change or the next session.
-            markNotifPrefsUnpublished(pubKey)
-            AppModule.postSystemMessage("Mute saved on this device only. Approve the signing request to sync it.")
+            // Declined prompt, or a signer that can't NIP-44. Indistinguishable here, and
+            // both mean the change was never agreed to.
+            revertNotificationPrefs("Mute undone: the signing request was not approved.")
+        } finally {
+            notifPrefsPublishing = false
         }
     }
 
@@ -939,10 +932,9 @@ class NostrRepository(
         }
         val dTag = tags.firstOrNull { it.size >= 2 && it[0] == "d" }?.get(1)
         if (dTag != Nip78.D_NOTIFICATIONS) return
-        // A local change is still waiting to be signed/published: it is newer than
-        // anything a relay can hand back, so applying this would undo the mute the user
-        // just made. Keep ours; the pending publish supersedes the event.
-        if (notifPrefsUnpublished) return
+        // A publish is mid-flight (the user may be staring at a signing prompt): let it
+        // settle rather than applying a payload it is about to supersede or be reverted to.
+        if (notifPrefsPublishing) return
         val createdAt = event["created_at"]?.jsonPrimitive?.longOrNull ?: 0L
         // <=, not <: a same-second replay carries no new information, and applying it
         // would fight a local change made in that same second.
@@ -963,7 +955,7 @@ class NostrRepository(
             val decoded = Nip78.decodeNotifications(plaintext) ?: return@launch
             // Superseded while decrypting (newer event, local change, account switch).
             if (createdAt <= notifPrefsCreatedAt) return@launch
-            if (notifPrefsUnpublished) return@launch
+            if (notifPrefsPublishing) return@launch
             if (sessionManager.getPublicKey() != pubKey) return@launch
             notifPrefsCreatedAt = createdAt
             SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, createdAt)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -127,6 +127,17 @@ private const val FOREGROUND_PROBE_MIN_SILENCE_MS = 60_000L
  */
 private const val NOTIF_PREFS_PUBLISH_DEBOUNCE_MS = 600L
 
+/** Floor between focus-driven kind:30078 re-fetches, so window flipping can't spam relays. */
+private const val NOTIF_PREFS_FETCH_MIN_INTERVAL_S = 10L
+
+/**
+ * Safety-net poll for kind:30078 while the app is focused. The standing REQ carries a
+ * `limit`, and not every relay keeps pushing new matches on such a filter; desktop also
+ * reports no window-focus change when the user clicks over to a browser beside it. One
+ * small REQ a minute makes both devices converge regardless.
+ */
+private const val NOTIF_PREFS_TICK_MS = 60_000L
+
 /**
  * Repository for Nostr operations.
  * Coordinates between specialized managers for different concerns.
@@ -804,6 +815,8 @@ class NostrRepository(
 
     private var notifPrefsPublishJob: Job? = null
     private var notifPrefsWatchJob: Job? = null
+    private var notifPrefsFocusJob: Job? = null
+    private var notifPrefsTickJob: Job? = null
 
     /**
      * Starts mirroring the account's per-group notification levels to kind:30078.
@@ -826,11 +839,66 @@ class NostrRepository(
                 schedulePublishNotificationPrefs()
             }
         }
+        notifPrefsFocusJob?.cancel()
+        notifPrefsFocusJob = scope.launch {
+            // Pull on every focus gain, so switching to this device shows what another one
+            // changed. drop(1) skips the tracker's current value; the initial fetch below
+            // covers startup. Web hooks real window focus/blur, which is what makes two
+            // apps side by side converge on a click; desktop only reports lifecycle stops,
+            // hence the tick below.
+            AppModule.focusTracker.isAppFocused.drop(1).collect { focused ->
+                if (focused) refreshNotificationPrefs()
+            }
+        }
+        notifPrefsTickJob?.cancel()
+        notifPrefsTickJob = scope.launch {
+            refreshNotificationPrefs()
+            while (true) {
+                delay(NOTIF_PREFS_TICK_MS)
+                // Only while the user is here: a backgrounded app converges on its next
+                // focus instead of polling relays it isn't showing.
+                if (AppModule.focusTracker.isAppFocused.value) refreshNotificationPrefs()
+            }
+        }
+    }
+
+    // Throttle for the focus-driven kind:30078 re-fetch (seconds).
+    private var lastNotifPrefsFetchAt = 0L
+
+    /**
+     * Re-request the account's kind:30078 from the general-purpose relays.
+     *
+     * A standing REQ is not enough on its own: the filter carries a `limit`, and whether
+     * a relay keeps pushing new matches afterwards is not something to depend on. This
+     * runs whenever the window regains focus, which is the moment the user looks at this
+     * device after changing something on another one — including two apps open side by
+     * side, where the browser's visibilitychange never fires.
+     */
+    private suspend fun refreshNotificationPrefs() {
+        val pubKey = sessionManager.getPublicKey() ?: return
+        val now = epochSeconds()
+        if (now - lastNotifPrefsFetchAt < NOTIF_PREFS_FETCH_MIN_INTERVAL_S) return
+        lastNotifPrefsFetchAt = now
+        val nip29Relays = outboxManager.kind10009Relays.value + connectionManager.currentRelayUrl.value
+        val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays)
+            .distinct()
+            .filter { it !in nip29Relays }
+        targets.forEach { relayUrl ->
+            runCatching {
+                val client = connectionManager.getClientForRelay(relayUrl)?.takeIf { it.isConnected() }
+                    ?: connectionManager.getOrConnectRelay(relayUrl, metadataMessageHandler)
+                client?.takeIf { it.isConnected() }?.requestNotificationPrefs(pubKey)
+            }
+        }
     }
 
     private fun stopNotificationPrefsSync() {
         notifPrefsWatchJob?.cancel()
         notifPrefsWatchJob = null
+        notifPrefsFocusJob?.cancel()
+        notifPrefsFocusJob = null
+        notifPrefsTickJob?.cancel()
+        notifPrefsTickJob = null
         notifPrefsPublishJob?.cancel()
         notifPrefsPublishJob = null
         notifPrefsPublishing = false

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -62,6 +62,7 @@ import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip78
+import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.DM_CACHE_KIND
@@ -784,8 +785,21 @@ class NostrRepository(
 
     private var notifPrefsCreatedAt = 0L
 
-    /** True while a relay's payload is being written into the settings, so the echo doesn't republish it. */
-    private var notifPrefsApplyingRemote = false
+    /**
+     * The override map as last agreed with the network: what this device published, or
+     * what it last accepted from another one. A change is only worth publishing when it
+     * differs from this.
+     *
+     * This is a content comparison rather than an "applying remote" flag on purpose.
+     * Writing an ingested payload into the settings makes [NotificationSettings.muteState]
+     * emit, and the watcher below observes that emission from another coroutine — after
+     * the ingest has already returned. Any flag raised around the write is back down by
+     * then, so the echo would be republished, prompting the signer on a device that only
+     * received the change and bouncing the event back to its origin.
+     *
+     * Null means "unknown", which makes the next change publish.
+     */
+    private var notifPrefsSynced: Map<String, NotificationLevel>? = null
 
     /**
      * A local change that has not reached a relay: the signer declined, was unavailable,
@@ -810,10 +824,13 @@ class NostrRepository(
         notifPrefsPublishJob?.cancel()
         notifPrefsCreatedAt = SecureStorage.loadKind30078TimestampFor(pubkey, Nip78.D_NOTIFICATIONS)
         notifPrefsUnpublished = SecureStorage.isNotifPrefsPendingFor(pubkey)
+        // What's on disk is what the last session left in agreement with the network,
+        // unless it left a change pending — then nothing is known to be synced.
+        notifPrefsSynced = if (notifPrefsUnpublished) null else settings.muteState.value.overrides
         notifPrefsWatchJob = scope.launch {
             // drop(1): the current value is what initialize() just loaded from disk, not a change.
-            settings.muteState.drop(1).collect {
-                if (notifPrefsApplyingRemote) return@collect
+            settings.muteState.drop(1).collect { state ->
+                if (state.overrides == notifPrefsSynced) return@collect
                 markNotifPrefsUnpublished(pubkey)
                 schedulePublishNotificationPrefs()
             }
@@ -830,6 +847,7 @@ class NostrRepository(
         notifPrefsPublishJob = null
         notifPrefsCreatedAt = 0L
         notifPrefsUnpublished = false
+        notifPrefsSynced = null
     }
 
     private fun markNotifPrefsUnpublished(pubkey: String) {
@@ -877,6 +895,8 @@ class NostrRepository(
             if (publishToGeneralPurposeRelays(message, eventId) is Result.Success) {
                 notifPrefsCreatedAt = signedEvent.createdAt
                 SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, signedEvent.createdAt)
+                // Exactly the snapshot that went out, so our own relay echo is a no-op.
+                notifPrefsSynced = state.overrides
                 notifPrefsUnpublished = false
                 SecureStorage.saveNotifPrefsPendingFor(pubKey, false)
             } else {
@@ -936,12 +956,10 @@ class NostrRepository(
             if (sessionManager.getPublicKey() != pubKey) return@launch
             notifPrefsCreatedAt = createdAt
             SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, createdAt)
-            notifPrefsApplyingRemote = true
-            try {
-                settings.applyRemoteGroupLevels(decoded.groupLevels)
-            } finally {
-                notifPrefsApplyingRemote = false
-            }
+            // Recorded BEFORE the write: applying it makes muteState emit, and the watcher
+            // must already see this payload as the agreed state or it republishes it.
+            notifPrefsSynced = decoded.groupLevels
+            settings.applyRemoteGroupLevels(decoded.groupLevels)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip78.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip78.kt
@@ -1,0 +1,74 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.nostr.nostrord.settings.NotificationLevel
+
+/**
+ * NIP-78 application-specific data (kind:30078): an addressable event whose `d` tag
+ * names the setting and whose content carries its value.
+ *
+ * Nostrord uses it for per-group notification levels, so muting a group follows the
+ * account to its other devices. The payload is NIP-44 self-encrypted before it is
+ * published: the ids inside are NIP-29 group ids, and a plaintext list of them would
+ * hand any relay the account's group membership.
+ */
+object Nip78 {
+    const val KIND_APP_DATA = 30078
+
+    /** `d` tag of the notification-preferences event. Versioned so a future shape can coexist. */
+    const val D_NOTIFICATIONS = "nostrord.notifications.v1"
+
+    /**
+     * `default` records the publishing device's global default for context. Ingest reads
+     * it but callers do not apply it: that setting's storage slot is device-global rather
+     * than per-account, so one account's event must not rewrite it.
+     */
+    @Serializable
+    data class NotificationPayload(
+        @SerialName("v") val version: Int = 1,
+        @SerialName("default") val defaultLevel: String = NotificationLevel.ALL.name,
+        @SerialName("groups") val groups: Map<String, String> = emptyMap(),
+    )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun encodeNotifications(
+        defaultLevel: NotificationLevel,
+        groupLevels: Map<String, NotificationLevel>,
+    ): String = json.encodeToString(
+        NotificationPayload(
+            defaultLevel = defaultLevel.name,
+            groups = groupLevels.mapValues { it.value.name },
+        ),
+    )
+
+    /**
+     * Parses a decrypted payload. Returns null for anything unreadable so a corrupt or
+     * future-shaped event leaves the local settings alone instead of wiping them.
+     * Unknown level names are dropped per-entry: a newer client's extra level must not
+     * take the whole map down with it.
+     */
+    fun decodeNotifications(plaintext: String): DecodedNotifications? {
+        val payload =
+            try {
+                json.decodeFromString<NotificationPayload>(plaintext)
+            } catch (_: Exception) {
+                return null
+            }
+        if (payload.version != 1) return null
+        val default = levelOrNull(payload.defaultLevel) ?: NotificationLevel.ALL
+        val groups = payload.groups.mapNotNull { (id, name) ->
+            levelOrNull(name)?.let { id to it }
+        }.toMap()
+        return DecodedNotifications(default, groups)
+    }
+
+    private fun levelOrNull(name: String): NotificationLevel? = NotificationLevel.entries.firstOrNull { it.name == name }
+
+    data class DecodedNotifications(
+        val defaultLevel: NotificationLevel,
+        val groupLevels: Map<String, NotificationLevel>,
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
@@ -135,6 +135,22 @@ class NotificationSettings {
         )
     }
 
+    /**
+     * Installs the per-group levels carried by a newer kind:30078 from another device.
+     * Replaces the whole override map rather than merging: the event is replaceable, and
+     * a merge would resurrect a group the other device just unmuted.
+     *
+     * [defaultLevel] is deliberately not synced. Its storage slot is device-global, not
+     * per-account, so letting one account's event write it would hand the next account
+     * that device's default too.
+     */
+    fun applyRemoteGroupLevels(groups: Map<String, NotificationLevel>) {
+        val pubkey = currentPubkey ?: return
+        _groupLevels.value = groups
+        syncMuteState()
+        SecureStorage.saveGroupNotificationLevelsFor(pubkey, groups.mapValues { it.value.name })
+    }
+
     /** Drops a group's override so it tracks [defaultLevel] again. */
     fun clearGroupLevel(groupId: String) {
         val pubkey = currentPubkey ?: return

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
@@ -17,10 +17,26 @@ import org.nostr.nostrord.storage.saveGroupNotificationLevelsFor
  *   user's own messages notify. Ordinary chatter is silent.
  * - [MUTED] — nothing notifies, not even direct mentions/replies.
  *
- * Unread badges are independent of this setting: a quiet or muted group still
- * accumulates its unread count, it just doesn't fire the feed/sound/popup.
+ * [MENTIONS_REPLIES] still shows the unread count; only the feed/sound/popup is
+ * skipped. [MUTED] additionally drops the group out of the rail and total badge
+ * rollups, so a muted group reads as a dim dot rather than a number. The count is
+ * still tracked internally, so the unread divider and jump-to-unread keep working
+ * once the group is opened.
  */
 enum class NotificationLevel { ALL, MENTIONS_REPLIES, MUTED }
+
+/**
+ * An immutable snapshot of "how loud is each group", published as one flow so a
+ * consumer resolves a group's level without racing the default against the overrides.
+ */
+data class MuteState(
+    val defaultLevel: NotificationLevel = NotificationLevel.ALL,
+    val overrides: Map<String, NotificationLevel> = emptyMap(),
+) {
+    fun levelFor(groupId: String): NotificationLevel = overrides[groupId] ?: defaultLevel
+
+    fun isMuted(groupId: String): Boolean = levelFor(groupId) == NotificationLevel.MUTED
+}
 
 /**
  * User-facing notification preferences — toggled from Settings → Notifications.
@@ -60,7 +76,16 @@ class NotificationSettings {
     private val _groupLevels = MutableStateFlow<Map<String, NotificationLevel>>(emptyMap())
     val groupLevels: StateFlow<Map<String, NotificationLevel>> = _groupLevels.asStateFlow()
 
+    // Default + overrides as one value, for consumers that resolve a group's level
+    // reactively (badge rollups, muted styling) and must not see the two halves apart.
+    private val _muteState = MutableStateFlow(MuteState(_defaultLevel.value))
+    val muteState: StateFlow<MuteState> = _muteState.asStateFlow()
+
     private var currentPubkey: String? = null
+
+    private fun syncMuteState() {
+        _muteState.value = MuteState(_defaultLevel.value, _groupLevels.value)
+    }
 
     fun setSoundEnabled(enabled: Boolean) {
         _soundEnabled.value = enabled
@@ -75,6 +100,7 @@ class NotificationSettings {
     fun setDefaultLevel(level: NotificationLevel) {
         _defaultLevel.value = level
         SecureStorage.saveStringPref(KEY_DEFAULT_LEVEL, level.name)
+        syncMuteState()
     }
 
     /** Load the active account's per-group overrides. Call on account activation. */
@@ -86,12 +112,14 @@ class NotificationSettings {
                     runCatching { id to NotificationLevel.valueOf(name) }.getOrNull()
                 }
                 .toMap()
+        syncMuteState()
     }
 
     /** Drop the active account's overrides on logout / account switch. */
     fun clear() {
         currentPubkey = null
         _groupLevels.value = emptyMap()
+        syncMuteState()
     }
 
     fun setGroupLevel(
@@ -100,6 +128,32 @@ class NotificationSettings {
     ) {
         val pubkey = currentPubkey ?: return
         _groupLevels.update { it + (groupId to level) }
+        syncMuteState()
+        SecureStorage.saveGroupNotificationLevelsFor(
+            pubkey,
+            _groupLevels.value.mapValues { it.value.name },
+        )
+    }
+
+    /**
+     * One-click mute from a group row. Unmuting returns the group to the global
+     * default rather than pinning it to [NotificationLevel.ALL], so a later change
+     * of the default still reaches it.
+     */
+    fun toggleMute(groupId: String) {
+        val pubkey = currentPubkey ?: return
+        _groupLevels.update {
+            if (isMuted(groupId)) {
+                if (_defaultLevel.value == NotificationLevel.MUTED) {
+                    it + (groupId to NotificationLevel.ALL)
+                } else {
+                    it - groupId
+                }
+            } else {
+                it + (groupId to NotificationLevel.MUTED)
+            }
+        }
+        syncMuteState()
         SecureStorage.saveGroupNotificationLevelsFor(
             pubkey,
             _groupLevels.value.mapValues { it.value.name },
@@ -107,6 +161,8 @@ class NotificationSettings {
     }
 
     fun effectiveLevelFor(groupId: String): NotificationLevel = _groupLevels.value[groupId] ?: _defaultLevel.value
+
+    fun isMuted(groupId: String): Boolean = effectiveLevelFor(groupId) == NotificationLevel.MUTED
 
     /**
      * Whether a notification should fire for a message of the given [level].

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/NotificationSettings.kt
@@ -135,6 +135,17 @@ class NotificationSettings {
         )
     }
 
+    /** Drops a group's override so it tracks [defaultLevel] again. */
+    fun clearGroupLevel(groupId: String) {
+        val pubkey = currentPubkey ?: return
+        _groupLevels.update { it - groupId }
+        syncMuteState()
+        SecureStorage.saveGroupNotificationLevelsFor(
+            pubkey,
+            _groupLevels.value.mapValues { it.value.name },
+        )
+    }
+
     /**
      * One-click mute from a group row. Unmuting returns the group to the global
      * default rather than pinning it to [NotificationLevel.ALL], so a later change

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1243,21 +1243,6 @@ fun SecureStorage.loadKind30078TimestampFor(
     return getStringPref(kind30078TimestampKey(pubkey, dTag), "0").toLongOrNull() ?: 0L
 }
 
-// Set while a local notification-prefs change has not reached a relay (the signer
-// declined, was unavailable, or every relay rejected). Survives a restart so the
-// change is retried instead of silently staying device-local.
-private fun notifPrefsPendingKey(pubkey: String): String = "notif_prefs_pending_${pubkeyDigest(pubkey)}"
-
-fun SecureStorage.saveNotifPrefsPendingFor(
-    pubkey: String,
-    pending: Boolean,
-) {
-    if (pubkey.isBlank()) return
-    saveStringPref(notifPrefsPendingKey(pubkey), if (pending) "true" else "")
-}
-
-fun SecureStorage.isNotifPrefsPendingFor(pubkey: String): Boolean = pubkey.isNotBlank() && getStringPref(notifPrefsPendingKey(pubkey), "") == "true"
-
 // Per-account "last active" timestamp in Unix seconds. Written when the user
 // switches away from this account and as a periodic heartbeat while active so
 // it survives crashes. Used to compute the catch-up `since` for notification

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1243,6 +1243,21 @@ fun SecureStorage.loadKind30078TimestampFor(
     return getStringPref(kind30078TimestampKey(pubkey, dTag), "0").toLongOrNull() ?: 0L
 }
 
+// Set while a local notification-prefs change has not reached a relay (the signer
+// declined, was unavailable, or every relay rejected). Survives a restart so the
+// change is retried instead of silently staying device-local.
+private fun notifPrefsPendingKey(pubkey: String): String = "notif_prefs_pending_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.saveNotifPrefsPendingFor(
+    pubkey: String,
+    pending: Boolean,
+) {
+    if (pubkey.isBlank()) return
+    saveStringPref(notifPrefsPendingKey(pubkey), if (pending) "true" else "")
+}
+
+fun SecureStorage.isNotifPrefsPendingFor(pubkey: String): Boolean = pubkey.isNotBlank() && getStringPref(notifPrefsPendingKey(pubkey), "") == "true"
+
 // Per-account "last active" timestamp in Unix seconds. Written when the user
 // switches away from this account and as a periodic heartbeat while active so
 // it survives crashes. Used to compute the catch-up `since` for notification

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1218,6 +1218,31 @@ fun SecureStorage.saveGroupNotificationLevelsFor(
     }
 }
 
+// Freshness floor for a NIP-78 (kind:30078) app-data event, per account and `d` tag.
+// A lagging relay replaying an older prefs event can't undo a change made in a
+// previous session.
+private fun kind30078TimestampKey(
+    pubkey: String,
+    dTag: String,
+): String = "kind30078_ts_${dTag}_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.saveKind30078TimestampFor(
+    pubkey: String,
+    dTag: String,
+    timestamp: Long,
+) {
+    if (pubkey.isBlank()) return
+    saveStringPref(kind30078TimestampKey(pubkey, dTag), timestamp.toString())
+}
+
+fun SecureStorage.loadKind30078TimestampFor(
+    pubkey: String,
+    dTag: String,
+): Long {
+    if (pubkey.isBlank()) return 0L
+    return getStringPref(kind30078TimestampKey(pubkey, dTag), "0").toLongOrNull() ?: 0L
+}
+
 // Per-account "last active" timestamp in Unix seconds. Written when the user
 // switches away from this account and as a periodic heartbeat while active so
 // it survives crashes. Used to compute the catch-up `since` for notification

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTree.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTree.kt
@@ -64,6 +64,25 @@ fun aggregateUnread(
     unreadCounts: Map<String, Int>,
 ): Int = channelTree(rootId, childrenByParent, emptyMap()).sumOf { unreadCounts[it.id] ?: 0 }
 
+/**
+ * [aggregateUnread] with muted subtrees removed, for badge rollups. Muting a root
+ * silences its whole tree (its channels are part of the same "server"); inside a live
+ * root, an individually muted channel drops out on its own. The underlying counts stay
+ * tracked either way, so opening a muted group still lands on its unread divider.
+ */
+fun aggregateUnreadUnmuted(
+    rootId: String,
+    childrenByParent: Map<String, Set<String>>,
+    unreadCounts: Map<String, Int>,
+    isMuted: (String) -> Boolean,
+): Int = if (isMuted(rootId)) {
+    0
+} else {
+    channelTree(rootId, childrenByParent, emptyMap())
+        .filterNot { isMuted(it.id) }
+        .sumOf { unreadCounts[it.id] ?: 0 }
+}
+
 /** A channel the user can see but not read/post without joining (private or closed, not a member). */
 fun isLockedChannel(meta: GroupMetadata?, isJoined: Boolean): Boolean = !isJoined && meta != null && (!meta.isPublic || !meta.isOpen)
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
@@ -27,10 +27,12 @@ import org.nostr.nostrord.network.UserGroupRef
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.notifications.NotificationHistoryStore
+import org.nostr.nostrord.settings.MuteState
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.loadFollowingCacheFor
 import org.nostr.nostrord.storage.saveFollowingCacheFor
 import org.nostr.nostrord.ui.screens.group.aggregateUnread
+import org.nostr.nostrord.ui.screens.group.aggregateUnreadUnmuted
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
@@ -128,6 +130,10 @@ class HomePageViewModel(
     // test dispatcher: with the real Default here, advanceUntilIdle can't see the transform's
     // in-flight work and the assertion races it.
     private val computeDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    // Per-group notification levels, for the badge rollups. Taken as a flow rather than the
+    // whole settings object so a test drives mute state without touching SecureStorage;
+    // the default silences nothing.
+    private val muteState: StateFlow<MuteState> = MutableStateFlow(MuteState()),
 ) : ViewModel() {
     private val _query = MutableStateFlow("")
     val query: StateFlow<String> = _query.asStateFlow()
@@ -332,12 +338,26 @@ class HomePageViewModel(
 
     /**
      * Rail badge counts: each root's own unread plus all its descendant channels', so a
-     * message in a subgroup still surfaces when the group is closed.
+     * message in a subgroup still surfaces when the group is closed. Muted groups report
+     * zero here and surface through [railMutedActivity] as a dot instead.
      */
     val railUnreadCounts: StateFlow<Map<String, Int>> =
-        combine(railRootGroups, repo.childrenByParent, repo.unreadCounts) { roots, children, unread ->
-            roots.associate { it.meta.id to aggregateUnread(it.meta.id, children, unread) }
+        combine(railRootGroups, repo.childrenByParent, repo.unreadCounts, muteState) { roots, children, unread, mute ->
+            roots.associate { it.meta.id to aggregateUnreadUnmuted(it.meta.id, children, unread, mute::isMuted) }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
+
+    /**
+     * Muted rail entries that have unread traffic behind the silence. The rail marks these
+     * with a dim dot: no number (that is the point of muting) but still a hint that the
+     * group moved.
+     */
+    val railMutedActivity: StateFlow<Set<String>> =
+        combine(railRootGroups, repo.childrenByParent, repo.unreadCounts, muteState) { roots, children, unread, mute ->
+            roots.mapNotNullTo(HashSet()) { root ->
+                val id = root.meta.id
+                id.takeIf { aggregateUnreadUnmuted(id, children, unread, mute::isMuted) == 0 && aggregateUnread(id, children, unread) > 0 }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
 
     /**
      * The Home page's "My groups" list. Without a query: root groups only (same predicate

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedGroupsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedGroupsViewModel.kt
@@ -38,15 +38,17 @@ class MutedGroupsViewModel(
      */
     val rows: StateFlow<List<MutedGroupRow>> =
         combine(settings.groupLevels, repo.groupsByRelay, repo.joinedGroupsByRelay) { levels, byRelay, joined ->
-            val located = buildMap {
-                joined.forEach { (relayUrl, ids) ->
-                    byRelay[relayUrl].orEmpty().forEach { meta ->
-                        if (meta.id in ids) putIfAbsent(meta.id, relayUrl to meta)
-                    }
+            // First relay wins for a same-id group joined twice: the panel is keyed by the
+            // bare id the override itself uses, so it can only point at one of them.
+            val located = mutableMapOf<String, Pair<String, GroupMetadata>>()
+            joined.forEach { (relayUrl, ids) ->
+                byRelay[relayUrl].orEmpty().forEach { meta ->
+                    if (meta.id in ids && meta.id !in located) located[meta.id] = relayUrl to meta
                 }
             }
             levels.map { (groupId, level) ->
-                val (relayUrl, meta) = located[groupId] ?: ("" to null as GroupMetadata?)
+                val relayUrl = located[groupId]?.first.orEmpty()
+                val meta = located[groupId]?.second
                 MutedGroupRow(
                     groupId = groupId,
                     relayUrl = relayUrl,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedGroupsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedGroupsViewModel.kt
@@ -1,0 +1,71 @@
+package org.nostr.nostrord.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import org.nostr.nostrord.network.GroupMetadata
+import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.settings.NotificationLevel
+import org.nostr.nostrord.settings.NotificationSettings
+
+/** A group the user has given a notification level of its own. */
+data class MutedGroupRow(
+    val groupId: String,
+    val relayUrl: String,
+    val name: String,
+    val picture: String?,
+    val level: NotificationLevel,
+)
+
+/**
+ * Shared logic for the Settings "Muted groups" panel: every group with a per-group
+ * override, so the user can find and undo one without opening the group first. Both
+ * the web and Compose panels consume this VM.
+ */
+class MutedGroupsViewModel(
+    private val repo: NostrRepositoryApi,
+    private val settings: NotificationSettings,
+) : ViewModel() {
+    val defaultLevel: StateFlow<NotificationLevel> = settings.defaultLevel
+
+    /**
+     * Overridden groups, muted first and then by name, so the list the user came here
+     * to prune sits at the top. Groups whose metadata hasn't arrived render under their
+     * bare id rather than disappearing.
+     */
+    val rows: StateFlow<List<MutedGroupRow>> =
+        combine(settings.groupLevels, repo.groupsByRelay, repo.joinedGroupsByRelay) { levels, byRelay, joined ->
+            val located = buildMap {
+                joined.forEach { (relayUrl, ids) ->
+                    byRelay[relayUrl].orEmpty().forEach { meta ->
+                        if (meta.id in ids) putIfAbsent(meta.id, relayUrl to meta)
+                    }
+                }
+            }
+            levels.map { (groupId, level) ->
+                val (relayUrl, meta) = located[groupId] ?: ("" to null as GroupMetadata?)
+                MutedGroupRow(
+                    groupId = groupId,
+                    relayUrl = relayUrl,
+                    name = meta?.name?.takeIf { it.isNotBlank() } ?: groupId,
+                    picture = meta?.picture,
+                    level = level,
+                )
+            }.sortedWith(compareBy({ it.level != NotificationLevel.MUTED }, { it.name.lowercase() }))
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
+    /** Drops the override so the group tracks the global default again. */
+    fun clearOverride(groupId: String) {
+        settings.clearGroupLevel(groupId)
+    }
+
+    fun setLevel(
+        groupId: String,
+        level: NotificationLevel,
+    ) {
+        settings.setGroupLevel(groupId, level)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip78Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip78Test.kt
@@ -1,0 +1,56 @@
+package org.nostr.nostrord.nostr
+
+import org.nostr.nostrord.settings.NotificationLevel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class Nip78Test {
+    @Test
+    fun notificationPayloadRoundTrips() {
+        val groups = mapOf(
+            "groupA" to NotificationLevel.MUTED,
+            "groupB" to NotificationLevel.MENTIONS_REPLIES,
+        )
+        val encoded = Nip78.encodeNotifications(NotificationLevel.ALL, groups)
+        val decoded = Nip78.decodeNotifications(encoded)
+
+        assertEquals(NotificationLevel.ALL, decoded?.defaultLevel)
+        assertEquals(groups, decoded?.groupLevels)
+    }
+
+    @Test
+    fun emptyOverridesRoundTrip() {
+        val decoded = Nip78.decodeNotifications(Nip78.encodeNotifications(NotificationLevel.MUTED, emptyMap()))
+        assertEquals(NotificationLevel.MUTED, decoded?.defaultLevel)
+        assertEquals(emptyMap(), decoded?.groupLevels)
+    }
+
+    @Test
+    fun unknownLevelDropsOnlyItsOwnEntry() {
+        // A newer client's extra level must not take the rest of the map down with it.
+        val payload = """{"v":1,"default":"ALL","groups":{"a":"MUTED","b":"SOMETHING_NEW"}}"""
+        val decoded = Nip78.decodeNotifications(payload)
+        assertEquals(mapOf("a" to NotificationLevel.MUTED), decoded?.groupLevels)
+    }
+
+    @Test
+    fun unknownDefaultFallsBackToAll() {
+        val decoded = Nip78.decodeNotifications("""{"v":1,"default":"WAT","groups":{}}""")
+        assertEquals(NotificationLevel.ALL, decoded?.defaultLevel)
+    }
+
+    @Test
+    fun garbageAndFutureVersionsAreRejectedRatherThanApplied() {
+        // Null means "leave local settings alone"; an empty result would wipe them.
+        assertNull(Nip78.decodeNotifications("not json"))
+        assertNull(Nip78.decodeNotifications(""))
+        assertNull(Nip78.decodeNotifications("""{"v":2,"default":"ALL","groups":{"a":"MUTED"}}"""))
+    }
+
+    @Test
+    fun unknownFieldsAreTolerated() {
+        val decoded = Nip78.decodeNotifications("""{"v":1,"default":"ALL","groups":{"a":"MUTED"},"future":true}""")
+        assertEquals(mapOf("a" to NotificationLevel.MUTED), decoded?.groupLevels)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
@@ -108,6 +108,22 @@ class NotificationSettingsMuteTest {
     }
 
     @Test
+    fun appliedRemoteLevelsSurfaceVerbatimInMuteState() {
+        // The sync layer decides "is this a local change worth publishing?" by comparing
+        // muteState.overrides against the payload it just applied. If this write ever
+        // normalized or filtered the map, that comparison would always differ and every
+        // device would republish what it just received, prompting its signer each round.
+        val settings = settingsFor("mute-test-remote-verbatim")
+        val payload = mapOf(
+            "a" to NotificationLevel.MUTED,
+            "b" to NotificationLevel.MENTIONS_REPLIES,
+            "c" to NotificationLevel.ALL,
+        )
+        settings.applyRemoteGroupLevels(payload)
+        assertEquals(payload, settings.muteState.value.overrides)
+    }
+
+    @Test
     fun remoteLevelsWithNoActiveAccountAreDropped() {
         // Guards the account-switch window: an in-flight decrypt that lands after clear()
         // must not write the previous account's groups into the next one.

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
@@ -108,6 +108,16 @@ class NotificationSettingsMuteTest {
     }
 
     @Test
+    fun remoteLevelsWithNoActiveAccountAreDropped() {
+        // Guards the account-switch window: an in-flight decrypt that lands after clear()
+        // must not write the previous account's groups into the next one.
+        val settings = settingsFor("mute-test-remote-noaccount")
+        settings.clear()
+        settings.applyRemoteGroupLevels(mapOf("ghost" to NotificationLevel.MUTED))
+        assertEquals(emptyMap(), settings.groupLevels.value)
+    }
+
+    @Test
     fun mentionsRepliesIsNotMuted() {
         val settings = settingsFor("mute-test-mentions")
         settings.setGroupLevel("groupF", NotificationLevel.MENTIONS_REPLIES)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
@@ -1,0 +1,96 @@
+package org.nostr.nostrord.settings
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Per-group mute behavior. Each test drives a throwaway pubkey so the per-account
+ * SecureStorage slot it writes can't collide with a real account's overrides.
+ */
+class NotificationSettingsMuteTest {
+    private fun settingsFor(pubkey: String) = NotificationSettings().apply { initialize(pubkey) }
+
+    @Test
+    fun toggleMuteMutesThenFallsBackToDefault() {
+        val settings = settingsFor("mute-test-toggle")
+        val originalDefault = settings.defaultLevel.value
+        try {
+            settings.setDefaultLevel(NotificationLevel.ALL)
+            assertFalse(settings.isMuted("groupA"))
+
+            settings.toggleMute("groupA")
+            assertTrue(settings.isMuted("groupA"))
+            assertEquals(NotificationLevel.MUTED, settings.effectiveLevelFor("groupA"))
+
+            // Unmuting drops the override entirely, so the group tracks the default again.
+            settings.toggleMute("groupA")
+            assertFalse(settings.isMuted("groupA"))
+            assertEquals(null, settings.groupLevels.value["groupA"])
+        } finally {
+            settings.setDefaultLevel(originalDefault)
+        }
+    }
+
+    @Test
+    fun unmutingUnderAMutedDefaultPinsTheGroupToAll() {
+        val settings = settingsFor("mute-test-default-muted")
+        val originalDefault = settings.defaultLevel.value
+        try {
+            settings.setDefaultLevel(NotificationLevel.MUTED)
+            // Inherits the muted default without an override of its own.
+            assertTrue(settings.isMuted("groupB"))
+
+            // Dropping the override here would leave it muted, so unmute has to pin ALL.
+            settings.toggleMute("groupB")
+            assertFalse(settings.isMuted("groupB"))
+            assertEquals(NotificationLevel.ALL, settings.effectiveLevelFor("groupB"))
+        } finally {
+            settings.setDefaultLevel(originalDefault)
+        }
+    }
+
+    @Test
+    fun muteStateTracksBothHalvesTogether() {
+        val settings = settingsFor("mute-test-state")
+        val originalDefault = settings.defaultLevel.value
+        try {
+            settings.setDefaultLevel(NotificationLevel.ALL)
+            settings.setGroupLevel("groupC", NotificationLevel.MUTED)
+
+            val state = settings.muteState.value
+            assertEquals(NotificationLevel.ALL, state.defaultLevel)
+            assertTrue(state.isMuted("groupC"))
+            assertFalse(state.isMuted("groupD"))
+
+            // A default change has to reach groups with no override of their own.
+            settings.setDefaultLevel(NotificationLevel.MUTED)
+            assertTrue(settings.muteState.value.isMuted("groupD"))
+        } finally {
+            settings.setDefaultLevel(originalDefault)
+        }
+    }
+
+    @Test
+    fun clearDropsOverridesOnAccountSwitch() {
+        val settings = settingsFor("mute-test-clear")
+        settings.setGroupLevel("groupE", NotificationLevel.MUTED)
+        assertTrue(settings.muteState.value.isMuted("groupE"))
+
+        settings.clear()
+        assertEquals(emptyMap(), settings.muteState.value.overrides)
+        // Writes with no active account are dropped rather than landing on the next one.
+        settings.toggleMute("groupE")
+        assertEquals(emptyMap(), settings.groupLevels.value)
+    }
+
+    @Test
+    fun mentionsRepliesIsNotMuted() {
+        val settings = settingsFor("mute-test-mentions")
+        settings.setGroupLevel("groupF", NotificationLevel.MENTIONS_REPLIES)
+        assertFalse(settings.isMuted("groupF"))
+        assertTrue(settings.shouldNotify(NotificationLevel.MENTIONS_REPLIES, isDirect = true))
+        assertFalse(settings.shouldNotify(NotificationLevel.MENTIONS_REPLIES, isDirect = false))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
@@ -124,6 +124,24 @@ class NotificationSettingsMuteTest {
     }
 
     @Test
+    fun revertingToTheSyncedMapUndoesAToggleExactly() {
+        // The sync layer reverts a change that could not be signed by writing back the
+        // last map that reached the network. That undo has to land on exactly the prior
+        // state, or a declined prompt would leave a third state behind.
+        val settings = settingsFor("mute-test-revert")
+        settings.setGroupLevel("keep", NotificationLevel.MENTIONS_REPLIES)
+        val synced = settings.muteState.value.overrides
+
+        settings.toggleMute("oops")
+        assertTrue(settings.isMuted("oops"))
+
+        settings.applyRemoteGroupLevels(synced)
+        assertFalse(settings.isMuted("oops"))
+        assertEquals(synced, settings.muteState.value.overrides)
+        assertEquals(NotificationLevel.MENTIONS_REPLIES, settings.effectiveLevelFor("keep"))
+    }
+
+    @Test
     fun remoteLevelsWithNoActiveAccountAreDropped() {
         // Guards the account-switch window: an in-flight decrypt that lands after clear()
         // must not write the previous account's groups into the next one.

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/NotificationSettingsMuteTest.kt
@@ -86,6 +86,28 @@ class NotificationSettingsMuteTest {
     }
 
     @Test
+    fun applyRemoteLevelsReplacesRatherThanMerges() {
+        val settings = settingsFor("mute-test-remote")
+        val originalDefault = settings.defaultLevel.value
+        try {
+            settings.setDefaultLevel(NotificationLevel.ALL)
+            settings.setGroupLevel("stale", NotificationLevel.MUTED)
+
+            // Another device unmuted "stale" and muted "fresh". A merge would resurrect
+            // "stale"; a replaceable event means the newer map wins whole.
+            settings.applyRemoteGroupLevels(mapOf("fresh" to NotificationLevel.MUTED))
+
+            assertEquals(mapOf("fresh" to NotificationLevel.MUTED), settings.groupLevels.value)
+            assertFalse(settings.isMuted("stale"))
+            assertTrue(settings.isMuted("fresh"))
+            // The device-global default is untouched by a per-account sync.
+            assertEquals(NotificationLevel.ALL, settings.defaultLevel.value)
+        } finally {
+            settings.setDefaultLevel(originalDefault)
+        }
+    }
+
+    @Test
     fun mentionsRepliesIsNotMuted() {
         val settings = settingsFor("mute-test-mentions")
         settings.setGroupLevel("groupF", NotificationLevel.MENTIONS_REPLIES)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -11,6 +12,8 @@ import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.notifications.NotificationEntry
 import org.nostr.nostrord.notifications.NotificationHistoryStore
 import org.nostr.nostrord.notifications.NotificationType
+import org.nostr.nostrord.settings.MuteState
+import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.ui.screens.home.Friend
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
 import org.nostr.nostrord.ui.screens.home.railKey
@@ -87,6 +90,39 @@ class HomePageViewModelTest {
             vm.myGroups.value.map { it.relayUrl to it.meta.name },
         )
         assertEquals(2, vm.railRootGroups.value.size)
+    }
+
+    @Test
+    fun `muted groups report no rail count and surface as activity instead`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._groupsByRelay.value = mapOf("wss://a" to listOf(meta("loud", "Loud"), meta("quiet", "Quiet")))
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("loud", "quiet"))
+        fake._unreadCounts.value = mapOf("loud" to 4, "quiet" to 7)
+        val mute = MutableStateFlow(MuteState(overrides = mapOf("quiet" to NotificationLevel.MUTED)))
+        val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher, muteState = mute)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(mapOf("loud" to 4, "quiet" to 0), vm.railUnreadCounts.value)
+        assertEquals(setOf("quiet"), vm.railMutedActivity.value)
+
+        // Unmuting restores the number without any new traffic.
+        mute.value = MuteState()
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(mapOf("loud" to 4, "quiet" to 7), vm.railUnreadCounts.value)
+        assertEquals(emptySet(), vm.railMutedActivity.value)
+    }
+
+    @Test
+    fun `a muted group with nothing unread shows no marker at all`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._groupsByRelay.value = mapOf("wss://a" to listOf(meta("quiet", "Quiet")))
+        fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("quiet"))
+        val mute = MutableStateFlow(MuteState(overrides = mapOf("quiet" to NotificationLevel.MUTED)))
+        val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher, muteState = mute)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(mapOf("quiet" to 0), vm.railUnreadCounts.value)
+        assertEquals(emptySet(), vm.railMutedActivity.value)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTreeTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTreeTest.kt
@@ -136,6 +136,33 @@ class ChannelTreeTest {
         assertEquals(order, moveChannelBefore(order, "a", "x"))
     }
 
+    // ── aggregateUnreadUnmuted ──────────────────────────────────────────────
+
+    @Test
+    fun mutedRootZeroesItsWholeTree() {
+        val children = mapOf("root" to setOf("c1", "c2"))
+        val unread = mapOf("root" to 3, "c1" to 5, "c2" to 1)
+        assertEquals(9, aggregateUnread("root", children, unread))
+        assertEquals(0, aggregateUnreadUnmuted("root", children, unread) { it == "root" })
+    }
+
+    @Test
+    fun mutedChannelDropsOutOfALiveRoot() {
+        val children = mapOf("root" to setOf("c1", "c2"))
+        val unread = mapOf("root" to 3, "c1" to 5, "c2" to 1)
+        assertEquals(4, aggregateUnreadUnmuted("root", children, unread) { it == "c1" })
+    }
+
+    @Test
+    fun nothingMutedMatchesThePlainAggregate() {
+        val children = mapOf("root" to setOf("c1"))
+        val unread = mapOf("root" to 2, "c1" to 4)
+        assertEquals(
+            aggregateUnread("root", children, unread),
+            aggregateUnreadUnmuted("root", children, unread) { false },
+        )
+    }
+
     // ── isLockedChannel ─────────────────────────────────────────────────────
 
     @Test

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/App.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/App.kt
@@ -33,6 +33,7 @@ import org.nostr.nostrord.startup.AppStartState
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.ui.components.chat.AvSpaceRoomHost
 import org.nostr.nostrord.ui.components.layout.AppFrame
+import org.nostr.nostrord.ui.components.layout.SystemMessageHost
 import org.nostr.nostrord.ui.components.navigation.MinimalTitleBar
 import org.nostr.nostrord.ui.navigation.clearBrowserUrlQuery
 import org.nostr.nostrord.ui.screens.login.NostrLoginScreen
@@ -231,6 +232,10 @@ fun App() {
 
             // AV room host: mounted once so every entry point shows the same room.
             AvSpaceRoomHost()
+
+            // Transient notices (AppModule.systemMessages). Mounted last so the toast
+            // draws over every screen and host above it.
+            SystemMessageHost()
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -258,7 +258,7 @@ fun ThreadMessageContextMenu(
 
 /** Popup chrome shared by the chat and thread menus: cursor-anchored position + scale/fade in. */
 @Composable
-private fun ContextMenuPopup(
+internal fun ContextMenuPopup(
     onDismiss: () -> Unit,
     anchorOffsetPx: Offset?,
     anchorWidthPx: Int,
@@ -355,7 +355,7 @@ internal class MessageMenuPositionProvider(
  */
 /** The menu card chrome (width, shadow, border), shared by the chat and thread menu contents. */
 @Composable
-private fun ContextMenuSurface(content: @Composable ColumnScope.() -> Unit) {
+internal fun ContextMenuSurface(content: @Composable ColumnScope.() -> Unit) {
     Column(
         modifier =
         Modifier

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/home/HomeCards.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/home/HomeCards.kt
@@ -18,11 +18,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.NotificationsOff
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
@@ -75,6 +79,9 @@ fun GroupCard(
     relayUrl: String = "",
     relayIconUrl: String? = null,
     isJoined: Boolean = false,
+    // Silenced group: the card recedes and carries a bell-off mark, matching the rail chip
+    // so the same group doesn't read as two different states on two surfaces.
+    muted: Boolean = false,
     onRelayClick: (() -> Unit)? = null,
     onClick: () -> Unit = {},
 ) {
@@ -93,6 +100,7 @@ fun GroupCard(
                     size = 48.dp,
                     shape = NostrordShapes.shapeMedium,
                     isGroup = true,
+                    modifier = Modifier.alpha(if (muted) 0.45f else 1f),
                 )
                 Spacer(modifier = Modifier.width(12.dp))
                 Column(modifier = Modifier.weight(1f)) {
@@ -108,6 +116,15 @@ fun GroupCard(
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f, fill = false),
                         )
+                        if (muted) {
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Icon(
+                                imageVector = Icons.Outlined.NotificationsOff,
+                                contentDescription = "Muted",
+                                tint = NostrordColors.TextMuted,
+                                modifier = Modifier.size(14.dp),
+                            )
+                        }
                         if (isJoined) {
                             Spacer(modifier = Modifier.width(6.dp))
                             TagBadge(text = "Joined", color = NostrordColors.Success)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/home/HomeCards.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/home/HomeCards.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -82,6 +84,9 @@ fun GroupCard(
     // Silenced group: the card recedes and carries a bell-off mark, matching the rail chip
     // so the same group doesn't read as two different states on two surfaces.
     muted: Boolean = false,
+    // Unmute straight from the card. Null leaves the mark inert (discovery lists, where
+    // the account has no level for the group).
+    onUnmute: (() -> Unit)? = null,
     onRelayClick: (() -> Unit)? = null,
     onClick: () -> Unit = {},
 ) {
@@ -118,12 +123,31 @@ fun GroupCard(
                         )
                         if (muted) {
                             Spacer(modifier = Modifier.width(6.dp))
-                            Icon(
-                                imageVector = Icons.Outlined.NotificationsOff,
-                                contentDescription = "Muted",
-                                tint = NostrordColors.TextMuted,
-                                modifier = Modifier.size(14.dp),
-                            )
+                            // Sits at the row's trailing edge because the name takes the free
+                            // space. As an action it earns that position: a tap unmutes without
+                            // opening the group.
+                            Box(
+                                modifier = Modifier
+                                    .size(24.dp)
+                                    .clip(NostrordShapes.shapeSmall)
+                                    .then(
+                                        if (onUnmute != null) {
+                                            Modifier
+                                                .clickable(onClick = onUnmute)
+                                                .pointerHoverIcon(PointerIcon.Hand)
+                                        } else {
+                                            Modifier
+                                        },
+                                    ),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Outlined.NotificationsOff,
+                                    contentDescription = if (onUnmute != null) "Unmute group" else "Muted",
+                                    tint = NostrordColors.TextMuted,
+                                    modifier = Modifier.size(14.dp),
+                                )
+                            }
                         }
                         if (isJoined) {
                             Spacer(modifier = Modifier.width(6.dp))

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -1086,6 +1087,9 @@ private fun RailGroupButton(
                 Modifier
                     .size(48.dp)
                     .clip(shape)
+                    // Muted chips recede, so a silenced group is recognisable at a glance
+                    // even when it has no traffic at all.
+                    .alpha(if (muted) 0.45f else 1f)
                     .hoverable(interactionSource),
                 shape = shape,
                 color = NostrordColors.Background,
@@ -1100,10 +1104,15 @@ private fun RailGroupButton(
                     isGroup = true,
                 )
             }
+            if (muted) {
+                RailMutedBadge(modifier = Modifier.align(Alignment.BottomEnd))
+            }
             if (unread > 0) {
                 RailBadge(count = unread, modifier = Modifier.align(Alignment.BottomEnd))
             } else if (mutedActivity) {
-                RailMutedDot(modifier = Modifier.align(Alignment.BottomEnd))
+                // Muted but moving: a dot in the free corner, since the bell-off badge
+                // owns the bottom one.
+                RailMutedDot(modifier = Modifier.align(Alignment.TopEnd))
             }
         }
     }
@@ -1126,6 +1135,30 @@ private fun RailBadge(
             color = Color.White,
             fontSize = 10.sp,
             fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+/**
+ * Persistent "this group is silenced" marker on a rail chip. Unlike the sidebar row
+ * there is no label to dim, so the state needs its own mark whether or not the group
+ * has unread traffic.
+ */
+@Composable
+private fun RailMutedBadge(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+        modifier
+            .size(16.dp)
+            .clip(CircleShape)
+            .background(NostrordColors.BackgroundDark),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.NotificationsOff,
+            contentDescription = "Muted",
+            tint = NostrordColors.TextMuted,
+            modifier = Modifier.size(10.dp),
         )
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -187,7 +188,13 @@ import kotlin.math.roundToInt
 fun AppFrame() {
     // HomePageViewModel re-arms its per-account state when the active account changes
     // (it observes repo.activePubkey), so a single long-lived instance is correct here.
-    val vm = viewModel { HomePageViewModel(AppModule.nostrRepository, AppModule.notificationHistoryStore) }
+    val vm = viewModel {
+        HomePageViewModel(
+            AppModule.nostrRepository,
+            AppModule.notificationHistoryStore,
+            muteState = AppModule.notificationSettings.muteState,
+        )
+    }
     // railGroups (not myGroups): the rail + back-history label only read meta/relayUrl, so this
     // meta-only projection (distinctUntilChanged) skips the member-avatar metadata waves that would
     // otherwise recompose the whole rail dozens of times on home open.
@@ -197,6 +204,8 @@ fun AppFrame() {
     // history labels, which must keep resolving subgroup routes.
     val railRoots by vm.railRootGroups.collectAsState()
     val railUnread by vm.railUnreadCounts.collectAsState()
+    val railMutedActivity by vm.railMutedActivity.collectAsState()
+    val muteState by AppModule.notificationSettings.muteState.collectAsState()
     val groupParents by vm.groupParents.collectAsState()
     val notificationUnread by vm.notificationUnread.collectAsState()
     val dmUnread by AppModule.nostrRepository.totalDmUnread.collectAsState()
@@ -456,6 +465,9 @@ fun AppFrame() {
                             picture = group.meta.picture,
                             groupId = group.meta.id,
                             unread = railUnread[group.meta.id] ?: 0,
+                            muted = muteState.isMuted(group.meta.id),
+                            mutedActivity = group.meta.id in railMutedActivity,
+                            onToggleMute = { AppModule.notificationSettings.toggleMute(group.meta.id) },
                             active = activeRootId == group.meta.id &&
                                 activeRelay == group.relayUrl.normalizeRelayUrl() &&
                                 !showNotifications,
@@ -969,6 +981,11 @@ private fun RailGroupButton(
     picture: String?,
     groupId: String,
     unread: Int,
+    muted: Boolean = false,
+    // Muted and holding unread traffic: shown as a dim dot, since the count is the
+    // noise the user muted.
+    mutedActivity: Boolean = false,
+    onToggleMute: () -> Unit = {},
     active: Boolean = false,
     dragging: Boolean = false,
     dropIndicator: Boolean = false,
@@ -990,6 +1007,7 @@ private fun RailGroupButton(
     val indicatorColor = NostrordColors.Primary
     val isHovered by interactionSource.collectIsHoveredAsState()
     val highlighted = active || isHovered
+    var menuOffset by remember { mutableStateOf<Offset?>(null) }
     // Smoothly morph the corner radius (16dp -> 12dp) rather than snapping the shape,
     // matching the softer rail feel on the main branch.
     val cornerRadius by animateDpAsState(
@@ -1028,9 +1046,19 @@ private fun RailGroupButton(
                     onDragEnd = { currentOnDragEnd() },
                     onDragCancel = { currentOnDragCancel() },
                 )
-            },
+            }
+            // Secondary click only: long-press already belongs to drag-reorder here, so
+            // touch reaches muting through the channel row or the group info modal.
+            .secondaryClickMenu(groupId) { menuOffset = it },
         contentAlignment = Alignment.Center,
     ) {
+        GroupContextMenu(
+            visible = menuOffset != null,
+            muted = muted,
+            onDismiss = { menuOffset = null },
+            onToggleMute = onToggleMute,
+            anchorOffsetPx = menuOffset,
+        )
         // Left pill marker: grows from 0 to 20dp on hover and 36dp when active (web .rail-item::before).
         val pillHeight by animateDpAsState(
             targetValue = if (active) {
@@ -1074,6 +1102,8 @@ private fun RailGroupButton(
             }
             if (unread > 0) {
                 RailBadge(count = unread, modifier = Modifier.align(Alignment.BottomEnd))
+            } else if (mutedActivity) {
+                RailMutedDot(modifier = Modifier.align(Alignment.BottomEnd))
             }
         }
     }
@@ -1098,6 +1128,18 @@ private fun RailBadge(
             fontWeight = FontWeight.Bold,
         )
     }
+}
+
+/** Muted-with-unread marker: the badge's footprint without the count. */
+@Composable
+private fun RailMutedDot(modifier: Modifier = Modifier) {
+    Box(
+        modifier =
+        modifier
+            .size(8.dp)
+            .clip(CircleShape)
+            .background(NostrordColors.TextMuted),
+    )
 }
 
 @Composable

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupContextMenu.kt
@@ -1,0 +1,67 @@
+package org.nostr.nostrord.ui.components.layout
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.NotificationsOff
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.isSecondaryPressed
+import androidx.compose.ui.input.pointer.pointerInput
+import org.nostr.nostrord.ui.components.chat.ContextMenuItem
+import org.nostr.nostrord.ui.components.chat.ContextMenuPopup
+import org.nostr.nostrord.ui.components.chat.ContextMenuSurface
+
+/**
+ * Right-click / long-press menu for a group row (rail chip, channel row, group card).
+ * Shares the message menu's popup chrome so both open the same card at the cursor.
+ *
+ * Muting is the whole menu today; it lives in its own component so group-scoped
+ * actions have a home rather than accreting onto the message menu.
+ */
+@Composable
+fun GroupContextMenu(
+    visible: Boolean,
+    muted: Boolean,
+    onDismiss: () -> Unit,
+    onToggleMute: () -> Unit,
+    anchorOffsetPx: Offset? = null,
+) {
+    if (!visible) return
+    ContextMenuPopup(onDismiss = onDismiss, anchorOffsetPx = anchorOffsetPx, anchorWidthPx = 0) {
+        ContextMenuSurface {
+            ContextMenuItem(
+                icon = if (muted) Icons.Outlined.Notifications else Icons.Outlined.NotificationsOff,
+                label = if (muted) "Unmute group" else "Mute group",
+                onClick = {
+                    onToggleMute()
+                    onDismiss()
+                },
+            )
+        }
+    }
+}
+
+/**
+ * Opens [onOpen] at the cursor on a secondary (right) click, reporting the position
+ * local to the modified element so [GroupContextMenu] can anchor there.
+ *
+ * Deliberately not the shared `rightClickContextMenuModifier`: its Android actual maps
+ * to a plain tap, which on a group row is already "open the group". Touch platforms
+ * reach muting through the row's long-press or the group info modal instead.
+ */
+fun Modifier.secondaryClickMenu(
+    key: Any?,
+    onOpen: (Offset) -> Unit,
+): Modifier = pointerInput(key) {
+    awaitPointerEventScope {
+        while (true) {
+            val event = awaitPointerEvent()
+            if (event.type == PointerEventType.Press && event.buttons.isSecondaryPressed) {
+                event.changes.forEach { it.consume() }
+                onOpen(event.changes.first().position)
+            }
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui.components.layout
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -30,6 +31,7 @@ import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.NotificationsOff
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
@@ -112,6 +114,7 @@ fun GroupSidebar(
     val groupAdmins by vm.groupAdmins.collectAsState()
     val joinedGroupsByRelay by vm.joinedGroupsByRelay.collectAsState()
     val unreadCounts by AppModule.nostrRepository.unreadCounts.collectAsState()
+    val muteState by AppModule.notificationSettings.muteState.collectAsState()
     val kind10009Relays by AppModule.nostrRepository.kind10009Relays.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()
 
@@ -292,6 +295,10 @@ fun GroupSidebar(
                         depth = entry.depth - 1,
                         locked = isLockedChannel(channel, isJoined = entry.id in joinedHere),
                         unread = unreadCounts[entry.id] ?: 0,
+                        // Muting the root silences the whole tree, so a channel inside a
+                        // muted group reads as muted without an override of its own.
+                        muted = muteState.isMuted(entry.id) || muteState.isMuted(rootId),
+                        onToggleMute = { AppModule.notificationSettings.toggleMute(entry.id) },
                         active = route.groupId == entry.id,
                         // Only first-level channels reorder: their order is the root's child
                         // tag positions; nested foreign rows just render.
@@ -536,6 +543,8 @@ private fun ChannelRow(
     depth: Int,
     locked: Boolean,
     unread: Int,
+    muted: Boolean = false,
+    onToggleMute: () -> Unit = {},
     active: Boolean,
     draggable: Boolean = false,
     dragging: Boolean = false,
@@ -550,6 +559,7 @@ private fun ChannelRow(
     val interactionSource = remember { MutableInteractionSource() }
     val isHovered by interactionSource.collectIsHoveredAsState()
     val highlighted = isHovered || active
+    var menuOffset by remember { mutableStateOf<Offset?>(null) }
     val indicatorColor = NostrordColors.Primary
     // pointerInput's coroutine only ever sees the lambdas captured when it launched,
     // but the drop math lives in callbacks the sidebar recreates every recomposition
@@ -581,11 +591,21 @@ private fun ChannelRow(
             .clip(NostrordShapes.shapeMedium)
             .background(if (highlighted) NostrordColors.HoverBackground else Color.Transparent)
             .hoverable(interactionSource)
-            .clickable(onClick = onClick)
+            .secondaryClickMenu(groupId) { menuOffset = it }
+            // Long-press is free on a channel row (reorder has its own drag handle), so
+            // touch reaches the menu here even though the rail chip can't offer it.
+            .combinedClickable(onClick = onClick, onLongClick = { menuOffset = Offset.Zero })
             .padding(horizontal = Spacing.sm, vertical = Spacing.xs + Spacing.xxs),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Spacing.xs + Spacing.xxs),
     ) {
+        GroupContextMenu(
+            visible = menuOffset != null,
+            muted = muted,
+            onDismiss = { menuOffset = null },
+            onToggleMute = onToggleMute,
+            anchorOffsetPx = menuOffset,
+        )
         if (draggable) {
             Icon(
                 imageVector = Icons.Default.DragIndicator,
@@ -619,7 +639,11 @@ private fun ChannelRow(
         )
         Text(
             name,
-            color = if (highlighted) NostrordColors.TextPrimary else NostrordColors.TextSecondary,
+            color = when {
+                muted -> NostrordColors.TextMuted
+                highlighted -> NostrordColors.TextPrimary
+                else -> NostrordColors.TextSecondary
+            },
             fontSize = 14.sp,
             fontWeight = FontWeight.Medium,
             maxLines = 1,
@@ -634,20 +658,39 @@ private fun ChannelRow(
                 modifier = Modifier.size(12.dp),
             )
         }
+        if (muted) {
+            Icon(
+                imageVector = Icons.Outlined.NotificationsOff,
+                contentDescription = "Muted",
+                tint = NostrordColors.TextMuted,
+                modifier = Modifier.size(12.dp),
+            )
+        }
         if (unread > 0) {
-            Box(
-                modifier =
-                Modifier
-                    .clip(CircleShape)
-                    .background(NostrordColors.BadgeBackground)
-                    .padding(horizontal = 5.dp, vertical = 1.dp),
-            ) {
-                Text(
-                    if (unread > 99) "99+" else "$unread",
-                    color = Color.White,
-                    fontSize = 10.sp,
-                    fontWeight = FontWeight.Bold,
+            if (muted) {
+                // Dot, not a count: the number is exactly the noise muting removes.
+                Box(
+                    modifier =
+                    Modifier
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(NostrordColors.TextMuted),
                 )
+            } else {
+                Box(
+                    modifier =
+                    Modifier
+                        .clip(CircleShape)
+                        .background(NostrordColors.BadgeBackground)
+                        .padding(horizontal = 5.dp, vertical = 1.dp),
+                ) {
+                    Text(
+                        if (unread > 99) "99+" else "$unread",
+                        color = Color.White,
+                        fontSize = 10.sp,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/SystemMessageHost.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/SystemMessageHost.kt
@@ -1,0 +1,90 @@
+package org.nostr.nostrord.ui.components.layout
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.ui.theme.Spacing
+
+/** How long a system message stays up before it fades out. */
+private const val TOAST_VISIBLE_MS = 4_000L
+
+/**
+ * Renders [AppModule.systemMessages] as a transient toast at the bottom of the app.
+ *
+ * Mount once, at the app root: the flow carries one-shot notices the user did not
+ * explicitly trigger (a revoked signer, a sync that could not be signed) as well as
+ * action confirmations, and without a host every one of them is dropped.
+ *
+ * Web parity: SystemMessageHost in web/components/SystemMessageHost.kt.
+ */
+@Composable
+fun SystemMessageHost() {
+    var message by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(Unit) {
+        AppModule.systemMessages.collect { message = it }
+    }
+    // Keyed on the message so a second notice restarts the timer rather than
+    // inheriting the first one's remaining time.
+    LaunchedEffect(message) {
+        if (message != null) {
+            delay(TOAST_VISIBLE_MS)
+            message = null
+        }
+    }
+
+    // Own full-size Box so the host can be dropped anywhere without the caller
+    // having to provide a BoxScope to align against.
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
+        AnimatedVisibility(
+            visible = message != null,
+            enter = fadeIn() + slideInVertically { it / 2 },
+            exit = fadeOut() + slideOutVertically { it / 2 },
+            modifier = Modifier.padding(Spacing.lg),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .widthIn(max = 420.dp)
+                    .shadow(12.dp, NostrordShapes.shapeMedium, ambientColor = Color.Black.copy(alpha = 0.4f))
+                    .clip(NostrordShapes.shapeMedium)
+                    .background(NostrordColors.Surface)
+                    .border(Spacing.dividerThickness, NostrordColors.Divider, NostrordShapes.shapeMedium)
+                    .padding(horizontal = Spacing.lg, vertical = Spacing.md),
+            ) {
+                Text(
+                    text = message.orEmpty(),
+                    color = NostrordColors.TextContent,
+                    fontSize = 14.sp,
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
@@ -352,6 +352,7 @@ fun HomePageScreen(
                                                 // earns its place only in the mixed lists.
                                                 isJoined = false,
                                                 muted = muteState.isMuted(group.meta.id),
+                                                onUnmute = { AppModule.notificationSettings.toggleMute(group.meta.id) },
                                                 onRelayClick = { onOpenRelay(group.relayUrl) },
                                                 onClick = { onOpenGroup(JoinedGroup(group.relayUrl, group.meta)) },
                                             )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageScreen.kt
@@ -107,6 +107,7 @@ fun HomePageScreen(
     val friendsGroupsLoading by vm.friendsGroupsLoading.collectAsState()
     val recommendedGroupsLoading by vm.recommendedGroupsLoading.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()
+    val muteState by AppModule.notificationSettings.muteState.collectAsState()
     val dmEnabled by AppModule.dmSettings.dmEnabled.collectAsState()
     // Membership per (relay, id), to flag the "Joined" badge on cards in mixed lists: ids
     // repeat across relays, so a flat id match badges a group you never joined.
@@ -350,6 +351,7 @@ fun HomePageScreen(
                                                 // Every card in My groups is joined; the badge
                                                 // earns its place only in the mixed lists.
                                                 isJoined = false,
+                                                muted = muteState.isMuted(group.meta.id),
                                                 onRelayClick = { onOpenRelay(group.relayUrl) },
                                                 onClick = { onOpenGroup(JoinedGroup(group.relayUrl, group.meta)) },
                                             )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedGroupsPanelContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/MutedGroupsPanelContent.kt
@@ -1,0 +1,129 @@
+package org.nostr.nostrord.ui.screens.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import org.nostr.nostrord.settings.NotificationLevel
+import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.navigation.GroupRoute
+import org.nostr.nostrord.ui.navigation.LocalFrameNavigator
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * Settings "Muted groups" panel: every group with a notification level of its own,
+ * so an override can be found and undone without opening the group. Web parity:
+ * MutedGroupsPanel in web/screens/SettingsScreen.kt.
+ */
+@Composable
+fun MutedGroupsPanelContent(vm: MutedGroupsViewModel) {
+    val rows by vm.rows.collectAsState()
+    val defaultLevel by vm.defaultLevel.collectAsState()
+    val frameNavigator = LocalFrameNavigator.current
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "Muted groups never notify and drop their unread count to a dot. " +
+                "These overrides are stored per account and sync to your other devices.",
+            color = NostrordColors.TextSecondary,
+            fontSize = 13.sp,
+        )
+        Spacer(Modifier.height(Spacing.lg))
+
+        if (rows.isEmpty()) {
+            Text(
+                text = "No group overrides yet. Right-click a group in the sidebar, or open its info panel, to mute it.",
+                color = NostrordColors.TextMuted,
+                fontSize = 13.sp,
+            )
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(Spacing.sm)) {
+                rows.forEach { row ->
+                    val openable = frameNavigator != null && row.relayUrl.isNotBlank()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(8.dp))
+                            .then(
+                                if (openable) {
+                                    Modifier
+                                        .clickable { frameNavigator?.invoke(GroupRoute(row.relayUrl, row.groupId)) }
+                                        .pointerHoverIcon(PointerIcon.Hand)
+                                } else {
+                                    Modifier
+                                },
+                            )
+                            .padding(vertical = 2.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                    ) {
+                        OptimizedSmallAvatar(
+                            imageUrl = row.picture,
+                            identifier = row.groupId,
+                            displayName = row.name,
+                            size = 36.dp,
+                            shape = NostrordShapes.shapeSmall,
+                            isGroup = true,
+                        )
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = row.name,
+                                color = NostrordColors.TextPrimary,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                text = levelLabel(row.level),
+                                color = NostrordColors.TextMuted,
+                                fontSize = 12.sp,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        AppButton(
+                            text = if (row.level == NotificationLevel.MUTED) "Unmute" else "Reset",
+                            onClick = { vm.clearOverride(row.groupId) },
+                            variant = AppButtonVariant.Secondary,
+                        )
+                    }
+                }
+            }
+            Spacer(Modifier.height(Spacing.md))
+            Text(
+                text = "Clearing an override returns the group to the global default (${levelLabel(defaultLevel).lowercase()}).",
+                color = NostrordColors.TextMuted,
+                fontSize = 12.sp,
+            )
+        }
+    }
+}
+
+internal fun levelLabel(level: NotificationLevel): String = when (level) {
+    NotificationLevel.ALL -> "All messages"
+    NotificationLevel.MENTIONS_REPLIES -> "Mentions & replies"
+    NotificationLevel.MUTED -> "Muted"
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -87,6 +87,7 @@ enum class SettingsSection(val label: String) {
     Media("Media"),
     Notifications("Notifications"),
     MutedUsers("Muted users"),
+    MutedGroups("Muted groups"),
     Security("Security"),
 }
 
@@ -258,6 +259,11 @@ fun SettingsScreen(
         MutedUsersPanelContent(mutedUsersVm)
     }
 
+    val mutedGroupsVm = viewModel { MutedGroupsViewModel(AppModule.nostrRepository, AppModule.notificationSettings) }
+    val mutedGroupsContent: @Composable () -> Unit = {
+        MutedGroupsPanelContent(mutedGroupsVm)
+    }
+
     val securityContent: @Composable () -> Unit = {
         SecurityPanelContent()
     }
@@ -312,6 +318,7 @@ fun SettingsScreen(
                 mediaContent = mediaContent,
                 notificationsContent = notificationsContent,
                 mutedUsersContent = mutedUsersContent,
+                mutedGroupsContent = mutedGroupsContent,
                 securityContent = securityContent,
             )
         } else {
@@ -329,6 +336,7 @@ fun SettingsScreen(
                 mediaContent = mediaContent,
                 notificationsContent = notificationsContent,
                 mutedUsersContent = mutedUsersContent,
+                mutedGroupsContent = mutedGroupsContent,
                 securityContent = securityContent,
             )
         }
@@ -352,6 +360,7 @@ private fun DesktopSettings(
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
     mutedUsersContent: @Composable () -> Unit,
+    mutedGroupsContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
@@ -399,7 +408,7 @@ private fun DesktopSettings(
                         .padding(top = 24.dp, start = 40.dp, end = 20.dp, bottom = 80.dp),
                 ) {
                     Box(modifier = Modifier.widthIn(max = 660.dp)) {
-                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, securityContent)
+                        SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, mutedGroupsContent, securityContent)
                     }
                 }
 
@@ -430,6 +439,7 @@ private fun MobileSettings(
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
     mutedUsersContent: @Composable () -> Unit,
+    mutedGroupsContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     if (!showPanel) {
@@ -471,7 +481,7 @@ private fun MobileSettings(
                     .verticalScroll(rememberScrollState())
                     .padding(horizontal = 20.dp, vertical = 24.dp),
             ) {
-                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, securityContent)
+                SettingsPanel(activeSection, profileContent, backupContent, relaysContent, dmRelaysContent, appearanceContent, mediaContent, notificationsContent, mutedUsersContent, mutedGroupsContent, securityContent)
             }
         }
     }
@@ -531,6 +541,9 @@ private fun SettingsSidebar(
     }
     SettingsNavItem("Muted users", activeSection == SettingsSection.MutedUsers, compact = compact) {
         onSelectSection(SettingsSection.MutedUsers)
+    }
+    SettingsNavItem("Muted groups", activeSection == SettingsSection.MutedGroups, compact = compact) {
+        onSelectSection(SettingsSection.MutedGroups)
     }
     if (PassphraseSettings.isApplicable) {
         SettingsNavItem("Security", activeSection == SettingsSection.Security, compact = compact) {
@@ -647,6 +660,7 @@ private fun SettingsPanel(
     mediaContent: @Composable () -> Unit,
     notificationsContent: @Composable () -> Unit,
     mutedUsersContent: @Composable () -> Unit,
+    mutedGroupsContent: @Composable () -> Unit,
     securityContent: @Composable () -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
@@ -669,6 +683,7 @@ private fun SettingsPanel(
             SettingsSection.Media -> mediaContent()
             SettingsSection.Notifications -> notificationsContent()
             SettingsSection.MutedUsers -> mutedUsersContent()
+            SettingsSection.MutedGroups -> mutedGroupsContent()
             SettingsSection.Security -> securityContent()
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -476,15 +476,15 @@ val AppFrame =
                                     setRailMenu(GroupMenuAnchor(group.meta.id, e.clientX.toDouble(), e.clientY.toDouble()))
                                 }
                                 button {
+                                    val chipActive = activeRootId == group.meta.id &&
+                                        activeRelay == group.relayUrl.normalizeRelayUrl() &&
+                                        !notificationsOpen
+                                    val chipMuted = muteState.isMuted(group.meta.id)
                                     className =
                                         ClassName(
-                                            if (activeRootId == group.meta.id &&
-                                                activeRelay == group.relayUrl.normalizeRelayUrl() &&
-                                                !notificationsOpen
-                                            ) {
-                                                "rail-group-btn active"
-                                            } else {
-                                                "rail-group-btn"
+                                            buildString {
+                                                append(if (chipActive) "rail-group-btn active" else "rail-group-btn")
+                                                if (chipMuted) append(" muted")
                                             },
                                         )
                                     title = name
@@ -502,6 +502,15 @@ val AppFrame =
                                         cls = "group-card-avatar"
                                     }
                                 }
+                                // Persistent silenced marker: unlike a sidebar row there is no
+                                // label to dim, so the state needs its own mark even with no traffic.
+                                if (muteState.isMuted(group.meta.id)) {
+                                    span {
+                                        className = ClassName("rail-muted-badge")
+                                        title = "Muted"
+                                        icon(Ic.NotificationsOff)
+                                    }
+                                }
                                 val unread = railUnread[group.meta.id] ?: 0
                                 if (unread > 0) {
                                     span {
@@ -509,8 +518,9 @@ val AppFrame =
                                         +(if (unread > 99) "99+" else "$unread")
                                     }
                                 } else if (group.meta.id in railMutedActivity) {
-                                    // Muted with traffic behind it: a dot, no number.
-                                    span { className = ClassName("rail-badge muted-dot") }
+                                    // Muted but moving: a dot in the free corner, since the
+                                    // bell-off badge owns the bottom one.
+                                    span { className = ClassName("rail-badge top muted-dot") }
                                 }
                             }
                         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -32,6 +32,8 @@ import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.BunkerStatusBanner
+import org.nostr.nostrord.web.components.GroupContextMenu
+import org.nostr.nostrord.web.components.GroupMenuAnchor
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.ImageViewerHost
 import org.nostr.nostrord.web.components.WebAvatar
@@ -99,11 +101,17 @@ private const val RAIL_SCROLL_STEP = 3.0
 val AppFrame =
     FC<Props> {
         val repo = AppModule.nostrRepository
-        val vm = useViewModel { HomePageViewModel(repo, AppModule.notificationHistoryStore) }
+        val vm = useViewModel {
+            HomePageViewModel(repo, AppModule.notificationHistoryStore, muteState = AppModule.notificationSettings.muteState)
+        }
         // Channel model: the rail shows only root groups; a subgroup lives in its root's
         // channel list, with the root chip aggregating the subtree's unread.
         val railRoots = useStateFlow(vm.railRootGroups)
         val railUnread = useStateFlow(vm.railUnreadCounts)
+        val railMutedActivity = useStateFlow(vm.railMutedActivity)
+        val muteState = useStateFlow(AppModule.notificationSettings.muteState)
+        // Open rail context menu: which group, and where it was right-clicked.
+        val (railMenu, setRailMenu) = useState<GroupMenuAnchor?> { null }
         val groupParents = useStateFlow(vm.groupParents)
         val friends = useStateFlow(vm.friends)
         val friendsLoading = useStateFlow(vm.friendsLoading)
@@ -463,6 +471,10 @@ val AppFrame =
                                 // Kill any native HTML drag started inside the chip; it would
                                 // take over the pointer stream the reorder needs.
                                 onDragStart = { it.preventDefault() }
+                                onContextMenu = { e ->
+                                    e.preventDefault()
+                                    setRailMenu(GroupMenuAnchor(group.meta.id, e.clientX.toDouble(), e.clientY.toDouble()))
+                                }
                                 button {
                                     className =
                                         ClassName(
@@ -496,6 +508,9 @@ val AppFrame =
                                         className = ClassName("rail-badge")
                                         +(if (unread > 99) "99+" else "$unread")
                                     }
+                                } else if (group.meta.id in railMutedActivity) {
+                                    // Muted with traffic behind it: a dot, no number.
+                                    span { className = ClassName("rail-badge muted-dot") }
                                 }
                             }
                         }
@@ -981,6 +996,17 @@ val AppFrame =
                     onCancel = { setConfirmLogout(false) },
                     onConfirm = { performLogout() },
                 )
+            }
+
+            // Rail chip context menu (right-click): mute without opening the group.
+            railMenu?.let { anchor ->
+                GroupContextMenu {
+                    x = anchor.x
+                    y = anchor.y
+                    muted = muteState.isMuted(anchor.groupId)
+                    onClose = { setRailMenu(null) }
+                    onToggleMute = { AppModule.notificationSettings.toggleMute(anchor.groupId) }
+                }
             }
 
             // Zap modal host: mounted once so any WebZapController.request(...) from a

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
@@ -19,6 +19,8 @@ import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
+import org.nostr.nostrord.web.components.GroupContextMenu
+import org.nostr.nostrord.web.components.GroupMenuAnchor
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.Portal
 import org.nostr.nostrord.web.components.WebAvatar
@@ -64,6 +66,9 @@ val GroupSidebar =
         val relayMetadata = useStateFlow(vm.relayMetadata)
         val joinedGroupsByRelay = useStateFlow(vm.joinedGroupsByRelay)
         val unreadCounts = useStateFlow(AppModule.nostrRepository.unreadCounts)
+        val muteState = useStateFlow(AppModule.notificationSettings.muteState)
+        // Open group context menu: which row, and where it was right-clicked.
+        val (groupMenu, setGroupMenu) = useState<GroupMenuAnchor?> { null }
         val (showMembers, setShowMembers) = useState { false }
         val (showCreateSubgroup, setShowCreateSubgroup) = useState { false }
         val (showManage, setShowManage) = useState { false }
@@ -310,6 +315,9 @@ val GroupSidebar =
                         // Only first-level channels reorder: their order is the root's child
                         // tag positions; nested foreign rows just render.
                         val draggable = isRootAdmin && entry.depth == 1
+                        // Muting the root silences the whole tree, so a channel inside a muted
+                        // group reads as muted without an override of its own.
+                        val channelMuted = muteState.isMuted(entry.id) || muteState.isMuted(rootId)
                         button {
                             key = entry.id
                             className =
@@ -318,10 +326,15 @@ val GroupSidebar =
                                         append(if (active) "group-side-row active$depthCls" else "group-side-row$depthCls")
                                         if (dragId == entry.id) append(" dragging")
                                         if (overId == entry.id && dragId != null && dragId != entry.id) append(" drag-over")
+                                        if (channelMuted) append(" muted")
                                     },
                                 )
                             if (draggable) asDynamic()["data-sgid"] = entry.id
                             onClick = { props.onNavigateGroup(GroupRoute(route.relayUrl, entry.id)) }
+                            onContextMenu = { e ->
+                                e.preventDefault()
+                                setGroupMenu(GroupMenuAnchor(entry.id, e.clientX.toDouble(), e.clientY.toDouble()))
+                            }
                             if (draggable) {
                                 span {
                                     className = ClassName("group-side-row-drag")
@@ -349,11 +362,23 @@ val GroupSidebar =
                                     icon(Ic.Lock)
                                 }
                             }
+                            if (channelMuted) {
+                                span {
+                                    className = ClassName("group-side-row-lock")
+                                    title = "Muted"
+                                    icon(Ic.NotificationsOff)
+                                }
+                            }
                             val unread = unreadCounts[entry.id] ?: 0
                             if (unread > 0) {
-                                span {
-                                    className = ClassName("count-badge")
-                                    +(if (unread > 99) "99+" else "$unread")
+                                if (channelMuted) {
+                                    // Dot, not a count: the number is exactly the noise muting removes.
+                                    span { className = ClassName("muted-dot") }
+                                } else {
+                                    span {
+                                        className = ClassName("count-badge")
+                                        +(if (unread > 99) "99+" else "$unread")
+                                    }
                                 }
                             }
                         }
@@ -366,6 +391,20 @@ val GroupSidebar =
                             asDynamic()["data-sgid"] = END_DROP
                         }
                     }
+                }
+            }
+        }
+
+        groupMenu?.let { anchor ->
+            // Portaled for the same reason as the modals below: the drawer's `transform`
+            // would trap a position:fixed menu inside it.
+            Portal {
+                GroupContextMenu {
+                    x = anchor.x
+                    y = anchor.y
+                    muted = muteState.isMuted(anchor.groupId)
+                    onClose = { setGroupMenu(null) }
+                    onToggleMute = { AppModule.notificationSettings.toggleMute(anchor.groupId) }
                 }
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/WebApp.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/WebApp.kt
@@ -9,6 +9,7 @@ import org.nostr.nostrord.ui.theme.paletteForTheme
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.AppLoading
+import org.nostr.nostrord.web.components.SystemMessageHost
 import org.nostr.nostrord.web.components.installGlobalModalFocusTrap
 import org.nostr.nostrord.web.components.installPullToRefresh
 import org.nostr.nostrord.web.modals.UnlockModal
@@ -97,6 +98,9 @@ val WebApp =
                     ?.setAttribute("data-app-ready", "true")
             }
         }
+
+        // Transient notices (AppModule.systemMessages), over every screen including login.
+        SystemMessageHost()
 
         // NIP-49 unlock gate: a password-protected account blocked session restore;
         // ask for the password over whatever screen is showing (mirrors native App.kt).

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupContextMenu.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupContextMenu.kt
@@ -1,0 +1,70 @@
+package org.nostr.nostrord.web.components
+
+import org.nostr.nostrord.web.screens.ctxItem
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+import react.useEffect
+import react.useRef
+import web.cssom.ClassName
+import web.html.HTMLDivElement
+import web.window.window
+
+external interface GroupContextMenuProps : Props {
+    /** Viewport coordinates of the click that opened the menu. */
+    var x: Double
+    var y: Double
+    var muted: Boolean
+    var onClose: () -> Unit
+    var onToggleMute: () -> Unit
+}
+
+/**
+ * Right-click / long-press menu for a group row (rail chip, channel row). Shares the
+ * message menu's `.ctx-menu` chrome so both open the same card at the cursor.
+ *
+ * Native parity: ui/components/layout/GroupContextMenu.kt.
+ */
+val GroupContextMenu =
+    FC<GroupContextMenuProps> { props ->
+        val menuRef = useRef<HTMLDivElement>(null)
+
+        // Clamp into the viewport once mounted; .ctx-menu starts visibility:hidden so the
+        // pre-clamp position never flashes.
+        useEffect(props.x, props.y) {
+            val el = menuRef.current?.asDynamic() ?: return@useEffect
+            val w = el.offsetWidth as Int
+            val h = el.offsetHeight as Int
+            var left = props.x
+            if (left + w > window.innerWidth - 8) left = (window.innerWidth - 8.0 - w).coerceAtLeast(8.0)
+            var top = props.y
+            if (top + h > window.innerHeight - 8) top = (props.y - h).coerceAtLeast(8.0)
+            el.style.left = "${left}px"
+            el.style.top = "${top}px"
+            el.style.visibility = "visible"
+        }
+
+        useEscClose { props.onClose() }
+
+        div {
+            className = ClassName("ctx-overlay")
+            onClick = { props.onClose() }
+            // No preventDefault: closing is enough, and swallowing it would deny the browser
+            // menu a right-click outside the row is entitled to (chat parity).
+            onContextMenu = { props.onClose() }
+        }
+        div {
+            ref = menuRef
+            className = ClassName("ctx-menu")
+            ctxItem(
+                if (props.muted) Ic.Notifications else Ic.NotificationsOff,
+                if (props.muted) "Unmute group" else "Mute group",
+            ) {
+                props.onToggleMute()
+                props.onClose()
+            }
+        }
+    }
+
+/** Menu anchor: where the row was right-clicked, plus which group it belongs to. */
+data class GroupMenuAnchor(val groupId: String, val x: Double, val y: Double)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/SystemMessageHost.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/SystemMessageHost.kt
@@ -1,0 +1,47 @@
+package org.nostr.nostrord.web.components
+
+import kotlinx.coroutines.delay
+import org.nostr.nostrord.di.AppModule
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+import react.useEffect
+import react.useEffectOnce
+import react.useState
+import web.cssom.ClassName
+
+/** How long a system message stays up before it fades out. */
+private const val TOAST_VISIBLE_MS = 4_000L
+
+/**
+ * Renders [AppModule.systemMessages] as a transient toast at the bottom of the page.
+ *
+ * Mount once, at the app root: the flow carries one-shot notices the user did not
+ * explicitly trigger (a revoked signer, a sync that could not be signed) as well as
+ * action confirmations, and without a host every one of them is dropped.
+ *
+ * Native parity: ui/components/layout/SystemMessageHost.kt.
+ */
+val SystemMessageHost =
+    FC<Props> {
+        val (message, setMessage) = useState<String?> { null }
+
+        useEffectOnce {
+            AppModule.systemMessages.collect { setMessage(it) }
+        }
+        // Keyed on the message so a second notice restarts the timer rather than
+        // inheriting the first one's remaining time.
+        useEffect(message) {
+            if (message != null) {
+                delay(TOAST_VISIBLE_MS)
+                setMessage(null)
+            }
+        }
+
+        message?.let { text ->
+            div {
+                className = ClassName("system-toast")
+                +text
+            }
+        }
+    }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
@@ -70,6 +70,7 @@ val HomePage =
         val friendsGroups = useStateFlow(vm.friendsGroups)
         val recommendedGroups = useStateFlow(vm.recommendedGroups)
         val myGroupsLoading = useStateFlow(vm.myGroupsLoading)
+        val muteState = useStateFlow(AppModule.notificationSettings.muteState)
         val friendsGroupsLoading = useStateFlow(vm.friendsGroupsLoading)
         val recommendedGroupsLoading = useStateFlow(vm.recommendedGroupsLoading)
         val relayMeta = useStateFlow(vm.relayMetadata)
@@ -222,7 +223,12 @@ val HomePage =
                                         myGroups.forEach { group ->
                                             // Every card here is joined; the badge earns its
                                             // place only in the mixed lists.
-                                            discoverGroupCard(group, relayMeta[group.relayUrl]?.icon, isJoined = false) {
+                                            discoverGroupCard(
+                                                group,
+                                                relayMeta[group.relayUrl]?.icon,
+                                                isJoined = false,
+                                                muted = muteState.isMuted(group.meta.id),
+                                            ) {
                                                 props.onOpenGroup(JoinedGroup(group.relayUrl, group.meta))
                                             }
                                         }
@@ -328,6 +334,9 @@ internal fun ChildrenBuilder.discoverGroupCard(
     showJoinCta: Boolean = false,
     interactive: Boolean = true,
     showRelay: Boolean = true,
+    // Silenced group: the card recedes and carries a bell-off mark, matching the rail chip
+    // so the same group doesn't read as two different states on two surfaces.
+    muted: Boolean = false,
     onOpen: () -> Unit,
 ) {
     val meta = dg.meta
@@ -341,7 +350,13 @@ internal fun ChildrenBuilder.discoverGroupCard(
         key = "${dg.relayUrl}/${meta.id}"
         // Non-interactive in onboarding: the card itself does nothing (no pointer); only
         // the Join button acts, so the user can join several groups without leaving.
-        className = ClassName(if (interactive) "group-card" else "group-card static")
+        className =
+            ClassName(
+                buildString {
+                    append(if (interactive) "group-card" else "group-card static")
+                    if (muted) append(" muted")
+                },
+            )
         if (interactive) onClick = { onOpen() }
         div {
             className = ClassName("group-card-head")
@@ -358,6 +373,13 @@ internal fun ChildrenBuilder.discoverGroupCard(
                     div {
                         className = ClassName("group-card-name")
                         +name
+                    }
+                    if (muted) {
+                        span {
+                            className = ClassName("group-card-muted")
+                            title = "Muted"
+                            icon(Ic.NotificationsOff)
+                        }
                     }
                     // The onboarding card carries its own trailing Join/Joined action
                     // (below); only the plain Home card shows the inline "Joined" badge.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/HomePage.kt
@@ -228,6 +228,7 @@ val HomePage =
                                                 relayMeta[group.relayUrl]?.icon,
                                                 isJoined = false,
                                                 muted = muteState.isMuted(group.meta.id),
+                                                onUnmute = { AppModule.notificationSettings.toggleMute(group.meta.id) },
                                             ) {
                                                 props.onOpenGroup(JoinedGroup(group.relayUrl, group.meta))
                                             }
@@ -337,6 +338,9 @@ internal fun ChildrenBuilder.discoverGroupCard(
     // Silenced group: the card recedes and carries a bell-off mark, matching the rail chip
     // so the same group doesn't read as two different states on two surfaces.
     muted: Boolean = false,
+    // Unmute straight from the card. Null leaves the mark inert (discovery lists, where
+    // the account has no level for the group).
+    onUnmute: (() -> Unit)? = null,
     onOpen: () -> Unit,
 ) {
     val meta = dg.meta
@@ -375,9 +379,18 @@ internal fun ChildrenBuilder.discoverGroupCard(
                         +name
                     }
                     if (muted) {
+                        // A span, not a button: the card itself is a <button> and nesting one
+                        // inside it is invalid. stopPropagation keeps the tap off the card's
+                        // own open-the-group handler (same pattern as the relay host link).
                         span {
-                            className = ClassName("group-card-muted")
-                            title = "Muted"
+                            className = ClassName(if (onUnmute != null) "group-card-muted action" else "group-card-muted")
+                            title = if (onUnmute != null) "Unmute group" else "Muted"
+                            onUnmute?.let { unmute ->
+                                onClick = {
+                                    it.stopPropagation()
+                                    unmute()
+                                }
+                            }
                             icon(Ic.NotificationsOff)
                         }
                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -14,12 +14,14 @@ import org.nostr.nostrord.notifications.playNotificationSound
 import org.nostr.nostrord.settings.AppTheme
 import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.ui.Identifier
+import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.screens.backup.BackupViewModel
 import org.nostr.nostrord.ui.screens.backup.MIN_BACKUP_PASSWORD
 import org.nostr.nostrord.ui.screens.backup.backupSecurityTips
 import org.nostr.nostrord.ui.screens.profile.EditProfileViewModel
 import org.nostr.nostrord.ui.screens.settings.DmRelaySettingsViewModel
+import org.nostr.nostrord.ui.screens.settings.MutedGroupsViewModel
 import org.nostr.nostrord.ui.screens.settings.MutedUsersViewModel
 import org.nostr.nostrord.ui.screens.settings.SecurityViewModel
 import org.nostr.nostrord.utils.Result
@@ -28,6 +30,7 @@ import org.nostr.nostrord.utils.toRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
+import org.nostr.nostrord.web.components.AvatarKind
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.IdentifierRow
 import org.nostr.nostrord.web.components.UploadButton
@@ -64,7 +67,7 @@ external interface SettingsScreenProps : Props {
 }
 
 private val sections =
-    listOf("Profile", "Backup Keys", "Relays (NIP-65)", "Direct Messages", "Appearance", "Media", "Notifications", "Muted users", "Security")
+    listOf("Profile", "Backup Keys", "Relays (NIP-65)", "Direct Messages", "Appearance", "Media", "Notifications", "Muted users", "Muted groups", "Security")
 
 /**
  * Settings — real port of the Compose SettingsScreen: a full-screen overlay with a section
@@ -162,6 +165,7 @@ val SettingsScreen =
                     "Media" -> MediaPanel()
                     "Notifications" -> NotificationsPanel()
                     "Muted users" -> MutedUsersPanel()
+                    "Muted groups" -> MutedGroupsPanel()
                     "Security" -> SecurityPanel()
                 }
             }
@@ -845,6 +849,87 @@ private val MutedUsersPanel =
             }
         }
     }
+
+/**
+ * Every group with a notification level of its own, so an override can be found and
+ * undone without opening the group. Compose parity: MutedGroupsPanelContent.kt.
+ */
+private val MutedGroupsPanel =
+    FC<Props> {
+        val vm = useViewModel { MutedGroupsViewModel(AppModule.nostrRepository, AppModule.notificationSettings) }
+        val rows = useStateFlow(vm.rows)
+        val defaultLevel = useStateFlow(vm.defaultLevel)
+
+        div {
+            className = ClassName("settings-card")
+            div {
+                className = ClassName("settings-info-text")
+                +(
+                    "Muted groups never notify and drop their unread count to a dot. " +
+                        "These overrides are stored per account and sync to your other devices."
+                    )
+            }
+        }
+
+        div {
+            className = ClassName("settings-card")
+            div {
+                className = ClassName("settings-section-head")
+                +"MUTED GROUPS"
+            }
+            if (rows.isEmpty()) {
+                div {
+                    className = ClassName("settings-info-text")
+                    +"No group overrides yet. Right-click a group in the sidebar, or open its info panel, to mute it."
+                }
+            }
+            rows.forEach { row ->
+                div {
+                    key = row.groupId
+                    className = ClassName("member-row")
+                    // Row opens the group; the route change closes the settings overlay.
+                    if (row.relayUrl.isNotBlank()) {
+                        onClick = { pushRoute(GroupRoute(row.relayUrl, row.groupId)) }
+                    }
+                    WebAvatar {
+                        url = row.picture
+                        seed = row.groupId
+                        this.name = row.name
+                        kind = AvatarKind.GROUP
+                        cls = "member-avatar"
+                    }
+                    span {
+                        className = ClassName("member-name")
+                        +row.name
+                    }
+                    span {
+                        className = ClassName("member-level")
+                        +webLevelLabel(row.level)
+                    }
+                    button {
+                        className = ClassName("btn-ghost")
+                        onClick = {
+                            it.stopPropagation()
+                            vm.clearOverride(row.groupId)
+                        }
+                        +(if (row.level == NotificationLevel.MUTED) "Unmute" else "Reset")
+                    }
+                }
+            }
+            if (rows.isNotEmpty()) {
+                div {
+                    className = ClassName("settings-info-text")
+                    +"Clearing an override returns the group to the global default (${webLevelLabel(defaultLevel).lowercase()})."
+                }
+            }
+        }
+    }
+
+private fun webLevelLabel(level: NotificationLevel): String = when (level) {
+    NotificationLevel.ALL -> "All messages"
+    NotificationLevel.MENTIONS_REPLIES -> "Mentions & replies"
+    NotificationLevel.MUTED -> "Muted"
+}
 
 // ── Notifications ────────────────────────────────────────────────────────────
 

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -1903,6 +1903,32 @@ body {
     bottom: auto;
 }
 
+/* Muted rail chip: the icon recedes so a silenced group reads at a glance even with
+   no traffic, and a bell-off badge names the reason. */
+.rail-group-btn.muted {
+    opacity: 0.45;
+}
+
+.rail-muted-badge {
+    position: absolute;
+    right: -2px;
+    bottom: -2px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    color: var(--color-text-muted);
+    background: var(--color-background-dark);
+    border-radius: var(--radius-full);
+    pointer-events: none;
+}
+
+.rail-muted-badge .ico {
+    width: 10px;
+    height: 10px;
+}
+
 .rail-divider {
     width: 32px;
     height: 1px;

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2091,6 +2091,28 @@ body {
     opacity: 0.4;
 }
 
+/* Muted channel: the label recedes to muted text, matching the native ChannelRow. */
+.group-side-row.muted .group-side-row-label {
+    color: var(--color-text-muted);
+}
+
+/* Unread inside a muted group: presence without a number, since the number is the
+   noise muting removes. Mirrors the native RailMutedDot / ChannelRow dot. */
+.muted-dot {
+    flex-shrink: 0;
+    width: 8px;
+    height: 8px;
+    background: var(--color-text-muted);
+    border-radius: var(--radius-full);
+}
+
+/* On the rail the dot replaces the badge, so it inherits the badge's corner anchor
+   and drops the pill's padding/border. */
+.rail-badge.muted-dot {
+    padding: 0;
+    border: 0;
+}
+
 .group-side-row.drag-over::before,
 .group-side-drop-end.drag-over::before {
     content: "";
@@ -7655,6 +7677,13 @@ body {
 }
 
 .member-name.dimmed {
+    color: var(--color-text-muted);
+}
+
+/* Per-group notification level on a Muted groups row, beside the group name. */
+.member-level {
+    flex-shrink: 0;
+    font-size: 12px;
     color: var(--color-text-muted);
 }
 

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -11406,3 +11406,21 @@ button.hierarchy-crumb-item:hover {
         transform: translate(-50%, 0);
     }
 }
+
+/* Muted group card (Home / My groups): mirrors the rail chip so the same group does not
+   read as two different states on two surfaces. */
+.group-card.muted .group-card-avatar {
+    opacity: 0.45;
+}
+
+.group-card-muted {
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    color: var(--color-text-muted);
+}
+
+.group-card-muted .ico {
+    width: 14px;
+    height: 14px;
+}

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -11376,3 +11376,33 @@ button.hierarchy-crumb-item:hover {
     font-size: 11px;
     font-weight: 700;
 }
+
+/* Transient system notice (AppModule.systemMessages). Bottom-centered over everything,
+   above modals so a notice raised by a modal action is not buried by it. */
+.system-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 24px;
+    z-index: 200;
+    max-width: min(420px, calc(100vw - 32px));
+    padding: 12px 16px;
+    transform: translateX(-50%);
+    font-size: 14px;
+    color: var(--color-text-content);
+    background: var(--color-surface);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-md);
+    box-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.55);
+    animation: system-toast-in 160ms ease-out;
+}
+
+@keyframes system-toast-in {
+    from {
+        opacity: 0;
+        transform: translate(-50%, 8px);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, 0);
+    }
+}

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -11413,11 +11413,26 @@ button.hierarchy-crumb-item:hover {
     opacity: 0.45;
 }
 
+/* Sits at the row's trailing edge because .group-card-name takes the free space. As an
+   action it earns that position: a tap unmutes without opening the group. */
 .group-card-muted {
     display: inline-flex;
     flex-shrink: 0;
     align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
     color: var(--color-text-muted);
+    border-radius: var(--radius-sm);
+}
+
+.group-card-muted.action {
+    cursor: pointer;
+}
+
+.group-card-muted.action:hover {
+    color: var(--color-text-primary);
+    background: var(--color-hover);
 }
 
 .group-card-muted .ico {

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -46,6 +46,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `GroupCardSkeleton` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/home/HomeCards.kt | Shimmer placeholder shaped like a [GroupCard], shown while a tab is still loading. |
 | `GroupCardSkeleton` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/loading/SkeletonLoader.kt | Skeleton loader for group cards on the home screen. |
 | `GroupCard` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/home/HomeCards.kt | Home page building blocks — Compose counterpart of the web's `.group-card` / |
+| `GroupContextMenu` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupContextMenu.kt | Right-click / long-press menu for a group row (rail chip, channel row, group card). |
 | `GroupGradientAvatar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/avatars/GradientAvatar.kt | Deterministic gradient fallback for group avatars (prototype gradientGroupAvatar): |
 | `GroupInviteCard` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt | DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name, |
 | `GroupSidebar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt | Second column when a group is open (prototype ChannelsSidebar group mode): the |
@@ -125,6 +126,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `GeneratedKeyCard` | webMain/kotlin/org/nostr/nostrord/web/components/GeneratedKeyCard.kt | Generated private key panel shown after "Generate New Identity". Displays the |
 | `GoogleLogo` | webMain/kotlin/org/nostr/nostrord/web/components/GoogleLogo.kt | The multicolor Google "G" mark, inlined so the login button needs no asset fetch. |
 | `GroupAvatarUploadRow` | webMain/kotlin/org/nostr/nostrord/web/components/GroupAvatarUploadRow.kt | Group avatar preview + "Change photo" upload. Shared by Create Group and Manage > Info so the |
+| `GroupContextMenu` | webMain/kotlin/org/nostr/nostrord/web/components/GroupContextMenu.kt | Right-click / long-press menu for a group row (rail chip, channel row). Shares the |
 | `GroupInfoModal` | webMain/kotlin/org/nostr/nostrord/web/modals/GroupInfoModal.kt | Group info modal — prototype GroupInfoModal: title bar, gradient cover with the |
 | `GroupInviteCard` | webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt | DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name, |
 | `GroupInviteModal` | webMain/kotlin/org/nostr/nostrord/web/modals/GroupInviteModal.kt | The pending-invite prompt (web counterpart of GroupScreen's GroupInviteDialog), in the |


### PR DESCRIPTION
Per-group muting already existed but was hard to reach and local to one device: three radio buttons inside `GroupInfoModal`, no entry point from a group row, and a muted group still showed its unread count, so it kept reading as noise. This makes muting reachable, makes it actually quiet the UI, and syncs it across devices over NIP-78.

A muted group reports zero to the rail and total rollups and surfaces as a dim dot instead of a number. The counts are still tracked underneath, so opening the group still lands on its unread divider and jump-to-unread keeps working. Muting a root silences its whole channel tree; a channel can still be muted on its own inside a live root.

Sync rides a NIP-78 `kind:30078` addressable event (`d=nostrord.notifications.v1`), NIP-44 self-encrypted: the payload is a list of NIP-29 group ids, and in plaintext it would hand any relay the account's group membership. Ingest is last-write-wins on `created_at` and replaces the whole map, which is what a replaceable event means; a union-merge would resurrect a group another device just unmuted. The REQ carries two filters, one limited to fetch the current value and one with `since` and no limit so changes push live rather than waiting for a poll, with a 30s backstop tick and a refresh on window focus for the cases a live filter can't cover.

A level change only stands once its event is signed and accepted by a relay. Declining the signing prompt puts the levels back and says why, rather than leaving the app acting on a change the user refused. The tradeoff is deliberate: muting with no signer or no reachable relay fails too, because NIP-07 reports a refusal and an error identically. This depends on `AppModule.systemMessages`, which turned out to have no consumer on either UI, so every notice ever emitted into it was dropped — including "Session ended. Please sign in.", "Link copied" and the file-save confirmations. Both UIs now render it as a toast.

The global default is not synced: its storage slot is device-global rather than per-account, so one account's event writing it would hand that default to the next account on the device. Mute keys stay the bare `groupId`, so two same-id groups on different relays share one setting — pre-existing, since `UnreadManager.unreadCounts` and the whole unread system key the same way, and unpicking it is a migration across all of that.

| Surface | Mute | Unmute |
|---|---|---|
| Rail chip | right-click | right-click |
| Channel row | right-click / long-press | same |
| Group info modal | NOTIFICATIONS, three levels | same |
| Home card (My groups) | — | tap the bell-off mark |
| Settings → Muted groups | — | Unmute / Reset per row |

Muted groups are marked consistently across those surfaces: rail chips and Home cards dim with a bell-off badge, channel rows dim their label and swap the count for a dot.

Rail long-press stays the drag-reorder gesture on both platforms, so touch reaches muting through the channel row or the info modal rather than the chip.

- `85ab628f` feat(notifications): mute a group, badges included
- `31855abe` feat(settings): reach muting from the group row and a Muted groups panel
- `f7ec82c2` feat(web): mute a group from the sidebar, rail and settings
- `690bfc1a` feat(nip78): sync per-group mute state across devices
- `5d82e121` fix(nip78): don't let an unsigned mute drift from the synced state
- `8f11887b` fix(ui): mark muted groups on the rail even with no unread
- `8494dc98` fix(nip78): stop a received mute from being republished by the receiver
- `76308c4a` fix(nip78): never drop a prefs publish silently
- `aba20c85` feat(ui): show system messages, which had no consumer at all
- `274c5d94` feat(nip78): a mute only stands once its sync event is signed
- `9801a6be` fix(nip78): converge mute state between devices without a restart
- `ec47e3a3` perf(nip78): push mute changes live instead of waiting for the poll
- `7cddf3ef` feat(home): mark muted groups on the My groups cards
- `6ea02c2d` feat(home): unmute from the card's bell-off mark

Validated on desktop and web, including a two-device round trip. `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid` and `:composeApp:jvmTest` all pass. Android and iOS are not device-validated yet; iOS is not compiled either, since this box is Linux. Worth checking on Android that muting via Amber behaves, as publishing needs both `nip44_encrypt` and `sign_event` and cancelling either now undoes the change.
