### PR TITLE
fix(nip46): stop the QR login losing the signer's connect event

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -18,6 +18,17 @@ import kotlin.random.Random
 // ("Waiting for signer..." forever) - mirrors the web's 20s timeout.
 private const val SIGNER_RELAY_CONNECT_TIMEOUT_MS = 20_000L
 
+// After the first signer relay is listening, how long the QR flow waits for the
+// rest before drawing the code. kind:24133 is ephemeral, so a connect event the
+// signer publishes to a relay we are not subscribed on is lost for good and the
+// screen waits for a signer that already answered. Short enough to stay
+// imperceptible when every relay is healthy, long enough to cover a slow one.
+private const val REMAINING_RELAY_GRACE_MS = 2_500L
+
+// Backoff bounds for re-opening a signer relay that dropped mid-session.
+private const val RELAY_RECONNECT_BASE_DELAY_MS = 1_000L
+private const val RELAY_RECONNECT_MAX_DELAY_MS = 15_000L
+
 actual class Nip46Client actual constructor(
     existingPrivateKey: String?,
 ) {
@@ -29,7 +40,27 @@ actual class Nip46Client actual constructor(
         }
 
     private var remoteSignerPubkey: String? = null
-    private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
+
+    // Every read is a snapshot and every mutation goes through addClient /
+    // removeClient under this lock: the list is touched from the ws frame
+    // threads (drop watch), the connect fan-out and concurrent sendRequests, so
+    // an unguarded iteration throws ConcurrentModificationException and fails a
+    // request that had nothing wrong with it.
+    private val relayClients: MutableList<NostrGroupClient> = mutableListOf()
+
+    private fun clientsSnapshot(): List<NostrGroupClient> = synchronized(relayClients) { relayClients.toList() }
+
+    private fun addClient(client: NostrGroupClient) {
+        synchronized(relayClients) { relayClients.add(client) }
+    }
+
+    private fun removeClient(client: NostrGroupClient) {
+        synchronized(relayClients) { relayClients.remove(client) }
+    }
+
+    // Set by disconnect(); stops the drop watch from resurrecting sockets.
+    @kotlin.concurrent.Volatile
+    private var closed = false
 
     // Guards ensureRelaysConnected's check-then-act (see its own doc comment):
     // without it, concurrent sendRequest calls racing on an empty relayClients
@@ -58,12 +89,86 @@ actual class Nip46Client actual constructor(
         relays: List<String>,
         name: String,
     ): String {
-        val relayParams = relays.joinToString("&") { "relay=${it.encodeForUri()}" }
+        // Advertise only the relays we are actually subscribed on. kind:24133 is
+        // ephemeral: a connect event published to a relay we are not listening on
+        // is dropped by the relay, not replayed later, and the QR screen then waits
+        // forever for a signer that already answered.
+        val advertised = clientsSnapshot()
+            .map { it.getRelayUrl() }
+            .ifEmpty { relays.map { it.trimEnd('/') }.distinct() }
+        val relayParams = advertised.joinToString("&") { "relay=${it.encodeForUri()}" }
         val metadata = """{"name":"$name"}"""
         val secretParam = nostrConnectSecret?.let { "&secret=${it.encodeForUri()}" } ?: ""
         val permsParam = "&perms=${NIP46_REQUESTED_PERMS.encodeForUri()}"
         val uri = "nostrconnect://${clientKeyPair.publicKeyHex}?$relayParams$secretParam$permsParam&metadata=${metadata.encodeForUri()}"
         return uri
+    }
+
+    /**
+     * Opens one signer relay end to end: WebSocket, durable response
+     * subscription, drop watch. Returns null when either the socket never
+     * opened or the REQ could not be sent — a socket with no live response sub
+     * is deaf, and counting it as a connection is what left the QR screen
+     * waiting for a signer event that could never be delivered. The caller owns
+     * adding the result to [relayClients].
+     */
+    private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
+        val client = NostrGroupClient(relayUrl)
+        client.connect { msg -> handleMessage(msg, client) }
+        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
+            client.disconnect()
+            null
+        } else {
+            armDropWatch(client, relayUrl)
+            client
+        }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
+
+    /**
+     * Re-open [relayUrl] when its socket drops. Without this the response
+     * subscription dies with the socket and nothing notices: the only liveness
+     * check is [ensureRelaysConnected] at the head of the next request, and the
+     * QR wait issues no requests at all, so the signer's reply lands on a relay
+     * we left.
+     */
+    private fun armDropWatch(client: NostrGroupClient, relayUrl: String) {
+        client.onConnectionLost = {
+            removeClient(client)
+            clientScope.launch { reconnectRelay(relayUrl) }
+        }
+    }
+
+    private suspend fun reconnectRelay(relayUrl: String) {
+        var delayMs = RELAY_RECONNECT_BASE_DELAY_MS
+        while (!closed) {
+            delay(delayMs)
+            if (closed) return
+            addRelays(listOf(relayUrl))
+            if (clientsSnapshot().any { it.getRelayUrl() == relayUrl }) return
+            delayMs = minOf(delayMs * 2, RELAY_RECONNECT_MAX_DELAY_MS)
+        }
+    }
+
+    /**
+     * Connect [relays] and register them, skipping any already connected, under
+     * [relayConnectMutex]. Every path that grows [relayClients] goes through
+     * here: a session restore's connect racing the first request's
+     * [ensureRelaysConnected] had both running their own fan-out and both
+     * appending, leaving two live sockets to one relay. Each request was then
+     * published twice and each signer reply delivered twice, which is what
+     * earned the "rate-limited: you are noting too much" rejections and got the
+     * relay to drop the socket mid-QR-wait.
+     */
+    private suspend fun addRelays(relays: List<String>) {
+        relayConnectMutex.withLock {
+            val known = clientsSnapshot().mapTo(mutableSetOf()) { it.getRelayUrl() }
+            val missing = relays.map { it.trimEnd('/') }.distinct().filterNot { it in known }
+            if (missing.isEmpty()) return@withLock
+            connectRelaysParallel(missing).forEach { addClient(it) }
+        }
     }
 
     private suspend fun connectRelaysParallel(relays: List<String>): List<NostrGroupClient> = coroutineScope {
@@ -73,75 +178,43 @@ actual class Nip46Client actual constructor(
         relays
             .map { it.trimEnd('/') }
             .distinct()
-            .map { relayUrl ->
-                async {
-                    try {
-                        val cleanUrl = relayUrl.trimEnd('/')
-                        val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg, client) }
-                        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
-                            // WS never opened (timeout) — drop it so callers don't
-                            // treat a dead socket as a live relay connection.
-                            client.disconnect()
-                            null
-                        } else {
-                            openResponseSubscription(client)
-                            client
-                        }
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-            }.awaitAll()
+            .map { relayUrl -> async { openRelay(relayUrl) } }
+            .awaitAll()
             .filterNotNull()
     }
 
     /**
-     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
-     * one relay's WebSocket is open and the durable response sub is sent.
-     * Remaining relays continue connecting in [clientScope] and are appended
-     * to [relayClients] as they become ready, so the listening sub spans all
-     * relays even when this function has already returned. Throws only if
-     * every relay fails — partial failure is acceptable.
+     * QR-flow variant of [connectRelaysParallel]. Unblocks as soon as one relay
+     * is listening, then gives the rest [REMAINING_RELAY_GRACE_MS] to join
+     * before the caller draws the code, so the advertised relay set matches the
+     * set we can actually hear on. Throws only if every relay fails.
      */
     private suspend fun connectRelaysFirstWins(relaysIn: List<String>) {
         val relays = relaysIn.map { it.trimEnd('/') }.distinct()
         if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
         val firstReady = CompletableDeferred<Unit>()
+        val allSettled = CompletableDeferred<Unit>()
         val total = relays.size
-        val failures = java.util.concurrent.atomic.AtomicInteger(0)
+        val settled = java.util.concurrent.atomic.AtomicInteger(0)
 
         for (relayUrl in relays) {
             clientScope.launch {
-                try {
-                    val cleanUrl = relayUrl.trimEnd('/')
-                    val client = NostrGroupClient(cleanUrl)
-                    client.connect { msg -> handleMessage(msg, client) }
-                    if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
-                        // WS never opened — drop it (mirrors connectRelaysParallel)
-                        // instead of adding a dead socket and completing firstReady.
-                        // Otherwise the QR displays while no listening sub is live,
-                        // so the signer's connect event never arrives and the user
-                        // has to restart the app. Common right after a logout, which
-                        // tears down many sockets at once and slows the next connect.
-                        client.disconnect()
-                        if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
-                            firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
-                        }
-                        return@launch
-                    }
-                    openResponseSubscription(client)
-                    synchronized(relayClients) { relayClients.add(client) }
+                val client = openRelay(relayUrl)
+                if (client != null) {
+                    addClient(client)
                     firstReady.complete(Unit)
-                } catch (_: Exception) {
-                    if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
+                }
+                if (settled.incrementAndGet() == total) {
+                    if (!firstReady.isCompleted) {
                         firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
                     }
+                    allSettled.complete(Unit)
                 }
             }
         }
 
         firstReady.await()
+        withTimeoutOrNull(REMAINING_RELAY_GRACE_MS) { allSettled.await() }
     }
 
     /**
@@ -175,8 +248,10 @@ actual class Nip46Client actual constructor(
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
      * one stable subscription replaces the previous per-request ephemeral REQs.
+     * Returns false when the REQ could not be sent, so the caller drops a socket
+     * that would otherwise sit in [relayClients] connected but deaf.
      */
-    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+    private suspend fun openResponseSubscription(client: NostrGroupClient): Boolean {
         val subId = responseSubscriptionId
             ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
         val since = (epochMillis() / 1000) - 10
@@ -190,27 +265,37 @@ actual class Nip46Client actual constructor(
             add(subId)
             add(filter)
         }.toString()
-        try {
+        return try {
             client.send(req)
-        } catch (_: Exception) {
+            true
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            false
         }
     }
 
+    /**
+     * Ensure at least one relay client is connected before sending a request.
+     * Disconnected clients are replaced with fresh connections.
+     */
     private suspend fun ensureRelaysConnected() {
         relayConnectMutex.withLock {
-            val dead = relayClients.filter { !it.isConnected() }
-            if (dead.isNotEmpty()) {
-                dead.forEach {
-                    try {
-                        it.disconnect()
-                    } catch (_: Exception) {
-                    }
+            // Remove dead clients
+            val dead = clientsSnapshot().filter { !it.isConnected() }
+            dead.forEach {
+                removeClient(it)
+                try {
+                    it.disconnect()
+                } catch (_: Exception) {
                 }
-                relayClients.removeAll(dead)
             }
-            if (relayClients.isNotEmpty()) return@withLock
+
+            // If we still have live clients, we're good
+            if (clientsSnapshot().isNotEmpty()) return@withLock
+
+            // Reconnect using stored relay URLs
             if (relayUrls.isEmpty()) return@withLock
-            relayClients.addAll(connectRelaysParallel(relayUrls))
+            connectRelaysParallel(relayUrls).forEach { addClient(it) }
         }
     }
 
@@ -220,8 +305,8 @@ actual class Nip46Client actual constructor(
     ) {
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }.distinct()
-        relayClients.addAll(connectRelaysParallel(relays))
-        if (relayClients.isEmpty()) throw Exception("Failed to connect to any bunker relay")
+        addRelays(relays)
+        if (clientsSnapshot().isEmpty()) throw Exception("Failed to connect to any bunker relay")
     }
 
     actual suspend fun startListeningForConnection(
@@ -236,9 +321,9 @@ actual class Nip46Client actual constructor(
         // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
 
-        // Return as soon as one relay is listening. Remaining relays finish
-        // in background; the durable sub on each picks up late-arriving
-        // signer events thanks to the `since = now - 10s` filter.
+        // Unblock on the first listening relay, then let the rest join within the
+        // grace window before the caller builds the URI: kind:24133 is ephemeral,
+        // so a relay that subscribes after the signer published replays nothing.
         connectRelaysFirstWins(relays)
     }
 
@@ -266,9 +351,9 @@ actual class Nip46Client actual constructor(
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }.distinct()
 
-        relayClients.addAll(connectRelaysParallel(relays))
+        addRelays(relays)
 
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("Failed to connect to any bunker relay")
         }
 
@@ -315,8 +400,9 @@ actual class Nip46Client actual constructor(
             remoteSignerPubkey
                 ?: throw Exception("Not connected to signer")
 
+        // Ensure relay connections are alive before sending
         ensureRelaysConnected()
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("No bunker relay connections available")
         }
 
@@ -375,7 +461,15 @@ actual class Nip46Client actual constructor(
                 // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
-                    val publishResults = relayClients.map { client ->
+                    // Re-read: a paced request can wait minutes for its turn, and
+                    // a disconnect (logout) in that window leaves nothing to
+                    // publish to. Reporting that as "rejected by every relay"
+                    // reads as a signer fault in the logs when it is a teardown.
+                    val targets = clientsSnapshot()
+                    if (targets.isEmpty()) {
+                        throw Exception("No bunker relay connections available")
+                    }
+                    val publishResults = targets.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()
                     if (publishResults.any { it is PublishResult.Success }) {
@@ -491,10 +585,10 @@ actual class Nip46Client actual constructor(
                                         add("EVENT")
                                         add(ackEvent.toJsonObject())
                                     }.toString()
-                                relayClients.forEach {
+                                clientsSnapshot().forEach {
                                     try {
                                         it.send(ackMessage)
-                                    } catch (_: Exception) {
+                                    } catch (e: Exception) {
                                     }
                                 }
                             } catch (e: Exception) {
@@ -598,8 +692,12 @@ actual class Nip46Client actual constructor(
     }
 
     actual fun disconnect() {
+        closed = true
         clientScope.coroutineContext.cancelChildren()
-        relayClients.forEach { client ->
+        val open = synchronized(relayClients) { relayClients.toList().also { relayClients.clear() } }
+        open.forEach { client ->
+            // Drop the watch first: a graceful close must not schedule a reconnect.
+            client.onConnectionLost = null
             clientScope.launch {
                 try {
                     client.disconnect()
@@ -607,7 +705,6 @@ actual class Nip46Client actual constructor(
                 }
             }
         }
-        relayClients.clear()
         // Fail any in-flight RPCs so callers unblock immediately instead of
         // waiting out their wrapping withTimeout.
         pendingRequests.values.forEach { it.completeExceptionally(CancellationException("Nip46Client disconnected")) }

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -4,6 +4,8 @@ import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.*
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
@@ -46,6 +48,16 @@ private class ConcurrentMap<K, V> : SynchronizedObject() {
 // ("Waiting for signer..." forever) - mirrors the web's 20s timeout.
 private const val SIGNER_RELAY_CONNECT_TIMEOUT_MS = 20_000L
 
+// After the first signer relay is listening, how long the QR flow waits for the
+// rest before drawing the code. kind:24133 is ephemeral, so a connect event the
+// signer publishes to a relay we are not subscribed on is lost for good and the
+// screen waits for a signer that already answered.
+private const val REMAINING_RELAY_GRACE_MS = 2_500L
+
+// Backoff bounds for re-opening a signer relay that dropped mid-session.
+private const val RELAY_RECONNECT_BASE_DELAY_MS = 1_000L
+private const val RELAY_RECONNECT_MAX_DELAY_MS = 15_000L
+
 actual class Nip46Client actual constructor(
     existingPrivateKey: String?,
 ) {
@@ -57,8 +69,31 @@ actual class Nip46Client actual constructor(
         }
 
     private var remoteSignerPubkey: String? = null
+
+    // Serialises every path that grows relayClients (see addRelays).
+    private val relayConnectMutex = Mutex()
+
+    // Every read is a snapshot and every mutation goes through addClient /
+    // removeClient under this lock: the list is touched from the ws frame
+    // threads (drop watch), the connect fan-out and concurrent sendRequests, so
+    // an unguarded iteration corrupts a request that had nothing wrong with it.
     private val relayClientsLock = SynchronizedObject()
-    private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
+    private val relayClients: MutableList<NostrGroupClient> = mutableListOf()
+
+    private fun clientsSnapshot(): List<NostrGroupClient> = synchronized(relayClientsLock) { relayClients.toList() }
+
+    private fun addClient(client: NostrGroupClient) {
+        synchronized(relayClientsLock) { relayClients.add(client) }
+    }
+
+    private fun removeClient(client: NostrGroupClient) {
+        synchronized(relayClientsLock) { relayClients.remove(client) }
+    }
+
+    // Set by disconnect(); stops the drop watch from resurrecting sockets.
+    @kotlin.concurrent.Volatile
+    private var closed = false
+
     private var relayUrls: List<String> = emptyList()
     private val pendingRequests = ConcurrentMap<String, CompletableDeferred<String>>()
 
@@ -78,7 +113,14 @@ actual class Nip46Client actual constructor(
         relays: List<String>,
         name: String,
     ): String {
-        val relayParams = relays.joinToString("&") { "relay=${it.encodeForUri()}" }
+        // Advertise only the relays we are actually subscribed on. kind:24133 is
+        // ephemeral: a connect event published to a relay we are not listening on
+        // is dropped by the relay, not replayed later, and the QR screen then waits
+        // forever for a signer that already answered.
+        val advertised = clientsSnapshot()
+            .map { it.getRelayUrl() }
+            .ifEmpty { relays.map { it.trimEnd('/') }.distinct() }
+        val relayParams = advertised.joinToString("&") { "relay=${it.encodeForUri()}" }
         val metadata = """{"name":"$name"}"""
         val secretParam = nostrConnectSecret?.let { "&secret=${it.encodeForUri()}" } ?: ""
         val permsParam = "&perms=${NIP46_REQUESTED_PERMS.encodeForUri()}"
@@ -86,76 +128,113 @@ actual class Nip46Client actual constructor(
         return uri
     }
 
+    /**
+     * Opens one signer relay end to end: WebSocket, durable response
+     * subscription, drop watch. Returns null when either the socket never
+     * opened or the REQ could not be sent — a socket with no live response sub
+     * is deaf, and counting it as a connection is what left the QR screen
+     * waiting for a signer event that could never be delivered. The caller owns
+     * adding the result to [relayClients].
+     */
+    private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
+        val client = NostrGroupClient(relayUrl)
+        client.connect { msg -> handleMessage(msg, client) }
+        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
+            client.disconnect()
+            null
+        } else {
+            armDropWatch(client, relayUrl)
+            client
+        }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
+
+    /**
+     * Re-open [relayUrl] when its socket drops. Without this the response
+     * subscription dies with the socket and nothing notices: the only liveness
+     * check is [ensureRelaysConnected] at the head of the next request, and the
+     * QR wait issues no requests at all, so the signer's reply lands on a relay
+     * we left.
+     */
+    private fun armDropWatch(client: NostrGroupClient, relayUrl: String) {
+        client.onConnectionLost = {
+            removeClient(client)
+            clientScope.launch { reconnectRelay(relayUrl) }
+        }
+    }
+
+    private suspend fun reconnectRelay(relayUrl: String) {
+        var delayMs = RELAY_RECONNECT_BASE_DELAY_MS
+        while (!closed) {
+            delay(delayMs)
+            if (closed) return
+            addRelays(listOf(relayUrl))
+            if (clientsSnapshot().any { it.getRelayUrl() == relayUrl }) return
+            delayMs = minOf(delayMs * 2, RELAY_RECONNECT_MAX_DELAY_MS)
+        }
+    }
+
+    /**
+     * Connect [relays] and register them, skipping any already connected, under
+     * [relayConnectMutex]. Every path that grows [relayClients] goes through
+     * here: a session restore's connect racing the first request's
+     * [ensureRelaysConnected] had both running their own fan-out and both
+     * appending, leaving two live sockets to one relay. Each request was then
+     * published twice and each signer reply delivered twice, which is what
+     * earned the "rate-limited: you are noting too much" rejections and got the
+     * relay to drop the socket mid-QR-wait.
+     */
+    private suspend fun addRelays(relays: List<String>) {
+        relayConnectMutex.withLock {
+            val known = clientsSnapshot().mapTo(mutableSetOf()) { it.getRelayUrl() }
+            val missing = relays.map { it.trimEnd('/') }.distinct().filterNot { it in known }
+            if (missing.isEmpty()) return@withLock
+            connectRelaysParallel(missing).forEach { addClient(it) }
+        }
+    }
+
     private suspend fun connectRelaysParallel(relays: List<String>): List<NostrGroupClient> = coroutineScope {
         relays
-            .map { relayUrl ->
-                async {
-                    try {
-                        val cleanUrl = relayUrl.trimEnd('/')
-                        val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg, client) }
-                        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
-                            // WS never opened (timeout) — drop it so callers don't
-                            // treat a dead socket as a live relay connection.
-                            client.disconnect()
-                            null
-                        } else {
-                            openResponseSubscription(client)
-                            client
-                        }
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-            }.awaitAll()
+            .map { it.trimEnd('/') }
+            .distinct()
+            .map { relayUrl -> async { openRelay(relayUrl) } }
+            .awaitAll()
             .filterNotNull()
     }
 
     /**
-     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
-     * one relay's WebSocket is open and the durable response sub is sent.
-     * Remaining relays continue connecting in [clientScope] and are appended
-     * to [relayClients] as they become ready, so the listening sub spans all
-     * relays even when this function has already returned. Throws only if
-     * every relay fails — partial failure is acceptable.
+     * QR-flow variant of [connectRelaysParallel]. Unblocks as soon as one relay
+     * is listening, then gives the rest [REMAINING_RELAY_GRACE_MS] to join
+     * before the caller draws the code, so the advertised relay set matches the
+     * set we can actually hear on. Throws only if every relay fails.
      */
     private suspend fun connectRelaysFirstWins(relays: List<String>) {
         if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
         val firstReady = CompletableDeferred<Unit>()
+        val allSettled = CompletableDeferred<Unit>()
         val total = relays.size
-        val failures = atomic(0)
+        val settled = atomic(0)
 
         for (relayUrl in relays) {
             clientScope.launch {
-                try {
-                    val cleanUrl = relayUrl.trimEnd('/')
-                    val client = NostrGroupClient(cleanUrl)
-                    client.connect { msg -> handleMessage(msg, client) }
-                    if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
-                        // WS never opened — drop it (mirrors connectRelaysParallel)
-                        // instead of adding a dead socket and completing firstReady.
-                        // Otherwise the QR displays while no listening sub is live,
-                        // so the signer's connect event never arrives and the user
-                        // has to restart the app. Common right after a logout, which
-                        // tears down many sockets at once and slows the next connect.
-                        client.disconnect()
-                        if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
-                            firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
-                        }
-                        return@launch
-                    }
-                    openResponseSubscription(client)
-                    synchronized(relayClientsLock) { relayClients.add(client) }
+                val client = openRelay(relayUrl.trimEnd('/'))
+                if (client != null) {
+                    addClient(client)
                     firstReady.complete(Unit)
-                } catch (_: Exception) {
-                    if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
+                }
+                if (settled.incrementAndGet() == total) {
+                    if (!firstReady.isCompleted) {
                         firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
                     }
+                    allSettled.complete(Unit)
                 }
             }
         }
 
         firstReady.await()
+        withTimeoutOrNull(REMAINING_RELAY_GRACE_MS) { allSettled.await() }
     }
 
     /**
@@ -189,8 +268,10 @@ actual class Nip46Client actual constructor(
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
      * one stable subscription replaces the previous per-request ephemeral REQs.
+     * Returns false when the REQ could not be sent, so the caller drops a socket
+     * that would otherwise sit in [relayClients] connected but deaf.
      */
-    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+    private suspend fun openResponseSubscription(client: NostrGroupClient): Boolean {
         val subId = responseSubscriptionId
             ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
         val since = (epochMillis() / 1000) - 10
@@ -204,9 +285,12 @@ actual class Nip46Client actual constructor(
             add(subId)
             add(filter)
         }.toString()
-        try {
+        return try {
             client.send(req)
-        } catch (_: Exception) {
+            true
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            false
         }
     }
 
@@ -216,24 +300,20 @@ actual class Nip46Client actual constructor(
      */
     private suspend fun ensureRelaysConnected() {
         // Remove dead clients
-        val dead = relayClients.filter { !it.isConnected() }
-        if (dead.isNotEmpty()) {
-            dead.forEach {
-                try {
-                    it.disconnect()
-                } catch (_: Exception) {
-                }
+        clientsSnapshot().filter { !it.isConnected() }.forEach {
+            removeClient(it)
+            try {
+                it.disconnect()
+            } catch (_: Exception) {
             }
-            relayClients.removeAll(dead)
         }
 
         // If we still have live clients, we're good
-        if (relayClients.isNotEmpty()) return
+        if (clientsSnapshot().isNotEmpty()) return
 
         // Reconnect using stored relay URLs
         if (relayUrls.isEmpty()) return
-        val fresh = connectRelaysParallel(relayUrls)
-        relayClients.addAll(fresh)
+        addRelays(relayUrls)
     }
 
     actual suspend fun connectRelaysOnly(
@@ -242,8 +322,8 @@ actual class Nip46Client actual constructor(
     ) {
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }
-        relayClients.addAll(connectRelaysParallel(relays))
-        if (relayClients.isEmpty()) throw Exception("Failed to connect to any bunker relay")
+        addRelays(relays)
+        if (clientsSnapshot().isEmpty()) throw Exception("Failed to connect to any bunker relay")
     }
 
     actual suspend fun startListeningForConnection(
@@ -258,9 +338,9 @@ actual class Nip46Client actual constructor(
         // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
 
-        // Return as soon as one relay is listening. Remaining relays finish
-        // in background; the durable sub on each picks up late-arriving
-        // signer events thanks to the `since = now - 10s` filter.
+        // Unblock on the first listening relay, then let the rest join within the
+        // grace window before the caller builds the URI: kind:24133 is ephemeral,
+        // so a relay that subscribes after the signer published replays nothing.
         connectRelaysFirstWins(relays)
     }
 
@@ -288,9 +368,9 @@ actual class Nip46Client actual constructor(
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }
 
-        relayClients.addAll(connectRelaysParallel(relays))
+        addRelays(relays)
 
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("Failed to connect to any bunker relay")
         }
 
@@ -339,7 +419,7 @@ actual class Nip46Client actual constructor(
 
         // Ensure relay connections are alive before sending
         ensureRelaysConnected()
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("No bunker relay connections available")
         }
 
@@ -398,7 +478,15 @@ actual class Nip46Client actual constructor(
                 // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
-                    val publishResults = relayClients.map { client ->
+                    // Re-read: a paced request can wait minutes for its turn, and
+                    // a disconnect (logout) in that window leaves nothing to
+                    // publish to. Reporting that as "rejected by every relay"
+                    // reads as a signer fault in the logs when it is a teardown.
+                    val targets = clientsSnapshot()
+                    if (targets.isEmpty()) {
+                        throw Exception("No bunker relay connections available")
+                    }
+                    val publishResults = targets.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()
                     if (publishResults.any { it is PublishResult.Success }) {
@@ -514,7 +602,7 @@ actual class Nip46Client actual constructor(
                                         add("EVENT")
                                         add(ackEvent.toJsonObject())
                                     }.toString()
-                                relayClients.forEach {
+                                clientsSnapshot().forEach {
                                     try {
                                         it.send(ackMessage)
                                     } catch (_: Exception) {
@@ -621,8 +709,12 @@ actual class Nip46Client actual constructor(
     }
 
     actual fun disconnect() {
+        closed = true
         clientScope.coroutineContext.cancelChildren()
-        relayClients.forEach { client ->
+        val open = synchronized(relayClientsLock) { relayClients.toList().also { relayClients.clear() } }
+        open.forEach { client ->
+            // Drop the watch first: a graceful close must not schedule a reconnect.
+            client.onConnectionLost = null
             clientScope.launch {
                 try {
                     client.disconnect()
@@ -630,7 +722,6 @@ actual class Nip46Client actual constructor(
                 }
             }
         }
-        relayClients.clear()
         // Fail any in-flight RPCs so callers unblock immediately instead of
         // waiting out their wrapping withTimeout.
         pendingRequests.values.forEach { it.completeExceptionally(CancellationException("Nip46Client disconnected")) }

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -20,6 +20,16 @@ import kotlin.random.Random
 // though the relays were reachable (a retry or app restart eventually connected).
 private const val NOSTRCONNECT_CONNECT_TIMEOUT_MS = 20_000L
 
+// After the first signer relay is listening, how long the QR flow waits for the
+// rest before drawing the code. kind:24133 is ephemeral, so a connect event the
+// signer publishes to a relay we are not subscribed on is lost for good and the
+// screen waits for a signer that already answered.
+private const val REMAINING_RELAY_GRACE_MS = 2_500L
+
+// Backoff bounds for re-opening a signer relay that dropped mid-session.
+private const val RELAY_RECONNECT_BASE_DELAY_MS = 1_000L
+private const val RELAY_RECONNECT_MAX_DELAY_MS = 15_000L
+
 actual class Nip46Client actual constructor(
     existingPrivateKey: String?,
 ) {
@@ -31,7 +41,25 @@ actual class Nip46Client actual constructor(
         }
 
     private var remoteSignerPubkey: String? = null
-    private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
+
+    // Mutated only through addClient / removeClient and read as a snapshot, so a
+    // socket dropping (drop watch) or a late relay joining mid-iteration cannot
+    // corrupt a publish fan-out. Single-threaded here; the same discipline on the
+    // JVM/Native actuals is what keeps this list safe under real concurrency.
+    private val relayClients: MutableList<NostrGroupClient> = mutableListOf()
+
+    private fun clientsSnapshot(): List<NostrGroupClient> = relayClients.toList()
+
+    private fun addClient(client: NostrGroupClient) {
+        relayClients.add(client)
+    }
+
+    private fun removeClient(client: NostrGroupClient) {
+        relayClients.remove(client)
+    }
+
+    // Set by disconnect(); stops the drop watch from resurrecting sockets.
+    private var closed = false
 
     // Guards ensureRelaysConnected's check-then-act (see its own doc comment):
     // without it, concurrent sendRequest calls racing on an empty relayClients
@@ -58,11 +86,85 @@ actual class Nip46Client actual constructor(
         relays: List<String>,
         name: String,
     ): String {
-        val relayParams = relays.joinToString("&") { "relay=${it.encodeForUri()}" }
+        // Advertise only the relays we are actually subscribed on. kind:24133 is
+        // ephemeral: a connect event published to a relay we are not listening on
+        // is dropped by the relay, not replayed later, and the QR screen then waits
+        // forever for a signer that already answered.
+        val advertised = clientsSnapshot()
+            .map { it.getRelayUrl() }
+            .ifEmpty { relays.map { it.trimEnd('/') }.distinct() }
+        val relayParams = advertised.joinToString("&") { "relay=${it.encodeForUri()}" }
         val metadata = """{"name":"$name"}"""
         val secretParam = nostrConnectSecret?.let { "&secret=${it.encodeForUri()}" } ?: ""
         val permsParam = "&perms=${NIP46_REQUESTED_PERMS.encodeForUri()}"
         return "nostrconnect://${clientKeyPair.publicKeyHex}?$relayParams$secretParam$permsParam&metadata=${metadata.encodeForUri()}"
+    }
+
+    /**
+     * Opens one signer relay end to end: WebSocket, durable response
+     * subscription, drop watch. Returns null when either the socket never
+     * opened or the REQ could not be sent — a socket with no live response sub
+     * is deaf, and counting it as a connection is what left the QR screen
+     * waiting for a signer event that could never be delivered. The caller owns
+     * adding the result to [relayClients].
+     */
+    private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
+        val client = NostrGroupClient(relayUrl)
+        client.connect { msg -> handleMessage(msg, client) }
+        if (!client.waitForConnection(NOSTRCONNECT_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
+            client.disconnect()
+            null
+        } else {
+            armDropWatch(client, relayUrl)
+            client
+        }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
+
+    /**
+     * Re-open [relayUrl] when its socket drops. Without this the response
+     * subscription dies with the socket and nothing notices: the only liveness
+     * check is [ensureRelaysConnected] at the head of the next request, and the
+     * QR wait issues no requests at all, so the signer's reply lands on a relay
+     * we left.
+     */
+    private fun armDropWatch(client: NostrGroupClient, relayUrl: String) {
+        client.onConnectionLost = {
+            removeClient(client)
+            clientScope.launch { reconnectRelay(relayUrl) }
+        }
+    }
+
+    private suspend fun reconnectRelay(relayUrl: String) {
+        var delayMs = RELAY_RECONNECT_BASE_DELAY_MS
+        while (!closed) {
+            delay(delayMs)
+            if (closed) return
+            addRelays(listOf(relayUrl))
+            if (clientsSnapshot().any { it.getRelayUrl() == relayUrl }) return
+            delayMs = minOf(delayMs * 2, RELAY_RECONNECT_MAX_DELAY_MS)
+        }
+    }
+
+    /**
+     * Connect [relays] and register them, skipping any already connected, under
+     * [relayConnectMutex]. Every path that grows [relayClients] goes through
+     * here: a session restore's connect racing the first request's
+     * [ensureRelaysConnected] had both running their own fan-out and both
+     * appending, leaving two live sockets to one relay. Each request was then
+     * published twice and each signer reply delivered twice, which is what
+     * earned the "rate-limited: you are noting too much" rejections and got the
+     * relay to drop the socket mid-QR-wait.
+     */
+    private suspend fun addRelays(relays: List<String>) {
+        relayConnectMutex.withLock {
+            val known = clientsSnapshot().mapTo(mutableSetOf()) { it.getRelayUrl() }
+            val missing = relays.map { it.trimEnd('/') }.distinct().filterNot { it in known }
+            if (missing.isEmpty()) return@withLock
+            connectRelaysParallel(missing).forEach { addClient(it) }
+        }
     }
 
     private suspend fun connectRelaysParallel(relays: List<String>): List<NostrGroupClient> = coroutineScope {
@@ -72,77 +174,43 @@ actual class Nip46Client actual constructor(
         relays
             .map { it.trimEnd('/') }
             .distinct()
-            .map { relayUrl ->
-                async {
-                    try {
-                        val cleanUrl = relayUrl.trimEnd('/')
-                        val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg, client) }
-                        if (!client.waitForConnection(NOSTRCONNECT_CONNECT_TIMEOUT_MS)) {
-                            // WS never opened (timeout) — drop it so callers don't
-                            // treat a dead socket as a live relay connection.
-                            client.disconnect()
-                            null
-                        } else {
-                            openResponseSubscription(client)
-                            client
-                        }
-                    } catch (_: Exception) {
-                        null
-                    }
-                }
-            }.awaitAll()
+            .map { relayUrl -> async { openRelay(relayUrl) } }
+            .awaitAll()
             .filterNotNull()
     }
 
     /**
-     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
-     * one relay's WebSocket is open and the durable response sub is sent.
-     * Remaining relays continue connecting in [clientScope] and are appended
-     * to [relayClients] as they become ready, so the listening sub spans all
-     * relays even when this function has already returned. Throws only if
-     * every relay fails. Single-threaded on JS — plain counter is fine.
+     * QR-flow variant of [connectRelaysParallel]. Unblocks as soon as one relay
+     * is listening, then gives the rest [REMAINING_RELAY_GRACE_MS] to join
+     * before the caller draws the code, so the advertised relay set matches the
+     * set we can actually hear on. Throws only if every relay fails.
      */
     private suspend fun connectRelaysFirstWins(relaysIn: List<String>) {
         val relays = relaysIn.map { it.trimEnd('/') }.distinct()
         if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
         val firstReady = CompletableDeferred<Unit>()
+        val allSettled = CompletableDeferred<Unit>()
         val total = relays.size
-        var failures = 0
+        var settled = 0
 
         for (relayUrl in relays) {
             clientScope.launch {
-                try {
-                    val cleanUrl = relayUrl.trimEnd('/')
-                    val client = NostrGroupClient(cleanUrl)
-                    client.connect { msg -> handleMessage(msg, client) }
-                    if (!client.waitForConnection(NOSTRCONNECT_CONNECT_TIMEOUT_MS)) {
-                        // WS never opened — drop it (mirrors connectRelaysParallel)
-                        // instead of adding a dead socket and completing firstReady.
-                        // Otherwise the QR displays while no listening sub is live,
-                        // so the signer's connect event never arrives and the user
-                        // has to restart the app. Common right after a logout, which
-                        // tears down many sockets at once and slows the next connect.
-                        client.disconnect()
-                        failures++
-                        if (failures == total && !firstReady.isCompleted) {
-                            firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
-                        }
-                        return@launch
-                    }
-                    openResponseSubscription(client)
-                    relayClients.add(client)
+                val client = openRelay(relayUrl)
+                if (client != null) {
+                    addClient(client)
                     firstReady.complete(Unit)
-                } catch (_: Exception) {
-                    failures++
-                    if (failures == total && !firstReady.isCompleted) {
+                }
+                if (++settled == total) {
+                    if (!firstReady.isCompleted) {
                         firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
                     }
+                    allSettled.complete(Unit)
                 }
             }
         }
 
         firstReady.await()
+        withTimeoutOrNull(REMAINING_RELAY_GRACE_MS) { allSettled.await() }
     }
 
     /**
@@ -175,8 +243,10 @@ actual class Nip46Client actual constructor(
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
      * one stable subscription replaces the previous per-request ephemeral REQs.
+     * Returns false when the REQ could not be sent, so the caller drops a socket
+     * that would otherwise sit in [relayClients] connected but deaf.
      */
-    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+    private suspend fun openResponseSubscription(client: NostrGroupClient): Boolean {
         val subId = responseSubscriptionId
             ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
         val since = (epochMillis() / 1000) - 10
@@ -190,27 +260,27 @@ actual class Nip46Client actual constructor(
             add(subId)
             add(filter)
         }.toString()
-        try {
+        return try {
             client.send(req)
-        } catch (_: Exception) {
+            true
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            false
         }
     }
 
     private suspend fun ensureRelaysConnected() {
         relayConnectMutex.withLock {
-            val dead = relayClients.filter { !it.isConnected() }
-            if (dead.isNotEmpty()) {
-                dead.forEach {
-                    try {
-                        it.disconnect()
-                    } catch (_: Exception) {
-                    }
+            clientsSnapshot().filter { !it.isConnected() }.forEach {
+                removeClient(it)
+                try {
+                    it.disconnect()
+                } catch (_: Exception) {
                 }
-                relayClients.removeAll(dead)
             }
-            if (relayClients.isNotEmpty()) return@withLock
+            if (clientsSnapshot().isNotEmpty()) return@withLock
             if (relayUrls.isEmpty()) return@withLock
-            relayClients.addAll(connectRelaysParallel(relayUrls))
+            connectRelaysParallel(relayUrls).forEach { addClient(it) }
         }
     }
 
@@ -220,8 +290,8 @@ actual class Nip46Client actual constructor(
     ) {
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }.distinct()
-        relayClients.addAll(connectRelaysParallel(relays))
-        if (relayClients.isEmpty()) throw Exception("Failed to connect to any bunker relay")
+        addRelays(relays)
+        if (clientsSnapshot().isEmpty()) throw Exception("Failed to connect to any bunker relay")
     }
 
     actual suspend fun startListeningForConnection(
@@ -236,9 +306,9 @@ actual class Nip46Client actual constructor(
         // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
 
-        // Return as soon as one relay is listening. Remaining relays finish
-        // in background; the durable sub on each picks up late-arriving
-        // signer events thanks to the `since = now - 10s` filter.
+        // Unblock on the first listening relay, then let the rest join within the
+        // grace window before the caller builds the URI: kind:24133 is ephemeral,
+        // so a relay that subscribes after the signer published replays nothing.
         connectRelaysFirstWins(relays)
     }
 
@@ -266,9 +336,9 @@ actual class Nip46Client actual constructor(
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }.distinct()
 
-        relayClients.addAll(connectRelaysParallel(relays))
+        addRelays(relays)
 
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("Failed to connect to any bunker relay")
         }
 
@@ -315,7 +385,7 @@ actual class Nip46Client actual constructor(
 
         // Ensure relay connections are alive before sending
         ensureRelaysConnected()
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("No bunker relay connections available")
         }
 
@@ -374,7 +444,15 @@ actual class Nip46Client actual constructor(
                 // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
-                    val publishResults = relayClients.map { client ->
+                    // Re-read: a paced request can wait minutes for its turn, and
+                    // a disconnect (logout) in that window leaves nothing to
+                    // publish to. Reporting that as "rejected by every relay"
+                    // reads as a signer fault in the logs when it is a teardown.
+                    val targets = clientsSnapshot()
+                    if (targets.isEmpty()) {
+                        throw Exception("No bunker relay connections available")
+                    }
+                    val publishResults = targets.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()
                     if (publishResults.any { it is PublishResult.Success }) {
@@ -487,7 +565,7 @@ actual class Nip46Client actual constructor(
                                         add("EVENT")
                                         add(ackEvent.toJsonObject())
                                     }.toString()
-                                relayClients.forEach {
+                                clientsSnapshot().forEach {
                                     try {
                                         it.send(ackMessage)
                                     } catch (_: Exception) {
@@ -566,7 +644,9 @@ actual class Nip46Client actual constructor(
     }
 
     actual fun disconnect() {
-        // Close each relay socket synchronously. cancelAndClose() shuts the Ktor
+        closed = true
+        // Close each relay socket synchronously. cancelAndClose() drops the drop
+        // watch (so a graceful close schedules no reconnect) and shuts the Ktor
         // HttpClient (and its WebSocket) down without suspending, so the browser's
         // per-page WS slots are released the moment disconnect() returns. The old
         // `clientScope.launch { client.disconnect() }` was fire-and-forget and ran
@@ -574,7 +654,7 @@ actual class Nip46Client actual constructor(
         // socket — leaking sockets across repeated QR attempts / logins until the
         // browser refused new connections and the next login failed with
         // "Failed to connect to any relay".
-        relayClients.forEach { client ->
+        clientsSnapshot().forEach { client ->
             try {
                 client.cancelAndClose()
             } catch (_: Exception) {

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -18,6 +18,17 @@ import kotlin.random.Random
 // ("Waiting for signer..." forever) - mirrors the web's 20s timeout.
 private const val SIGNER_RELAY_CONNECT_TIMEOUT_MS = 20_000L
 
+// After the first signer relay is listening, how long the QR flow waits for the
+// rest before drawing the code. kind:24133 is ephemeral, so a connect event the
+// signer publishes to a relay we are not subscribed on is lost for good and the
+// screen waits for a signer that already answered. Short enough to stay
+// imperceptible when every relay is healthy, long enough to cover a slow one.
+private const val REMAINING_RELAY_GRACE_MS = 2_500L
+
+// Backoff bounds for re-opening a signer relay that dropped mid-session.
+private const val RELAY_RECONNECT_BASE_DELAY_MS = 1_000L
+private const val RELAY_RECONNECT_MAX_DELAY_MS = 15_000L
+
 actual class Nip46Client actual constructor(
     existingPrivateKey: String?,
 ) {
@@ -29,7 +40,27 @@ actual class Nip46Client actual constructor(
         }
 
     private var remoteSignerPubkey: String? = null
-    private var relayClients: MutableList<NostrGroupClient> = mutableListOf()
+
+    // Every read is a snapshot and every mutation goes through addClient /
+    // removeClient under this lock: the list is touched from the ws frame
+    // threads (drop watch), the connect fan-out and concurrent sendRequests, so
+    // an unguarded iteration throws ConcurrentModificationException and fails a
+    // request that had nothing wrong with it.
+    private val relayClients: MutableList<NostrGroupClient> = mutableListOf()
+
+    private fun clientsSnapshot(): List<NostrGroupClient> = synchronized(relayClients) { relayClients.toList() }
+
+    private fun addClient(client: NostrGroupClient) {
+        synchronized(relayClients) { relayClients.add(client) }
+    }
+
+    private fun removeClient(client: NostrGroupClient) {
+        synchronized(relayClients) { relayClients.remove(client) }
+    }
+
+    // Set by disconnect(); stops the drop watch from resurrecting sockets.
+    @kotlin.concurrent.Volatile
+    private var closed = false
 
     // Guards ensureRelaysConnected's check-then-act (see its own doc comment):
     // without it, concurrent sendRequest calls racing on an empty relayClients
@@ -58,12 +89,86 @@ actual class Nip46Client actual constructor(
         relays: List<String>,
         name: String,
     ): String {
-        val relayParams = relays.joinToString("&") { "relay=${it.encodeForUri()}" }
+        // Advertise only the relays we are actually subscribed on. kind:24133 is
+        // ephemeral: a connect event published to a relay we are not listening on
+        // is dropped by the relay, not replayed later, and the QR screen then waits
+        // forever for a signer that already answered.
+        val advertised = clientsSnapshot()
+            .map { it.getRelayUrl() }
+            .ifEmpty { relays.map { it.trimEnd('/') }.distinct() }
+        val relayParams = advertised.joinToString("&") { "relay=${it.encodeForUri()}" }
         val metadata = """{"name":"$name"}"""
         val secretParam = nostrConnectSecret?.let { "&secret=${it.encodeForUri()}" } ?: ""
         val permsParam = "&perms=${NIP46_REQUESTED_PERMS.encodeForUri()}"
         val uri = "nostrconnect://${clientKeyPair.publicKeyHex}?$relayParams$secretParam$permsParam&metadata=${metadata.encodeForUri()}"
         return uri
+    }
+
+    /**
+     * Opens one signer relay end to end: WebSocket, durable response
+     * subscription, drop watch. Returns null when either the socket never
+     * opened or the REQ could not be sent — a socket with no live response sub
+     * is deaf, and counting it as a connection is what left the QR screen
+     * waiting for a signer event that could never be delivered. The caller owns
+     * adding the result to [relayClients].
+     */
+    private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
+        val client = NostrGroupClient(relayUrl)
+        client.connect { msg -> handleMessage(msg, client) }
+        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
+            client.disconnect()
+            null
+        } else {
+            armDropWatch(client, relayUrl)
+            client
+        }
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        null
+    }
+
+    /**
+     * Re-open [relayUrl] when its socket drops. Without this the response
+     * subscription dies with the socket and nothing notices: the only liveness
+     * check is [ensureRelaysConnected] at the head of the next request, and the
+     * QR wait issues no requests at all, so the signer's reply lands on a relay
+     * we left.
+     */
+    private fun armDropWatch(client: NostrGroupClient, relayUrl: String) {
+        client.onConnectionLost = {
+            removeClient(client)
+            clientScope.launch { reconnectRelay(relayUrl) }
+        }
+    }
+
+    private suspend fun reconnectRelay(relayUrl: String) {
+        var delayMs = RELAY_RECONNECT_BASE_DELAY_MS
+        while (!closed) {
+            delay(delayMs)
+            if (closed) return
+            addRelays(listOf(relayUrl))
+            if (clientsSnapshot().any { it.getRelayUrl() == relayUrl }) return
+            delayMs = minOf(delayMs * 2, RELAY_RECONNECT_MAX_DELAY_MS)
+        }
+    }
+
+    /**
+     * Connect [relays] and register them, skipping any already connected, under
+     * [relayConnectMutex]. Every path that grows [relayClients] goes through
+     * here: a session restore's connect racing the first request's
+     * [ensureRelaysConnected] had both running their own fan-out and both
+     * appending, leaving two live sockets to one relay. Each request was then
+     * published twice and each signer reply delivered twice, which is what
+     * earned the "rate-limited: you are noting too much" rejections and got the
+     * relay to drop the socket mid-QR-wait.
+     */
+    private suspend fun addRelays(relays: List<String>) {
+        relayConnectMutex.withLock {
+            val known = clientsSnapshot().mapTo(mutableSetOf()) { it.getRelayUrl() }
+            val missing = relays.map { it.trimEnd('/') }.distinct().filterNot { it in known }
+            if (missing.isEmpty()) return@withLock
+            connectRelaysParallel(missing).forEach { addClient(it) }
+        }
     }
 
     private suspend fun connectRelaysParallel(relays: List<String>): List<NostrGroupClient> = coroutineScope {
@@ -73,75 +178,43 @@ actual class Nip46Client actual constructor(
         relays
             .map { it.trimEnd('/') }
             .distinct()
-            .map { relayUrl ->
-                async {
-                    try {
-                        val cleanUrl = relayUrl.trimEnd('/')
-                        val client = NostrGroupClient(cleanUrl)
-                        client.connect { msg -> handleMessage(msg, client) }
-                        if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
-                            // WS never opened (timeout) — drop it so callers don't
-                            // treat a dead socket as a live relay connection.
-                            client.disconnect()
-                            null
-                        } else {
-                            openResponseSubscription(client)
-                            client
-                        }
-                    } catch (e: Exception) {
-                        null
-                    }
-                }
-            }.awaitAll()
+            .map { relayUrl -> async { openRelay(relayUrl) } }
+            .awaitAll()
             .filterNotNull()
     }
 
     /**
-     * First-relay-wins variant of [connectRelaysParallel]. Returns as soon as
-     * one relay's WebSocket is open and the durable response sub is sent.
-     * Remaining relays continue connecting in [clientScope] and are appended
-     * to [relayClients] as they become ready, so the listening sub spans all
-     * relays even when this function has already returned. Throws only if
-     * every relay fails — partial failure is acceptable.
+     * QR-flow variant of [connectRelaysParallel]. Unblocks as soon as one relay
+     * is listening, then gives the rest [REMAINING_RELAY_GRACE_MS] to join
+     * before the caller draws the code, so the advertised relay set matches the
+     * set we can actually hear on. Throws only if every relay fails.
      */
     private suspend fun connectRelaysFirstWins(relaysIn: List<String>) {
         val relays = relaysIn.map { it.trimEnd('/') }.distinct()
         if (relays.isEmpty()) throw Exception("Failed to connect to any relay")
         val firstReady = CompletableDeferred<Unit>()
+        val allSettled = CompletableDeferred<Unit>()
         val total = relays.size
-        val failures = java.util.concurrent.atomic.AtomicInteger(0)
+        val settled = java.util.concurrent.atomic.AtomicInteger(0)
 
         for (relayUrl in relays) {
             clientScope.launch {
-                try {
-                    val cleanUrl = relayUrl.trimEnd('/')
-                    val client = NostrGroupClient(cleanUrl)
-                    client.connect { msg -> handleMessage(msg, client) }
-                    if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS)) {
-                        // WS never opened — drop it (mirrors connectRelaysParallel)
-                        // instead of adding a dead socket and completing firstReady.
-                        // Otherwise the QR displays while no listening sub is live,
-                        // so the signer's connect event never arrives and the user
-                        // has to restart the app. Common right after a logout, which
-                        // tears down many sockets at once and slows the next connect.
-                        client.disconnect()
-                        if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
-                            firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
-                        }
-                        return@launch
-                    }
-                    openResponseSubscription(client)
-                    synchronized(relayClients) { relayClients.add(client) }
+                val client = openRelay(relayUrl)
+                if (client != null) {
+                    addClient(client)
                     firstReady.complete(Unit)
-                } catch (_: Exception) {
-                    if (failures.incrementAndGet() == total && !firstReady.isCompleted) {
+                }
+                if (settled.incrementAndGet() == total) {
+                    if (!firstReady.isCompleted) {
                         firstReady.completeExceptionally(Exception("Failed to connect to any relay"))
                     }
+                    allSettled.complete(Unit)
                 }
             }
         }
 
         firstReady.await()
+        withTimeoutOrNull(REMAINING_RELAY_GRACE_MS) { allSettled.await() }
     }
 
     /**
@@ -175,8 +248,10 @@ actual class Nip46Client actual constructor(
      * (`kinds:[24133], #p:[clientPubkey]`) covers both incoming `connect`
      * requests (nostrconnect:// flow) and signer replies (bunker:// flow), so
      * one stable subscription replaces the previous per-request ephemeral REQs.
+     * Returns false when the REQ could not be sent, so the caller drops a socket
+     * that would otherwise sit in [relayClients] connected but deaf.
      */
-    private suspend fun openResponseSubscription(client: NostrGroupClient) {
+    private suspend fun openResponseSubscription(client: NostrGroupClient): Boolean {
         val subId = responseSubscriptionId
             ?: "nip46-resp-${clientKeyPair.publicKeyHex.take(8)}".also { responseSubscriptionId = it }
         val since = (epochMillis() / 1000) - 10
@@ -190,9 +265,12 @@ actual class Nip46Client actual constructor(
             add(subId)
             add(filter)
         }.toString()
-        try {
+        return try {
             client.send(req)
-        } catch (_: Exception) {
+            true
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            false
         }
     }
 
@@ -203,24 +281,21 @@ actual class Nip46Client actual constructor(
     private suspend fun ensureRelaysConnected() {
         relayConnectMutex.withLock {
             // Remove dead clients
-            val dead = relayClients.filter { !it.isConnected() }
-            if (dead.isNotEmpty()) {
-                dead.forEach {
-                    try {
-                        it.disconnect()
-                    } catch (_: Exception) {
-                    }
+            val dead = clientsSnapshot().filter { !it.isConnected() }
+            dead.forEach {
+                removeClient(it)
+                try {
+                    it.disconnect()
+                } catch (_: Exception) {
                 }
-                relayClients.removeAll(dead)
             }
 
             // If we still have live clients, we're good
-            if (relayClients.isNotEmpty()) return@withLock
+            if (clientsSnapshot().isNotEmpty()) return@withLock
 
             // Reconnect using stored relay URLs
             if (relayUrls.isEmpty()) return@withLock
-            val fresh = connectRelaysParallel(relayUrls)
-            relayClients.addAll(fresh)
+            connectRelaysParallel(relayUrls).forEach { addClient(it) }
         }
     }
 
@@ -230,8 +305,8 @@ actual class Nip46Client actual constructor(
     ) {
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }.distinct()
-        relayClients.addAll(connectRelaysParallel(relays))
-        if (relayClients.isEmpty()) throw Exception("Failed to connect to any bunker relay")
+        addRelays(relays)
+        if (clientsSnapshot().isEmpty()) throw Exception("Failed to connect to any bunker relay")
     }
 
     actual suspend fun startListeningForConnection(
@@ -246,9 +321,9 @@ actual class Nip46Client actual constructor(
         // delivering events — first-relay-wins must not race the dispatch.
         pendingRequests["_incoming_connect"] = CompletableDeferred()
 
-        // Return as soon as one relay is listening. Remaining relays finish
-        // in background; the durable sub on each picks up late-arriving
-        // signer events thanks to the `since = now - 10s` filter.
+        // Unblock on the first listening relay, then let the rest join within the
+        // grace window before the caller builds the URI: kind:24133 is ephemeral,
+        // so a relay that subscribes after the signer published replays nothing.
         connectRelaysFirstWins(relays)
     }
 
@@ -276,9 +351,9 @@ actual class Nip46Client actual constructor(
         this.remoteSignerPubkey = remoteSignerPubkey
         this.relayUrls = relays.map { it.trimEnd('/') }.distinct()
 
-        relayClients.addAll(connectRelaysParallel(relays))
+        addRelays(relays)
 
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("Failed to connect to any bunker relay")
         }
 
@@ -327,7 +402,7 @@ actual class Nip46Client actual constructor(
 
         // Ensure relay connections are alive before sending
         ensureRelaysConnected()
-        if (relayClients.isEmpty()) {
+        if (clientsSnapshot().isEmpty()) {
             throw Exception("No bunker relay connections available")
         }
 
@@ -386,7 +461,15 @@ actual class Nip46Client actual constructor(
                 // to slow down. Any other rejection throws immediately.
                 while (true) {
                     publishPacer.awaitTurn(background)
-                    val publishResults = relayClients.map { client ->
+                    // Re-read: a paced request can wait minutes for its turn, and
+                    // a disconnect (logout) in that window leaves nothing to
+                    // publish to. Reporting that as "rejected by every relay"
+                    // reads as a signer fault in the logs when it is a teardown.
+                    val targets = clientsSnapshot()
+                    if (targets.isEmpty()) {
+                        throw Exception("No bunker relay connections available")
+                    }
+                    val publishResults = targets.map { client ->
                         async { client.sendAndAwaitOkOrError(eventMessage, eventId) }
                     }.awaitAll()
                     if (publishResults.any { it is PublishResult.Success }) {
@@ -502,10 +585,10 @@ actual class Nip46Client actual constructor(
                                         add("EVENT")
                                         add(ackEvent.toJsonObject())
                                     }.toString()
-                                relayClients.forEach {
+                                clientsSnapshot().forEach {
                                     try {
                                         it.send(ackMessage)
-                                    } catch (_: Exception) {
+                                    } catch (e: Exception) {
                                     }
                                 }
                             } catch (e: Exception) {
@@ -609,8 +692,12 @@ actual class Nip46Client actual constructor(
     }
 
     actual fun disconnect() {
+        closed = true
         clientScope.coroutineContext.cancelChildren()
-        relayClients.forEach { client ->
+        val open = synchronized(relayClients) { relayClients.toList().also { relayClients.clear() } }
+        open.forEach { client ->
+            // Drop the watch first: a graceful close must not schedule a reconnect.
+            client.onConnectionLost = null
             clientScope.launch {
                 try {
                     client.disconnect()
@@ -618,7 +705,6 @@ actual class Nip46Client actual constructor(
                 }
             }
         }
-        relayClients.clear()
         // Fail any in-flight RPCs so callers unblock immediately instead of
         // waiting out their wrapping withTimeout.
         pendingRequests.values.forEach { it.completeExceptionally(CancellationException("Nip46Client disconnected")) }


### PR DESCRIPTION
Logging in over NIP-46 on desktop intermittently never completed: the QR screen sat on "Waiting for signer..." with no error and only a fresh attempt got through. kind:24133 is ephemeral, so a connect event the signer publishes to a relay we are not subscribed on is dropped by the relay, never replayed, and `awaitIncomingConnection` has no deadline to surface it.

A traced desktop session caught the failure live: nos.lol closed our socket at +126.8s, mid-QR-wait, and the signer's connect event arrived 7s later on that same relay. The same trace showed why the relay was closing on us - two "listening" and two EOSE for nos.lol, every publish answered by both a plain OK and an "OK ... duplicate: have this event", every signer reply delivered twice. A session restore's connect and the first request's `ensureRelaysConnected` were running their own relay fan-out concurrently and both appending, so the client held two live sockets to one relay. Doubled traffic is what earns "rate-limited: you are noting too much" and gets the socket closed.

A follow-up run after the fix logs in on the first try in 7.7s, with zero `duplicate: have this event`, no drops and no retries.

| Problem | Fix |
|---|---|
| QR advertised every requested relay but was drawn as soon as the first was listening | Short grace for the rest, then advertise only the relays actually subscribed |
| A failed response REQ was swallowed, leaving a socket counted as a connection while deaf | `openResponseSubscription` reports the failure and the socket is dropped |
| Nothing watched the signer sockets; the only liveness check runs at the head of the next request, and the QR wait issues none | Each relay reconnects on drop and re-arms its response sub |
| Restore-connect racing `ensureRelaysConnected` left two sockets on one relay | Every path that grows `relayClients` goes through `addRelays`: one mutex, relays already connected skipped |
| `relayClients` mixed three locking disciplines and was iterated unguarded from the frame threads | Snapshot reads, add/remove under one lock |

iOS gains the `relayConnectMutex` the other three actuals already had, so the duplicate-socket fix is larger there. On the web target Kotlin/JS is single-threaded, so the locking change is uniform discipline rather than a live bug.

Validated with `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid` and `:composeApp:jvmTest`, and device-tested on desktop only - that is where the traces came from. iOS does not compile on this Linux box, so that actual is code review only and its new `Mutex`/`withLock` has not been through a compiler; worth a run on a Mac before considering iOS covered.

Not included, deliberately: `CLOSED` and `AUTH` frames are still dropped without a trace in `handleMessage`, so a relay that kills our subscription goes unnoticed. It never appeared in any trace, so it is a separate change rather than scope added here.

- abfd30b4 fix(nip46): stop the QR login losing the signer's connect event