### PR TITLE
Keep the notification chime silent under Do Not Disturb, and say so in Settings

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.android.kt
@@ -1,7 +1,10 @@
 package org.nostr.nostrord.notifications
 
 import android.annotation.SuppressLint
+import android.app.NotificationManager
 import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioManager
 import android.media.MediaPlayer
 import org.nostr.nostrord.R
 
@@ -17,10 +20,40 @@ object AndroidNotificationSoundInit {
     }
 }
 
+/**
+ * The app plays its own sound instead of posting a system notification, so no
+ * NotificationChannel policy applies to it. Silence has to be enforced here:
+ * Do Not Disturb and silent/vibrate ringer only mute the ring and notification
+ * streams, and only USAGE_NOTIFICATION routes there — the MediaPlayer default
+ * (USAGE_MEDIA) is audible through both.
+ */
+private fun shouldStayQuiet(context: Context): Boolean {
+    val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
+    // Match the DND filters explicitly: INTERRUPTION_FILTER_UNKNOWN also fails the
+    // "== ALL" test, and treating it as DND would mute the sound for good.
+    val dnd = when (nm?.currentInterruptionFilter) {
+        NotificationManager.INTERRUPTION_FILTER_PRIORITY,
+        NotificationManager.INTERRUPTION_FILTER_ALARMS,
+        NotificationManager.INTERRUPTION_FILTER_NONE,
+        -> true
+        else -> false
+    }
+    if (dnd) return true
+    val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+    return am != null && am.ringerMode != AudioManager.RINGER_MODE_NORMAL
+}
+
 actual fun playNotificationSound() {
     val context = AndroidNotificationSoundInit.appContext ?: return
     try {
-        val player = MediaPlayer.create(context, R.raw.message_incoming) ?: return
+        if (shouldStayQuiet(context)) return
+        val attributes = AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_NOTIFICATION)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+            .build()
+        val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+        val sessionId = audioManager?.generateAudioSessionId() ?: AudioManager.AUDIO_SESSION_ID_GENERATE
+        val player = MediaPlayer.create(context, R.raw.message_incoming, attributes, sessionId) ?: return
         player.setVolume(0.6f, 0.6f)
         player.setOnCompletionListener { it.release() }
         player.setOnErrorListener { mp, _, _ ->

--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.android.kt
@@ -2,11 +2,22 @@ package org.nostr.nostrord.notifications
 
 import android.annotation.SuppressLint
 import android.app.NotificationManager
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.MediaPlayer
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import org.nostr.nostrord.R
+
+private val suppression = MutableStateFlow<SoundSuppression?>(null)
+
+actual val notificationSoundSuppression: StateFlow<SoundSuppression?> = suppression.asStateFlow()
 
 /**
  * Must be called once from Application.onCreate() before [playNotificationSound].
@@ -15,8 +26,25 @@ object AndroidNotificationSoundInit {
     @SuppressLint("StaticFieldLeak") // Application context is safe to hold statically
     internal var appContext: Context? = null
 
+    // Both broadcasts are system-protected, so the receiver stays not-exported. It lives
+    // for the process lifetime: the suppression state has to stay live while Settings is
+    // open, and the notification shade doesn't pause the activity.
+    private val systemStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent?) {
+            suppression.value = currentSuppression(context.applicationContext)
+        }
+    }
+
     fun initialize(context: Context) {
-        appContext = context.applicationContext
+        if (appContext != null) return
+        val app = context.applicationContext
+        appContext = app
+        suppression.value = currentSuppression(app)
+        val filter = IntentFilter().apply {
+            addAction(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED)
+            addAction(AudioManager.RINGER_MODE_CHANGED_ACTION)
+        }
+        ContextCompat.registerReceiver(app, systemStateReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
     }
 }
 
@@ -27,7 +55,7 @@ object AndroidNotificationSoundInit {
  * streams, and only USAGE_NOTIFICATION routes there — the MediaPlayer default
  * (USAGE_MEDIA) is audible through both.
  */
-private fun shouldStayQuiet(context: Context): Boolean {
+private fun currentSuppression(context: Context): SoundSuppression? {
     val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as? NotificationManager
     // Match the DND filters explicitly: INTERRUPTION_FILTER_UNKNOWN also fails the
     // "== ALL" test, and treating it as DND would mute the sound for good.
@@ -38,15 +66,22 @@ private fun shouldStayQuiet(context: Context): Boolean {
         -> true
         else -> false
     }
-    if (dnd) return true
+    if (dnd) return SoundSuppression.DoNotDisturb
     val am = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
-    return am != null && am.ringerMode != AudioManager.RINGER_MODE_NORMAL
+    if (am != null && am.ringerMode != AudioManager.RINGER_MODE_NORMAL) {
+        return SoundSuppression.SilentRinger
+    }
+    return null
 }
 
 actual fun playNotificationSound() {
     val context = AndroidNotificationSoundInit.appContext ?: return
     try {
-        if (shouldStayQuiet(context)) return
+        // Re-read rather than trust the broadcast state: a missed broadcast would
+        // otherwise leak an audible chime under DND.
+        val quiet = currentSuppression(context)
+        suppression.value = quiet
+        if (quiet != null) return
         val attributes = AudioAttributes.Builder()
             .setUsage(AudioAttributes.USAGE_NOTIFICATION)
             .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.kt
@@ -1,8 +1,35 @@
 package org.nostr.nostrord.notifications
 
+import kotlinx.coroutines.flow.StateFlow
+
 /**
  * Play the notification chime. Web uses HTML5 Audio, JVM uses JLayer, Android
  * uses MediaPlayer; iOS is a no-op for now. Browsers may swallow the first call
  * until the user has interacted with the page.
  */
 expect fun playNotificationSound()
+
+/** Platform-level reason the chime stays silent, whatever the app's own setting says. */
+enum class SoundSuppression {
+    DoNotDisturb,
+    SilentRinger,
+    ;
+
+    /** Copy shown next to the disabled test-sound control. */
+    val notice: String
+        get() = when (this) {
+            DoNotDisturb ->
+                "Do Not Disturb is on, so the system silences the chime. " +
+                    "Turn it off to hear notification sounds."
+            SilentRinger ->
+                "The ringer is set to silent or vibrate, so the system silences the chime. " +
+                    "Switch it back to normal to hear notification sounds."
+        }
+}
+
+/**
+ * Current suppression reason, or null when the chime would be audible. Only Android
+ * reports one: the other platforms have no equivalent system-wide mute that applies
+ * to in-process playback.
+ */
+expect val notificationSoundSuppression: StateFlow<SoundSuppression?>

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/SoundSuppressionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/SoundSuppressionTest.kt
@@ -1,0 +1,28 @@
+package org.nostr.nostrord.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SoundSuppressionTest {
+    @Test
+    fun `every reason names the system control the user has to change`() {
+        assertTrue(SoundSuppression.DoNotDisturb.notice.contains("Do Not Disturb"))
+        assertTrue(SoundSuppression.SilentRinger.notice.contains("silent or vibrate"))
+    }
+
+    @Test
+    fun `notices carry no em-dash and stay English`() {
+        SoundSuppression.entries.forEach { reason ->
+            assertEquals(-1, reason.notice.indexOf('—'), "em-dash in ${reason.name}")
+        }
+    }
+
+    @Test
+    fun `platforms without a system mute report no suppression`() {
+        // Android overrides this; every other actual is a constant null flow, which is what
+        // keeps the test-sound button enabled on web, desktop and iOS.
+        assertNull(notificationSoundSuppression.value)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.ios.kt
@@ -1,3 +1,9 @@
 package org.nostr.nostrord.notifications
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+// Nothing to suppress while playback itself is a no-op.
+actual val notificationSoundSuppression: StateFlow<SoundSuppression?> = MutableStateFlow(null)
+
 actual fun playNotificationSound() { /* no-op */ }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.js.kt
@@ -1,5 +1,11 @@
 package org.nostr.nostrord.notifications
 
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+// Browsers expose no system-wide mute state to a page.
+actual val notificationSoundSuppression: StateFlow<SoundSuppression?> = MutableStateFlow(null)
+
 actual fun playNotificationSound() {
     try {
         val audio = js("new Audio('message-incoming.mp3')")

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/notifications/NotificationSound.jvm.kt
@@ -1,8 +1,13 @@
 package org.nostr.nostrord.notifications
 
 import javazoom.jl.player.Player
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import java.io.BufferedInputStream
 import kotlin.concurrent.thread
+
+// Desktop playback goes to the media mixer; no OS focus mode gates it.
+actual val notificationSoundSuppression: StateFlow<SoundSuppression?> = MutableStateFlow(null)
 
 // Anchors resource loading so we don't rely on anonymous-class `javaClass`.
 private class ClassLoaderAnchor

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -879,6 +879,7 @@ private fun NotificationsPanelContent() {
     val notificationService = AppModule.notificationService
 
     val soundEnabled by settings.soundEnabled.collectAsState()
+    val soundSuppression by org.nostr.nostrord.notifications.notificationSoundSuppression.collectAsState()
     val systemEnabled by settings.systemNotificationsEnabled.collectAsState()
     val defaultLevel by settings.defaultLevel.collectAsState()
     val permission by notificationService.permission.collectAsState()
@@ -904,14 +905,30 @@ private fun NotificationsPanelContent() {
                     onCheckedChange = { settings.setSoundEnabled(it) },
                 )
                 if (soundEnabled) {
+                    // The system mutes the chime regardless of this setting, so the test
+                    // button would look broken instead of blocked.
+                    val suppression = soundSuppression
                     Spacer(Modifier.height(Spacing.sm))
                     TextButton(
                         onClick = {
                             org.nostr.nostrord.notifications.playNotificationSound()
                         },
+                        enabled = suppression == null,
                         modifier = Modifier.pointerHoverIcon(PointerIcon.Hand),
                     ) {
-                        Text("Test sound", color = NostrordColors.Primary, fontSize = 13.sp)
+                        Text(
+                            "Test sound",
+                            color = if (suppression == null) NostrordColors.Primary else NostrordColors.TextMuted,
+                            fontSize = 13.sp,
+                        )
+                    }
+                    if (suppression != null) {
+                        Text(
+                            suppression.notice,
+                            color = NostrordColors.Warning,
+                            fontSize = 12.sp,
+                            lineHeight = 16.sp,
+                        )
                     }
                 }
             }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -9,6 +9,7 @@ import org.nostr.nostrord.network.upload.MediaUploadService
 import org.nostr.nostrord.network.upload.mediaServerDisplayName
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.notifications.NotificationPermission
+import org.nostr.nostrord.notifications.notificationSoundSuppression
 import org.nostr.nostrord.notifications.playNotificationSound
 import org.nostr.nostrord.settings.AppTheme
 import org.nostr.nostrord.settings.NotificationLevel
@@ -852,6 +853,7 @@ private val NotificationsPanel =
         val settings = AppModule.notificationSettings
         val service = AppModule.notificationService
         val soundEnabled = useStateFlow(settings.soundEnabled)
+        val soundSuppression = useStateFlow(notificationSoundSuppression)
         val systemEnabled = useStateFlow(settings.systemNotificationsEnabled)
         val defaultLevel = useStateFlow(settings.defaultLevel)
         val permission = useStateFlow(service.permission)
@@ -864,8 +866,15 @@ private val NotificationsPanel =
             if (soundEnabled) {
                 button {
                     className = ClassName("settings-test-sound")
+                    disabled = soundSuppression != null
                     onClick = { playNotificationSound() }
                     +"Test sound"
+                }
+                soundSuppression?.let {
+                    div {
+                        className = ClassName("settings-sound-notice")
+                        +it.notice
+                    }
                 }
             }
             // Desktop notifications live in the same box, separated by a divider (native layout).

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -6881,8 +6881,18 @@ body {
     font-weight: 600;
     cursor: pointer;
 }
-.settings-test-sound:hover {
+.settings-test-sound:hover:not(:disabled) {
     text-decoration: underline;
+}
+.settings-test-sound:disabled {
+    color: var(--color-text-muted);
+    cursor: default;
+}
+/* Shown when the OS silences the chime (Do Not Disturb / silent ringer). */
+.settings-sound-notice {
+    color: var(--color-warning);
+    font-size: 12px;
+    line-height: 16px;
 }
 
 /* Fenced code block + inline code (mirrors native CodeBlockContent / Monospace) */


### PR DESCRIPTION
Nostrord kept beeping on Android with Do Not Disturb on. The cause is that the Android target posts no system notification at all (`NotificationService.android.kt` reports `isSupported() = false` and `notify()` is a no-op), so there is no NotificationChannel for the system policy to act on. The alert is a plain in-process `MediaPlayer`, and `MediaPlayer.create()` without `AudioAttributes` defaults to `USAGE_MEDIA`. DND mutes the ring and notification streams, never media, so the sound played through and followed the media volume slider instead of the notification one.

The sound now declares `USAGE_NOTIFICATION` / `CONTENT_TYPE_SONIFICATION`, and playback is skipped up front whenever an interruption filter or a non-normal ringer mode is active. `INTERRUPTION_FILTER_UNKNOWN` is matched out explicitly, since a blanket `!= INTERRUPTION_FILTER_ALL` test would treat it as DND and mute the sound permanently.

That left Settings > Notifications with a "Test sound" button that silently did nothing, which reads as a bug. The second commit exposes the reason as `SoundSuppression` over a `StateFlow` both settings panels consume: the button goes disabled and a warning line names the system control to change. Android backs the flow with a receiver on `ACTION_INTERRUPTION_FILTER_CHANGED` and `RINGER_MODE_CHANGED_ACTION`, because the notification shade does not pause the activity and a one-shot read on screen entry would go stale while the panel is open. Playback still re-reads the state rather than trusting the flow, so a missed broadcast cannot leak an audible chime. JVM, JS and iOS have no equivalent system mute and report a constant null, so their test button is unchanged.

| | |
|---|---|
| Cause | In-process `MediaPlayer` on the media stream, no notification channel involved |
| Fix | Notification audio attributes + early return on DND / silent / vibrate, surfaced in Settings |
| Known gap | DND in Priority mode with Nostrord allowed as an exception is silenced too; without a real notification channel the app cannot see that allowlist |
| Validation | `compileDebugKotlinAndroid`, `compileKotlinJvm`, `compileKotlinJs`, `jvmTest`. Device check pending: enable DND, receive a group message, confirm silence and the disabled test button, disable and confirm both return |

The lasting fix is to give Android real notifications with a `NotificationChannel` and let the channel own the sound, which drops this manual check and restores the per-app DND exception. Out of scope here.

- 75a6a396 fix(android): keep the notification sound silent under Do Not Disturb
- b0889fab feat(settings): explain why the test sound stays silent