### PR TITLE
Scope the leave and delete markers per relay

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -452,7 +452,7 @@ class NostrRepository(
     override val groupRolesByRelay: StateFlow<Map<String, Map<String, List<RoleDefinition>>>> = groupManager.groupRolesByRelay
     override val loadingMembers: StateFlow<Set<String>> = groupManager.loadingMembers
     override val restrictedGroups: StateFlow<Map<String, String>> = groupManager.restrictedGroups
-    override val leftGroups: StateFlow<Set<String>> = groupManager.leftGroups
+    override val leftGroups: StateFlow<Map<String, Set<String>>> = groupManager.leftGroups
     override val pendingGroupInvites: StateFlow<Map<String, PendingGroupInvite>> = groupManager.pendingGroupInvites
 
     override suspend fun acceptGroupInvite(groupId: String) {
@@ -4695,7 +4695,7 @@ class NostrRepository(
                             }
                         },
                         messageHandler = { m, c -> enqueueToRelayPipeline(m, c) },
-                        isGroupDropped = { groupManager.isLocallyDropped(it) },
+                        isGroupDropped = { relay, gid -> groupManager.isLocallyDropped(gid, relay) },
                         decryptPrivate = { ciphertext -> decryptOwnListSection(ciphertext) },
                     )
                 }
@@ -5372,7 +5372,7 @@ class NostrRepository(
                                 }
                             },
                             messageHandler = { m, c -> enqueueToRelayPipeline(m, c) },
-                            isGroupDropped = { groupManager.isLocallyDropped(it) },
+                            isGroupDropped = { relay, gid -> groupManager.isLocallyDropped(gid, relay) },
                             decryptPrivate = { ciphertext -> decryptOwnListSection(ciphertext) },
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -146,8 +146,12 @@ interface NostrRepositoryApi {
     /** Groups whose subscriptions were CLOSED with "restricted" — private group, non-member. */
     val restrictedGroups: StateFlow<Map<String, String>>
 
-    /** Groups the user explicitly LEFT (durable, survives restart); membership reads NONE for these. */
-    val leftGroups: StateFlow<Set<String>>
+    /**
+     * Groups the user explicitly LEFT (durable, survives restart), keyed by the relay they were
+     * left on; membership reads NONE for these. Relay-scoped because the same group id names
+     * independent groups on different relays.
+     */
+    val leftGroups: StateFlow<Map<String, Set<String>>>
 
     /**
      * External adds (an admin's kind:9000) awaiting the user's accept/decline, keyed by

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -228,6 +228,9 @@ class GroupManager(
      * re-emitted metadata event (relay replaying, or a relay that doesn't actually honor
      * 9008) doesn't resurrect the group into "Other Groups".
      */
+    // Groups deleted or forgotten on this device, keyed by [droppedKey] (relay + group). Relay-scoped
+    // for the same reason the left markers are: a bare id blocks the kind:10009 merge for the same-id
+    // group on EVERY relay, and unlike a left marker nothing self-heals it.
     private val deletedGroupIds = mutableSetOf<String>()
 
     // Debounce mux refresh: coalesces rapid calls (auth + EOSE + CLOSED) into one.
@@ -640,7 +643,20 @@ class GroupManager(
      * True when the group was deleted or left on THIS device. Stale kind:10009
      * merges skip these so a lagging relay cannot resurrect them.
      */
-    fun isLocallyDropped(groupId: String, relayUrl: String? = null): Boolean = groupId in deletedGroupIds || isRecentlyLeft(relayUrl, groupId)
+    fun isLocallyDropped(groupId: String, relayUrl: String? = null): Boolean = isDropped(relayUrl, groupId) || isRecentlyLeft(relayUrl, groupId)
+
+    /**
+     * Key of a dropped-group entry. Relay first, so the relay part can never contain the
+     * separator and splitting on the FIRST '|' is unambiguous even for a group id that has one.
+     */
+    private fun droppedKey(relayUrl: String, groupId: String): String = "${relayUrl.normalizeRelayUrl()}|$groupId"
+
+    /** Whether [groupId] was deleted/forgotten on [relayUrl]; a null relay scans every relay. */
+    private fun isDropped(relayUrl: String?, groupId: String): Boolean = if (relayUrl != null) {
+        droppedKey(relayUrl, groupId) in deletedGroupIds
+    } else {
+        deletedGroupIds.any { it.substringAfter('|', "") == groupId }
+    }
     private val LEFT_GROUP_GRACE_MS = 5_000L
 
     // Relay-of-origin per groupId, recorded from the WebSocket that delivered
@@ -1613,7 +1629,7 @@ class GroupManager(
             // them before the OK (the old order) silently dropped the durable left protection
             // when the relay rejected or timed out the request. Still BEFORE the joined-set
             // write below, so the additive kind:10009 merge can't drop the fresh join.
-            deletedGroupIds.remove(groupId)
+            deletedGroupIds.remove(droppedKey(groupRelayUrl, groupId))
             persistDroppedGroups()
             recentlyLeftAt.remove(recentLeaveKey(groupRelayUrl, groupId))
             clearLeft(groupRelayUrl, groupId)
@@ -2083,7 +2099,7 @@ class GroupManager(
             _groupMembers.update { it - idsToRemove }
             _liveKitParticipants.update { it - idsToRemove }
             idsToRemove.forEach { loadingRegistry.remove(it) }
-            deletedGroupIds.addAll(idsToRemove)
+            deletedGroupIds.addAll(idsToRemove.map { droppedKey(normalizedGroupRelay, it) })
             persistDroppedGroups(pubKey)
             recomputeSubgroupTopology()
 
@@ -2104,7 +2120,7 @@ class GroupManager(
         // Once a deletion has been processed, don't re-process it. The joinGroup()
         // method clears the id from deletedGroupIds, so a future deletion after
         // re-join will still be handled correctly.
-        if (groupId in deletedGroupIds) return false
+        if (isDropped(relayUrl, groupId)) return false
 
         val idsToRemove = setOf(groupId)
         // Intentionally do NOT remove from _joinedGroupsByRelay / kind:10009 — orphaned groups
@@ -2129,7 +2145,7 @@ class GroupManager(
         _groupAdmins.update { it - idsToRemove }
         _groupMembers.update { it - idsToRemove }
         idsToRemove.forEach { loadingRegistry.remove(it) }
-        deletedGroupIds.addAll(idsToRemove)
+        deletedGroupIds.addAll(idsToRemove.map { droppedKey(relayUrl, it) })
         persistDroppedGroups(pubKey)
         recomputeSubgroupTopology()
         return false
@@ -2158,7 +2174,7 @@ class GroupManager(
                 SecureStorage.saveJoinedGroupsForRelay(pubKey, normalized, updatedPerRelay)
             } catch (_: Exception) {}
         }
-        deletedGroupIds.add(groupId)
+        deletedGroupIds.add(droppedKey(normalized, groupId))
         persistDroppedGroups(pubKey)
         return true
     }
@@ -3758,7 +3774,7 @@ class GroupManager(
      * so returning to this relay later is instant without a network re-fetch.
      */
     fun handleGroupMetadata(metadata: GroupMetadata, relayUrl: String) {
-        if (metadata.id in deletedGroupIds) return
+        if (isDropped(relayUrl, metadata.id)) return
         val normalized = relayUrl.normalizeRelayUrl()
         pendingFetchSeenGroups[normalized]?.add(metadata.id)
         muxMetaSeenIds[normalized]?.add(metadata.id)
@@ -4245,7 +4261,7 @@ class GroupManager(
         val valid = stored.filter {
             !isJoinedOn(it.relayUrl, it.groupId) &&
                 leftAtOn(it.relayUrl, it.groupId) == null &&
-                it.groupId !in deletedGroupIds
+                !isDropped(it.relayUrl, it.groupId)
         }
         if (valid.isEmpty()) return
         // Keep in-memory entries: a live registration this session is fresher than the slot.
@@ -4269,7 +4285,7 @@ class GroupManager(
         // Our own put-user echoed back (some relays emit one for the group creator, and we
         // are the actor when we add ourselves) is not an external add.
         if (actorPubkey != null && actorPubkey == currentPubkey) return
-        if (isRecentlyLeft(relayUrl, groupId) || groupId in deletedGroupIds) return
+        if (isRecentlyLeft(relayUrl, groupId) || isDropped(relayUrl, groupId)) return
         val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
         // Per relay: the same id joined elsewhere is a different group. Matching across all
         // relays swallowed the invite, so a group we are a relay-side member of never got a
@@ -4416,7 +4432,7 @@ class GroupManager(
                 discardPendingInvite(groupId)
                 return@launch
             }
-            deletedGroupIds.remove(groupId)
+            deletedGroupIds.remove(droppedKey(relay, groupId))
             persistDroppedGroups(pubkey)
             recentlyLeftAt.remove(recentLeaveKey(relay, groupId))
             clearLeft(relay, groupId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -606,11 +606,17 @@ class GroupManager(
     // with a 30-day TTL and restored on cold start. This is the authoritative override the membership
     // derivation checks BEFORE the relay's kind:39002, so a left group reads as not-a-member ("Request
     // to Join") even when the relay keeps listing us (some relays do after a 9022). A rejoin clears it.
-    private val _leftGroups = MutableStateFlow<Map<String, Long>>(emptyMap())
-    val leftGroups: StateFlow<Set<String>> =
+    //
+    // Keyed by relay, THEN group id. The same id names independent groups on different relays
+    // ("nostrord" exists on several), and the storage slot behind this is already per-relay, so a
+    // bare-id marker made leaving one of them read as leaving all of them — with no way back, since
+    // the self-heal then cleared the marker from the wrong relay's slot and the restore re-flattened
+    // it on every cold start.
+    private val _leftGroups = MutableStateFlow<Map<String, Map<String, Long>>>(emptyMap())
+    val leftGroups: StateFlow<Map<String, Set<String>>> =
         _leftGroups
-            .map { it.keys }
-            .stateIn(scope, SharingStarted.Eagerly, emptySet())
+            .map { byRelay -> byRelay.mapValues { (_, marks) -> marks.keys } }
+            .stateIn(scope, SharingStarted.Eagerly, emptyMap())
 
     // Lets clientForGroup reconnect a group's own relay on demand. Wired by NostrRepository.
     var messageHandler: ((String, NostrGroupClient) -> Unit)? = null
@@ -627,13 +633,14 @@ class GroupManager(
     // Drops the relay's kind:9022 echo and updated kind:39002 that arrive in
     // the milliseconds after a leave, otherwise they re-populate the lists we
     // just cleared and the UI shows zombie members + a "you left" message.
+    // Keyed by [recentLeaveKey] (relay + group), like the durable marker above.
     private val recentlyLeftAt = mutableMapOf<String, Long>()
 
     /**
      * True when the group was deleted or left on THIS device. Stale kind:10009
      * merges skip these so a lagging relay cannot resurrect them.
      */
-    fun isLocallyDropped(groupId: String): Boolean = groupId in deletedGroupIds || recentlyLeftAt.containsKey(groupId)
+    fun isLocallyDropped(groupId: String, relayUrl: String? = null): Boolean = groupId in deletedGroupIds || isRecentlyLeft(relayUrl, groupId)
     private val LEFT_GROUP_GRACE_MS = 5_000L
 
     // Relay-of-origin per groupId, recorded from the WebSocket that delivered
@@ -654,11 +661,58 @@ class GroupManager(
         groupRelayHints.update { if (it[groupId] == normalized) it else it + (groupId to normalized) }
     }
 
-    private fun isRecentlyLeft(groupId: String): Boolean {
-        val at = recentlyLeftAt[groupId] ?: return false
-        if (epochMillis() - at < LEFT_GROUP_GRACE_MS) return true
-        recentlyLeftAt.remove(groupId)
-        return false
+    private fun recentLeaveKey(relayUrl: String, groupId: String): String = "${relayUrl.normalizeRelayUrl()}\u0000$groupId"
+
+    /**
+     * Leave grace window for [groupId] on [relayUrl]. A null relay means the event carried no
+     * relay of origin, and falls back to any relay's window: this guard only suppresses echoes
+     * of our own leave for 5s, so a cross-relay false positive there is bounded and self-clearing.
+     */
+    private fun isRecentlyLeft(relayUrl: String?, groupId: String): Boolean {
+        val keys =
+            if (relayUrl != null) {
+                listOf(recentLeaveKey(relayUrl, groupId))
+            } else {
+                recentlyLeftAt.keys.filter { it.endsWith("\u0000$groupId") }.toList()
+            }
+        var recent = false
+        for (key in keys) {
+            val at = recentlyLeftAt[key] ?: continue
+            if (epochMillis() - at < LEFT_GROUP_GRACE_MS) recent = true else recentlyLeftAt.remove(key)
+        }
+        return recent
+    }
+
+    /** Durable leave timestamp for [groupId] on [relayUrl]; null relay scans every relay. */
+    private fun leftAtOn(relayUrl: String?, groupId: String): Long? {
+        val relay = relayUrl?.normalizeRelayUrl()
+            ?: return _leftGroups.value.values.firstNotNullOfOrNull { it[groupId] }
+        return _leftGroups.value[relay]?.get(groupId)
+    }
+
+    private fun markLeft(relayUrl: String, groupId: String, atSeconds: Long) {
+        val relay = relayUrl.normalizeRelayUrl()
+        _leftGroups.update { it + (relay to (it[relay].orEmpty() + (groupId to atSeconds))) }
+    }
+
+    /**
+     * A kind:9021 rejection that means "you are already in this group". Relays word it freely
+     * ("duplicate: already a member", "invalid: user already in group"), so match on the shape.
+     * Treated as a successful join so the local markers get reconciled with the relay's truth.
+     */
+    private fun isAlreadyMemberRejection(reason: String?): Boolean {
+        val text = reason?.lowercase() ?: return false
+        if ("already" !in text) return false
+        return "member" in text || "in group" in text || "in the group" in text || "joined" in text
+    }
+
+    private fun clearLeft(relayUrl: String, groupId: String) {
+        val relay = relayUrl.normalizeRelayUrl()
+        _leftGroups.update { current ->
+            val marks = current[relay] ?: return@update current
+            if (groupId !in marks) return@update current
+            current + (relay to (marks - groupId))
+        }
     }
 
     // When a group was joined this session. Auto-forget skips groups joined within
@@ -933,8 +987,9 @@ class GroupManager(
         // A group we durably left, AND are no longer joined to, must not re-enter the shared mux via
         // the loaded/opened terms (reopening it to see the locked panel would otherwise re-subscribe
         // its live chat). A still-joined group is NEVER excluded — a stale left marker on a rejoined
-        // group must not cut off its live messages.
-        val excluded = _leftGroups.value.keys - joined
+        // group must not cut off its live messages. Only THIS relay's markers count: the same id
+        // left on another relay is a different group and must keep streaming here.
+        val excluded = _leftGroups.value[normalized]?.keys.orEmpty() - joined
         return (joined + loaded + opened).distinct().filter { it !in excluded }
     }
 
@@ -1421,12 +1476,22 @@ class GroupManager(
         // reads NONE after a restart. We do NOT filter the joined set against them: leaveGroup already
         // removes the group from the joined slot, and filtering here risked excluding a rejoined group
         // whose marker hadn't been cleared yet, breaking its live messages.
-        val leftAll = mutableMapOf<String, Long>()
-        for (url in relayUrls) leftAll.putAll(SecureStorage.getLeftGroupsForRelay(pubKey, url, now))
+        // Each relay's slot stays under its own key: flattening them into one id-keyed map made a
+        // leave on one relay suppress the same-id group on every other relay, and it came back on
+        // every cold start because the restore re-flattened it.
+        val leftAll = mutableMapOf<String, Map<String, Long>>()
+        for (url in relayUrls) {
+            val marks = SecureStorage.getLeftGroupsForRelay(pubKey, url, now)
+            if (marks.isNotEmpty()) leftAll[url.normalizeRelayUrl()] = marks
+        }
         val updates = relayUrls.associate { url ->
             url.normalizeRelayUrl() to SecureStorage.getJoinedGroupsForRelay(pubKey, url)
         }.filter { (_, groups) -> groups.isNotEmpty() }
-        if (leftAll.isNotEmpty()) _leftGroups.update { it + leftAll }
+        if (leftAll.isNotEmpty()) {
+            _leftGroups.update { current ->
+                current + leftAll.mapValues { (relay, marks) -> current[relay].orEmpty() + marks }
+            }
+        }
         if (updates.isNotEmpty()) {
             // Additive, like loadJoinedGroupsFromStorage: never wipe a fresher join.
             _joinedGroupsByRelay.update { current ->
@@ -1532,7 +1597,12 @@ class GroupManager(
             when (val publish = currentClient.sendAndAwaitOk(message, eventId)) {
                 is org.nostr.nostrord.network.PublishResult.Success -> Unit
                 is org.nostr.nostrord.network.PublishResult.Rejected ->
-                    return Result.Error(AppError.Group.JoinFailed(groupId, Exception(publish.reason)))
+                    // "Already a member" is the relay agreeing with the join, not refusing it. Failing
+                    // here left the local left/dropped markers set forever: they only clear on success,
+                    // so a user whose markers disagreed with the relay could never rejoin.
+                    if (!isAlreadyMemberRejection(publish.reason)) {
+                        return Result.Error(AppError.Group.JoinFailed(groupId, Exception(publish.reason)))
+                    }
                 is org.nostr.nostrord.network.PublishResult.Timeout ->
                     return Result.Error(AppError.Group.JoinFailed(groupId, Exception("The relay did not confirm the join request.")))
                 is org.nostr.nostrord.network.PublishResult.Error ->
@@ -1545,8 +1615,8 @@ class GroupManager(
             // write below, so the additive kind:10009 merge can't drop the fresh join.
             deletedGroupIds.remove(groupId)
             persistDroppedGroups()
-            recentlyLeftAt.remove(groupId)
-            _leftGroups.update { it - groupId }
+            recentlyLeftAt.remove(recentLeaveKey(groupRelayUrl, groupId))
+            clearLeft(groupRelayUrl, groupId)
             try {
                 SecureStorage.removeLeftGroupForRelay(pubKey, groupRelayUrl.normalizeRelayUrl(), groupId)
             } catch (_: Exception) {}
@@ -2390,7 +2460,16 @@ class GroupManager(
                 }
             }
 
-            val relayGroups = _joinedGroupsByRelay.value[groupRelayUrl] ?: emptySet()
+            // Merge with the persisted slot like joinGroup and acceptInvite: the in-memory map can be
+            // partial early in a session (the storage restore is async), and a memory-only write would
+            // drop this relay's OTHER groups from the slot — and then from the kind:10009 we publish
+            // right below, so the loss propagates to every client.
+            val storedGroups = try {
+                SecureStorage.getJoinedGroupsForRelay(pubKey, groupRelayUrl)
+            } catch (_: Exception) {
+                emptySet()
+            }
+            val relayGroups = (_joinedGroupsByRelay.value[groupRelayUrl] ?: emptySet()) + storedGroups
             val updatedAfterLeave = relayGroups - groupId
             SecureStorage.saveJoinedGroupsForRelay(pubKey, groupRelayUrl, updatedAfterLeave)
             _joinedGroupsByRelay.update { it + (groupRelayUrl to updatedAfterLeave) }
@@ -2398,12 +2477,12 @@ class GroupManager(
 
             publishJoinedGroups()
 
-            recentlyLeftAt[groupId] = epochMillis()
+            recentlyLeftAt[recentLeaveKey(groupRelayUrl, groupId)] = epochMillis()
             // Leaving also settles a pending external add (this IS the decline path).
             discardPendingInvite(groupId)
             // Durable leave intent: outlives recentlyLeftAt (5s) and a restart, so the membership
             // derivation keeps reporting NONE even when the relay still lists us in kind:39002.
-            _leftGroups.update { it + (groupId to epochSeconds()) }
+            markLeft(groupRelayUrl, groupId, epochSeconds())
             try {
                 SecureStorage.addLeftGroupForRelay(pubKey, groupRelayUrl, groupId, epochSeconds())
             } catch (_: Exception) {}
@@ -3996,7 +4075,7 @@ class GroupManager(
      * Returns list of member pubkeys that need metadata fetching
      */
     fun handleGroupMembers(members: GroupMembers, createdAt: Long = 0L, relayUrl: String? = null): List<String> {
-        if (isRecentlyLeft(members.groupId)) {
+        if (isRecentlyLeft(relayUrl, members.groupId)) {
             _loadingMembers.value = _loadingMembers.value - members.groupId
             return emptyList()
         }
@@ -4051,11 +4130,11 @@ class GroupManager(
         // lists us) leaves us NOT joined, so the marker stays and the group keeps reading "left".
         if (self != null &&
             self in members.members &&
-            members.groupId in _leftGroups.value &&
             hostRelay != null &&
+            leftAtOn(hostRelay, members.groupId) != null &&
             isJoinedOn(hostRelay, members.groupId)
         ) {
-            _leftGroups.update { it - members.groupId }
+            clearLeft(hostRelay, members.groupId)
             currentPubkey?.let { pk ->
                 try {
                     SecureStorage.removeLeftGroupForRelay(pk, hostRelay, members.groupId)
@@ -4164,7 +4243,9 @@ class GroupManager(
         }
         if (stored.isEmpty()) return
         val valid = stored.filter {
-            !isJoinedOn(it.relayUrl, it.groupId) && it.groupId !in _leftGroups.value && it.groupId !in deletedGroupIds
+            !isJoinedOn(it.relayUrl, it.groupId) &&
+                leftAtOn(it.relayUrl, it.groupId) == null &&
+                it.groupId !in deletedGroupIds
         }
         if (valid.isEmpty()) return
         // Keep in-memory entries: a live registration this session is fresher than the slot.
@@ -4188,7 +4269,7 @@ class GroupManager(
         // Our own put-user echoed back (some relays emit one for the group creator, and we
         // are the actor when we add ourselves) is not an external add.
         if (actorPubkey != null && actorPubkey == currentPubkey) return
-        if (isRecentlyLeft(groupId) || groupId in deletedGroupIds) return
+        if (isRecentlyLeft(relayUrl, groupId) || groupId in deletedGroupIds) return
         val relay = (relayUrl ?: getRelayForGroup(groupId) ?: currentRelayUrl ?: return).normalizeRelayUrl()
         // Per relay: the same id joined elsewhere is a different group. Matching across all
         // relays swallowed the invite, so a group we are a relay-side member of never got a
@@ -4197,12 +4278,12 @@ class GroupManager(
         // A create/join we initiated is still in flight (id pre-claimed before the send):
         // the relay's put-user echo for it is our own doing, not an external add.
         if (isRecentlyJoined(groupId)) return
-        val leftAt = _leftGroups.value[groupId]
+        val leftAt = leftAtOn(relay, groupId)
         if (leftAt != null) {
             // Only an actual put-user event dated after the leave re-opens; 39002 listings
             // carry no causality (the relay may simply have never processed our 9022).
             if (actorPubkey == null || createdAtSeconds <= leftAt) return
-            _leftGroups.update { it - groupId }
+            clearLeft(relay, groupId)
             currentPubkey?.let { pk ->
                 try {
                     SecureStorage.removeLeftGroupForRelay(pk, relay, groupId)
@@ -4337,8 +4418,8 @@ class GroupManager(
             }
             deletedGroupIds.remove(groupId)
             persistDroppedGroups(pubkey)
-            recentlyLeftAt.remove(groupId)
-            _leftGroups.update { it - groupId }
+            recentlyLeftAt.remove(recentLeaveKey(relay, groupId))
+            clearLeft(relay, groupId)
             try {
                 SecureStorage.removeLeftGroupForRelay(pubkey, relay, groupId)
             } catch (_: Exception) {}
@@ -4427,7 +4508,7 @@ class GroupManager(
      * Handle incoming group admins (kind 39001)
      */
     fun handleGroupAdmins(admins: GroupAdmins, createdAt: Long = 0L, relayUrl: String? = null) {
-        if (isRecentlyLeft(admins.groupId)) return
+        if (isRecentlyLeft(relayUrl, admins.groupId)) return
         updateRelayScopedList(_groupAdminsByRelay, scopedAdminEventTimestamps, relayUrl, admins.groupId, createdAt, admins.admins)
         val existing = adminEventTimestamps[admins.groupId] ?: 0L
         if (createdAt > 0L && createdAt < existing) {
@@ -4472,7 +4553,7 @@ class GroupManager(
      * Handle incoming group roles (kind 39003)
      */
     fun handleGroupRoles(roles: GroupRoles, createdAt: Long = 0L, relayUrl: String? = null) {
-        if (isRecentlyLeft(roles.groupId)) return
+        if (isRecentlyLeft(relayUrl, roles.groupId)) return
         updateRelayScopedList(_groupRolesByRelay, scopedRoleEventTimestamps, relayUrl, roles.groupId, createdAt, roles.roles)
         val existing = roleEventTimestamps[roles.groupId] ?: 0L
         if (createdAt > 0L && createdAt < existing) {
@@ -4494,7 +4575,7 @@ class GroupManager(
      * so it is stored like any other update rather than skipped.
      */
     fun handleLiveKitParticipants(participants: LiveKitParticipants, createdAt: Long = 0L) {
-        if (isRecentlyLeft(participants.groupId)) return
+        if (isRecentlyLeft(null, participants.groupId)) return
         val existing = liveKitEventTimestamps[participants.groupId] ?: 0L
         if (createdAt > 0L && createdAt < existing) return
         if (createdAt > 0L) liveKitEventTimestamps[participants.groupId] = createdAt
@@ -4680,7 +4761,7 @@ class GroupManager(
         if (message.kind in threadKinds) {
             if (message.id.isBlank()) return null
             val groupId = extractGroupIdFromMessage(rawMsg) ?: return null
-            if (isRecentlyLeft(groupId)) return null
+            if (isRecentlyLeft(relayUrl, groupId)) return null
             // Ahead of the dedup: a resubscribe replays the same roots, and those replays are
             // exactly what proves the relay still serves them. Deduping first would leave the
             // answer window looking empty and the EOSE would reconcile live threads away.
@@ -4709,7 +4790,7 @@ class GroupManager(
 
         val groupId = extractGroupIdFromMessage(rawMsg) ?: return null
 
-        if (isRecentlyLeft(groupId)) return null
+        if (isRecentlyLeft(relayUrl, groupId)) return null
 
         if (relayUrl != null) {
             _latestMessageRelayByGroup.update { it + (groupId to relayUrl) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -712,7 +712,9 @@ class OutboxManager(
         onRelaysRestored: suspend (List<String>) -> Unit = {},
         onRelayGroupsUpdated: (Map<String, Set<String>>) -> Unit = {},
         messageHandler: (String, NostrGroupClient) -> Unit = { _, _ -> },
-        isGroupDropped: (String) -> Boolean = { false },
+        // (relayUrl, groupId): the drop guard is per relay, since the same id on two relays is
+        // two independent groups and only one of them may have been dropped here.
+        isGroupDropped: (String, String) -> Boolean = { _, _ -> false },
         decryptPrivate: suspend (String) -> String? = { null },
     ) {
         // Author guard: relays may deliver kind:10009 events for the *previous*
@@ -895,7 +897,7 @@ class OutboxManager(
             val additions =
                 immutableRelayGroups
                     .mapValues { (relay, ids) ->
-                        ids.filterNot { it in known[relay].orEmpty() || isGroupDropped(it) }.toSet()
+                        ids.filterNot { it in known[relay].orEmpty() || isGroupDropped(relay, it) }.toSet()
                     }.filterValues { it.isNotEmpty() }
             if (additions.isEmpty()) return
             groupsMutex.withLock {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1424,10 +1424,15 @@ fun SecureStorage.clearAllCredentialsForAccount(pubkey: String) {
 private fun droppedGroupsForAccountKey(pubkey: String) = "dropped_groups_${pubkeyDigest(pubkey)}"
 
 /**
- * Group ids the user deleted or left on this device. Persisted so the additive kind:10009 merge
- * (OutboxManager) keeps skipping them after a restart: a relay that never received the updated list
- * still serves the old one, and without this guard the stale copy resurrects the group in the rail.
- * Cleared (per id) on re-join.
+ * Groups the user deleted or forgot on this device, as "<relay>|<groupId>". Persisted so the
+ * additive kind:10009 merge (OutboxManager) keeps skipping them after a restart: a relay that never
+ * received the updated list still serves the old one, and without this guard the stale copy
+ * resurrects the group in the rail. Cleared (per entry) on re-join.
+ *
+ * Relay-qualified because the same id names independent groups on different relays. Bare legacy
+ * entries are dropped on load: keeping them would go on suppressing a same-id group the user never
+ * touched, with no self-heal, and the cost of dropping one is bounded — a deleted group can
+ * reappear from a lagging relay's stale list until it is deleted again.
  */
 fun SecureStorage.saveDroppedGroupIds(
     pubkey: String,
@@ -1445,7 +1450,7 @@ fun SecureStorage.loadDroppedGroupIds(pubkey: String): Set<String> {
     val raw = getStringPref(droppedGroupsForAccountKey(pubkey), "")
     if (raw.isBlank()) return emptySet()
     return try {
-        Json.decodeFromString<List<String>>(raw).toSet()
+        Json.decodeFromString<List<String>>(raw).filter { '|' in it }.toSet()
     } catch (_: Exception) {
         emptySet()
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
@@ -76,11 +76,19 @@ class GroupMembershipModel(
             val messagesByGroup = arr[3] as Map<String, List<NostrGroupClient.NostrMessage>>
             val allGroups = arr[4] as List<GroupMetadata>
             val pendingByGroup = arr[6] as Map<String, Long>
-            val leftSet = arr[7] as Set<String>
+            val leftByRelay = arr[7] as Map<String, Set<String>>
             val byRelay = arr[8] as Map<String, List<GroupMetadata>>
 
             val pubkey = repo.getPublicKey()
-            val locallyLeft = groupId in leftSet
+            // Scoped exactly like `joined` below: leaving the same-id group on another relay says
+            // nothing about this one, and treating it as a leave here locked users out of a group
+            // the relay still had them in.
+            val locallyLeft =
+                if (hostRelay != null) {
+                    leftByRelay.atRelay(hostRelay)?.contains(groupId) == true
+                } else {
+                    leftByRelay.values.any { groupId in it }
+                }
             // With an explicit host relay only ITS joined set counts: being in the same-id
             // group on another relay is membership in a different group.
             val joined =

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -661,7 +661,7 @@ class FakeNostrRepository : NostrRepositoryApi {
 
     override val groupRoles: StateFlow<Map<String, List<RoleDefinition>>> = MutableStateFlow(emptyMap())
     override val restrictedGroups: StateFlow<Map<String, String>> = MutableStateFlow(emptyMap())
-    override val leftGroups: StateFlow<Set<String>> = MutableStateFlow(emptySet())
+    override val leftGroups: StateFlow<Map<String, Set<String>>> = MutableStateFlow(emptyMap())
 
     val pendingGroupInvitesFlow = MutableStateFlow<Map<String, PendingGroupInvite>>(emptyMap())
     override val pendingGroupInvites: StateFlow<Map<String, PendingGroupInvite>> = pendingGroupInvitesFlow

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupExternalMembershipAdoptionTest.kt
@@ -172,7 +172,7 @@ class GroupExternalMembershipAdoptionTest {
         gm.setCurrentPubkey(pubkey)
         gm.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay))
         testScheduler.advanceUntilIdle()
-        assertTrue(group in gm.leftGroups.value)
+        assertTrue(group in gm.leftGroups.value[relay].orEmpty())
 
         gm.handleGroupMembers(GroupMembers(group, listOf(pubkey)), createdAt = 100, relayUrl = relay)
         testScheduler.advanceUntilIdle()
@@ -253,7 +253,7 @@ class GroupExternalMembershipAdoptionTest {
         gm.setCurrentPubkey(pubkey)
         gm.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay))
         testScheduler.advanceUntilIdle()
-        assertTrue(group in gm.leftGroups.value)
+        assertTrue(group in gm.leftGroups.value[relay].orEmpty())
 
         fun putUser(createdAt: Long) {
             val msg = NostrGroupClient.NostrMessage(
@@ -277,7 +277,7 @@ class GroupExternalMembershipAdoptionTest {
         putUser(leftAt + 100)
         testScheduler.advanceUntilIdle()
         assertTrue(group in gm.pendingGroupInvites.value, "a fresh put-user re-opens the invite")
-        assertFalse(group in gm.leftGroups.value, "the durable left marker is cleared")
+        assertFalse(group in gm.leftGroups.value[relay].orEmpty(), "the durable left marker is cleared")
 
         scope.cancel()
     }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupLeftMarkerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupLeftMarkerTest.kt
@@ -11,6 +11,7 @@ import org.nostr.nostrord.storage.addLeftGroupForRelay
 import org.nostr.nostrord.storage.getLeftGroupsForRelay
 import org.nostr.nostrord.storage.removeLeftGroupForRelay
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.normalizeRelayUrl
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -23,15 +24,24 @@ import kotlin.test.assertTrue
 class GroupLeftMarkerTest {
     private val pubkey = "00000000000000000000000000000000000000000000000000000000deadbeef"
     private val relay = "wss://test.relay"
+    private val otherRelay = "wss://other.relay"
     private val groupA = "left-marker-group-a"
     private val groupB = "left-marker-group-b"
 
+    // The bug this file guards: the same group id names independent groups on different relays.
+    private val sharedId = "nostrord"
+
     private fun makeManager(scope: TestScope): GroupManager = GroupManager(connectionManager = ConnectionManager(scope), scope = scope)
 
+    private fun GroupManager.leftOn(relayUrl: String): Set<String> = leftGroups.value[relayUrl.normalizeRelayUrl()].orEmpty()
+
     private fun reset() {
-        SecureStorage.saveJoinedGroupsForRelay(pubkey, relay, emptySet())
-        SecureStorage.removeLeftGroupForRelay(pubkey, relay, groupA)
-        SecureStorage.removeLeftGroupForRelay(pubkey, relay, groupB)
+        for (url in listOf(relay, otherRelay)) {
+            SecureStorage.saveJoinedGroupsForRelay(pubkey, url, emptySet())
+            SecureStorage.removeLeftGroupForRelay(pubkey, url, groupA)
+            SecureStorage.removeLeftGroupForRelay(pubkey, url, groupB)
+            SecureStorage.removeLeftGroupForRelay(pubkey, url, sharedId)
+        }
     }
 
     @BeforeTest fun before() = reset()
@@ -53,8 +63,8 @@ class GroupLeftMarkerTest {
         testScheduler.advanceUntilIdle()
 
         // Both markers restored into the flow (drives the membership NONE override).
-        assertTrue(groupA in gm.leftGroups.value)
-        assertTrue(groupB in gm.leftGroups.value)
+        assertTrue(groupA in gm.leftOn(relay))
+        assertTrue(groupB in gm.leftOn(relay))
         // ...but the joined set is NOT filtered against them: a still-joined group must keep its
         // subscription (the regression where a rejoined group lost its live messages).
         assertTrue(groupA in gm.getGroupIdsForMux(relay), "a joined group must stay in the mux even with a stale left marker")
@@ -73,14 +83,63 @@ class GroupLeftMarkerTest {
         gm.loadJoinedGroupsFromStorage(pubkey, relay)
         gm.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay))
         testScheduler.advanceUntilIdle()
-        assertTrue(groupA in gm.leftGroups.value)
+        assertTrue(groupA in gm.leftOn(relay))
 
         // The relay confirms us as a member AND we are joined -> the marker is stale (we rejoined).
         gm.handleGroupMembers(GroupMembers(groupA, listOf(pubkey)), createdAt = 200)
         testScheduler.advanceUntilIdle()
 
-        assertFalse(groupA in gm.leftGroups.value, "self-heal clears the stale marker in memory")
+        assertFalse(groupA in gm.leftOn(relay), "self-heal clears the stale marker in memory")
         assertEquals(emptyMap(), SecureStorage.getLeftGroupsForRelay(pubkey, relay, nowSeconds = epochSeconds()), "and in storage")
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a left marker on one relay does not touch the same id on another relay`() = runTest {
+        val scope = TestScope(testScheduler)
+        // "nostrord" exists on both relays. The user left it on `relay` and is still joined on
+        // `otherRelay` — the exact shape that locked users out of the group they never left.
+        SecureStorage.saveJoinedGroupsForRelay(pubkey, otherRelay, setOf(sharedId))
+        SecureStorage.addLeftGroupForRelay(pubkey, relay, sharedId, nowSeconds = epochSeconds())
+
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        gm.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay, otherRelay))
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(sharedId in gm.leftOn(relay), "the relay we actually left keeps its marker")
+        assertFalse(sharedId in gm.leftOn(otherRelay), "the other relay's same-id group is untouched")
+        assertTrue(
+            sharedId in gm.getGroupIdsForMux(otherRelay),
+            "the group we are still joined to must keep streaming",
+        )
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a left marker survives a restart on its own relay only`() = runTest {
+        val scope = TestScope(testScheduler)
+        SecureStorage.addLeftGroupForRelay(pubkey, relay, sharedId, nowSeconds = epochSeconds())
+        SecureStorage.saveJoinedGroupsForRelay(pubkey, otherRelay, setOf(sharedId))
+
+        // Cold start #1: the relay lists us as a member of the OTHER relay's group, which self-heals
+        // that relay's (absent) marker and must not clear the real one on `relay`.
+        val first = makeManager(scope)
+        first.setCurrentPubkey(pubkey)
+        first.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay, otherRelay))
+        first.handleGroupMembers(GroupMembers(sharedId, listOf(pubkey)), createdAt = 200, relayUrl = otherRelay)
+        testScheduler.advanceUntilIdle()
+
+        // Cold start #2 reads storage back: the marker is still filed under `relay` alone.
+        val second = makeManager(scope)
+        second.setCurrentPubkey(pubkey)
+        second.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay, otherRelay))
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(sharedId in second.leftOn(relay), "the leave is durable on the relay it happened on")
+        assertFalse(sharedId in second.leftOn(otherRelay), "and never migrates to another relay")
 
         scope.cancel()
     }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupLeftMarkerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupLeftMarkerTest.kt
@@ -119,6 +119,27 @@ class GroupLeftMarkerTest {
     }
 
     @Test
+    fun `deleting a group on one relay does not suppress the same id on another`() = runTest {
+        val scope = TestScope(testScheduler)
+        SecureStorage.saveJoinedGroupsForRelay(pubkey, otherRelay, setOf(sharedId))
+
+        val gm = makeManager(scope)
+        gm.setCurrentPubkey(pubkey)
+        gm.loadAllJoinedGroupsFromStorage(pubkey, listOf(relay, otherRelay))
+        // The throwaway group on `relay` is deleted by its owner.
+        gm.handleRemoteDeleteGroup(sharedId, relay, pubkey)
+        testScheduler.advanceUntilIdle()
+
+        assertTrue(gm.isLocallyDropped(sharedId, relay), "the deleted group stays dropped on its relay")
+        assertFalse(
+            gm.isLocallyDropped(sharedId, otherRelay),
+            "the same-id group on another relay must still accept the kind:10009 merge",
+        )
+
+        scope.cancel()
+    }
+
+    @Test
     fun `a left marker survives a restart on its own relay only`() = runTest {
         val scope = TestScope(testScheduler)
         SecureStorage.addLeftGroupForRelay(pubkey, relay, sharedId, nowSeconds = epochSeconds())

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -25,6 +25,7 @@ import org.nostr.nostrord.ui.screens.group.rootGroupId
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
 import org.nostr.nostrord.ui.screens.home.railKey
 import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
+import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.accountDisplayLabel
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
@@ -340,7 +341,16 @@ val AppFrame =
                         repo.switchRelay(r.relayUrl)
                     }
                     if (code != null) {
-                        repo.joinGroup(r.groupId, code)
+                        // No ViewModel on the deep-link path, so the rejection reason goes to the
+                        // system snackbar; swallowing it made a bad invite code look like nothing
+                        // happened at all.
+                        val join = repo.joinGroup(r.groupId, code)
+                        if (join is org.nostr.nostrord.utils.Result.Error) {
+                            val reason = (join.error as? AppError.Group.JoinFailed)?.cause?.message
+                            AppModule.postSystemMessage(
+                                if (reason.isNullOrBlank()) "Could not join the group." else "Could not join: $reason",
+                            )
+                        }
                     }
                     // A forwarded / deep-linked group we are not a member of isn't in our joined
                     // list, so its kind:39000 never loads and the rail shows the raw id. Fetch the

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2687,7 +2687,10 @@ val ChatScreen =
                     this.isGroupClosed = !group.isOpen
                     onConfirm = { listPrivately ->
                         setPendingJoin { null }
-                        launchApp { repo.joinGroup(group.id, intent.inviteCode, listPrivately) }
+                        // Through the ViewModel, not the repo: it is what records the rejection
+                        // reason that joinErrorDialog below renders. Calling the repo directly
+                        // made a rejected join look like a no-op.
+                        vm.joinGroup(intent.inviteCode, listPrivately)
                     }
                     onClose = { setPendingJoin { null } }
                 }


### PR DESCRIPTION
NIP-29 identifies a group by the pair (relay, id), and the same id is common across relays: `nostrord` exists on both `groups.0xchat.com` and `chat.wisp.talk`. The membership derivation was already relay-scoped, but the two markers that SUPPRESS a group were keyed by bare id. Leaving `nostrord` on one relay therefore made `nostrord` on the other read as left: Join button, blocked composer, and the relay still listing the user as a member (reported by a user, reproduced on web.nostrord.com).

It was an absorbing state, not a glitch. The 39002 self-heal cleared the marker from the host relay's storage slot while the marker lived in the other relay's slot; the cold-start restore flattened every relay's slot into one id-keyed map, so it came back on every reload; and the rejoin could not clear it either, because the markers only clear on a successful kind:9021 and the relay rejects a join from someone who is already a member.

Storage was already per-relay for the left markers, so that half needs no migration. The dropped-group slot was a flat `Set<String>` and its bare legacy entries are discarded on load: keeping them would go on suppressing a group the user never touched, with no self-heal, while the cost of dropping one is bounded to a deleted group reappearing from a lagging relay until it is deleted again.

| Area | Change |
|---|---|
| `_leftGroups` | `Map<groupId, ts>` to `Map<relay, Map<groupId, ts>>`; `recentlyLeftAt` keyed relay + group |
| `deletedGroupIds` | entries become `<relay>\|<groupId>`; bare legacy entries dropped on read |
| `isRecentlyLeft` / `isLocallyDropped` / `isGroupDropped` | take a relay; a null relay keeps the old any-relay behavior |
| `GroupMembershipModel.locallyLeft` | scoped by `hostRelay`, exactly like `joined` |
| `loadAllJoinedGroupsFromStorage` | keeps each relay's slot under its own key instead of flattening |
| `leaveGroup` | merges the persisted slot before writing it, like `joinGroup` and `acceptInvite` |
| `joinGroup` | an "already a member" rejection counts as success and reconciles the local markers |
| web join | goes through the ViewModel so `joinErrorDialog` gets the reason; the deep-link path reports via the system snackbar |

The `leaveGroup` merge is its own cross-client bug: a partial in-memory map dropped the relay's other groups from the slot and from the kind:10009 published immediately after, propagating the loss to every other client reading that list.

Tests: `GroupLeftMarkerTest` grows to 5, covering same id on two relays for leave, delete, and a restart round-trip. `compileKotlinJvm` + `compileKotlinJs` + `compileDebugKotlinAndroid` + `jvmTest` green.

- 555b626a fix(groups): scope the durable left marker per relay
- 3f2a7b0c fix(web): surface the relay's join rejection instead of a no-op
- 12c314a9 fix(groups): scope the dropped-group guard per relay