### PR TITLE
fix(chat): render markdown image embeds as images

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownMedia.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/MarkdownMedia.kt
@@ -1,0 +1,28 @@
+package org.nostr.nostrord.ui.text
+
+/**
+ * Markdown media embeds written by other clients: `![alt](url)` and the optional title form
+ * `![alt](url "title")`. Both UIs already render a bare media url inline, so the syntax is
+ * unwrapped to the url before parsing instead of carrying an image node through every renderer.
+ * Alt text and title are dropped (no renderer shows them).
+ */
+object MarkdownMedia {
+    /**
+     * Only http(s) and inline `data:image/` targets match, and the url stops at whitespace or a
+     * parenthesis, so a stray `![` in ordinary text is left alone.
+     *
+     * Every literal bracket is escaped, including the closing `\]`: Kotlin/JS builds this with the
+     * unicode flag, where a lone `]` is a SyntaxError and the whole pattern fails to construct.
+     */
+    private val imageEmbed =
+        Regex(
+            """!\[[^\]\n]*\]\([ \t]*((?:https?://|data:image/)[^\s()]+)(?:[ \t]+"[^"\n]*")?[ \t]*\)""",
+            RegexOption.IGNORE_CASE,
+        )
+
+    /** Replaces every `![alt](url)` embed in [content] with its bare url. */
+    fun unwrapImages(content: String): String {
+        if (!content.contains("![")) return content
+        return imageEmbed.replace(content) { it.groupValues[1] }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownMediaTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/MarkdownMediaTest.kt
@@ -1,0 +1,54 @@
+package org.nostr.nostrord.ui.text
+
+import org.nostr.nostrord.ui.components.chat.MessageContentParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class MarkdownMediaTest {
+    @Test
+    fun `unwraps image embed to bare url`() {
+        assertEquals(
+            "Testando imagem\nhttps://24242.io/abc.jpg",
+            MarkdownMedia.unwrapImages("Testando imagem\n![image](https://24242.io/abc.jpg)"),
+        )
+    }
+
+    @Test
+    fun `unwraps every embed including the title form`() {
+        assertEquals(
+            "https://a.com/1.png and https://b.com/2.gif",
+            MarkdownMedia.unwrapImages("""![](https://a.com/1.png) and ![alt text](https://b.com/2.gif "a title")"""),
+        )
+    }
+
+    @Test
+    fun `unwraps inline data image embed`() {
+        assertEquals(
+            "data:image/png;base64,AAAA",
+            MarkdownMedia.unwrapImages("![img](data:image/png;base64,AAAA)"),
+        )
+    }
+
+    @Test
+    fun `leaves non-embed text alone`() {
+        val untouched =
+            listOf(
+                "look at this ![ thing",
+                "![alt](/relative/path.jpg)",
+                "[link](https://example.com/page)",
+            )
+        untouched.forEach { assertEquals(it, MarkdownMedia.unwrapImages(it)) }
+    }
+
+    @Test
+    fun `parser renders an image embed as an image part`() {
+        val parts = MessageContentParser.parse("Testando imagem ![image](https://24242.io/abc.jpg)")
+
+        assertEquals(2, parts.size)
+        assertIs<MessageContentParser.ParsedPart.Text>(parts[0])
+        assertEquals("Testando imagem ", (parts[0] as MessageContentParser.ParsedPart.Text).content)
+        assertIs<MessageContentParser.ParsedPart.Image>(parts[1])
+        assertEquals("https://24242.io/abc.jpg", (parts[1] as MessageContentParser.ParsedPart.Image).url)
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContentParser.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.ui.components.chat
 import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.nostr.Nip68
 import org.nostr.nostrord.ui.text.MarkdownEmphasis
+import org.nostr.nostrord.ui.text.MarkdownMedia
 
 /**
  * # Chat Message Content Parser
@@ -179,15 +180,19 @@ object MessageContentParser {
      * - Pass 1: Extract code blocks first (they protect content from formatting)
      * - Pass 2: Parse remaining content (URLs, mentions, formatting, hashtags, emojis)
      *
-     * @param content Raw message content
+     * @param rawContent Raw message content
      * @param emojiMap Map of shortcode to image URL from NIP-30 emoji tags
      * @return List of parsed parts in order, preserving original text positions
      */
     fun parse(
-        content: String,
+        rawContent: String,
         emojiMap: Map<String, String> = emptyMap(),
     ): List<ParsedPart> {
-        if (content.isEmpty()) return emptyList()
+        if (rawContent.isEmpty()) return emptyList()
+
+        // Markdown image embeds collapse to their bare url so the media passes below see a
+        // plain link; the surrounding `![alt](` / `)` would otherwise render as literal text.
+        val content = MarkdownMedia.unwrapImages(rawContent)
 
         // Check cache first — avoids 8 regex passes for previously seen messages
         val cacheKey = if (emojiMap.isEmpty()) content else "$content\u0000${emojiMap.hashCode()}"

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -35,6 +35,7 @@ import org.nostr.nostrord.ui.screens.group.pluralizeSystemAction
 import org.nostr.nostrord.ui.scroll.ChatScrollPolicy
 import org.nostr.nostrord.ui.scroll.JumpPillTarget
 import org.nostr.nostrord.ui.text.MarkdownEmphasis
+import org.nostr.nostrord.ui.text.MarkdownMedia
 import org.nostr.nostrord.utils.ChatSearch
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
@@ -3564,7 +3565,7 @@ private val BLOCKQUOTE_REGEX = Regex("^[ \\t]*>[ \\t]?.*(?:\\r?\\n[ \\t]*>[ \\t]
 private val BLOCKQUOTE_LINE_PREFIX = Regex("^[ \\t]*>[ \\t]?", RegexOption.MULTILINE)
 
 internal fun ChildrenBuilder.renderMessageContent(
-    content: String,
+    rawContent: String,
     tags: List<List<String>>,
     userMetadata: Map<String, UserMetadata>,
     messagesById: Map<String, NostrGroupClient.NostrMessage>,
@@ -3572,6 +3573,9 @@ internal fun ChildrenBuilder.renderMessageContent(
     onEventRef: (String) -> Unit,
     onGroupRef: (String, String?) -> Unit,
 ) {
+    // Markdown image embeds collapse to their bare url so URL_REGEX sees a plain link; the
+    // surrounding `![alt](` / `)` would otherwise render as literal text. Mirrors native.
+    val content = MarkdownMedia.unwrapImages(rawContent)
     val emojiMap = extractEmojiMap(tags)
     val posters = extractVideoPosters(tags)
     val dims = Nip68.extractImetaDimensions(tags)


### PR DESCRIPTION
Messages written as `![alt](url)` by other clients rendered the literal `![alt](` and `)` around the image: the url itself already matched the media pass in both renderers, but the surrounding markdown fell through as text. Some clients emit this form even though a bare url is enough, so both UIs now unwrap the embed to its bare url before parsing and let the existing image / video / audio / YouTube detection take over. Alt text and title are dropped, since no renderer shows them.

The shared helper is `MarkdownMedia.unwrapImages` in commonMain, called from `MessageContentParser.parse` (Compose) and `renderMessageContent` (web) so the two stay in step. Its pattern escapes every literal bracket, including the closing `\]`: Kotlin/JS builds `Regex` with the unicode flag, where a lone `]` is a SyntaxError. That one throws only in the browser, and because Kotlin/JS assigns the object instance before its fields, the half-built instance surfaced later as `Cannot read properties of undefined (reading 'replace_...')` at the call site rather than at construction.

| Target | Entry point |
|---|---|
| Compose (android / desktop / iOS) | `MessageContentParser.parse()` |
| Web (React) | `renderMessageContent()` in `ChatScreen.kt` |

`MarkdownMediaTest` covers the plain embed, several embeds plus the `![alt](url "title")` form, an inline `data:image/` target, inputs that must not change (relative path, plain markdown link, stray `![`), and the parser end to end producing `ParsedPart.Image`. `compileKotlinJvm`, `compileKotlinJs` and `:composeApp:jvmTest` pass; the emitted JS pattern was also checked under the `ui` flags. Browser validation still pending.

- b8a80d99 fix(chat): render markdown image embeds as images