### PR TITLE
feat(spells): saved Nostr queries as live, pinnable feeds

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -652,6 +652,11 @@ object AppModule {
 
     val dmSettings: DmSettings by lazy { DmSettings() }
 
+    /** The active account's pinned rail spells. Reloads itself on every account switch. */
+    val spellLibrary: org.nostr.nostrord.settings.SpellLibrary by lazy {
+        org.nostr.nostrord.settings.SpellLibrary(appScope)
+    }
+
     /** Holds an open AV room across screen changes; see [org.nostr.nostrord.ui.screens.avspace.AvSpaceHost]. */
     val avSpaceHost: org.nostr.nostrord.ui.screens.avspace.AvSpaceHost by lazy {
         org.nostr.nostrord.ui.screens.avspace.AvSpaceHost(nostrRepository)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -12,6 +12,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.livekit.isHexPubkey
+import org.nostr.nostrord.nostr.NostrFilter
 import org.nostr.nostrord.utils.epochMillis
 
 @Serializable
@@ -1100,6 +1101,36 @@ class NostrGroupClient(
                     put("limit", limit)
                 },
             )
+        }.toString()
+        send(req)
+        return subscriptionId
+    }
+
+    /**
+     * REQ an arbitrary set of already-resolved filters (spells).
+     *
+     * Multiple filters ride one REQ, which is how an author list chunked past the relay's
+     * accepted size stays a single subscription with a single EOSE. Sends CLOSE first so
+     * re-entry with the same id is idempotent.
+     */
+    suspend fun requestFilters(
+        subscriptionId: String,
+        filters: List<NostrFilter>,
+        until: Long? = null,
+    ): String {
+        if (filters.isEmpty()) return subscriptionId
+        send(
+            buildJsonArray {
+                add("CLOSE")
+                add(subscriptionId)
+            }.toString(),
+        )
+        val req = buildJsonArray {
+            add("REQ")
+            add(subscriptionId)
+            filters.forEach { filter ->
+                add((if (until != null) filter.copy(until = until) else filter).toJsonObject())
+            }
         }.toString()
         send(req)
         return subscriptionId

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -45,6 +45,7 @@ import org.nostr.nostrord.network.managers.ConnectionStats
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmManager
 import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.managers.LiveCursorStore
 import org.nostr.nostrord.network.managers.MetadataManager
@@ -54,6 +55,7 @@ import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.RelayMetadataManager
 import org.nostr.nostrord.network.managers.RelayReconnectScheduler
 import org.nostr.nostrord.network.managers.SessionManager
+import org.nostr.nostrord.network.managers.SpellManager
 import org.nostr.nostrord.network.managers.UnreadManager
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
@@ -61,6 +63,8 @@ import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellContext
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.DM_CACHE_KIND
@@ -404,6 +408,32 @@ class NostrRepository(
             } != null
         },
     )
+
+    // Saved-query feeds. Reaches relays outside the group pool, so it connects on demand
+    // through the same pipeline every other read uses.
+    private val spellManager = SpellManager(
+        scope = scope,
+        connectRelay = { relayUrl ->
+            connectionManager.getClientForRelay(relayUrl)
+                ?: connectionManager.getOrConnectRelay(relayUrl) { msg, c -> enqueueToRelayPipeline(msg, c) }
+        },
+        pooledRelay = { relayUrl -> connectionManager.getClientForRelay(relayUrl) },
+    )
+
+    override val spellEvents: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> = spellManager.events
+    override val spellStates: StateFlow<Map<String, GroupLoadingState>> = spellManager.states
+
+    override suspend fun openSpell(
+        spell: Spell,
+        ctx: SpellContext,
+        nip65ReadRelays: List<String>,
+    ): Result<Unit> = spellManager.open(spell, ctx, nip65ReadRelays)
+
+    override suspend fun loadMoreSpell(spellKey: String): Boolean = spellManager.loadMore(spellKey)
+
+    override fun closeSpell(spellKey: String) {
+        scope.launch { spellManager.close(spellKey) }
+    }
 
     private val _isInitialized = MutableStateFlow(false)
     override val isInitialized: StateFlow<Boolean> = _isInitialized.asStateFlow()
@@ -4892,6 +4922,10 @@ class NostrRepository(
                 val sourceRelayUrl = client.getRelayUrl()
                 scope.launch {
                     yield()
+                    if (spellManager.owns(subId)) {
+                        spellManager.handleEose(subId, sourceRelayUrl)
+                        return@launch
+                    }
                     // A msg_ initial load that EOSEs while the relay still needs AUTH (some
                     // relays empty-EOSE instead of CLOSED auth-required) is not a real empty
                     // result: hold it in InitialLoading so the UI keeps skeletons until
@@ -5140,6 +5174,15 @@ class NostrRepository(
                 val subId = arr[1].jsonPrimitive.content
                 val event = arr[2].jsonObject
                 val kind = event["kind"]?.jsonPrimitive?.int
+
+                // Spell feeds carry arbitrary kinds, so they route on the subscription id
+                // before the kind dispatch below can claim a group-shaped event.
+                if (spellManager.owns(subId)) {
+                    client.parseMessage(event)?.let { parsed ->
+                        spellManager.handleEvent(subId, parsed.copy(relayUrl = client.getRelayUrl()))
+                    }
+                    return
+                }
 
                 // Handle event subscriptions (event_* or e_*) for quotes
                 if (subId.startsWith("event_") || subId.startsWith("e_")) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -13,6 +13,8 @@ import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip46Client
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellContext
 import org.nostr.nostrord.utils.Result
 
 /**
@@ -103,6 +105,31 @@ interface NostrRepositoryApi {
      * group open before any kind:9 has streamed).
      */
     val groupStates: StateFlow<Map<String, org.nostr.nostrord.network.managers.GroupLoadingState>>
+
+    /** Events delivered by each open spell, keyed by [org.nostr.nostrord.network.managers.key]. */
+    val spellEvents: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>>
+
+    /** Loading state per open spell, same state machine group chat uses. */
+    val spellStates: StateFlow<Map<String, org.nostr.nostrord.network.managers.GroupLoadingState>>
+
+    /**
+     * Resolve [spell] against [ctx] and subscribe on its target relays. Fails when a runtime
+     * variable cannot be resolved, rather than sending a filter that would match nothing.
+     */
+    suspend fun openSpell(
+        spell: Spell,
+        ctx: SpellContext,
+        nip65ReadRelays: List<String> = emptyList(),
+    ): Result<Unit>
+
+    /** Fetch the page before the spell's current cursor. */
+    suspend fun loadMoreSpell(spellKey: String): Boolean
+
+    /**
+     * CLOSE the spell's subscriptions and drop its cached events. Fire and forget: the caller is
+     * a ViewModel teardown, where no scope is left alive to await on.
+     */
+    fun closeSpell(spellKey: String)
 
     /**
      * Groups whose initial history read is waiting on NIP-42 AUTH (private group on a relay

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupLoadingController.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupLoadingController.kt
@@ -160,6 +160,9 @@ data class SubscriptionTracker(
 /**
  * Per-group loading controller with its own mutex.
  * Manages state transitions and subscription tracking for a single group.
+ *
+ * [subIdPrefix] namespaces the generated subscription ids. NostrRepository routes inbound
+ * frames by subId prefix, so a non-group consumer of this controller must pick its own.
  */
 class GroupLoadingController(
     private val groupId: String,
@@ -168,6 +171,7 @@ class GroupLoadingController(
     private val timeoutMs: Long = 10_000L,
     private val maxRetries: Int = 3,
     private val maxConsecutivePaginationTimeouts: Int = 3,
+    private val subIdPrefix: String = "msg",
 ) {
     // Zero-event pagination timeouts in a row on the current frontier. Reset by any
     // completed page (EOSE) or partial delivery; reaching the cap transitions to Stalled.
@@ -200,7 +204,7 @@ class GroupLoadingController(
             is GroupLoadingState.Idle,
             is GroupLoadingState.Error,
             -> {
-                val subId = "msg_${groupId.take(8)}_${epochMillis()}"
+                val subId = "${subIdPrefix}_${groupId.take(8)}_${epochMillis()}"
                 val tracker = SubscriptionTracker(
                     subscriptionId = subId,
                     groupId = groupId,
@@ -256,7 +260,7 @@ class GroupLoadingController(
 
         when (currentState) {
             is GroupLoadingState.HasMore -> {
-                val subId = "msg_${groupId.take(8)}_${epochMillis()}"
+                val subId = "${subIdPrefix}_${groupId.take(8)}_${epochMillis()}"
                 val cursor = currentState.cursor
                 val tracker = SubscriptionTracker(
                     subscriptionId = subId,
@@ -440,7 +444,7 @@ class GroupLoadingController(
                     return@withLock null // Max retries exceeded
                 }
 
-                val subId = "msg_${groupId.take(8)}_${epochMillis()}"
+                val subId = "${subIdPrefix}_${groupId.take(8)}_${epochMillis()}"
                 val tracker = SubscriptionTracker(
                     subscriptionId = subId,
                     groupId = groupId,
@@ -575,6 +579,7 @@ class GroupLoadingRegistry(
     private val scope: CoroutineScope,
     private val pageSize: Int = 50,
     private val timeoutMs: Long = 10_000L,
+    private val subIdPrefix: String = "msg",
 ) {
     private val mutex = Mutex()
     private val controllers = mutableMapOf<String, GroupLoadingController>()
@@ -587,7 +592,7 @@ class GroupLoadingRegistry(
      */
     suspend fun getController(groupId: String): GroupLoadingController = mutex.withLock {
         controllers.getOrPut(groupId) {
-            GroupLoadingController(groupId, scope, pageSize, timeoutMs)
+            GroupLoadingController(groupId, scope, pageSize, timeoutMs, subIdPrefix = subIdPrefix)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SpellManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SpellManager.kt
@@ -181,20 +181,22 @@ class SpellManager(
         }
     }
 
-    /** Route one inbound EOSE, settling the page and advancing the cursor. */
+    /**
+     * Route one inbound EOSE, settling the page and advancing the cursor.
+     *
+     * The subscription stays mapped afterwards. EOSE ends the stored page, not the feed: the REQ
+     * is still open on the relay (spells are deliberately absent from the one-shot auto-CLOSE
+     * list), so dropping the mapping here would silently discard every live event that follows.
+     * Only [close] unmaps.
+     */
     suspend fun handleEose(
         subId: String,
         relayUrl: String,
     ) {
-        val key = mutex.withLock { subToKey[subId] } ?: return
+        mutex.withLock { subToKey[subId] } ?: return
         registry.handleEose(subId, relayUrl)
         // The page is settled; anything still buffered belongs to it.
         buffer.flushAll()
-        val settled = registry.getController(key).state.value
-        if (settled !is GroupLoadingState.Paginating && settled !is GroupLoadingState.InitialLoading) {
-            mutex.withLock { subToKey.remove(subId) }
-            registry.unregisterSubscription(subId)
-        }
     }
 
     /** Drop every spell's state. Called on logout and account switch. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SpellManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SpellManager.kt
@@ -1,0 +1,294 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.nostr.NostrFilter
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellContext
+import org.nostr.nostrord.nostr.resolveChunked
+import org.nostr.nostrord.nostr.targetRelays
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
+
+/** Subscription id namespace. NostrRepository routes inbound frames on this prefix. */
+const val SPELL_SUB_PREFIX = "spell"
+
+/**
+ * Runs saved queries (kind:777) as live feeds.
+ *
+ * One open spell means one subscription id fanned out to every target relay, so the loading
+ * state machine, the ordering buffer and the cursor are all keyed by [Spell.key] exactly the
+ * way group chat keys them by group id.
+ *
+ * Events are held in memory only, capped at [MAX_EVENTS_PER_SPELL]: a kind:1 feed is a
+ * firehose and nothing here is worth surviving a restart.
+ */
+class SpellManager(
+    private val scope: CoroutineScope,
+    private val connectRelay: suspend (relayUrl: String) -> NostrGroupClient?,
+    /**
+     * Pool lookup with no connect. CLOSE goes through this so tearing a feed down cannot
+     * resurrect a socket that already died.
+     */
+    private val pooledRelay: suspend (relayUrl: String) -> NostrGroupClient? = connectRelay,
+    private val pageSize: Int = PAGE_SIZE,
+) {
+    companion object {
+        const val PAGE_SIZE = 50
+        const val MAX_EVENTS_PER_SPELL = 500
+        const val AUTH_TIMEOUT_MS = 12_000L
+    }
+
+    private val registry = GroupLoadingRegistry(scope, pageSize, subIdPrefix = SPELL_SUB_PREFIX)
+    private val mutex = Mutex()
+
+    /** Spells with a live subscription, by [Spell.key]. */
+    private val open = mutableMapOf<String, OpenSpell>()
+
+    /** Reverse routing for inbound frames, which carry only the subscription id. */
+    private val subToKey = mutableMapOf<String, String>()
+
+    /**
+     * Per-key job mirroring a controller's state into [states].
+     *
+     * Held so [close] can cancel it: the controller is discarded on close and a re-open builds a
+     * fresh one, so a surviving collector would keep writing the dead controller's state and
+     * strand the feed in a stale loading spinner.
+     */
+    private val stateJobs = mutableMapOf<String, Job>()
+
+    private val _events = MutableStateFlow<Map<String, List<NostrGroupClient.NostrMessage>>>(emptyMap())
+    val events: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> = _events.asStateFlow()
+
+    private val _states = MutableStateFlow<Map<String, GroupLoadingState>>(emptyMap())
+    val states: StateFlow<Map<String, GroupLoadingState>> = _states.asStateFlow()
+
+    private val buffer =
+        EventOrderingBuffer(scope) { key, messages ->
+            appendEvents(key, messages)
+        }
+
+    private data class OpenSpell(
+        val spell: Spell,
+        val filters: List<NostrFilter>,
+        val relays: List<String>,
+    )
+
+    /**
+     * Resolve [spell] against the caller's identity and subscribe on every target relay.
+     *
+     * Idempotent: re-opening an already-loading spell is a no-op, so a screen remount does not
+     * restart the feed.
+     */
+    suspend fun open(
+        spell: Spell,
+        ctx: SpellContext,
+        nip65ReadRelays: List<String>,
+    ): Result<Unit> {
+        val filters =
+            when (val r = spell.resolveChunked(ctx)) {
+                is Result.Success -> r.data
+                is Result.Error -> return Result.Error(r.error)
+            }
+        val relays = spell.targetRelays(nip65ReadRelays)
+        if (relays.isEmpty()) {
+            return Result.Error(AppError.Spell.Malformed("no relay to query for '${spell.name}'"))
+        }
+
+        val key = spell.key
+        val controller = registry.getController(key)
+        val subId = controller.startInitialLoad(armTimeout = false) ?: return Result.Success(Unit)
+        registry.registerSubscription(subId, controller)
+        observeState(key, controller)
+
+        mutex.withLock {
+            open[key] = OpenSpell(spell, filters, relays)
+            subToKey[subId] = key
+        }
+
+        val sent = fanOut(subId, relays, filters, until = null)
+        if (sent == 0) {
+            mutex.withLock { subToKey.remove(subId) }
+            registry.unregisterSubscription(subId)
+            controller.handleSendFailure(subId)
+            return Result.Error(AppError.Network.Disconnected(relays.first()))
+        }
+        controller.armInitialTimeout(subId)
+        return Result.Success(Unit)
+    }
+
+    /** Fetch the page before the current cursor. Returns false when the spell cannot paginate. */
+    suspend fun loadMore(key: String): Boolean {
+        val entry = mutex.withLock { open[key] } ?: return false
+        val controller = registry.getController(key)
+        val (subId, cursor) = controller.startPagination() ?: return false
+        registry.registerSubscription(subId, controller)
+        mutex.withLock { subToKey[subId] = key }
+
+        val sent = fanOut(subId, entry.relays, entry.filters, until = cursor.untilTimestamp)
+        if (sent == 0) {
+            mutex.withLock { subToKey.remove(subId) }
+            registry.unregisterSubscription(subId)
+            controller.handleSendFailure(subId)
+            return false
+        }
+        return true
+    }
+
+    /** CLOSE the spell's subscriptions on every relay it reached and drop its cached events. */
+    suspend fun close(key: String) {
+        val entry = mutex.withLock { open.remove(key) } ?: return
+        val subIds = mutex.withLock {
+            val owned = subToKey.filterValues { it == key }.keys.toList()
+            owned.forEach { subToKey.remove(it) }
+            owned
+        }
+        subIds.forEach { registry.unregisterSubscription(it) }
+        registry.remove(key)
+        mutex.withLock { stateJobs.remove(key) }?.cancel()
+        _events.update { it - key }
+        _states.update { it - key }
+
+        for (relayUrl in entry.relays) {
+            val client = runCatchingCancellable { pooledRelay(relayUrl) } ?: continue
+            subIds.forEach { subId ->
+                runCatchingCancellable { client.closeSubscription(subId) }
+            }
+        }
+    }
+
+    /** True when [subId] belongs to a spell, so NostrRepository can route the frame here. */
+    fun owns(subId: String): Boolean = subId.startsWith("${SPELL_SUB_PREFIX}_")
+
+    /** Route one inbound EVENT. Unknown subscription ids are dropped. */
+    fun handleEvent(
+        subId: String,
+        message: NostrGroupClient.NostrMessage,
+    ) {
+        scope.launch {
+            val key = mutex.withLock { subToKey[subId] } ?: return@launch
+            registry.trackMessage(subId, message.createdAt, message.id)
+            buffer.enqueue(key, message)
+        }
+    }
+
+    /** Route one inbound EOSE, settling the page and advancing the cursor. */
+    suspend fun handleEose(
+        subId: String,
+        relayUrl: String,
+    ) {
+        val key = mutex.withLock { subToKey[subId] } ?: return
+        registry.handleEose(subId, relayUrl)
+        // The page is settled; anything still buffered belongs to it.
+        buffer.flushAll()
+        val settled = registry.getController(key).state.value
+        if (settled !is GroupLoadingState.Paginating && settled !is GroupLoadingState.InitialLoading) {
+            mutex.withLock { subToKey.remove(subId) }
+            registry.unregisterSubscription(subId)
+        }
+    }
+
+    /** Drop every spell's state. Called on logout and account switch. */
+    suspend fun clear() {
+        val keys = mutex.withLock { open.keys.toList() }
+        keys.forEach { close(it) }
+        buffer.flushAll()
+        registry.clear()
+        mutex.withLock {
+            open.clear()
+            subToKey.clear()
+            stateJobs.values.forEach { it.cancel() }
+            stateJobs.clear()
+        }
+        _events.value = emptyMap()
+        _states.value = emptyMap()
+    }
+
+    private suspend fun fanOut(
+        subId: String,
+        relays: List<String>,
+        filters: List<NostrFilter>,
+        until: Long?,
+    ): Int {
+        var sent = 0
+        for (relayUrl in relays) {
+            val client = runCatchingCancellable { connectRelay(relayUrl) } ?: continue
+            // A restricted relay answers a pre-AUTH REQ with zero events, which the state
+            // machine would settle as an empty feed. Wait for the challenge to resolve first.
+            if (client.requiresAuth() && !client.hasAuthSucceeded()) {
+                runCatchingCancellable { client.awaitAuthOrTimeout(AUTH_TIMEOUT_MS) }
+            }
+            val ok = runCatchingCancellable { client.requestFilters(subId, filters, until) } != null
+            if (ok) sent++
+        }
+        return sent
+    }
+
+    private fun appendEvents(
+        key: String,
+        messages: List<NostrGroupClient.NostrMessage>,
+    ) {
+        if (messages.isEmpty()) return
+        _events.update { current ->
+            val existing = current[key].orEmpty()
+            val merged = mergeSpellEvents(existing, messages, MAX_EVENTS_PER_SPELL)
+            if (merged === existing) current else current + (key to merged)
+        }
+    }
+
+    private suspend fun observeState(
+        key: String,
+        controller: GroupLoadingController,
+    ) {
+        mutex.withLock {
+            if (stateJobs.containsKey(key)) return
+            stateJobs[key] = scope.launch {
+                controller.state.collect { state ->
+                    _states.update { it + (key to state) }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Stable identity for a spell within an account: the group it is bound to plus its own id.
+ * The same spell id under two groups is two independent feeds.
+ */
+val Spell.key: String
+    get() = group?.let { "${it.relayUrl}|${it.groupId}|$id" } ?: id
+
+/**
+ * Merge a delivered batch into a feed: newest first, deduplicated by event id, capped at [cap].
+ *
+ * Returns [existing] unchanged when the batch adds nothing, so an idle relay redelivering the
+ * same page does not churn the StateFlow. Fanning one subscription across several relays makes
+ * duplicates the normal case, not the exception.
+ */
+internal fun mergeSpellEvents(
+    existing: List<NostrGroupClient.NostrMessage>,
+    incoming: List<NostrGroupClient.NostrMessage>,
+    cap: Int,
+): List<NostrGroupClient.NostrMessage> {
+    val seen = existing.mapTo(mutableSetOf()) { it.id }
+    val fresh = incoming.filter { seen.add(it.id) }
+    if (fresh.isEmpty()) return existing
+    return (existing + fresh).sortedByDescending { it.createdAt }.take(cap)
+}
+
+private inline fun <T> runCatchingCancellable(block: () -> T): T? = try {
+    block()
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Throwable) {
+    null
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/NostrFilter.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/NostrFilter.kt
@@ -1,0 +1,49 @@
+package org.nostr.nostrord.nostr
+
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/**
+ * A resolved NIP-01 REQ filter.
+ *
+ * Every field is final: variables and relative timestamps are already expanded. Build one with
+ * [Spell.resolve] rather than by hand, so the group-relay routing guard is not bypassed.
+ *
+ * [tags] keys carry the `#` prefix ("#t", "#h", "#p") to match the wire format.
+ */
+data class NostrFilter(
+    val ids: List<String>? = null,
+    val authors: List<String>? = null,
+    val kinds: List<Int>? = null,
+    val tags: Map<String, List<String>> = emptyMap(),
+    val since: Long? = null,
+    val until: Long? = null,
+    val limit: Int? = null,
+    val search: String? = null,
+) {
+    fun toJsonObject(): JsonObject = buildJsonObject {
+        ids?.takeIf { it.isNotEmpty() }?.let { list ->
+            put("ids", buildJsonArray { list.forEach { add(it) } })
+        }
+        authors?.takeIf { it.isNotEmpty() }?.let { list ->
+            put("authors", buildJsonArray { list.forEach { add(it) } })
+        }
+        kinds?.takeIf { it.isNotEmpty() }?.let { list ->
+            put("kinds", buildJsonArray { list.forEach { add(it) } })
+        }
+        tags.entries.sortedBy { it.key }.forEach { (key, values) ->
+            if (values.isNotEmpty()) {
+                put(key, buildJsonArray { values.forEach { add(it) } })
+            }
+        }
+        since?.let { put("since", it) }
+        until?.let { put("until", it) }
+        limit?.let { put("limit", it) }
+        search?.takeIf { it.isNotBlank() }?.let { put("search", it) }
+    }
+
+    override fun toString(): String = toJsonObject().toString()
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Spell.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Spell.kt
@@ -1,0 +1,361 @@
+package org.nostr.nostrord.nostr
+
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
+
+/** Spell event: a portable, shareable saved query. */
+const val SPELL_KIND = 777
+
+/** Spellbook: addressable index of pinned spells, scoped per group by its `d` tag. */
+const val SPELLBOOK_KIND = 30777
+
+/** Author lists longer than this are rejected by many relays; [Spell.resolveChunked] splits them. */
+const val SPELL_AUTHOR_CAP = 500
+
+const val VAR_ME = "\$me"
+const val VAR_CONTACTS = "\$contacts"
+const val VAR_MEMBERS = "\$members"
+
+enum class SpellCmd { REQ, COUNT }
+
+/**
+ * Binds a spell to a NIP-29 group, carried as `["group", <relay>, <group-id>]`.
+ *
+ * Keeps a published spell self-contained: `$members` resolves from the bound group rather than
+ * from whatever screen happens to cast it.
+ */
+data class GroupBinding(
+    val relayUrl: String,
+    val groupId: String,
+)
+
+/** Identity resolved at cast time. Distinct per user and per group, so it is never cached. */
+data class SpellContext(
+    val me: String? = null,
+    val contacts: List<String> = emptyList(),
+    val members: List<String> = emptyList(),
+    val now: Long,
+)
+
+/**
+ * A saved query in its **unresolved** form: `$me` / `$contacts` / `$members` and relative
+ * timestamps such as `7d` stay literal.
+ *
+ * This is the invariant that keeps a spell alive rather than a frozen snapshot. Resolving at
+ * creation time would pin the author list and the time window to the day it was written.
+ *
+ * [tagFilters] keys are bare tag letters ("t", "h", "p"); the `#` prefix is added on resolve.
+ */
+data class Spell(
+    val id: String,
+    val name: String,
+    val description: String = "",
+    val cmd: SpellCmd = SpellCmd.REQ,
+    val kinds: List<Int> = emptyList(),
+    val authors: List<String> = emptyList(),
+    val ids: List<String> = emptyList(),
+    val tagFilters: Map<String, List<String>> = emptyMap(),
+    val relays: List<String> = emptyList(),
+    val limit: Int? = null,
+    val since: String? = null,
+    val until: String? = null,
+    val search: String? = null,
+    val closeOnEose: Boolean = false,
+    val topics: List<String> = emptyList(),
+    val forkedFrom: String? = null,
+    val group: GroupBinding? = null,
+    val pubkey: String? = null,
+    val createdAt: Long? = null,
+) {
+    /** True when the spell carries no filter tag at all, which the format forbids. */
+    val hasFilter: Boolean
+        get() = kinds.isNotEmpty() ||
+            authors.isNotEmpty() ||
+            ids.isNotEmpty() ||
+            tagFilters.isNotEmpty() ||
+            !search.isNullOrBlank() ||
+            since != null ||
+            until != null
+
+    val usesVariables: Boolean
+        get() = (authors + tagFilters.values.flatten()).any { it.isVariable() }
+}
+
+private fun String.isVariable(): Boolean = this == VAR_ME || this == VAR_CONTACTS || this == VAR_MEMBERS
+
+// ---------------------------------------------------------------------------
+// Relative timestamps
+// ---------------------------------------------------------------------------
+
+private val RELATIVE_TIME = Regex("^(\\d+)(s|mo|m|h|d|w|y)$")
+
+private fun unitSeconds(unit: String): Long = when (unit) {
+    "s" -> 1L
+    "m" -> 60L
+    "h" -> 3_600L
+    "d" -> 86_400L
+    "w" -> 604_800L
+    "mo" -> 2_592_000L // approximate: 30 days
+    "y" -> 31_536_000L // approximate: 365 days
+    else -> 0L
+}
+
+/**
+ * Resolves `now`, a bare unix timestamp, or a relative expression (`7d`, `12h`, `3mo`) against
+ * [now]. Returns null when the value does not parse.
+ */
+fun parseRelativeTime(
+    value: String,
+    now: Long,
+): Long? {
+    val trimmed = value.trim()
+    if (trimmed.isEmpty()) return null
+    if (trimmed == "now") return now
+    trimmed.toLongOrNull()?.let { return it }
+    val match = RELATIVE_TIME.matchEntire(trimmed) ?: return null
+    val amount = match.groupValues[1].toLongOrNull() ?: return null
+    return now - amount * unitSeconds(match.groupValues[2])
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+private fun malformed(reason: String): Result.Error<Nothing> = Result.Error(AppError.Spell.Malformed(reason))
+
+/** Parses a `kind:777` event into a [Spell], keeping variables and relative times unresolved. */
+fun parseSpell(event: Event): Result<Spell> {
+    if (event.kind != SPELL_KIND) return malformed("expected kind $SPELL_KIND, got ${event.kind}")
+
+    var cmd: SpellCmd? = null
+    var name = ""
+    var limit: Int? = null
+    var since: String? = null
+    var until: String? = null
+    var search: String? = null
+    var closeOnEose = false
+    var forkedFrom: String? = null
+    var group: GroupBinding? = null
+    val kinds = mutableListOf<Int>()
+    val authors = mutableListOf<String>()
+    val ids = mutableListOf<String>()
+    val relays = mutableListOf<String>()
+    val topics = mutableListOf<String>()
+    val tagFilters = mutableMapOf<String, MutableList<String>>()
+
+    for (tag in event.tags) {
+        val label = tag.firstOrNull() ?: continue
+        val values = tag.drop(1)
+        when (label) {
+            "cmd" ->
+                cmd = when (values.firstOrNull()?.uppercase()) {
+                    "REQ" -> SpellCmd.REQ
+                    "COUNT" -> SpellCmd.COUNT
+                    else -> return malformed("unknown cmd '${values.firstOrNull()}'")
+                }
+            "k" -> values.firstOrNull()?.toIntOrNull()?.let { kinds += it }
+            "authors" -> authors += values.filter { it.isNotBlank() }
+            "ids" -> ids += values.filter { it.isNotBlank() }
+            "relays" -> relays += values.filter { it.isNotBlank() }
+            "limit" -> limit = values.firstOrNull()?.toIntOrNull()
+            "since" -> since = values.firstOrNull()?.takeIf { it.isNotBlank() }
+            "until" -> until = values.firstOrNull()?.takeIf { it.isNotBlank() }
+            "search" -> search = values.firstOrNull()?.takeIf { it.isNotBlank() }
+            "close-on-eose" -> closeOnEose = true
+            "name" -> name = values.firstOrNull().orEmpty()
+            "t" -> values.firstOrNull()?.takeIf { it.isNotBlank() }?.let { topics += it }
+            "e" -> forkedFrom = values.firstOrNull()?.takeIf { it.isNotBlank() }
+            "group" -> {
+                val relay = values.getOrNull(0)?.takeIf { it.isNotBlank() }
+                val gid = values.getOrNull(1)?.takeIf { it.isNotBlank() }
+                if (relay != null && gid != null) group = GroupBinding(relay, gid)
+            }
+            // Filter conditions on event tags are namespaced under "tag" so a ["p", ...] filter
+            // parameter is never mistaken for a social-graph reference.
+            "tag" -> {
+                val letter = values.firstOrNull()?.takeIf { it.length == 1 } ?: continue
+                val conditions = values.drop(1).filter { it.isNotBlank() }
+                if (conditions.isNotEmpty()) {
+                    tagFilters.getOrPut(letter) { mutableListOf() } += conditions
+                }
+            }
+        }
+    }
+
+    val resolvedCmd = cmd ?: return malformed("missing cmd tag")
+
+    val spell =
+        Spell(
+            id = event.id.orEmpty(),
+            name = name,
+            description = event.content,
+            cmd = resolvedCmd,
+            kinds = kinds.distinct(),
+            authors = authors.distinct(),
+            ids = ids.distinct(),
+            tagFilters = tagFilters.mapValues { (_, v) -> v.distinct() },
+            relays = relays.distinct(),
+            limit = limit,
+            since = since,
+            until = until,
+            search = search,
+            closeOnEose = closeOnEose,
+            topics = topics.distinct(),
+            forkedFrom = forkedFrom,
+            group = group,
+            pubkey = event.pubkey,
+            createdAt = event.createdAt,
+        )
+
+    if (!spell.hasFilter) return malformed("spell carries no filter tag")
+    return Result.Success(spell)
+}
+
+// ---------------------------------------------------------------------------
+// Encode
+// ---------------------------------------------------------------------------
+
+/** Builds the unsigned `kind:777` event. Tag order matches the draft's worked examples. */
+fun Spell.toUnsignedEvent(
+    pubkey: String,
+    now: Long,
+): Event {
+    val tags = mutableListOf<List<String>>()
+    tags += listOf("cmd", cmd.name)
+    if (name.isNotBlank()) tags += listOf("name", name)
+    tags += listOf("alt", "Spell: ${name.ifBlank { "saved query" }}")
+    group?.let { tags += listOf("group", it.relayUrl, it.groupId) }
+    kinds.forEach { tags += listOf("k", it.toString()) }
+    if (authors.isNotEmpty()) tags += listOf("authors") + authors
+    if (ids.isNotEmpty()) tags += listOf("ids") + ids
+    tagFilters.entries.sortedBy { it.key }.forEach { (letter, values) ->
+        if (values.isNotEmpty()) tags += listOf("tag", letter) + values
+    }
+    if (relays.isNotEmpty()) tags += listOf("relays") + relays
+    limit?.let { tags += listOf("limit", it.toString()) }
+    since?.let { tags += listOf("since", it) }
+    until?.let { tags += listOf("until", it) }
+    search?.takeIf { it.isNotBlank() }?.let { tags += listOf("search", it) }
+    if (closeOnEose) tags += listOf("close-on-eose")
+    topics.forEach { tags += listOf("t", it) }
+    forkedFrom?.let { tags += listOf("e", it) }
+
+    return Event(
+        pubkey = pubkey,
+        createdAt = now,
+        kind = SPELL_KIND,
+        tags = tags,
+        content = description,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Resolve
+// ---------------------------------------------------------------------------
+
+private fun expand(
+    values: List<String>,
+    ctx: SpellContext,
+): Result<List<String>> {
+    val out = mutableListOf<String>()
+    for (value in values) {
+        when (value) {
+            VAR_ME -> {
+                val me = ctx.me
+                    ?: return Result.Error(AppError.Spell.UnresolvedVariable(VAR_ME, "no signed-in account"))
+                out += me
+            }
+            VAR_CONTACTS -> {
+                if (ctx.contacts.isEmpty()) {
+                    return Result.Error(AppError.Spell.UnresolvedVariable(VAR_CONTACTS, "contact list is empty"))
+                }
+                out += ctx.contacts
+            }
+            VAR_MEMBERS -> {
+                if (ctx.members.isEmpty()) {
+                    return Result.Error(AppError.Spell.UnresolvedVariable(VAR_MEMBERS, "member list not loaded"))
+                }
+                out += ctx.members
+            }
+            else -> out += value
+        }
+    }
+    return Result.Success(out.distinct())
+}
+
+/**
+ * Expands variables and relative timestamps into a sendable filter.
+ *
+ * Fails rather than degrading: an unresolvable variable must never reach a relay as a literal
+ * `$members`, which would silently match nothing.
+ */
+fun Spell.resolve(ctx: SpellContext): Result<NostrFilter> {
+    val resolvedAuthors =
+        when (val r = expand(authors, ctx)) {
+            is Result.Success -> r.data
+            is Result.Error -> return Result.Error(r.error)
+        }
+
+    val resolvedTags = mutableMapOf<String, List<String>>()
+    for ((letter, values) in tagFilters) {
+        when (val r = expand(values, ctx)) {
+            is Result.Success -> resolvedTags["#$letter"] = r.data
+            is Result.Error -> return Result.Error(r.error)
+        }
+    }
+
+    val resolvedSince = since?.let {
+        parseRelativeTime(it, ctx.now)
+            ?: return malformed("bad since '$it'")
+    }
+    val resolvedUntil = until?.let {
+        parseRelativeTime(it, ctx.now)
+            ?: return malformed("bad until '$it'")
+    }
+
+    return Result.Success(
+        NostrFilter(
+            ids = ids.takeIf { it.isNotEmpty() },
+            authors = resolvedAuthors.takeIf { it.isNotEmpty() },
+            kinds = kinds.takeIf { it.isNotEmpty() },
+            tags = resolvedTags,
+            since = resolvedSince,
+            until = resolvedUntil,
+            limit = limit,
+            search = search,
+        ),
+    )
+}
+
+/**
+ * Resolves into one filter per author chunk.
+ *
+ * `$members` on a large group produces an author list many relays reject outright, so the caller
+ * sends the chunks as separate REQs rather than one oversized filter.
+ */
+fun Spell.resolveChunked(
+    ctx: SpellContext,
+    cap: Int = SPELL_AUTHOR_CAP,
+): Result<List<NostrFilter>> {
+    val filter =
+        when (val r = resolve(ctx)) {
+            is Result.Success -> r.data
+            is Result.Error -> return Result.Error(r.error)
+        }
+    val allAuthors = filter.authors
+    if (allAuthors == null || allAuthors.size <= cap) return Result.Success(listOf(filter))
+    return Result.Success(allAuthors.chunked(cap).map { filter.copy(authors = it) })
+}
+
+/**
+ * Relays to send this spell to.
+ *
+ * The bound group's relay is dropped from the NIP-65 fallback: a NIP-29 relay serves group
+ * events only, so a kind:1 query routed there returns empty and reads as a broken feed. Presets
+ * that genuinely target the group relay carry it in [Spell.relays] explicitly.
+ */
+fun Spell.targetRelays(nip65ReadRelays: List<String>): List<String> {
+    if (relays.isNotEmpty()) return relays.distinct()
+    val groupRelay = group?.relayUrl
+    return nip65ReadRelays.distinct().filterNot { it.equals(groupRelay, ignoreCase = true) }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/SpellDraft.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/SpellDraft.kt
@@ -1,0 +1,100 @@
+package org.nostr.nostrord.nostr
+
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.epochMillis
+import org.nostr.nostrord.utils.toRelayUrl
+
+/** Id namespace for a spell the user built here and has not published yet. */
+const val LOCAL_ID_PREFIX = "local:"
+
+/**
+ * The create-spell form as the user typed it, before validation.
+ *
+ * Lives in commonMain so both UIs parse identically: the Compose dialog and the web modal are
+ * only text fields over [toSpell].
+ */
+data class SpellDraft(
+    val name: String = "",
+    val kinds: String = "",
+    val authors: String = "",
+    val relays: String = "",
+    val hashtags: String = "",
+    val limit: String = "",
+) {
+    val isRelayFeed: Boolean
+        get() = relays.isNotBlank() && authors.isBlank()
+}
+
+private val SEPARATORS = Regex("[,\\s]+")
+
+private fun split(raw: String): List<String> = raw.split(SEPARATORS).map { it.trim() }.filter { it.isNotEmpty() }
+
+/**
+ * Normalizes one author entry: a runtime variable, an npub, or raw hex.
+ *
+ * Returns null when the entry is none of those, so a typo is reported rather than silently
+ * shipped to a relay as an author that matches nothing.
+ */
+internal fun parseAuthor(raw: String): String? {
+    val value = raw.trim()
+    return when {
+        value == VAR_ME || value == VAR_CONTACTS || value == VAR_MEMBERS -> value
+        value.startsWith("npub") -> (Nip19.decode(value) as? Nip19.Entity.Npub)?.pubkey
+        value.length == 64 && value.all { it.isDigit() || it in 'a'..'f' || it in 'A'..'F' } -> value.lowercase()
+        else -> null
+    }
+}
+
+/**
+ * Validates the draft into a spell ready to pin.
+ *
+ * A spell with only relays and no other condition is valid: that is fiatjaf's relay feed, where
+ * the relay itself is the whole selection criterion.
+ */
+fun SpellDraft.toSpell(now: Long = epochMillis()): Result<Spell> {
+    val trimmedName = name.trim()
+    if (trimmedName.isEmpty()) {
+        return Result.Error(AppError.Spell.Malformed("give the spell a name"))
+    }
+
+    val parsedKinds = mutableListOf<Int>()
+    for (entry in split(kinds)) {
+        val kind = entry.toIntOrNull()
+            ?: return Result.Error(AppError.Spell.Malformed("'$entry' is not a kind number"))
+        parsedKinds += kind
+    }
+
+    val parsedAuthors = mutableListOf<String>()
+    for (entry in split(authors)) {
+        parsedAuthors += parseAuthor(entry)
+            ?: return Result.Error(AppError.Spell.Malformed("'$entry' is not an npub, hex key or variable"))
+    }
+
+    val parsedRelays = split(relays).map { it.toRelayUrl() }.filter { it.isNotBlank() }
+    val parsedTags = split(hashtags).map { it.removePrefix("#") }.filter { it.isNotBlank() }
+
+    val parsedLimit = limit.trim().takeIf { it.isNotEmpty() }?.let {
+        it.toIntOrNull()?.takeIf { n -> n > 0 }
+            ?: return Result.Error(AppError.Spell.Malformed("'$it' is not a positive limit"))
+    }
+
+    val spell =
+        Spell(
+            id = "$LOCAL_ID_PREFIX$now",
+            name = trimmedName,
+            description = "",
+            kinds = parsedKinds.distinct(),
+            authors = parsedAuthors.distinct(),
+            tagFilters = if (parsedTags.isEmpty()) emptyMap() else mapOf("t" to parsedTags.distinct()),
+            relays = parsedRelays.distinct(),
+            limit = parsedLimit ?: DEFAULT_DRAFT_LIMIT,
+        )
+
+    if (!spell.hasFilter && spell.relays.isEmpty()) {
+        return Result.Error(AppError.Spell.Malformed("add at least a kind, an author, a hashtag or a relay"))
+    }
+    return Result.Success(spell)
+}
+
+private const val DEFAULT_DRAFT_LIMIT = 50

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/SpellPresets.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/SpellPresets.kt
@@ -1,0 +1,179 @@
+package org.nostr.nostrord.nostr
+
+/**
+ * Built-in spells, materialized per group.
+ *
+ * Presets are code, not events: every platform derives the identical spell from
+ * `(relayUrl, groupId)`, so nothing about them needs to sync. Only the pin state does, keyed by
+ * [SpellPreset.slug].
+ */
+enum class PresetFamily {
+    /** Account-level feed for the rail. Resolves from the signed-in identity alone. */
+    Rail,
+
+    /** Group content on the group's own relay, scoped by `#h`. Already connected and authed. */
+    GroupRelay,
+
+    /** Member-authored content on general relays. Must not be routed to the NIP-29 relay. */
+    MemberGraph,
+}
+
+data class SpellPreset(
+    val slug: String,
+    val displayName: String,
+    val family: PresetFamily,
+    val kinds: List<Int>,
+    val description: String,
+)
+
+object SpellPresets {
+    // Rail: account-level, zero config. Every one resolves from the signed-in identity, so a
+    // fresh install has something in the rail before the user builds anything.
+    val CONTACT_NOTES =
+        SpellPreset("contacts-notes", "From contacts", PresetFamily.Rail, listOf(1), "Notes from people you follow")
+    val MENTIONS =
+        SpellPreset("mentions", "Mentions", PresetFamily.Rail, listOf(1), "Notes that mention you")
+    val MY_NOTES =
+        SpellPreset("my-notes", "My notes", PresetFamily.Rail, listOf(1), "Notes you published")
+
+    // Group content by kind. Kind 11 (NIP-7D threads) is deliberately absent: Nostrord already
+    // ships it as the Threads view, and a preset that duplicates a screen splits the feature.
+    val IMAGES = SpellPreset("images", "Images", PresetFamily.GroupRelay, listOf(20), "Pictures posted in this group")
+    val VIDEOS = SpellPreset("videos", "Videos", PresetFamily.GroupRelay, listOf(21, 22), "Videos posted in this group")
+    val POLLS = SpellPreset("polls", "Polls", PresetFamily.GroupRelay, listOf(1068), "Polls opened in this group")
+    val FILES = SpellPreset("files", "Files", PresetFamily.GroupRelay, listOf(1063), "Files shared in this group")
+    val FIREHOSE = SpellPreset("firehose", "Raw firehose", PresetFamily.GroupRelay, emptyList(), "Every event in this group")
+
+    val MEMBER_NOTES =
+        SpellPreset("member-notes", "Notes from members", PresetFamily.MemberGraph, listOf(1), "Public notes by group members")
+    val MEMBER_ARTICLES =
+        SpellPreset("member-articles", "Long-form from members", PresetFamily.MemberGraph, listOf(30023), "Articles by group members")
+    val MEMBER_HIGHLIGHTS =
+        SpellPreset("member-highlights", "Highlights from members", PresetFamily.MemberGraph, listOf(9802), "Highlights by group members")
+
+    /** Rail presets in display order. */
+    val rail: List<SpellPreset> = listOf(CONTACT_NOTES, MENTIONS, MY_NOTES)
+
+    /** Group presets in display order. */
+    val group: List<SpellPreset> =
+        listOf(IMAGES, VIDEOS, POLLS, FILES, FIREHOSE, MEMBER_NOTES, MEMBER_ARTICLES, MEMBER_HIGHLIGHTS)
+
+    val all: List<SpellPreset> = rail + group
+
+    val slugs: List<String> = all.map { it.slug }
+
+    fun bySlug(slug: String): SpellPreset? = all.firstOrNull { it.slug == slug }
+
+    /** Every rail preset, in display order. */
+    fun forRail(): List<Spell> = rail.map { it.toRailSpell() }
+
+    fun forRail(slug: String): Spell? = rail.firstOrNull { it.slug == slug }?.toRailSpell()
+
+    /**
+     * Resolve a spell id carried by [org.nostr.nostrord.ui.navigation.SpellRoute] back to its
+     * rail spell. Returns null for a custom (published) id, which comes from storage instead.
+     */
+    fun railSpellById(spellId: String): Spell? {
+        if (!spellId.startsWith(PRESET_ID_PREFIX)) return null
+        return forRail(spellId.removePrefix(PRESET_ID_PREFIX))
+    }
+
+    /** Every group preset bound to the given group, in display order. */
+    fun forGroup(
+        relayUrl: String,
+        groupId: String,
+    ): List<Spell> = group.map { it.toSpell(relayUrl, groupId) }
+
+    fun forGroup(
+        slug: String,
+        relayUrl: String,
+        groupId: String,
+    ): Spell? = group.firstOrNull { it.slug == slug }?.toSpell(relayUrl, groupId)
+}
+
+/**
+ * Materializes a rail preset.
+ *
+ * Relays stay empty so [targetRelays] falls back to the user's NIP-65 read relays: none of these
+ * are group content, and a NIP-29 relay does not serve kind:1.
+ */
+fun SpellPreset.toRailSpell(): Spell {
+    require(family == PresetFamily.Rail) { "$slug is not a rail preset" }
+    val base =
+        Spell(
+            id = "$PRESET_ID_PREFIX$slug",
+            name = displayName,
+            description = description,
+            kinds = kinds,
+            limit = DEFAULT_PRESET_LIMIT,
+        )
+    return when (slug) {
+        SpellPresets.MENTIONS.slug -> base.copy(tagFilters = mapOf("p" to listOf(VAR_ME)))
+        SpellPresets.MY_NOTES.slug -> base.copy(authors = listOf(VAR_ME))
+        else -> base.copy(authors = listOf(VAR_CONTACTS))
+    }
+}
+
+/**
+ * fiatjaf's first example: a feed of one or more kinds straight off specific relays.
+ *
+ * Needs exactly one input (the relays), which is why it is a builder rather than a preset or a
+ * trip through the full editor.
+ */
+fun relayFeed(
+    name: String,
+    relays: List<String>,
+    kinds: List<Int> = listOf(1),
+    limit: Int = DEFAULT_PRESET_LIMIT,
+): Spell = Spell(
+    id = "relay:${relays.joinToString(",")}",
+    name = name,
+    description = "Everything on ${relays.joinToString(", ")}",
+    kinds = kinds,
+    relays = relays,
+    limit = limit,
+)
+
+/**
+ * Binds a preset to a group.
+ *
+ * [PresetFamily.GroupRelay] pins the group relay explicitly and filters by `#h`;
+ * [PresetFamily.MemberGraph] leaves relays empty so [targetRelays] falls back to NIP-65 with the
+ * group relay excluded, and queries `$members` instead.
+ */
+fun SpellPreset.toSpell(
+    relayUrl: String,
+    groupId: String,
+): Spell {
+    require(family != PresetFamily.Rail) { "$slug is a rail preset; use toRailSpell()" }
+    val binding = GroupBinding(relayUrl, groupId)
+    return when (family) {
+        PresetFamily.Rail -> error("unreachable")
+        PresetFamily.GroupRelay ->
+            Spell(
+                id = "$PRESET_ID_PREFIX$slug",
+                name = displayName,
+                description = description,
+                kinds = kinds,
+                tagFilters = mapOf("h" to listOf(groupId)),
+                relays = listOf(relayUrl),
+                limit = DEFAULT_PRESET_LIMIT,
+                group = binding,
+            )
+        PresetFamily.MemberGraph ->
+            Spell(
+                id = "$PRESET_ID_PREFIX$slug",
+                name = displayName,
+                description = description,
+                kinds = kinds,
+                authors = listOf(VAR_MEMBERS),
+                limit = DEFAULT_PRESET_LIMIT,
+                group = binding,
+            )
+    }
+}
+
+/** Id namespace for built-in spells, so a preset id can never collide with an event id. */
+const val PRESET_ID_PREFIX = "preset:"
+
+private const val DEFAULT_PRESET_LIMIT = 50

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/SpellLibrary.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/settings/SpellLibrary.kt
@@ -1,0 +1,136 @@
+package org.nostr.nostrord.settings
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.nostr.nostrord.auth.ActiveAccountManager
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.PRESET_ID_PREFIX
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellPresets
+import org.nostr.nostrord.nostr.parseSpell
+import org.nostr.nostrord.nostr.toUnsignedEvent
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.epochSeconds
+
+/**
+ * One entry of the rail's pinned-spell list.
+ *
+ * A preset stores only its slug, since the spell itself is code and an app update should be able
+ * to improve it. A custom spell stores the kind:777 event it will eventually be published as, so
+ * the local format and the wire format cannot drift apart.
+ */
+@Serializable
+internal data class SpellPin(
+    val preset: String? = null,
+    val id: String? = null,
+    val event: Event? = null,
+)
+
+/**
+ * The account's rail spells: which are pinned and in what order.
+ *
+ * Local and authoritative. Publishing (kind:777) and the shared kind:30777 index are a later
+ * step; nothing here reaches a relay.
+ */
+class SpellLibrary(
+    scope: CoroutineScope,
+) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    private val _pinned = MutableStateFlow(SpellPresets.forRail())
+    val pinned: StateFlow<List<Spell>> = _pinned.asStateFlow()
+
+    private var pubkey: String? = null
+
+    init {
+        scope.launch {
+            ActiveAccountManager.session.collect { session -> load(session?.pubkey) }
+        }
+    }
+
+    /**
+     * The spell behind a route id: a pinned one first, then an unpinned built-in so a shared
+     * link to a preset still opens. Null for a custom spell this device has never stored.
+     */
+    fun spellById(spellId: String): Spell? = _pinned.value.firstOrNull { it.id == spellId } ?: SpellPresets.railSpellById(spellId)
+
+    /** True when [spellId] is already in the rail. */
+    fun isPinned(spellId: String): Boolean = _pinned.value.any { it.id == spellId }
+
+    fun add(spell: Spell) {
+        if (isPinned(spell.id)) return
+        mutate { it + spell }
+    }
+
+    fun remove(spellId: String) {
+        mutate { list -> list.filterNot { it.id == spellId } }
+    }
+
+    /** Reorder to match [orderedIds]; ids not present are appended in their current order. */
+    fun reorder(orderedIds: List<String>) {
+        mutate { list ->
+            val byId = list.associateBy { it.id }
+            orderedIds.mapNotNull { byId[it] } + list.filterNot { it.id in orderedIds }
+        }
+    }
+
+    /** Restore the built-in set, discarding custom spells. */
+    fun resetToDefaults() {
+        mutate { SpellPresets.forRail() }
+    }
+
+    private fun load(newPubkey: String?) {
+        pubkey = newPubkey
+        if (newPubkey == null) {
+            _pinned.value = SpellPresets.forRail()
+            return
+        }
+        val raw = SecureStorage.getStringPref(key(newPubkey), "")
+        // Absent means "never customised", which is not the same as "emptied on purpose": only
+        // the first seeds the defaults, so removing every spell survives a restart.
+        if (raw.isBlank()) {
+            _pinned.value = SpellPresets.forRail()
+            return
+        }
+        _pinned.value = runCatching { json.decodeFromString<List<SpellPin>>(raw) }
+            .getOrDefault(emptyList())
+            .mapNotNull { it.toSpell() }
+    }
+
+    private fun mutate(transform: (List<Spell>) -> List<Spell>) {
+        val next = transform(_pinned.value)
+        _pinned.value = next
+        val owner = pubkey ?: return
+        val pins = next.map { it.toPin(owner) }
+        SecureStorage.saveStringPref(key(owner), json.encodeToString(pins))
+    }
+
+    private companion object {
+        fun key(pubkey: String) = "spell_pins_$pubkey"
+    }
+}
+
+internal fun SpellPin.toSpell(): Spell? = when {
+    preset != null -> SpellPresets.forRail(preset)
+    event != null -> when (val parsed = parseSpell(event)) {
+        // The stored event is unsigned, so it carries no id; the pin keeps the local one.
+        is Result.Success -> parsed.data.copy(id = id ?: parsed.data.id)
+        is Result.Error -> null
+    }
+    else -> null
+}
+
+internal fun Spell.toPin(ownerPubkey: String): SpellPin = if (id.startsWith(PRESET_ID_PREFIX)) {
+    SpellPin(preset = id.removePrefix(PRESET_ID_PREFIX))
+} else {
+    SpellPin(id = id, event = toUnsignedEvent(ownerPubkey, createdAt ?: epochSeconds()))
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/GroupRoute.kt
@@ -85,6 +85,7 @@ fun persistedRouteHash(route: HashRoute?): String? = when (route) {
     null -> "" // default Groups home is the empty hash
     is HomeRoute -> route.toHash()
     is GroupRoute -> GroupRoute(route.relayUrl, route.groupId).toHash()
+    is SpellRoute -> route.toHash()
     else -> null
 }
 
@@ -97,7 +98,7 @@ fun persistedRouteHash(route: HashRoute?): String? = when (route) {
 fun restoredRoute(saved: String?): HashRoute? {
     val hash = saved?.takeIf { it.isNotBlank() } ?: return null
     return when (val route = parseHashRoute(hash)) {
-        is GroupRoute, is HomeRoute -> route
+        is GroupRoute, is HomeRoute, is SpellRoute -> route
         else -> null
     }
 }
@@ -142,6 +143,15 @@ data object NotificationsRoute : HashRoute
  */
 data object SettingsRoute : HashRoute
 
+/**
+ * Route for a spell feed pinned in the rail: #/s/<spell-id>. [spellId] is the preset slug for a
+ * built-in ("preset:mentions") or the kind:777 event id for a saved one, so the hash is stable
+ * across devices once the spell is published.
+ */
+data class SpellRoute(
+    val spellId: String,
+) : HashRoute
+
 /** The Home page tabs, in pill order. [Groups] is the default home (no hash). */
 enum class HomeTab { Groups, Friends, Recommended, People }
 
@@ -156,6 +166,7 @@ data class HomeRoute(val tab: HomeTab) : HashRoute
 private const val GROUP_HASH_PREFIX = "#/g/"
 private const val RELAY_HASH_PREFIX = "#/r/"
 private const val USER_HASH_PREFIX = "#/u/"
+private const val SPELL_HASH_PREFIX = "#/s/"
 private const val DM_HASH_PREFIX = "#/dm"
 private const val NOTIFICATIONS_HASH = "#/notifications"
 private const val SETTINGS_HASH = "#/settings"
@@ -168,6 +179,7 @@ fun HashRoute.toHash(): String = when (this) {
     is GroupRoute -> toHash()
     is RelayRoute -> toHash()
     is UserRoute -> toHash()
+    is SpellRoute -> toHash()
     is DmRoute -> toHash()
     is NotificationsRoute -> NOTIFICATIONS_HASH
     is SettingsRoute -> SETTINGS_HASH
@@ -179,7 +191,17 @@ fun HashRoute.toHash(): String = when (this) {
     }
 }
 
-fun parseHashRoute(hash: String): HashRoute? = parseGroupHash(hash) ?: parseRelayHash(hash) ?: parseUserHash(hash) ?: parseDmHash(hash) ?: parseNotificationsHash(hash) ?: parseSettingsHash(hash) ?: parseHomeTabHash(hash)
+fun parseHashRoute(hash: String): HashRoute? = parseGroupHash(hash) ?: parseRelayHash(hash) ?: parseUserHash(hash) ?: parseSpellHash(hash) ?: parseDmHash(hash) ?: parseNotificationsHash(hash) ?: parseSettingsHash(hash) ?: parseHomeTabHash(hash)
+
+fun SpellRoute.toHash(): String = "$SPELL_HASH_PREFIX${encodeSegment(spellId)}"
+
+/** Parses a `#/s/<spell-id>` hash; null for any other hash. */
+fun parseSpellHash(hash: String): SpellRoute? {
+    if (!hash.startsWith(SPELL_HASH_PREFIX)) return null
+    val seg = hash.removePrefix(SPELL_HASH_PREFIX).substringBefore('?')
+    if (seg.isEmpty() || seg.contains('/')) return null
+    return SpellRoute(decodeSegment(seg))
+}
 
 fun RelayRoute.toHash(): String = "$RELAY_HASH_PREFIX${encodeSegment(relayUrl.removePrefix("wss://").removePrefix("ws://"))}"
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/NavigationHistory.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/navigation/NavigationHistory.kt
@@ -23,6 +23,7 @@ fun routeKey(route: HashRoute?): String = when (route) {
     is GroupRoute -> "g:${route.relayUrl}/${route.groupId}:${route.view}:${route.threadRootId ?: ""}"
     is RelayRoute -> "r:${route.relayUrl}"
     is UserRoute -> "u:${route.pubkey}"
+    is SpellRoute -> "s:${route.spellId}"
     is DmRoute -> "dm:${route.pubkey ?: ""}"
     is NotificationsRoute -> "notifications"
     is SettingsRoute -> "settings"

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/spell/SpellViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/spell/SpellViewModel.kt
@@ -17,7 +17,6 @@ import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.managers.key
 import org.nostr.nostrord.nostr.Spell
 import org.nostr.nostrord.nostr.SpellContext
-import org.nostr.nostrord.nostr.SpellPresets
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
 
@@ -30,9 +29,10 @@ import org.nostr.nostrord.utils.epochSeconds
 class SpellViewModel(
     private val repo: NostrRepositoryApi = AppModule.nostrRepository,
     val spellId: String,
+    resolveSpell: (String) -> Spell? = { AppModule.spellLibrary.spellById(it) },
 ) : ViewModel() {
     /** Null when the id names a spell this build does not know (stale link, unsynced custom). */
-    val spell: Spell? = SpellPresets.railSpellById(spellId)
+    val spell: Spell? = resolveSpell(spellId)
 
     private val key: String? = spell?.key
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/spell/SpellViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/spell/SpellViewModel.kt
@@ -1,0 +1,97 @@
+package org.nostr.nostrord.ui.screens.spell
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.network.managers.GroupLoadingState
+import org.nostr.nostrord.network.managers.key
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellContext
+import org.nostr.nostrord.nostr.SpellPresets
+import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.epochSeconds
+
+/**
+ * One spell feed, shared by the Compose and web screens.
+ *
+ * Deliberately not a [org.nostr.nostrord.ui.screens.group.GroupViewModel] subclass: a feed has no
+ * membership, no roles and no composer, and that VM is saturated with all three.
+ */
+class SpellViewModel(
+    private val repo: NostrRepositoryApi = AppModule.nostrRepository,
+    val spellId: String,
+) : ViewModel() {
+    /** Null when the id names a spell this build does not know (stale link, unsynced custom). */
+    val spell: Spell? = SpellPresets.railSpellById(spellId)
+
+    private val key: String? = spell?.key
+
+    val title: String = spell?.name ?: "Unknown spell"
+    val subtitle: String = spell?.description.orEmpty()
+
+    val events: StateFlow<List<NostrGroupClient.NostrMessage>> =
+        repo.spellEvents
+            .map { it[key].orEmpty() }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    val loadingState: StateFlow<GroupLoadingState> =
+        repo.spellStates
+            .map { it[key] ?: GroupLoadingState.Idle }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), GroupLoadingState.Idle)
+
+    /**
+     * Why the feed is empty, when it is empty for a reason the user can act on: no contact list
+     * yet, no read relay configured, nothing reachable. Null once a REQ is on the wire.
+     */
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private var opened = false
+
+    init {
+        val target = spell
+        if (target == null) {
+            _error.value = "This spell is not available on this device."
+        } else {
+            viewModelScope.launch {
+                // Re-attempts on every identity change: a spell over $contacts cannot resolve
+                // until kind:3 lands, which is routinely after the screen is already open.
+                combine(repo.activePubkey, repo.following, repo.userRelayList) { me, follows, relays ->
+                    Triple(me, follows.toList(), relays.filter { it.read }.map { it.url })
+                }.collect { (me, follows, readRelays) ->
+                    if (opened) return@collect
+                    val ctx = SpellContext(me = me, contacts = follows, now = epochSeconds())
+                    when (val result = repo.openSpell(target, ctx, readRelays)) {
+                        is Result.Success -> {
+                            opened = true
+                            _error.value = null
+                        }
+                        is Result.Error -> _error.value = result.error.message
+                    }
+                }
+            }
+        }
+    }
+
+    fun loadMore() {
+        val k = key ?: return
+        viewModelScope.launch { repo.loadMoreSpell(k) }
+    }
+
+    override fun onCleared() {
+        // The screen owns the subscription: leaving CLOSEs it rather than leaving a firehose
+        // streaming into a feed nobody is reading.
+        key?.let { repo.closeSpell(it) }
+        super.onCleared()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/Result.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/Result.kt
@@ -135,6 +135,22 @@ sealed class AppError(
         ) : Group("Failed to update group" + (cause?.message?.takeIf { it.isNotBlank() }?.let { ": $it" } ?: ""), cause)
     }
 
+    /** Saved-query (kind:777) errors */
+    sealed class Spell(
+        override val message: String,
+        override val cause: Throwable? = null,
+    ) : AppError(message, cause) {
+        data class Malformed(
+            val reason: String,
+        ) : Spell("Malformed spell: $reason")
+
+        /** A `$me` / `$contacts` / `$members` placeholder the current context cannot fill. */
+        data class UnresolvedVariable(
+            val variable: String,
+            val reason: String,
+        ) : Spell("Cannot resolve $variable: $reason")
+    }
+
     /** Generic/unknown errors */
     data class Unknown(
         override val message: String,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -124,6 +124,21 @@ class FakeNostrRepository : NostrRepositoryApi {
         _groupStates
     override val groupsAwaitingAuthRead: StateFlow<Set<String>> = MutableStateFlow(emptySet())
 
+    override val spellEvents: StateFlow<Map<String, List<NostrGroupClient.NostrMessage>>> =
+        MutableStateFlow(emptyMap())
+    override val spellStates: StateFlow<Map<String, org.nostr.nostrord.network.managers.GroupLoadingState>> =
+        MutableStateFlow(emptyMap())
+
+    override suspend fun openSpell(
+        spell: org.nostr.nostrord.nostr.Spell,
+        ctx: org.nostr.nostrord.nostr.SpellContext,
+        nip65ReadRelays: List<String>,
+    ): Result<Unit> = Result.Success(Unit)
+
+    override suspend fun loadMoreSpell(spellKey: String): Boolean = false
+
+    override fun closeSpell(spellKey: String) {}
+
     override suspend fun resetGroupLoadingState(groupId: String) {}
     override val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = _reactions
     override val groupMembers: StateFlow<Map<String, List<String>>> = _groupMembers

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/SpellManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/SpellManagerTest.kt
@@ -1,0 +1,144 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellContext
+import org.nostr.nostrord.nostr.SpellPresets
+import org.nostr.nostrord.nostr.toSpell
+import org.nostr.nostrord.utils.AppError
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+private const val GROUP_RELAY = "wss://groups.example"
+private const val GROUP_ID = "g1"
+private const val NOW = 1_740_000_000L
+private val MEMBER = "aa".repeat(32)
+
+private fun msg(id: String, createdAt: Long) = NostrGroupClient.NostrMessage(id = id, pubkey = MEMBER, content = "", createdAt = createdAt, kind = 1)
+
+class SpellKeyTest {
+    @Test
+    fun scopesTheSameSpellPerGroup() {
+        val images = SpellPresets.IMAGES
+        val a = images.toSpell(GROUP_RELAY, "g1").key
+        val b = images.toSpell(GROUP_RELAY, "g2").key
+        val c = images.toSpell("wss://other.example", "g1").key
+
+        // The same group id on two relays is two independent groups, so three distinct feeds.
+        assertNotEquals(a, b)
+        assertNotEquals(a, c)
+    }
+
+    @Test
+    fun fallsBackToTheSpellIdWhenUnbound() {
+        assertEquals("solo", Spell(id = "solo", name = "n", kinds = listOf(1)).key)
+    }
+}
+
+class SpellRoutingPrefixTest {
+    @Test
+    fun ownsOnlyItsOwnSubscriptionIds() = runTest {
+        val manager = SpellManager(backgroundScope, connectRelay = { null })
+        assertTrue(manager.owns("spell_abc_123"))
+        // Group chat routing keys on msg_; a collision would feed group events into a spell.
+        assertFalse(manager.owns("msg_abc_123"))
+        assertFalse(manager.owns("mux_chat_1"))
+        assertFalse(manager.owns("spell"))
+    }
+
+    @Test
+    fun theRegistryNamespacesGeneratedIds() = runTest {
+        val registry = GroupLoadingRegistry(backgroundScope, subIdPrefix = SPELL_SUB_PREFIX)
+        val subId = registry.getController("$GROUP_RELAY|$GROUP_ID|preset:images").startInitialLoad()
+        assertTrue(subId!!.startsWith("${SPELL_SUB_PREFIX}_"), subId)
+    }
+
+    @Test
+    fun groupLoadingKeepsItsDefaultPrefix() = runTest {
+        val registry = GroupLoadingRegistry(backgroundScope)
+        assertTrue(registry.getController(GROUP_ID).startInitialLoad()!!.startsWith("msg_"))
+    }
+}
+
+class SpellManagerOpenTest {
+    private val ctx = SpellContext(me = MEMBER, members = listOf(MEMBER), now = NOW)
+
+    @Test
+    fun failsWhenAVariableCannotBeResolved() = runTest {
+        val manager = SpellManager(backgroundScope, connectRelay = { error("must not connect") })
+        val spell = SpellPresets.MEMBER_NOTES.toSpell(GROUP_RELAY, GROUP_ID)
+
+        val result = manager.open(spell, ctx.copy(members = emptyList()), listOf("wss://nos.lol"))
+
+        // Resolution fails before any socket work, so an unloaded member list costs nothing.
+        assertTrue(result.errorOrNull() is AppError.Spell.UnresolvedVariable)
+        assertTrue(manager.states.value.isEmpty())
+    }
+
+    @Test
+    fun failsWhenNoRelayIsLeftToQuery() = runTest {
+        val manager = SpellManager(backgroundScope, connectRelay = { error("must not connect") })
+        val spell = SpellPresets.MEMBER_NOTES.toSpell(GROUP_RELAY, GROUP_ID)
+
+        // The only NIP-65 relay is the group's own, which a member-graph spell must not use.
+        val result = manager.open(spell, ctx, listOf(GROUP_RELAY))
+
+        assertTrue(result.errorOrNull() is AppError.Spell.Malformed)
+    }
+
+    @Test
+    fun failsWhenEveryRelayIsUnreachable() = runTest {
+        val manager = SpellManager(backgroundScope, connectRelay = { null })
+        val spell = SpellPresets.IMAGES.toSpell(GROUP_RELAY, GROUP_ID)
+
+        val result = manager.open(spell, ctx, emptyList())
+
+        assertTrue(result.errorOrNull() is AppError.Network.Disconnected)
+    }
+
+    @Test
+    fun loadMoreIsANoOpForAClosedSpell() = runTest {
+        val manager = SpellManager(backgroundScope, connectRelay = { null })
+        assertFalse(manager.loadMore("$GROUP_RELAY|$GROUP_ID|preset:images"))
+    }
+
+    @Test
+    fun closingAnUnopenedSpellDoesNothing() = runTest {
+        val manager = SpellManager(backgroundScope, connectRelay = { error("must not connect") })
+        manager.close("nope")
+        assertTrue(manager.events.value.isEmpty())
+    }
+}
+
+class SpellEventMergeTest {
+    @Test
+    fun ordersNewestFirst() {
+        val merged = mergeSpellEvents(emptyList(), listOf(msg("a", 100), msg("b", 300), msg("c", 200)), 10)
+        assertEquals(listOf("b", "c", "a"), merged.map { it.id })
+    }
+
+    @Test
+    fun deduplicatesAcrossRelays() {
+        val existing = listOf(msg("a", 300), msg("b", 200))
+        val merged = mergeSpellEvents(existing, listOf(msg("b", 200), msg("c", 100)), 10)
+        assertEquals(listOf("a", "b", "c"), merged.map { it.id })
+    }
+
+    @Test
+    fun returnsTheSameListWhenNothingIsNew() {
+        val existing = listOf(msg("a", 300), msg("b", 200))
+        // Identity, not just equality: a new list would churn the StateFlow on every redelivery.
+        assertTrue(mergeSpellEvents(existing, listOf(msg("a", 300)), 10) === existing)
+    }
+
+    @Test
+    fun capsTheFeedKeepingTheNewest() {
+        val incoming = (1..10).map { msg("e$it", it.toLong()) }
+        val merged = mergeSpellEvents(emptyList(), incoming, 3)
+        assertEquals(listOf("e10", "e9", "e8"), merged.map { it.id })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/SpellCodecTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/SpellCodecTest.kt
@@ -1,0 +1,385 @@
+package org.nostr.nostrord.nostr
+
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val NOW = 1_740_000_000L
+private val ALICE = "aa".repeat(32)
+private val BOB = "bb".repeat(32)
+private val CAROL = "cc".repeat(32)
+
+private fun spellEvent(
+    tags: List<List<String>>,
+    content: String = "",
+    kind: Int = SPELL_KIND,
+) = Event(id = "e".repeat(64), pubkey = ALICE, createdAt = NOW, kind = kind, tags = tags, content = content)
+
+private fun <T> Result<T>.unwrap(): T = when (this) {
+    is Result.Success -> data
+    is Result.Error -> error("expected success, got ${error.message}")
+}
+
+private fun <T> Result<T>.errorOf(): AppError = when (this) {
+    is Result.Success -> error("expected failure, got $data")
+    is Result.Error -> error
+}
+
+class RelativeTimeTest {
+    @Test
+    fun resolvesEveryUnit() {
+        assertEquals(NOW - 30, parseRelativeTime("30s", NOW))
+        assertEquals(NOW - 5 * 60, parseRelativeTime("5m", NOW))
+        assertEquals(NOW - 12 * 3_600, parseRelativeTime("12h", NOW))
+        assertEquals(NOW - 7 * 86_400, parseRelativeTime("7d", NOW))
+        assertEquals(NOW - 2 * 604_800, parseRelativeTime("2w", NOW))
+        assertEquals(NOW - 3 * 2_592_000, parseRelativeTime("3mo", NOW))
+        assertEquals(NOW - 31_536_000, parseRelativeTime("1y", NOW))
+    }
+
+    @Test
+    fun monthsWinOverMinutes() {
+        // "mo" must not be parsed as "m" with a trailing character.
+        assertEquals(NOW - 2_592_000, parseRelativeTime("1mo", NOW))
+        assertEquals(NOW - 60, parseRelativeTime("1m", NOW))
+    }
+
+    @Test
+    fun resolvesNowAndAbsolute() {
+        assertEquals(NOW, parseRelativeTime("now", NOW))
+        assertEquals(1_704_067_200L, parseRelativeTime("1704067200", NOW))
+    }
+
+    @Test
+    fun rejectsGarbage() {
+        assertNull(parseRelativeTime("", NOW))
+        assertNull(parseRelativeTime("soon", NOW))
+        assertNull(parseRelativeTime("7x", NOW))
+        assertNull(parseRelativeTime("d7", NOW))
+        assertNull(parseRelativeTime("-7d", NOW))
+    }
+}
+
+class SpellParseTest {
+    @Test
+    fun parsesTheDraftReqExample() {
+        val spell =
+            parseSpell(
+                spellEvent(
+                    content = "Notes about Bitcoin from my contacts",
+                    tags =
+                    listOf(
+                        listOf("cmd", "REQ"),
+                        listOf("name", "Bitcoin from contacts"),
+                        listOf("alt", "Spell: notes about Bitcoin from contacts"),
+                        listOf("k", "1"),
+                        listOf("authors", VAR_CONTACTS),
+                        listOf("tag", "t", "bitcoin"),
+                        listOf("since", "7d"),
+                        listOf("limit", "50"),
+                        listOf("t", "bitcoin"),
+                        listOf("t", "social"),
+                    ),
+                ),
+            ).unwrap()
+
+        assertEquals(SpellCmd.REQ, spell.cmd)
+        assertEquals("Bitcoin from contacts", spell.name)
+        assertEquals("Notes about Bitcoin from my contacts", spell.description)
+        assertEquals(listOf(1), spell.kinds)
+        assertEquals(listOf(VAR_CONTACTS), spell.authors)
+        assertEquals(mapOf("t" to listOf("bitcoin")), spell.tagFilters)
+        assertEquals("7d", spell.since)
+        assertEquals(50, spell.limit)
+        // A top-level ["t", ...] categorizes the spell; ["tag","t",...] filters events. Both here.
+        assertEquals(listOf("bitcoin", "social"), spell.topics)
+    }
+
+    @Test
+    fun parsesTheDraftCountExample() {
+        val spell =
+            parseSpell(
+                spellEvent(
+                    tags =
+                    listOf(
+                        listOf("cmd", "COUNT"),
+                        listOf("k", "1"),
+                        listOf("k", "6"),
+                        listOf("k", "7"),
+                        listOf("authors", VAR_ME),
+                        listOf("since", "1704067200"),
+                        listOf("close-on-eose"),
+                    ),
+                ),
+            ).unwrap()
+
+        assertEquals(SpellCmd.COUNT, spell.cmd)
+        assertEquals(listOf(1, 6, 7), spell.kinds)
+        assertTrue(spell.closeOnEose)
+    }
+
+    @Test
+    fun parsesTheDraftSearchExample() {
+        val spell =
+            parseSpell(
+                spellEvent(
+                    content = "Search for Nostr dev discussions",
+                    tags =
+                    listOf(
+                        listOf("cmd", "REQ"),
+                        listOf("name", "Nostr dev search"),
+                        listOf("k", "1"),
+                        listOf("search", "nostr development"),
+                        listOf("relays", "wss://relay.damus.io", "wss://nos.lol"),
+                        listOf("limit", "100"),
+                    ),
+                ),
+            ).unwrap()
+
+        assertEquals("nostr development", spell.search)
+        assertEquals(listOf("wss://relay.damus.io", "wss://nos.lol"), spell.relays)
+    }
+
+    @Test
+    fun parsesGroupBindingAndFork() {
+        val spell =
+            parseSpell(
+                spellEvent(
+                    tags =
+                    listOf(
+                        listOf("cmd", "REQ"),
+                        listOf("k", "1"),
+                        listOf("group", "wss://relay.example", "abc123"),
+                        listOf("e", "f".repeat(64)),
+                    ),
+                ),
+            ).unwrap()
+
+        assertEquals(GroupBinding("wss://relay.example", "abc123"), spell.group)
+        assertEquals("f".repeat(64), spell.forkedFrom)
+    }
+
+    @Test
+    fun rejectsWrongKind() {
+        val err = parseSpell(spellEvent(tags = listOf(listOf("cmd", "REQ"), listOf("k", "1")), kind = 1)).errorOf()
+        assertTrue(err is AppError.Spell.Malformed)
+    }
+
+    @Test
+    fun rejectsMissingCmd() {
+        val err = parseSpell(spellEvent(tags = listOf(listOf("k", "1")))).errorOf()
+        assertTrue(err is AppError.Spell.Malformed)
+    }
+
+    @Test
+    fun rejectsUnknownCmd() {
+        val err = parseSpell(spellEvent(tags = listOf(listOf("cmd", "DELETE"), listOf("k", "1")))).errorOf()
+        assertTrue(err is AppError.Spell.Malformed)
+    }
+
+    @Test
+    fun rejectsSpellWithNoFilter() {
+        val err = parseSpell(spellEvent(tags = listOf(listOf("cmd", "REQ"), listOf("name", "empty")))).errorOf()
+        assertTrue(err is AppError.Spell.Malformed)
+    }
+
+    @Test
+    fun ignoresMalformedTagsWithoutFailing() {
+        val spell =
+            parseSpell(
+                spellEvent(
+                    tags =
+                    listOf(
+                        listOf("cmd", "REQ"),
+                        listOf("k", "1"),
+                        listOf("k", "not-a-number"),
+                        listOf("tag"),
+                        listOf("tag", "toolong", "x"),
+                        listOf("tag", "t"),
+                        listOf("group", "wss://relay.example"),
+                        emptyList(),
+                    ),
+                ),
+            ).unwrap()
+
+        assertEquals(listOf(1), spell.kinds)
+        assertEquals(emptyMap(), spell.tagFilters)
+        assertNull(spell.group)
+    }
+}
+
+class SpellEncodeTest {
+    @Test
+    fun roundTripsThroughAnEvent() {
+        val original =
+            Spell(
+                id = "",
+                name = "Members with photos",
+                description = "what the group posts",
+                cmd = SpellCmd.REQ,
+                kinds = listOf(20, 21),
+                authors = listOf(VAR_MEMBERS, ALICE),
+                ids = listOf("d".repeat(64)),
+                tagFilters = mapOf("h" to listOf("group-1"), "t" to listOf("art", "photo")),
+                relays = listOf("wss://relay.example"),
+                limit = 25,
+                since = "3d",
+                until = "now",
+                search = "sunset",
+                closeOnEose = true,
+                topics = listOf("photography"),
+                forkedFrom = "f".repeat(64),
+                group = GroupBinding("wss://relay.example", "group-1"),
+            )
+
+        val event = original.toUnsignedEvent(ALICE, NOW)
+        assertEquals(SPELL_KIND, event.kind)
+
+        val reparsed = parseSpell(event.copy(id = "e".repeat(64))).unwrap()
+        assertEquals(original.copy(id = reparsed.id, pubkey = ALICE, createdAt = NOW), reparsed)
+    }
+
+    @Test
+    fun encodesTagFiltersUnderTheTagNamespace() {
+        val event =
+            Spell(id = "", name = "n", kinds = listOf(1), tagFilters = mapOf("p" to listOf(BOB)))
+                .toUnsignedEvent(ALICE, NOW)
+
+        // A bare ["p", ...] would read as a social-graph reference to the network.
+        assertTrue(event.tags.none { it.firstOrNull() == "p" })
+        assertTrue(event.tags.any { it == listOf("tag", "p", BOB) })
+        assertTrue(event.tags.any { it == listOf("k", "1") })
+    }
+}
+
+class SpellResolveTest {
+    private val ctx = SpellContext(me = ALICE, contacts = listOf(BOB), members = listOf(BOB, CAROL), now = NOW)
+
+    @Test
+    fun expandsVariablesAndRelativeTimes() {
+        val filter =
+            Spell(
+                id = "",
+                name = "n",
+                kinds = listOf(1),
+                authors = listOf(VAR_MEMBERS, VAR_ME),
+                tagFilters = mapOf("t" to listOf("bitcoin")),
+                since = "7d",
+                limit = 50,
+            ).resolve(ctx).unwrap()
+
+        assertEquals(listOf(BOB, CAROL, ALICE), filter.authors)
+        assertEquals(listOf(1), filter.kinds)
+        assertEquals(mapOf("#t" to listOf("bitcoin")), filter.tags)
+        assertEquals(NOW - 7 * 86_400, filter.since)
+        assertEquals(50, filter.limit)
+    }
+
+    @Test
+    fun deduplicatesOverlappingAuthors() {
+        val filter =
+            Spell(id = "", name = "n", kinds = listOf(1), authors = listOf(VAR_MEMBERS, BOB))
+                .resolve(ctx).unwrap()
+        assertEquals(listOf(BOB, CAROL), filter.authors)
+    }
+
+    @Test
+    fun expandsVariablesInsideTagFilters() {
+        val filter =
+            Spell(id = "", name = "n", kinds = listOf(1), tagFilters = mapOf("p" to listOf(VAR_ME)))
+                .resolve(ctx).unwrap()
+        assertEquals(mapOf("#p" to listOf(ALICE)), filter.tags)
+    }
+
+    @Test
+    fun failsWhenMeHasNoAccount() {
+        val err =
+            Spell(id = "", name = "n", kinds = listOf(1), authors = listOf(VAR_ME))
+                .resolve(ctx.copy(me = null)).errorOf()
+        assertEquals(VAR_ME, (err as AppError.Spell.UnresolvedVariable).variable)
+    }
+
+    @Test
+    fun failsWhenContactsAreEmpty() {
+        val err =
+            Spell(id = "", name = "n", kinds = listOf(1), authors = listOf(VAR_CONTACTS))
+                .resolve(ctx.copy(contacts = emptyList())).errorOf()
+        assertEquals(VAR_CONTACTS, (err as AppError.Spell.UnresolvedVariable).variable)
+    }
+
+    @Test
+    fun failsWhenMembersAreNotLoaded() {
+        // Sending the literal "${'$'}members" would match nothing and read as an empty feed.
+        val err =
+            Spell(id = "", name = "n", kinds = listOf(1), authors = listOf(VAR_MEMBERS))
+                .resolve(ctx.copy(members = emptyList())).errorOf()
+        assertEquals(VAR_MEMBERS, (err as AppError.Spell.UnresolvedVariable).variable)
+    }
+
+    @Test
+    fun failsOnUnparseableSince() {
+        val err = Spell(id = "", name = "n", kinds = listOf(1), since = "whenever").resolve(ctx).errorOf()
+        assertTrue(err is AppError.Spell.Malformed)
+    }
+
+    @Test
+    fun serializesToAWireFilter() {
+        val json =
+            Spell(id = "", name = "n", kinds = listOf(1), authors = listOf(VAR_ME), tagFilters = mapOf("t" to listOf("nostr")))
+                .resolve(ctx).unwrap().toJsonObject().toString()
+
+        assertEquals("""{"authors":["$ALICE"],"kinds":[1],"#t":["nostr"]}""", json)
+    }
+}
+
+class SpellChunkingTest {
+    private val many = (0 until 1_200).map { it.toString().padStart(64, '0') }
+
+    @Test
+    fun keepsSmallAuthorListsWhole() {
+        val filters =
+            Spell(id = "", name = "n", kinds = listOf(1), authors = listOf(VAR_MEMBERS))
+                .resolveChunked(SpellContext(members = many.take(10), now = NOW)).unwrap()
+        assertEquals(1, filters.size)
+    }
+
+    @Test
+    fun splitsOversizedAuthorLists() {
+        val filters =
+            Spell(id = "", name = "n", kinds = listOf(1), authors = listOf(VAR_MEMBERS))
+                .resolveChunked(SpellContext(members = many, now = NOW)).unwrap()
+
+        assertEquals(3, filters.size)
+        assertEquals(listOf(500, 500, 200), filters.map { it.authors!!.size })
+        assertEquals(many, filters.flatMap { it.authors!! })
+        assertTrue(filters.all { it.kinds == listOf(1) })
+    }
+}
+
+class SpellRoutingTest {
+    private val groupRelay = "wss://groups.example"
+    private val nip65 = listOf("wss://relay.damus.io", groupRelay, "wss://nos.lol")
+
+    @Test
+    fun explicitRelaysWin() {
+        val spell =
+            Spell(id = "", name = "n", kinds = listOf(20), relays = listOf(groupRelay), group = GroupBinding(groupRelay, "g1"))
+        assertEquals(listOf(groupRelay), spell.targetRelays(nip65))
+    }
+
+    @Test
+    fun fallbackDropsTheGroupRelay() {
+        // A NIP-29 relay serves group events only, so a kind:1 query there returns empty.
+        val spell = Spell(id = "", name = "n", kinds = listOf(1), group = GroupBinding(groupRelay, "g1"))
+        assertEquals(listOf("wss://relay.damus.io", "wss://nos.lol"), spell.targetRelays(nip65))
+    }
+
+    @Test
+    fun fallbackIgnoresRelayUrlCasing() {
+        val spell = Spell(id = "", name = "n", kinds = listOf(1), group = GroupBinding("WSS://Groups.Example", "g1"))
+        assertEquals(listOf("wss://relay.damus.io", "wss://nos.lol"), spell.targetRelays(nip65))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/SpellDraftTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/SpellDraftTest.kt
@@ -1,0 +1,125 @@
+package org.nostr.nostrord.nostr
+
+import org.nostr.nostrord.utils.Result
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private val HEX = "aa".repeat(32)
+private const val NOW = 1_740_000_000L
+
+private fun Result<Spell>.spell(): Spell = when (this) {
+    is Result.Success -> data
+    is Result.Error -> error("expected a spell, got ${error.message}")
+}
+
+private fun Result<Spell>.reason(): String = when (this) {
+    is Result.Success -> error("expected a failure, got ${data.name}")
+    is Result.Error -> error.message
+}
+
+class SpellDraftTest {
+    @Test
+    fun buildsARelayFeed() {
+        // fiatjaf's first example: kind:1 straight off named relays, no author criterion.
+        val draft = SpellDraft(name = "Damus", kinds = "1", relays = "relay.damus.io, wss://nos.lol")
+        val spell = draft.toSpell(NOW).spell()
+
+        assertTrue(draft.isRelayFeed)
+        assertEquals(listOf(1), spell.kinds)
+        assertEquals(listOf("wss://relay.damus.io", "wss://nos.lol"), spell.relays)
+        assertTrue(spell.authors.isEmpty())
+        assertEquals("$LOCAL_ID_PREFIX$NOW", spell.id)
+    }
+
+    @Test
+    fun acceptsRelaysAloneAsTheWholeCriterion() {
+        // No kind, no author: the relay is the selection. hasFilter is false here by design.
+        val spell = SpellDraft(name = "Everything", relays = "wss://nos.lol").toSpell(NOW).spell()
+        assertEquals(listOf("wss://nos.lol"), spell.relays)
+        assertTrue(spell.kinds.isEmpty())
+    }
+
+    @Test
+    fun splitsOnCommasAndWhitespaceAlike() {
+        val spell = SpellDraft(name = "n", kinds = "1, 6  7,,30023").toSpell(NOW).spell()
+        assertEquals(listOf(1, 6, 7, 30023), spell.kinds)
+    }
+
+    @Test
+    fun keepsRuntimeVariablesUnresolved() {
+        val spell = SpellDraft(name = "n", kinds = "1", authors = "\$me, \$contacts").toSpell(NOW).spell()
+        // Resolving here would freeze the follow list into the saved spell.
+        assertEquals(listOf(VAR_ME, VAR_CONTACTS), spell.authors)
+    }
+
+    @Test
+    fun acceptsHexAuthorsAndNormalizesCase() {
+        val spell = SpellDraft(name = "n", kinds = "1", authors = HEX.uppercase()).toSpell(NOW).spell()
+        assertEquals(listOf(HEX), spell.authors)
+    }
+
+    @Test
+    fun acceptsNpubAuthors() {
+        val npub = Nip19.encodeNpub(HEX)
+        val spell = SpellDraft(name = "n", kinds = "1", authors = npub).toSpell(NOW).spell()
+        assertEquals(listOf(HEX), spell.authors)
+    }
+
+    @Test
+    fun stripsTheHashFromHashtags() {
+        val spell = SpellDraft(name = "n", kinds = "1", hashtags = "#bitcoin nostr").toSpell(NOW).spell()
+        assertEquals(mapOf("t" to listOf("bitcoin", "nostr")), spell.tagFilters)
+    }
+
+    @Test
+    fun deduplicatesEveryList() {
+        val spell =
+            SpellDraft(name = "n", kinds = "1 1", authors = "$HEX $HEX", relays = "wss://nos.lol nos.lol")
+                .toSpell(NOW).spell()
+        assertEquals(listOf(1), spell.kinds)
+        assertEquals(listOf(HEX), spell.authors)
+        assertEquals(listOf("wss://nos.lol"), spell.relays)
+    }
+
+    @Test
+    fun rejectsAnEmptyName() {
+        assertTrue(SpellDraft(name = "   ", kinds = "1").toSpell(NOW).reason().contains("name"))
+    }
+
+    @Test
+    fun rejectsADraftWithNothingToQuery() {
+        assertTrue(SpellDraft(name = "n").toSpell(NOW).reason().contains("at least"))
+    }
+
+    @Test
+    fun rejectsGarbageRatherThanQueryingForNothing() {
+        // A typo'd author would be a valid REQ matching nothing, which reads as an empty feed.
+        assertTrue(SpellDraft(name = "n", kinds = "1", authors = "npub1nope").toSpell(NOW).reason().contains("npub1nope"))
+        assertTrue(SpellDraft(name = "n", kinds = "notes").toSpell(NOW).reason().contains("notes"))
+        assertTrue(SpellDraft(name = "n", kinds = "1", limit = "0").toSpell(NOW).reason().contains("limit"))
+    }
+
+    @Test
+    fun theResultIsAPinnableSpell() {
+        val spell = SpellDraft(name = "Bitcoin", kinds = "1", hashtags = "bitcoin").toSpell(NOW).spell()
+        val event = spell.toUnsignedEvent(HEX, NOW)
+        val reparsed = parseSpell(event.copy(id = "e".repeat(64)))
+
+        assertEquals(spell.kinds, reparsed.spell().kinds)
+        assertEquals(spell.tagFilters, reparsed.spell().tagFilters)
+        assertNull(spell.group)
+    }
+}
+
+class ParseAuthorTest {
+    @Test
+    fun rejectsAnythingItCannotResolve() {
+        assertNull(parseAuthor(""))
+        assertNull(parseAuthor("alice@example.com"))
+        assertNull(parseAuthor("\$everyone"))
+        assertNull(parseAuthor("ab".repeat(20)))
+        assertEquals(VAR_ME, parseAuthor("\$me"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/SpellPresetsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/SpellPresetsTest.kt
@@ -1,0 +1,175 @@
+package org.nostr.nostrord.nostr
+
+import org.nostr.nostrord.utils.Result
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val GROUP_RELAY = "wss://groups.example"
+private const val GROUP_ID = "abc123"
+private const val NOW = 1_740_000_000L
+private val MEMBER_A = "aa".repeat(32)
+private val MEMBER_B = "bb".repeat(32)
+
+private val ctx = SpellContext(me = MEMBER_A, contacts = listOf(MEMBER_B), members = listOf(MEMBER_A, MEMBER_B), now = NOW)
+
+private fun preset(slug: String): Spell = requireNotNull(SpellPresets.forGroup(slug, GROUP_RELAY, GROUP_ID))
+
+private fun Spell.filter(): NostrFilter = when (val r = resolve(ctx)) {
+    is Result.Success -> r.data
+    is Result.Error -> error("preset $id failed to resolve: ${r.error.message}")
+}
+
+class SpellPresetsTest {
+    @Test
+    fun slugsAreUniqueAndStable() {
+        assertEquals(SpellPresets.slugs.distinct().size, SpellPresets.slugs.size)
+        // Slugs are the sync key in the kind:30777 index, so renaming one silently unpins it.
+        assertEquals(listOf("contacts-notes", "mentions", "my-notes"), SpellPresets.rail.map { it.slug })
+        assertEquals(
+            listOf("images", "videos", "polls", "files", "firehose", "member-notes", "member-articles", "member-highlights"),
+            SpellPresets.group.map { it.slug },
+        )
+    }
+
+    @Test
+    fun everyPresetBindsToTheGroupAndResolves() {
+        val spells = SpellPresets.forGroup(GROUP_RELAY, GROUP_ID)
+        assertEquals(SpellPresets.group.size, spells.size)
+        spells.forEach { spell ->
+            assertEquals(GroupBinding(GROUP_RELAY, GROUP_ID), spell.group)
+            assertTrue(spell.hasFilter, "${spell.id} carries no filter")
+            spell.filter()
+        }
+    }
+
+    @Test
+    fun groupContentPresetsCarryTheExpectedKinds() {
+        assertEquals(listOf(20), preset("images").kinds)
+        assertEquals(listOf(21, 22), preset("videos").kinds)
+        assertEquals(listOf(1068), preset("polls").kinds)
+        assertEquals(listOf(1063), preset("files").kinds)
+    }
+
+    @Test
+    fun groupContentPresetsQueryTheGroupRelayScopedByH() {
+        listOf("images", "videos", "polls", "files", "firehose").forEach { slug ->
+            val spell = preset(slug)
+            assertEquals(listOf(GROUP_RELAY), spell.targetRelays(listOf("wss://nos.lol")), slug)
+            assertEquals(mapOf("#h" to listOf(GROUP_ID)), spell.filter().tags, slug)
+        }
+    }
+
+    @Test
+    fun firehoseIsKindAgnostic() {
+        assertNull(preset("firehose").filter().kinds)
+    }
+
+    @Test
+    fun memberPresetsQueryMembersOffTheGroupRelay() {
+        listOf("member-notes", "member-articles", "member-highlights").forEach { slug ->
+            val spell = preset(slug)
+            assertEquals(listOf(VAR_MEMBERS), spell.authors, slug)
+            // Routing these to the NIP-29 relay returns empty and reads as a broken feed.
+            assertEquals(listOf("wss://nos.lol"), spell.targetRelays(listOf("wss://nos.lol", GROUP_RELAY)), slug)
+            assertEquals(listOf(MEMBER_A, MEMBER_B), spell.filter().authors, slug)
+        }
+    }
+
+    @Test
+    fun memberPresetsCarryTheExpectedKinds() {
+        assertEquals(listOf(1), preset("member-notes").kinds)
+        assertEquals(listOf(30023), preset("member-articles").kinds)
+        assertEquals(listOf(9802), preset("member-highlights").kinds)
+    }
+
+    @Test
+    fun memberPresetsFailClosedWithoutAMemberList() {
+        val result = preset("member-notes").resolve(ctx.copy(members = emptyList()))
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun noPresetDuplicatesTheThreadsView() {
+        // Kind 11 (NIP-7D) already ships as the Threads screen.
+        assertTrue(SpellPresets.all.none { 11 in it.kinds })
+    }
+
+    @Test
+    fun presetsSurviveAnEventRoundTrip() {
+        SpellPresets.forGroup(GROUP_RELAY, GROUP_ID).forEach { spell ->
+            val event = spell.toUnsignedEvent(MEMBER_A, NOW).copy(id = "e".repeat(64))
+            val reparsed =
+                when (val r = parseSpell(event)) {
+                    is Result.Success -> r.data
+                    is Result.Error -> error("${spell.id} did not round-trip: ${r.error.message}")
+                }
+            assertEquals(spell.kinds, reparsed.kinds, spell.id)
+            assertEquals(spell.authors, reparsed.authors, spell.id)
+            assertEquals(spell.tagFilters, reparsed.tagFilters, spell.id)
+            assertEquals(spell.group, reparsed.group, spell.id)
+        }
+    }
+
+    @Test
+    fun unknownSlugsResolveToNothing() {
+        assertNull(SpellPresets.bySlug("nope"))
+        assertNull(SpellPresets.forGroup("nope", GROUP_RELAY, GROUP_ID))
+        assertNotNull(SpellPresets.bySlug("images"))
+    }
+
+    @Test
+    fun railPresetsResolveFromIdentityAlone() {
+        val spells = SpellPresets.forRail()
+        assertEquals(SpellPresets.rail.size, spells.size)
+        spells.forEach { spell ->
+            assertNull(spell.group, spell.id)
+            // Empty relays means "use my NIP-65 read list"; a pinned relay would be wrong here.
+            assertTrue(spell.relays.isEmpty(), spell.id)
+            assertEquals(listOf(1), spell.kinds, spell.id)
+            spell.filter()
+        }
+    }
+
+    @Test
+    fun railPresetsCarryTheExpectedFilters() {
+        assertEquals(listOf(VAR_CONTACTS), requireNotNull(SpellPresets.forRail("contacts-notes")).authors)
+        assertEquals(listOf(VAR_ME), requireNotNull(SpellPresets.forRail("my-notes")).authors)
+        // Mentions is a #p condition, not an author filter.
+        assertEquals(mapOf("p" to listOf(VAR_ME)), requireNotNull(SpellPresets.forRail("mentions")).tagFilters)
+        assertEquals(emptyList(), requireNotNull(SpellPresets.forRail("mentions")).authors)
+    }
+
+    @Test
+    fun railPresetsNeverTargetAGroupRelay() {
+        val nip65 = listOf("wss://nos.lol", GROUP_RELAY)
+        // Unbound spells have no group relay to exclude, so the caller must not pass one in.
+        SpellPresets.forRail().forEach { assertEquals(nip65, it.targetRelays(nip65), it.id) }
+    }
+
+    @Test
+    fun railAndGroupSlugsDoNotCollide() {
+        assertEquals(SpellPresets.all.size, SpellPresets.slugs.distinct().size)
+        assertNull(SpellPresets.forRail("images"))
+        assertNull(SpellPresets.forGroup("mentions", GROUP_RELAY, GROUP_ID))
+    }
+
+    @Test
+    fun relayFeedTargetsExactlyTheGivenRelays() {
+        val feed = relayFeed("Damus firehose", listOf("wss://relay.damus.io"))
+        assertEquals(listOf("wss://relay.damus.io"), feed.targetRelays(listOf("wss://nos.lol")))
+        // No author filter at all: the relay is the whole selection criterion.
+        assertTrue(feed.authors.isEmpty())
+        val filter = feed.filter()
+        assertEquals(listOf(1), filter.kinds)
+        assertNull(filter.authors)
+    }
+
+    @Test
+    fun displayNamesAvoidEmDash() {
+        assertFalse(SpellPresets.all.any { it.displayName.contains("—") || it.description.contains("—") })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/SpellPinTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/settings/SpellPinTest.kt
@@ -1,0 +1,61 @@
+package org.nostr.nostrord.settings
+
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.SpellPresets
+import org.nostr.nostrord.nostr.relayFeed
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+private val OWNER = "aa".repeat(32)
+
+class SpellPinTest {
+    @Test
+    fun presetsStoreOnlyTheirSlug() {
+        val mentions = requireNotNull(SpellPresets.forRail("mentions"))
+        val pin = mentions.toPin(OWNER)
+
+        // Storing the built-in's filter would freeze it on the day it was pinned; the slug lets
+        // an app update improve the spell under a rail the user already arranged.
+        assertEquals("mentions", pin.preset)
+        assertNull(pin.event)
+        assertEquals(mentions, pin.toSpell())
+    }
+
+    @Test
+    fun customSpellsRoundTripThroughTheirEvent() {
+        val feed = relayFeed("Damus firehose", listOf("wss://relay.damus.io"))
+        val restored = assertNotNull(feed.toPin(OWNER).toSpell())
+
+        assertEquals(feed.id, restored.id)
+        assertEquals(feed.name, restored.name)
+        assertEquals(feed.kinds, restored.kinds)
+        assertEquals(feed.relays, restored.relays)
+        assertEquals(feed.limit, restored.limit)
+    }
+
+    @Test
+    fun customSpellsKeepTheirLocalIdDespiteAnUnsignedEvent() {
+        val feed = relayFeed("Nos", listOf("wss://nos.lol"))
+        val pin = feed.toPin(OWNER)
+
+        // The stored event is unsigned, so it has no event id to be identified by.
+        assertNull(pin.event?.id)
+        assertEquals(feed.id, pin.id)
+        assertEquals(feed.id, pin.toSpell()?.id)
+    }
+
+    @Test
+    fun unknownEntriesDropOutInsteadOfCrashing() {
+        assertNull(SpellPin(preset = "was-removed-in-an-update").toSpell())
+        assertNull(SpellPin().toSpell())
+        // A stored event that is no longer a valid spell must not take the rail down with it.
+        assertNull(
+            SpellPin(
+                id = "local:1",
+                event = Event(pubkey = OWNER, createdAt = 1L, kind = 777, tags = emptyList(), content = ""),
+            ).toSpell(),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/SpellViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/SpellViewModelTest.kt
@@ -1,0 +1,88 @@
+package org.nostr.nostrord.ui
+
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.nostr.PRESET_ID_PREFIX
+import org.nostr.nostrord.nostr.SpellPresets
+import org.nostr.nostrord.ui.navigation.SpellRoute
+import org.nostr.nostrord.ui.navigation.parseHashRoute
+import org.nostr.nostrord.ui.navigation.persistedRouteHash
+import org.nostr.nostrord.ui.navigation.restoredRoute
+import org.nostr.nostrord.ui.navigation.routeKey
+import org.nostr.nostrord.ui.navigation.toHash
+import org.nostr.nostrord.ui.screens.spell.SpellViewModel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SpellRouteTest {
+    @Test
+    fun roundTripsThroughTheHash() {
+        val route = SpellRoute("${PRESET_ID_PREFIX}mentions")
+        assertEquals("#/s/preset%3Amentions", route.toHash())
+        assertEquals(route, parseHashRoute(route.toHash()))
+    }
+
+    @Test
+    fun everyRailPresetHasAReachableHash() {
+        SpellPresets.forRail().forEach { spell ->
+            val route = SpellRoute(spell.id)
+            assertEquals(route, parseHashRoute(route.toHash()), spell.id)
+            assertNotNull(SpellPresets.railSpellById(route.spellId), spell.id)
+        }
+    }
+
+    @Test
+    fun rejectsMalformedSpellHashes() {
+        assertNull(parseHashRoute("#/s/"))
+        // A second segment would be a different page shape, not a spell.
+        assertNull(parseHashRoute("#/s/a/b"))
+    }
+
+    @Test
+    fun routeKeyDoesNotCollideWithOtherPages() {
+        val key = routeKey(SpellRoute("preset:mentions"))
+        assertEquals("s:preset:mentions", key)
+        assertTrue(key != routeKey(null))
+    }
+
+    @Test
+    fun survivesAppRestart() {
+        val route = SpellRoute("preset:my-notes")
+        // A rail destination must reopen on launch, exactly like a group does.
+        assertEquals(route, restoredRoute(persistedRouteHash(route)))
+    }
+}
+
+class SpellViewModelTest {
+    private fun vm(
+        repo: FakeNostrRepository,
+        id: String,
+    ) = SpellViewModel(repo = repo, spellId = id)
+
+    @Test
+    fun exposesThePresetItNames() = runTest {
+        val model = vm(FakeNostrRepository(), "${PRESET_ID_PREFIX}mentions")
+        assertNotNull(model.spell)
+        assertEquals("Mentions", model.title)
+        assertNull(model.error.value)
+    }
+
+    @Test
+    fun reportsAnUnknownSpellInsteadOfRenderingEmpty() = runTest {
+        // A link to a custom spell this device has never synced must say so, not look like a
+        // feed with no posts.
+        val model = vm(FakeNostrRepository(), "cafe".repeat(16))
+        assertNull(model.spell)
+        assertNotNull(model.error.value)
+        assertTrue(model.events.value.isEmpty())
+    }
+
+    @Test
+    fun startsEmptyBeforeAnyEventArrives() = runTest {
+        val model = vm(FakeNostrRepository(), "${PRESET_ID_PREFIX}contacts-notes")
+        assertTrue(model.events.value.isEmpty())
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -49,6 +49,7 @@ import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.outlined.AutoAwesome
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -113,6 +114,7 @@ import org.nostr.nostrord.auth.removeAccountDialogTitle
 import org.nostr.nostrord.auth.signerLabel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.SpellPresets
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
@@ -143,6 +145,7 @@ import org.nostr.nostrord.ui.navigation.NotificationsRoute
 import org.nostr.nostrord.ui.navigation.PlatformBackHandler
 import org.nostr.nostrord.ui.navigation.RelayRoute
 import org.nostr.nostrord.ui.navigation.SettingsRoute
+import org.nostr.nostrord.ui.navigation.SpellRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.navigation.persistedRouteHash
 import org.nostr.nostrord.ui.navigation.restoredRoute
@@ -165,6 +168,7 @@ import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
 import org.nostr.nostrord.ui.screens.profile.ProfilePageScreen
 import org.nostr.nostrord.ui.screens.relay.RelayPageScreen
 import org.nostr.nostrord.ui.screens.settings.SettingsScreen
+import org.nostr.nostrord.ui.screens.spell.SpellScreen
 import org.nostr.nostrord.ui.theme.NostrordAnimation
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
@@ -490,6 +494,22 @@ fun AppFrame() {
                                 .clip(NostrordShapes.shapeSmall)
                                 .background(NostrordColors.Primary),
                         )
+                    }
+                    // Spells sit below the groups behind a divider: a saved query is a
+                    // destination like a group, but must never be mistaken for one.
+                    val railSpells = remember { SpellPresets.forRail() }
+                    if (railSpells.isNotEmpty()) {
+                        HorizontalDivider(modifier = Modifier.width(32.dp), color = NostrordColors.Divider)
+                        railSpells.forEach { spell ->
+                            RailButton(
+                                icon = Icons.Outlined.AutoAwesome,
+                                label = spell.name,
+                                active = (route as? SpellRoute)?.spellId == spell.id && !showNotifications,
+                            ) {
+                                history.navigate(SpellRoute(spell.id))
+                                closeDrawer()
+                            }
+                        }
                     }
                     // Add-group is the last scrollable item (after the groups) so the group
                     // list keeps all the rail space and scrolls together with it.
@@ -850,6 +870,8 @@ private fun FrameContent(
                     onOpenNotifications = onOpenNotifications,
                     onOpenDrawer = onOpenDrawer,
                 )
+            is SpellRoute ->
+                SpellScreen(spellId = route.spellId, onOpenDrawer = onOpenDrawer)
             is UserRoute ->
                 ProfilePageScreen(
                     pubkey = route.pubkey,
@@ -1567,6 +1589,7 @@ private fun navEntryLabel(route: HashRoute?, groupName: (String) -> String?): St
     is RelayRoute -> route.relayUrl.removePrefix("wss://").removePrefix("ws://")
     is UserRoute -> runCatching { Nip19.encodeNpub(route.pubkey).take(12) + "…" }.getOrDefault("Profile")
     is DmRoute -> if (route.pubkey == null) "Direct messages" else "Direct message"
+    is SpellRoute -> SpellPresets.railSpellById(route.spellId)?.name ?: "Spell"
     is NotificationsRoute -> "Notifications"
     is SettingsRoute -> "Settings"
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -168,6 +168,7 @@ import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
 import org.nostr.nostrord.ui.screens.profile.ProfilePageScreen
 import org.nostr.nostrord.ui.screens.relay.RelayPageScreen
 import org.nostr.nostrord.ui.screens.settings.SettingsScreen
+import org.nostr.nostrord.ui.screens.spell.CreateSpellModal
 import org.nostr.nostrord.ui.screens.spell.SpellScreen
 import org.nostr.nostrord.ui.theme.NostrordAnimation
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -200,6 +201,8 @@ fun AppFrame() {
     // channel list. `groups` stays the full joined list for restore validation and
     // history labels, which must keep resolving subgroup routes.
     val railRoots by vm.railRootGroups.collectAsState()
+    val railSpells by AppModule.spellLibrary.pinned.collectAsState()
+    var createSpellOpen by remember { mutableStateOf(false) }
     val railUnread by vm.railUnreadCounts.collectAsState()
     val groupParents by vm.groupParents.collectAsState()
     val notificationUnread by vm.notificationUnread.collectAsState()
@@ -497,8 +500,7 @@ fun AppFrame() {
                     }
                     // Spells sit below the groups behind a divider: a saved query is a
                     // destination like a group, but must never be mistaken for one.
-                    val railSpells = remember { SpellPresets.forRail() }
-                    if (railSpells.isNotEmpty()) {
+                    run {
                         HorizontalDivider(modifier = Modifier.width(32.dp), color = NostrordColors.Divider)
                         railSpells.forEach { spell ->
                             RailButton(
@@ -509,6 +511,10 @@ fun AppFrame() {
                                 history.navigate(SpellRoute(spell.id))
                                 closeDrawer()
                             }
+                        }
+                        RailButton(icon = Icons.Outlined.AutoAwesome, label = "New spell") {
+                            createSpellOpen = true
+                            closeDrawer()
                         }
                     }
                     // Add-group is the last scrollable item (after the groups) so the group
@@ -551,6 +557,16 @@ fun AppFrame() {
                 }
             }
         }
+    }
+
+    if (createSpellOpen) {
+        CreateSpellModal(
+            onDismiss = { createSpellOpen = false },
+            onCreated = { spell ->
+                createSpellOpen = false
+                history.navigate(SpellRoute(spell.id))
+            },
+        )
     }
 
     val sidebarContent: @Composable () -> Unit = {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/spell/CreateSpellModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/spell/CreateSpellModal.kt
@@ -1,0 +1,83 @@
+package org.nostr.nostrord.ui.screens.spell
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellDraft
+import org.nostr.nostrord.nostr.toSpell
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.utils.Result
+
+/**
+ * Build a spell and pin it to the rail.
+ *
+ * One form rather than a mode switch: leaving authors empty and naming relays is already
+ * fiatjaf's relay feed, so a second flow would only duplicate the same fields.
+ */
+@Composable
+fun CreateSpellModal(
+    onDismiss: () -> Unit,
+    onCreated: (Spell) -> Unit,
+) {
+    var draft by remember { mutableStateOf(SpellDraft()) }
+    var error by remember { mutableStateOf<String?>(null) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("New spell") },
+        confirmButton = {
+            TextButton(onClick = {
+                when (val result = draft.toSpell()) {
+                    is Result.Success -> {
+                        AppModule.spellLibrary.add(result.data)
+                        onCreated(result.data)
+                    }
+                    is Result.Error -> error = result.error.message
+                }
+            }) { Text("Create") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Field("Name", draft.name, "Bitcoin from friends") { draft = draft.copy(name = it) }
+                Field("Kinds", draft.kinds, "1, 30023 (blank = any)") { draft = draft.copy(kinds = it) }
+                Field("Authors", draft.authors, "\$contacts, \$me or an npub") { draft = draft.copy(authors = it) }
+                Field("Hashtags", draft.hashtags, "bitcoin, nostr") { draft = draft.copy(hashtags = it) }
+                Field("Relays", draft.relays, "relay.damus.io (blank = your read relays)") {
+                    draft = draft.copy(relays = it)
+                }
+                error?.let { Text(it, color = NostrordColors.Error) }
+            }
+        },
+    )
+}
+
+@Composable
+private fun Field(
+    label: String,
+    value: String,
+    placeholder: String,
+    onChange: (String) -> Unit,
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = onChange,
+        label = { Text(label) },
+        placeholder = { Text(placeholder) },
+        singleLine = true,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/spell/SpellScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/spell/SpellScreen.kt
@@ -1,0 +1,134 @@
+package org.nostr.nostrord.ui.screens.spell
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
+import org.nostr.nostrord.ui.components.chat.MessageContent
+import org.nostr.nostrord.ui.components.layout.PageHeader
+import org.nostr.nostrord.ui.components.loading.EmptyState
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.utils.formatTimestamp
+
+/**
+ * A saved query rendered as a feed. Read-only: a spell has no composer, no membership and no
+ * moderation, which is why it does not go through the group chat screen.
+ */
+@Composable
+fun SpellScreen(
+    spellId: String,
+    onOpenDrawer: (() -> Unit)? = null,
+) {
+    val vm: SpellViewModel = viewModel(key = "spell:$spellId") { SpellViewModel(spellId = spellId) }
+    val events by vm.events.collectAsState()
+    val state by vm.loadingState.collectAsState()
+    val error by vm.error.collectAsState()
+    val metadata by AppModule.nostrRepository.userMetadata.collectAsState()
+
+    val listState = rememberLazyListState()
+    val atEnd by remember {
+        derivedStateOf {
+            val last = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            last >= events.lastIndex - 3
+        }
+    }
+    LaunchedEffect(atEnd, state.canLoadMore) {
+        if (atEnd && state.canLoadMore) vm.loadMore()
+    }
+
+    Column(Modifier.fillMaxSize().background(NostrordColors.Background)) {
+        PageHeader(icon = Icons.Outlined.AutoAwesome, title = vm.title, onOpenDrawer = onOpenDrawer)
+
+        when {
+            error != null && events.isEmpty() ->
+                EmptyState(message = error.orEmpty(), icon = Icons.Outlined.AutoAwesome)
+
+            events.isEmpty() && state.isLoading ->
+                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = NostrordColors.Primary)
+                }
+
+            events.isEmpty() ->
+                EmptyState(message = "Nothing here yet. ${vm.subtitle}", icon = Icons.Outlined.AutoAwesome)
+
+            else -> LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
+                items(events, key = { it.id }) { event ->
+                    SpellEventRow(
+                        event = event,
+                        displayName = metadata[event.pubkey]?.displayName
+                            ?: metadata[event.pubkey]?.name
+                            ?: event.pubkey.take(8),
+                        avatarUrl = metadata[event.pubkey]?.picture,
+                    )
+                }
+                if (state.isLoading) {
+                    item {
+                        Box(Modifier.fillMaxWidth().padding(16.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(Modifier.height(20.dp), color = NostrordColors.Primary)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpellEventRow(
+    event: NostrGroupClient.NostrMessage,
+    displayName: String,
+    avatarUrl: String?,
+) {
+    Row(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 10.dp)) {
+        OptimizedSmallAvatar(
+            imageUrl = avatarUrl,
+            identifier = event.pubkey,
+            displayName = displayName,
+            size = 36.dp,
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = displayName,
+                    color = NostrordColors.TextPrimary,
+                    fontWeight = FontWeight.SemiBold,
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = formatTimestamp(event.createdAt),
+                    color = NostrordColors.TextMuted,
+                )
+            }
+            MessageContent(content = event.content, tags = event.tags)
+        }
+    }
+}

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -11,6 +11,7 @@ import org.nostr.nostrord.auth.signerLabel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.SpellPresets
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.GroupView
@@ -19,6 +20,7 @@ import org.nostr.nostrord.ui.navigation.HomeTab
 import org.nostr.nostrord.ui.navigation.NotificationsRoute
 import org.nostr.nostrord.ui.navigation.RelayRoute
 import org.nostr.nostrord.ui.navigation.SettingsRoute
+import org.nostr.nostrord.ui.navigation.SpellRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
 import org.nostr.nostrord.ui.screens.group.moveChannelBefore
 import org.nostr.nostrord.ui.screens.group.rootGroupId
@@ -62,6 +64,7 @@ import org.nostr.nostrord.web.screens.NotificationsSidebar
 import org.nostr.nostrord.web.screens.ProfilePage
 import org.nostr.nostrord.web.screens.RelayScreen
 import org.nostr.nostrord.web.screens.SettingsScreen
+import org.nostr.nostrord.web.screens.SpellScreen
 import org.nostr.nostrord.web.screens.ThreadsScreen
 import react.FC
 import react.Props
@@ -489,6 +492,31 @@ val AppFrame =
                                 }
                             }
                         }
+                        // Spells sit below the groups behind a divider: a saved query is a
+                        // destination like a group, but must never be mistaken for one.
+                        val spells = SpellPresets.forRail()
+                        if (spells.isNotEmpty()) {
+                            div { className = ClassName("rail-divider") }
+                            spells.forEach { spell ->
+                                div {
+                                    key = spell.id
+                                    className = ClassName("rail-group")
+                                    button {
+                                        className =
+                                            ClassName(
+                                                if ((route as? SpellRoute)?.spellId == spell.id && !notificationsOpen) {
+                                                    "rail-spell-btn active"
+                                                } else {
+                                                    "rail-spell-btn"
+                                                },
+                                            )
+                                        title = spell.name
+                                        onClick = { pushRoute(SpellRoute(spell.id)) }
+                                        +spell.name.take(1).uppercase()
+                                    }
+                                }
+                            }
+                        }
                         // End drop strip, only while dragging: a chip target always inserts
                         // BEFORE it, so this is the only way to land after the last group.
                         // Hidden for the last chip itself, which is already there.
@@ -817,6 +845,11 @@ val AppFrame =
                             this.vm = notifVm
                             onOpenDrawer = { setDrawerOpen(true) }
                             onOpenRoute = { pushRoute(it) }
+                        }
+                    r is SpellRoute ->
+                        SpellScreen {
+                            spellId = r.spellId
+                            onOpenDrawer = { setDrawerOpen(true) }
                         }
                     r is UserRoute ->
                         ProfilePage {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -573,263 +573,267 @@ val AppFrame =
                 }
 
                 // ── Sidebar: home hub or the open group's tree ───────────────
-                div {
-                    className = ClassName("sidebar")
-                    val dmRoute = route as? DmRoute
-                    if (notificationsOpen) {
-                        NotificationsSidebar { this.vm = notifVm }
-                    } else if (groupRoute != null) {
-                        GroupSidebar {
-                            this.route = groupRoute
-                            onNavigateGroup = { pushRoute(it) }
-                        }
-                    } else if (dmRoute != null && dmEnabled) {
-                        DmSidebar {
-                            activePubkey = dmRoute.pubkey
-                            onOpenConversation = { pushRoute(it) }
-                        }
-                    } else {
-                        div {
-                            className = ClassName("sidebar-header")
-                            +"nostrord"
-                        }
-                        div {
-                            className = ClassName("sidebar-body")
+                // A spell has no second column: it is a top-level destination, so the feed
+                // takes the width the friends hub would otherwise occupy.
+                if (route !is SpellRoute || notificationsOpen) {
+                    div {
+                        className = ClassName("sidebar")
+                        val dmRoute = route as? DmRoute
+                        if (notificationsOpen) {
+                            NotificationsSidebar { this.vm = notifVm }
+                        } else if (groupRoute != null) {
+                            GroupSidebar {
+                                this.route = groupRoute
+                                onNavigateGroup = { pushRoute(it) }
+                            }
+                        } else if (dmRoute != null && dmEnabled) {
+                            DmSidebar {
+                                activePubkey = dmRoute.pubkey
+                                onOpenConversation = { pushRoute(it) }
+                            }
+                        } else {
                             div {
-                                className = ClassName("tab-strip")
-                                tabItem(hub == 0, Ic.People, "Friends") { setHub(0) }
-                                tabItem(hub == 1, Ic.Bookmark, "Saved") { setHub(1) }
+                                className = ClassName("sidebar-header")
+                                +"nostrord"
                             }
-                            if (hub == 0 && friends.isNotEmpty()) {
+                            div {
+                                className = ClassName("sidebar-body")
                                 div {
-                                    className = ClassName("sidebar-friends-search")
-                                    searchInput(
-                                        placeholder = "Search friends...",
-                                        value = friendQuery,
-                                        onChange = { setFriendQuery(it) },
-                                        compact = true,
-                                    )
+                                    className = ClassName("tab-strip")
+                                    tabItem(hub == 0, Ic.People, "Friends") { setHub(0) }
+                                    tabItem(hub == 1, Ic.Bookmark, "Saved") { setHub(1) }
                                 }
-                            }
-                            when {
-                                hub == 1 ->
+                                if (hub == 0 && friends.isNotEmpty()) {
                                     div {
-                                        className = ClassName("sidebar-note")
-                                        +"Coming soon"
+                                        className = ClassName("sidebar-friends-search")
+                                        searchInput(
+                                            placeholder = "Search friends...",
+                                            value = friendQuery,
+                                            onChange = { setFriendQuery(it) },
+                                            compact = true,
+                                        )
                                     }
-                                friendsLoading ->
-                                    div {
-                                        className = ClassName("sidebar-friends")
-                                        repeat(6) { memberSkeleton() }
-                                    }
-                                friends.isEmpty() ->
-                                    div {
-                                        className = ClassName("sidebar-follow-empty")
+                                }
+                                when {
+                                    hub == 1 ->
                                         div {
                                             className = ClassName("sidebar-note")
-                                            +"You don't follow anyone yet."
+                                            +"Coming soon"
                                         }
-                                        button {
-                                            className = ClassName("sidebar-follow-cta")
-                                            onClick = { AppModule.requestOnboarding() }
-                                            icon(Ic.PersonAdd)
-                                            +"Follow people"
+                                    friendsLoading ->
+                                        div {
+                                            className = ClassName("sidebar-friends")
+                                            repeat(6) { memberSkeleton() }
                                         }
-                                    }
-                                else ->
-                                    div {
-                                        className = ClassName("sidebar-friends")
-                                        val filtered =
-                                            if (friendQuery.isBlank()) {
-                                                friends
-                                            } else {
-                                                friends.filter { f ->
-                                                    val n =
-                                                        f.metadata?.displayName?.takeIf { it.isNotBlank() }
-                                                            ?: f.metadata?.name?.takeIf { it.isNotBlank() }
-                                                            ?: Nip19.encodeNpub(f.pubkey)
-                                                    n.contains(friendQuery, ignoreCase = true)
-                                                }
-                                            }
-                                        if (filtered.isEmpty()) {
+                                    friends.isEmpty() ->
+                                        div {
+                                            className = ClassName("sidebar-follow-empty")
                                             div {
                                                 className = ClassName("sidebar-note")
-                                                +"No friends match."
+                                                +"You don't follow anyone yet."
                                             }
-                                        }
-                                        filtered.forEach { friend ->
-                                            val friendName =
-                                                friend.metadata?.displayName?.takeIf { it.isNotBlank() }
-                                                    ?: friend.metadata?.name?.takeIf { it.isNotBlank() }
-                                                    ?: (Nip19.encodeNpub(friend.pubkey).take(12) + "…")
                                             button {
-                                                key = friend.pubkey
-                                                className = ClassName("sidebar-friend")
-                                                onClick = {
-                                                    setDrawerOpen(false)
-                                                    setProfileUser(friend.pubkey)
-                                                }
-                                                WebAvatar {
-                                                    url = friend.metadata?.picture
-                                                    seed = friend.pubkey
-                                                    name = friendName
-                                                    cls = "sidebar-friend-avatar"
-                                                }
-                                                span {
-                                                    className = ClassName("sidebar-friend-name")
-                                                    +friendName
-                                                }
+                                                className = ClassName("sidebar-follow-cta")
+                                                onClick = { AppModule.requestOnboarding() }
+                                                icon(Ic.PersonAdd)
+                                                +"Follow people"
                                             }
                                         }
-                                    }
-                            }
-                        }
-                    }
-                    div {
-                        className = ClassName("account-menu")
-                        if (menuOpen) {
-                            div {
-                                className = ClassName("account-pop-backdrop")
-                                onClick = { setMenuOpen(false) }
-                            }
-                            div {
-                                className = ClassName("account-pop")
-                                div {
-                                    className = ClassName("account-pop-label")
-                                    +"Accounts"
-                                }
-                                accounts.forEach { account ->
-                                    val isActiveAccount = account.id == activeId
-                                    val m = userMetadata[account.pubkey]
-                                    val npub = runCatching { Nip19.encodeNpub(account.pubkey) }.getOrDefault("")
-                                    // Fall back to the npub (not the generic "Account N" label)
-                                    // when the account has no name metadata.
-                                    val name =
-                                        m?.displayName?.takeIf { it.isNotBlank() }
-                                            ?: m?.name?.takeIf { it.isNotBlank() }
-                                            ?: npub
-                                    // Two sibling buttons, not a copy nested inside the switch
-                                    // button: a tiny nested target let near-misses fall through
-                                    // and change account by accident.
-                                    div {
-                                        key = account.id
-                                        className =
-                                            ClassName(
-                                                if (isActiveAccount) "account-pop-row active" else "account-pop-row",
-                                            )
-                                        button {
-                                            className = ClassName("account-pop-switch")
-                                            onClick = {
-                                                setMenuOpen(false)
-                                                if (!isActiveAccount) {
-                                                    launchApp { AppModule.accountManager.switchAccount(account.id) }
+                                    else ->
+                                        div {
+                                            className = ClassName("sidebar-friends")
+                                            val filtered =
+                                                if (friendQuery.isBlank()) {
+                                                    friends
+                                                } else {
+                                                    friends.filter { f ->
+                                                        val n =
+                                                            f.metadata?.displayName?.takeIf { it.isNotBlank() }
+                                                                ?: f.metadata?.name?.takeIf { it.isNotBlank() }
+                                                                ?: Nip19.encodeNpub(f.pubkey)
+                                                        n.contains(friendQuery, ignoreCase = true)
+                                                    }
+                                                }
+                                            if (filtered.isEmpty()) {
+                                                div {
+                                                    className = ClassName("sidebar-note")
+                                                    +"No friends match."
                                                 }
                                             }
-                                            WebAvatar {
-                                                url = m?.picture
-                                                seed = account.pubkey
-                                                this.name = name
-                                                cls = "account-pop-avatar"
-                                            }
-                                            div {
-                                                className = ClassName("account-pop-meta")
-                                                div {
-                                                    className = ClassName("account-pop-name")
-                                                    +name
-                                                }
-                                                div {
-                                                    className = ClassName("account-pop-npub-row")
+                                            filtered.forEach { friend ->
+                                                val friendName =
+                                                    friend.metadata?.displayName?.takeIf { it.isNotBlank() }
+                                                        ?: friend.metadata?.name?.takeIf { it.isNotBlank() }
+                                                        ?: (Nip19.encodeNpub(friend.pubkey).take(12) + "…")
+                                                button {
+                                                    key = friend.pubkey
+                                                    className = ClassName("sidebar-friend")
+                                                    onClick = {
+                                                        setDrawerOpen(false)
+                                                        setProfileUser(friend.pubkey)
+                                                    }
+                                                    WebAvatar {
+                                                        url = friend.metadata?.picture
+                                                        seed = friend.pubkey
+                                                        name = friendName
+                                                        cls = "sidebar-friend-avatar"
+                                                    }
                                                     span {
-                                                        className = ClassName("signer-chip")
-                                                        +signerLabel(account)
+                                                        className = ClassName("sidebar-friend-name")
+                                                        +friendName
                                                     }
                                                 }
                                             }
                                         }
-                                        button {
-                                            className =
-                                                ClassName(
-                                                    if (copiedNpub == account.id) {
-                                                        "account-pop-copy copied"
-                                                    } else {
-                                                        "account-pop-copy"
-                                                    },
-                                                )
-                                            title = "Copy npub"
-                                            onClick = {
-                                                copyToClipboard(npub)
-                                                setCopiedNpub(account.id)
-                                                window.setTimeout({ setCopiedNpub(null) }, 1200)
-                                            }
-                                            icon(if (copiedNpub == account.id) Ic.Check else Ic.ContentCopy)
-                                        }
-                                    }
-                                }
-                                div { className = ClassName("account-pop-divider") }
-                                active?.let { acct ->
-                                    button {
-                                        className = ClassName("account-pop-action")
-                                        onClick = {
-                                            setMenuOpen(false)
-                                            pushRoute(UserRoute(acct.pubkey))
-                                        }
-                                        icon(Ic.Person)
-                                        +"View profile"
-                                    }
-                                }
-                                button {
-                                    className = ClassName("account-pop-action")
-                                    onClick = {
-                                        setMenuOpen(false)
-                                        setAddAccountOpen(true)
-                                    }
-                                    icon(Ic.Add)
-                                    +"Add account"
-                                }
-                                button {
-                                    className = ClassName("account-pop-action danger")
-                                    onClick = {
-                                        setMenuOpen(false)
-                                        setConfirmLogout(true)
-                                    }
-                                    icon(Ic.Logout)
-                                    +logoutLabel
                                 }
                             }
                         }
                         div {
-                            className = ClassName("account-bar")
-                            button {
-                                className = ClassName("account-bar-trigger")
-                                title = "Switch account"
-                                onClick = { setMenuOpen(!menuOpen) }
-                                WebAvatar {
-                                    url = meta?.picture
-                                    seed = active?.pubkey
-                                    this.name = displayName
-                                    cls = "account-bar-avatar"
+                            className = ClassName("account-menu")
+                            if (menuOpen) {
+                                div {
+                                    className = ClassName("account-pop-backdrop")
+                                    onClick = { setMenuOpen(false) }
                                 }
                                 div {
-                                    className = ClassName("account-bar-meta")
+                                    className = ClassName("account-pop")
                                     div {
-                                        className = ClassName("account-bar-name")
-                                        +displayName
+                                        className = ClassName("account-pop-label")
+                                        +"Accounts"
                                     }
-                                    div {
-                                        className = ClassName("account-bar-status")
-                                        +"online"
+                                    accounts.forEach { account ->
+                                        val isActiveAccount = account.id == activeId
+                                        val m = userMetadata[account.pubkey]
+                                        val npub = runCatching { Nip19.encodeNpub(account.pubkey) }.getOrDefault("")
+                                        // Fall back to the npub (not the generic "Account N" label)
+                                        // when the account has no name metadata.
+                                        val name =
+                                            m?.displayName?.takeIf { it.isNotBlank() }
+                                                ?: m?.name?.takeIf { it.isNotBlank() }
+                                                ?: npub
+                                        // Two sibling buttons, not a copy nested inside the switch
+                                        // button: a tiny nested target let near-misses fall through
+                                        // and change account by accident.
+                                        div {
+                                            key = account.id
+                                            className =
+                                                ClassName(
+                                                    if (isActiveAccount) "account-pop-row active" else "account-pop-row",
+                                                )
+                                            button {
+                                                className = ClassName("account-pop-switch")
+                                                onClick = {
+                                                    setMenuOpen(false)
+                                                    if (!isActiveAccount) {
+                                                        launchApp { AppModule.accountManager.switchAccount(account.id) }
+                                                    }
+                                                }
+                                                WebAvatar {
+                                                    url = m?.picture
+                                                    seed = account.pubkey
+                                                    this.name = name
+                                                    cls = "account-pop-avatar"
+                                                }
+                                                div {
+                                                    className = ClassName("account-pop-meta")
+                                                    div {
+                                                        className = ClassName("account-pop-name")
+                                                        +name
+                                                    }
+                                                    div {
+                                                        className = ClassName("account-pop-npub-row")
+                                                        span {
+                                                            className = ClassName("signer-chip")
+                                                            +signerLabel(account)
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                            button {
+                                                className =
+                                                    ClassName(
+                                                        if (copiedNpub == account.id) {
+                                                            "account-pop-copy copied"
+                                                        } else {
+                                                            "account-pop-copy"
+                                                        },
+                                                    )
+                                                title = "Copy npub"
+                                                onClick = {
+                                                    copyToClipboard(npub)
+                                                    setCopiedNpub(account.id)
+                                                    window.setTimeout({ setCopiedNpub(null) }, 1200)
+                                                }
+                                                icon(if (copiedNpub == account.id) Ic.Check else Ic.ContentCopy)
+                                            }
+                                        }
                                     }
-                                }
-                                span {
-                                    className = ClassName(if (menuOpen) "account-chevron open" else "account-chevron")
-                                    icon(Ic.ChevronRight)
+                                    div { className = ClassName("account-pop-divider") }
+                                    active?.let { acct ->
+                                        button {
+                                            className = ClassName("account-pop-action")
+                                            onClick = {
+                                                setMenuOpen(false)
+                                                pushRoute(UserRoute(acct.pubkey))
+                                            }
+                                            icon(Ic.Person)
+                                            +"View profile"
+                                        }
+                                    }
+                                    button {
+                                        className = ClassName("account-pop-action")
+                                        onClick = {
+                                            setMenuOpen(false)
+                                            setAddAccountOpen(true)
+                                        }
+                                        icon(Ic.Add)
+                                        +"Add account"
+                                    }
+                                    button {
+                                        className = ClassName("account-pop-action danger")
+                                        onClick = {
+                                            setMenuOpen(false)
+                                            setConfirmLogout(true)
+                                        }
+                                        icon(Ic.Logout)
+                                        +logoutLabel
+                                    }
                                 }
                             }
-                            button {
-                                className = ClassName("icon-btn")
-                                title = "Settings"
-                                onClick = { pushRoute(SettingsRoute) }
-                                icon(Ic.Settings)
+                            div {
+                                className = ClassName("account-bar")
+                                button {
+                                    className = ClassName("account-bar-trigger")
+                                    title = "Switch account"
+                                    onClick = { setMenuOpen(!menuOpen) }
+                                    WebAvatar {
+                                        url = meta?.picture
+                                        seed = active?.pubkey
+                                        this.name = displayName
+                                        cls = "account-bar-avatar"
+                                    }
+                                    div {
+                                        className = ClassName("account-bar-meta")
+                                        div {
+                                            className = ClassName("account-bar-name")
+                                            +displayName
+                                        }
+                                        div {
+                                            className = ClassName("account-bar-status")
+                                            +"online"
+                                        }
+                                    }
+                                    span {
+                                        className = ClassName(if (menuOpen) "account-chevron open" else "account-chevron")
+                                        icon(Ic.ChevronRight)
+                                    }
+                                }
+                                button {
+                                    className = ClassName("icon-btn")
+                                    title = "Settings"
+                                    onClick = { pushRoute(SettingsRoute) }
+                                    icon(Ic.Settings)
+                                }
                             }
                         }
                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -11,7 +11,6 @@ import org.nostr.nostrord.auth.signerLabel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.nostr.Nip19
-import org.nostr.nostrord.nostr.SpellPresets
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.GroupView
@@ -48,6 +47,7 @@ import org.nostr.nostrord.web.modals.AddAccountModal
 import org.nostr.nostrord.web.modals.AddGroupModal
 import org.nostr.nostrord.web.modals.AvSpaceModalHost
 import org.nostr.nostrord.web.modals.CreateGroupModal
+import org.nostr.nostrord.web.modals.CreateSpellModal
 import org.nostr.nostrord.web.modals.JoinGroupModal
 import org.nostr.nostrord.web.modals.UserProfileModal
 import org.nostr.nostrord.web.navigation.consumeInviteInHash
@@ -105,6 +105,8 @@ val AppFrame =
         // Channel model: the rail shows only root groups; a subgroup lives in its root's
         // channel list, with the root chip aggregating the subtree's unread.
         val railRoots = useStateFlow(vm.railRootGroups)
+        val railSpells = useStateFlow(AppModule.spellLibrary.pinned)
+        val (createSpellOpen, setCreateSpellOpen) = useState(false)
         val railUnread = useStateFlow(vm.railUnreadCounts)
         val groupParents = useStateFlow(vm.groupParents)
         val friends = useStateFlow(vm.friends)
@@ -494,10 +496,9 @@ val AppFrame =
                         }
                         // Spells sit below the groups behind a divider: a saved query is a
                         // destination like a group, but must never be mistaken for one.
-                        val spells = SpellPresets.forRail()
-                        if (spells.isNotEmpty()) {
+                        run {
                             div { className = ClassName("rail-divider") }
-                            spells.forEach { spell ->
+                            railSpells.forEach { spell ->
                                 div {
                                     key = spell.id
                                     className = ClassName("rail-group")
@@ -512,9 +513,21 @@ val AppFrame =
                                             )
                                         title = spell.name
                                         onClick = { pushRoute(SpellRoute(spell.id)) }
+                                        // Right-click unpins, mirroring the group chip's menu.
+                                        onContextMenu = { e ->
+                                            e.preventDefault()
+                                            AppModule.spellLibrary.remove(spell.id)
+                                            if ((route as? SpellRoute)?.spellId == spell.id) pushRoute(HomeRoute(HomeTab.Groups))
+                                        }
                                         +spell.name.take(1).uppercase()
                                     }
                                 }
+                            }
+                            button {
+                                className = ClassName("rail-spell-btn rail-spell-add")
+                                title = "New spell"
+                                onClick = { setCreateSpellOpen(true) }
+                                +"+"
                             }
                         }
                         // End drop strip, only while dragging: a chip target always inserts
@@ -950,6 +963,16 @@ val AppFrame =
                             pushRoute(GroupRoute(relayUrl.normalizeRelayUrl(), groupId, inviteCode))
                         }
                     }
+            }
+
+            if (createSpellOpen) {
+                CreateSpellModal {
+                    onDismiss = { setCreateSpellOpen(false) }
+                    onCreated = { spell ->
+                        setCreateSpellOpen(false)
+                        pushRoute(SpellRoute(spell.id))
+                    }
+                }
             }
 
             // Quick profile modal for a friend tapped in the home sidebar. No groupId

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateSpellModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateSpellModal.kt
@@ -1,0 +1,117 @@
+package org.nostr.nostrord.web.modals
+
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.nostr.Spell
+import org.nostr.nostrord.nostr.SpellDraft
+import org.nostr.nostrord.nostr.toSpell
+import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.useEscClose
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.input
+import react.useState
+import web.cssom.ClassName
+
+external interface CreateSpellModalProps : Props {
+    var onDismiss: () -> Unit
+    var onCreated: (Spell) -> Unit
+}
+
+/**
+ * Build a spell and pin it to the rail. Mirrors the Compose `CreateSpellModal`: both are text
+ * fields over [SpellDraft.toSpell], so validation lives in commonMain and cannot drift.
+ */
+val CreateSpellModal = FC<CreateSpellModalProps> { props ->
+    var draft by useState(SpellDraft())
+    var error by useState<String?>(null)
+    useEscClose { props.onDismiss() }
+
+    div {
+        className = ClassName("modal-overlay")
+        onClick = { props.onDismiss() }
+
+        div {
+            className = ClassName("modal-card")
+            onClick = { it.stopPropagation() }
+
+            div {
+                className = ClassName("modal-header")
+                div {
+                    className = ClassName("modal-header-text")
+                    div {
+                        className = ClassName("modal-title")
+                        +"New spell"
+                    }
+                    div {
+                        className = ClassName("modal-subtitle")
+                        +"A saved query, pinned to the rail. Name relays and leave authors blank for a relay feed."
+                    }
+                }
+                button {
+                    className = ClassName("modal-close")
+                    onClick = { props.onDismiss() }
+                    icon(Ic.Close)
+                }
+            }
+
+            field("Name", draft.name, "Bitcoin from friends") { draft = draft.copy(name = it) }
+            field("Kinds", draft.kinds, "1, 30023 (blank = any)") { draft = draft.copy(kinds = it) }
+            field("Authors", draft.authors, "\$contacts, \$me or an npub") { draft = draft.copy(authors = it) }
+            field("Hashtags", draft.hashtags, "bitcoin, nostr") { draft = draft.copy(hashtags = it) }
+            field("Relays", draft.relays, "relay.damus.io (blank = your read relays)") {
+                draft = draft.copy(relays = it)
+            }
+
+            error?.let { message ->
+                div {
+                    className = ClassName("field-hint modal-error-text")
+                    +message
+                }
+            }
+
+            div {
+                className = ClassName("modal-footer")
+                button {
+                    className = ClassName("btn-text")
+                    onClick = { props.onDismiss() }
+                    +"Cancel"
+                }
+                button {
+                    className = ClassName("btn-primary")
+                    onClick = {
+                        when (val result = draft.toSpell()) {
+                            is Result.Success -> {
+                                AppModule.spellLibrary.add(result.data)
+                                props.onCreated(result.data)
+                            }
+                            is Result.Error -> error = result.error.message
+                        }
+                    }
+                    +"Create"
+                }
+            }
+        }
+    }
+}
+
+private fun react.ChildrenBuilder.field(
+    caption: String,
+    current: String,
+    hint: String,
+    onValue: (String) -> Unit,
+) {
+    div {
+        className = ClassName("field-label")
+        +caption
+    }
+    input {
+        className = ClassName("modal-input")
+        value = current
+        placeholder = hint
+        onChange = { event -> onValue(event.currentTarget.value) }
+    }
+}

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SpellScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SpellScreen.kt
@@ -7,7 +7,9 @@ import org.nostr.nostrord.utils.formatTimestamp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.AvatarKind
+import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.navigation.pushRoute
 import react.FC
 import react.Props
@@ -35,10 +37,11 @@ val SpellScreen = FC<SpellScreenProps> { props ->
     div {
         className = ClassName("page-header")
         props.onOpenDrawer?.let { open ->
+            // Hidden above 767px by .chat-drawer-btn: on desktop the rail is already on screen.
             button {
-                className = ClassName("page-header-menu")
+                className = ClassName("chat-icon-btn chat-drawer-btn")
                 onClick = { open() }
-                +"☰"
+                icon(Ic.Menu)
             }
         }
         span {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SpellScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SpellScreen.kt
@@ -1,0 +1,118 @@
+package org.nostr.nostrord.web.screens
+
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.navigation.UserRoute
+import org.nostr.nostrord.ui.screens.spell.SpellViewModel
+import org.nostr.nostrord.utils.formatTimestamp
+import org.nostr.nostrord.web.bridge.useStateFlow
+import org.nostr.nostrord.web.bridge.useViewModel
+import org.nostr.nostrord.web.components.AvatarKind
+import org.nostr.nostrord.web.components.WebAvatar
+import org.nostr.nostrord.web.navigation.pushRoute
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.span
+import web.cssom.ClassName
+
+external interface SpellScreenProps : Props {
+    var spellId: String
+    var onOpenDrawer: (() -> Unit)?
+}
+
+/**
+ * A saved query rendered as a feed. Read-only, mirroring the Compose `SpellScreen`: both consume
+ * the same [SpellViewModel], so behaviour lives in commonMain and only layout differs here.
+ */
+val SpellScreen = FC<SpellScreenProps> { props ->
+    val vm = useViewModel(props.spellId) { SpellViewModel(spellId = props.spellId) }
+    val events = useStateFlow(vm.events)
+    val state = useStateFlow(vm.loadingState)
+    val error = useStateFlow(vm.error)
+    val metadata = useStateFlow(AppModule.nostrRepository.userMetadata)
+
+    div {
+        className = ClassName("page-header")
+        props.onOpenDrawer?.let { open ->
+            button {
+                className = ClassName("page-header-menu")
+                onClick = { open() }
+                +"☰"
+            }
+        }
+        span {
+            className = ClassName("page-header-title")
+            +vm.title
+        }
+    }
+
+    div {
+        className = ClassName("spell-feed")
+
+        when {
+            error != null && events.isEmpty() -> div {
+                className = ClassName("spell-empty")
+                +error
+            }
+            events.isEmpty() && state.isLoading -> div {
+                className = ClassName("spell-empty")
+                +"Loading…"
+            }
+            events.isEmpty() -> div {
+                className = ClassName("spell-empty")
+                +"Nothing here yet. ${vm.subtitle}"
+            }
+            else -> events.forEach { event ->
+                val meta = metadata[event.pubkey]
+                val displayName = meta?.displayName ?: meta?.name ?: event.pubkey.take(8)
+                div {
+                    key = event.id
+                    className = ClassName("spell-row")
+                    WebAvatar {
+                        url = meta?.picture
+                        seed = event.pubkey
+                        name = displayName
+                        kind = AvatarKind.USER
+                        cls = "spell-row-avatar"
+                    }
+                    div {
+                        className = ClassName("spell-row-body")
+                        div {
+                            className = ClassName("spell-row-head")
+                            span {
+                                className = ClassName("spell-row-name")
+                                +displayName
+                            }
+                            span {
+                                className = ClassName("spell-row-time")
+                                +formatTimestamp(event.createdAt)
+                            }
+                        }
+                        div {
+                            className = ClassName("spell-row-content")
+                            // Same renderer chat uses: links, media, emoji and nostr refs.
+                            renderMessageContent(
+                                content = event.content,
+                                tags = event.tags,
+                                userMetadata = metadata,
+                                messagesById = emptyMap(),
+                                onUser = { pushRoute(UserRoute(it)) },
+                                onEventRef = {},
+                                onGroupRef = { _, _ -> },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if (state.canLoadMore && events.isNotEmpty()) {
+            button {
+                className = ClassName("spell-load-more")
+                onClick = { vm.loadMore() }
+                +if (state.isLoading) "Loading…" else "Load more"
+            }
+        }
+    }
+}

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -11437,3 +11437,16 @@ button.hierarchy-crumb-item:hover {
     background: var(--color-hover);
     color: var(--color-text-primary);
 }
+
+/* The rail's add-spell affordance: same chip geometry, muted until hovered. */
+.rail-spell-add {
+    font-size: 22px;
+    font-weight: 400;
+    border-style: dashed;
+    color: var(--color-text-muted);
+}
+
+/* Validation message under the create-spell fields. */
+.modal-error-text {
+    color: var(--color-error);
+}

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -11311,3 +11311,98 @@ button.hierarchy-crumb-item:hover {
     font-size: 11px;
     font-weight: 700;
 }
+
+/* ---------------------------------------------------------------------------
+   Spells: saved queries rendered as a feed. Rail chips reuse the group chip
+   geometry but carry an initial instead of an avatar, so a spell reads as a
+   destination without being mistaken for a group.
+   --------------------------------------------------------------------------- */
+
+.rail-spell-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+    padding: 0;
+    border: 1px solid var(--color-divider);
+    border-radius: 16px;
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    font-size: 18px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-radius 0.15s ease, color 0.15s ease, background 0.15s ease;
+}
+
+.rail-spell-btn:hover,
+.rail-spell-btn.active {
+    border-radius: 12px;
+    color: var(--color-text-primary);
+    background: var(--color-background);
+}
+
+.spell-feed {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: var(--space-2) 0 var(--space-6);
+}
+
+.spell-row {
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--color-divider);
+}
+
+.spell-row-avatar {
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    border-radius: 50%;
+}
+
+.spell-row-body {
+    min-width: 0;
+    flex: 1;
+}
+
+.spell-row-head {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+}
+
+.spell-row-name {
+    font-weight: 600;
+    color: var(--color-text-primary);
+}
+
+.spell-row-time {
+    font-size: 12px;
+    color: var(--color-text-muted);
+}
+
+.spell-row-content {
+    color: var(--color-text-content);
+    overflow-wrap: anywhere;
+}
+
+.spell-empty {
+    padding: var(--space-8) var(--space-4);
+    text-align: center;
+    color: var(--color-text-muted);
+}
+
+.spell-load-more {
+    display: block;
+    margin: var(--space-4) auto;
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    cursor: pointer;
+}

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -11327,7 +11327,7 @@ button.hierarchy-crumb-item:hover {
     flex-shrink: 0;
     padding: 0;
     border: 1px solid var(--color-divider);
-    border-radius: 16px;
+    border-radius: var(--radius-lg);
     background: var(--color-surface);
     color: var(--color-text-secondary);
     font-size: 18px;
@@ -11338,30 +11338,38 @@ button.hierarchy-crumb-item:hover {
 
 .rail-spell-btn:hover,
 .rail-spell-btn.active {
-    border-radius: 12px;
+    border-radius: var(--radius-md);
     color: var(--color-text-primary);
     background: var(--color-background);
 }
 
+/* Owns the vertical space under the page header, so the feed scrolls on its own
+   instead of pushing the frame. */
 .spell-feed {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
-    padding: var(--space-2) 0 var(--space-6);
+    background: var(--color-background);
 }
 
 .spell-row {
     display: flex;
-    gap: var(--space-3);
-    padding: var(--space-3) var(--space-4);
-    border-bottom: 1px solid var(--color-divider);
+    gap: var(--space-md);
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space-md) var(--space-lg);
+    border-bottom: 1px solid var(--color-line);
+}
+
+.spell-row:hover {
+    background: var(--color-message-hover);
 }
 
 .spell-row-avatar {
-    width: 36px;
-    height: 36px;
+    width: 40px;
+    height: 40px;
     flex-shrink: 0;
-    border-radius: 50%;
+    border-radius: var(--radius-full);
 }
 
 .spell-row-body {
@@ -11372,37 +11380,60 @@ button.hierarchy-crumb-item:hover {
 .spell-row-head {
     display: flex;
     align-items: baseline;
-    gap: var(--space-2);
+    gap: var(--space-sm);
+    margin-bottom: var(--space-xxs);
 }
 
 .spell-row-name {
     font-weight: 600;
     color: var(--color-text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .spell-row-time {
+    flex-shrink: 0;
     font-size: 12px;
     color: var(--color-text-muted);
 }
 
 .spell-row-content {
     color: var(--color-text-content);
+    line-height: 1.4;
     overflow-wrap: anywhere;
 }
 
+/* Feed media is decoration, not the subject: cap it so one image cannot own the
+   viewport the way a chat attachment can. */
+.spell-row-content img,
+.spell-row-content video {
+    max-width: 100%;
+    max-height: 320px;
+    height: auto;
+    border-radius: var(--radius-md);
+}
+
 .spell-empty {
-    padding: var(--space-8) var(--space-4);
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space-xxxl) var(--space-lg);
     text-align: center;
     color: var(--color-text-muted);
 }
 
 .spell-load-more {
     display: block;
-    margin: var(--space-4) auto;
-    padding: var(--space-2) var(--space-4);
+    margin: var(--space-lg) auto var(--space-xxxl);
+    padding: var(--space-sm) var(--space-lg);
     border: 1px solid var(--color-divider);
     border-radius: var(--radius-md);
     background: var(--color-surface);
     color: var(--color-text-secondary);
     cursor: pointer;
+}
+
+.spell-load-more:hover {
+    background: var(--color-hover);
+    color: var(--color-text-primary);
 }


### PR DESCRIPTION
Spells are saved Nostr queries (kind:777) that run as live subscriptions and pin to the rail next to groups. A spell stores its filters unresolved: `$me` / `$contacts` / `$members` and relative timestamps stay literal in the event and expand on every cast, so a spell stays live instead of freezing its author list and time window at save time. `resolve()` fails closed on an unresolvable variable, since sending the literal `"$contacts"` would be a valid REQ matching nothing, which reads as an empty feed rather than an error.

`targetRelays()` drops a bound group's relay from the NIP-65 fallback: a NIP-29 relay serves group events only, so a kind:1 spell routed there comes back empty. Presets that do want the group relay name it explicitly. `$members` and the `["group", relay, id]` binding extend the draft NIP, which cannot express a group-scoped query today.

`SpellManager` keeps the subscription open past EOSE so live events keep arriving, and both UIs render the same feed from the shared ViewModel: a `SpellScreen` in Compose and in React, plus create-and-pin from either side.

| Area | Change |
|---|---|
| `nostr/Spell.kt`, `SpellPresets.kt` | kind:777 codec, variable + relative-time resolution, preset catalogue |
| `network/managers/SpellManager.kt` | cast as a live subscription, per-spell event flow, EOSE handling |
| `NostrRepository` / `NostrRepositoryApi` | spell CRUD + cast surface for the UI |
| `ui/screens/spell/` (commonMain) | shared `SpellViewModel` consumed by both render trees |
| Compose + web `SpellScreen`, `CreateSpellModal` | feed, rail pinning, create flow |
| `styles.css`, `AppFrame.kt` | web spell rail + feed styling |

Commits:
- `feat(spells): kind:777 saved-query codec and presets`
- `feat(spells): run spells as live subscriptions`
- `feat(spells): pin spells in the rail on both UIs`
- `fix(spells): keep live events after EOSE, correct the web feed styling`
- `feat(spells): create and pin your own spells`

Tested with `compileKotlinJvm`, `compileKotlinJs`, `:composeApp:jvmTest` (all green); device validation pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
