### PR TITLE
Mention users and groups from the thread pages

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -30,6 +30,7 @@ import org.nostr.nostrord.network.managers.UnreadManager
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.EventDeduplicator
 import org.nostr.nostrord.network.outbox.RelayListManager
+import org.nostr.nostrord.network.toCachedEvent
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.notifications.FocusTracker
@@ -257,6 +258,9 @@ object AppModule {
             },
             onThreadEventReceived = { groupId, event ->
                 unreadManager.onThreadEventReceived(groupId, event)
+            },
+            onThreadEventCached = { event ->
+                metadataManager.handleCachedEvent(event.toCachedEvent())
             },
         ).also { gm ->
             // Feed + popup for "an admin added you to a group" (kind:9000, live or catch-up).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -131,6 +131,19 @@ data class CachedEvent(
 )
 
 /**
+ * The same event as a generic cached one, for the by-id lookups the quote cards do. The group
+ * stores are keyed by group and kind; a renderer resolving a bare nevent has neither.
+ */
+fun NostrGroupClient.NostrMessage.toCachedEvent(): CachedEvent = CachedEvent(
+    id = id,
+    pubkey = pubkey,
+    kind = kind,
+    content = content,
+    createdAt = createdAt,
+    tags = tags,
+)
+
+/**
  * Result of publishing an event to a relay.
  * Represents the relay's OK response per NIP-01.
  */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -3821,7 +3821,12 @@ class NostrRepository(
 
     override suspend fun fetchThread(groupId: String, rootId: String) = groupManager.fetchThread(groupId, rootId)
 
-    override suspend fun createThread(groupId: String, title: String, content: String): Result<String> {
+    override suspend fun createThread(
+        groupId: String,
+        title: String,
+        content: String,
+        mentions: Map<String, String>,
+    ): Result<String> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
         return groupManager.createThread(
@@ -3829,6 +3834,7 @@ class NostrRepository(
             title = title,
             content = content,
             pubKey = pubKey,
+            mentions = mentions,
             signEvent = { sessionManager.signEvent(it) },
         )
     }
@@ -3838,6 +3844,7 @@ class NostrRepository(
         root: NostrGroupClient.NostrMessage,
         parent: NostrGroupClient.NostrMessage,
         content: String,
+        mentions: Map<String, String>,
     ): Result<Unit> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
@@ -3847,6 +3854,7 @@ class NostrRepository(
             parent = parent,
             content = content,
             pubKey = pubKey,
+            mentions = mentions,
             signEvent = { sessionManager.signEvent(it) },
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -4722,8 +4722,8 @@ class NostrRepository(
         }
     }
 
-    override suspend fun requestEventById(eventId: String, relayHints: List<String>, author: String?) {
-        metadataManager.requestEventById(eventId, relayHints, author) { msg, client ->
+    override suspend fun requestEventById(eventId: String, relayHints: List<String>, author: String?, groupId: String?) {
+        metadataManager.requestEventById(eventId, relayHints, author, groupId) { msg, client ->
             handleRelayMessage(msg, client)
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -624,18 +624,28 @@ interface NostrRepositoryApi {
     suspend fun fetchThread(groupId: String, rootId: String)
 
     /** Create a forum thread (kind:11 root). [title] becomes a NIP-14 subject tag when non-blank. */
-    /** Publish a kind:11 thread root. Success carries the root's event id (stable NIP-01 id). */
-    suspend fun createThread(groupId: String, title: String, content: String): Result<String>
+    /**
+     * Publish a kind:11 thread root. Success carries the root's event id (stable NIP-01 id).
+     * [mentions] maps a typed `@displayName` to its pubkey (resolved to `nostr:npub` + a `p` tag).
+     */
+    suspend fun createThread(
+        groupId: String,
+        title: String,
+        content: String,
+        mentions: Map<String, String> = emptyMap(),
+    ): Result<String>
 
     /**
      * Publish a NIP-22 reply (kind:1111). [root] is the kind:11 thread root; [parent] is the item
-     * being replied to (pass [root] itself for a top-level reply).
+     * being replied to (pass [root] itself for a top-level reply). [mentions] maps a typed
+     * `@displayName` to its pubkey (resolved to `nostr:npub` + a `p` tag).
      */
     suspend fun sendThreadReply(
         groupId: String,
         root: NostrGroupClient.NostrMessage,
         parent: NostrGroupClient.NostrMessage,
         content: String,
+        mentions: Map<String, String> = emptyMap(),
     ): Result<Unit>
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -809,6 +809,8 @@ interface NostrRepositoryApi {
         eventId: String,
         relayHints: List<String> = emptyList(),
         author: String? = null,
+        /** Group the reference was seen in, so the REQ can carry `#h` for relays that demand it. */
+        groupId: String? = null,
     )
 
     suspend fun requestAddressableEvent(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -93,6 +93,8 @@ class GroupManager(
     // [onNewMessagesFlushed]: threads live in their own stores and never enter the chat
     // batch, so notifications would otherwise never see a thread reply.
     private val onThreadEventReceived: ((groupId: String, event: NostrGroupClient.NostrMessage) -> Unit)? = null,
+    /** Mirrors a thread event into the generic by-id event cache the quote cards read. */
+    private val onThreadEventCached: ((event: NostrGroupClient.NostrMessage) -> Unit)? = null,
 ) {
     private val json = Json { ignoreUnknownKeys = true }
     private val eventDeduplicator = EventDeduplicator()
@@ -3278,6 +3280,11 @@ class GroupManager(
         // Notify only on a real insert of a relay-delivered event: a disk hydration is not news,
         // and an un-echoed optimistic send is our own.
         if (inserted && persist && message.relayUrl != null) onThreadEventReceived?.invoke(groupId, message)
+        // A quoted kind:11 (the "Share to chat" announcement) resolves through the by-id event
+        // cache, which the thread stores never reach: without this the card pays a network
+        // round-trip for an event already in memory, and reads as removed when the relay
+        // withholds it. Skipped on disk hydration, whose events the mirror already persisted.
+        if (inserted && persist) onThreadEventCached?.invoke(message)
         // Write-through OUTSIDE the in-memory dedup: the relay echo of an optimistic
         // (relay-less) insert is deduped above, yet it is the first relay-attributed copy
         // and the one that must reach the disk cache. Upserts are idempotent.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3022,13 +3022,8 @@ class GroupManager(
             tags.add(listOf("q", replyToMessageId))
         }
 
-        // Replace @displayName with nostr:npub... in content
-        var processedContent = content
-        mentions.forEach { (displayName, pubkeyHex) ->
-            val npub = org.nostr.nostrord.nostr.Nip19.encodeNpub(pubkeyHex)
-            processedContent = processedContent.replace("@$displayName", "nostr:$npub")
-            tags.add(listOf("p", pubkeyHex))
-        }
+        val (processedContent, mentionTags) = MentionTags.apply(content, mentions, tags)
+        tags.addAll(mentionTags)
 
         // p-tag the author of the message being replied to (NIP-10/22). Without
         // it the recipient is only classified as "replied to" when they happen
@@ -3510,10 +3505,12 @@ class GroupManager(
         title: String,
         content: String,
         pubKey: String,
+        mentions: Map<String, String> = emptyMap(),
         signEvent: suspend (Event) -> Event,
     ): Result<String> = try {
         val tags = ThreadTags.root(groupId, getRelayForGroup(groupId), title)
-        publishThreadEvent(groupId, kind = 11, content = content, tags = tags, pubKey = pubKey, signEvent = signEvent)
+        val (body, mentionTags) = MentionTags.apply(content, mentions, tags)
+        publishThreadEvent(groupId, kind = 11, content = body, tags = tags + mentionTags, pubKey = pubKey, signEvent = signEvent)
     } catch (e: Throwable) {
         Result.Error(AppError.Group.SendFailed(groupId, e))
     }
@@ -3530,10 +3527,13 @@ class GroupManager(
         parent: NostrGroupClient.NostrMessage,
         content: String,
         pubKey: String,
+        mentions: Map<String, String> = emptyMap(),
         signEvent: suspend (Event) -> Event,
     ): Result<Unit> = try {
         val tags = ThreadTags.reply(groupId, getRelayForGroup(groupId), root, parent)
-        when (val result = publishThreadEvent(groupId, kind = 1111, content = content, tags = tags, pubKey = pubKey, signEvent = signEvent)) {
+        // The reply already p-tags the parent author, so mentioning them adds no second tag.
+        val (body, mentionTags) = MentionTags.apply(content, mentions, tags)
+        when (val result = publishThreadEvent(groupId, kind = 1111, content = body, tags = tags + mentionTags, pubKey = pubKey, signEvent = signEvent)) {
             is Result.Success -> Result.Success(Unit)
             is Result.Error -> Result.Error(result.error)
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MentionTags.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MentionTags.kt
@@ -1,0 +1,34 @@
+package org.nostr.nostrord.network.managers
+
+import org.nostr.nostrord.nostr.Nip19
+
+/**
+ * Resolution of composer `@displayName` mentions into event content + NIP-01 `p` tags. Shared by
+ * every kind the composers publish (kind:9 chat, kind:11 thread root, kind:1111 thread reply) so a
+ * mention notifies the same way wherever it was typed.
+ *
+ * `%group` mentions are resolved to `nostr:naddr...` by the UI before the send, since only the UI
+ * knows which relay hosts the mentioned group.
+ */
+internal object MentionTags {
+    /**
+     * [content] with each `@displayName` replaced by its `nostr:npub...`, plus the `p` tags for the
+     * mentioned pubkeys. Pubkeys already tagged by [existingTags] are skipped: a duplicate `p`
+     * carries nothing and inflates the indexable-tag count some NIP-29 relays reject.
+     */
+    fun apply(
+        content: String,
+        mentions: Map<String, String>,
+        existingTags: List<List<String>> = emptyList(),
+    ): Pair<String, List<List<String>>> {
+        if (mentions.isEmpty()) return content to emptyList()
+        val tagged = existingTags.filter { it.size >= 2 && it[0] == "p" }.mapTo(mutableSetOf()) { it[1] }
+        val tags = mutableListOf<List<String>>()
+        var text = content
+        mentions.forEach { (displayName, pubkeyHex) ->
+            text = text.replace("@$displayName", "nostr:${Nip19.encodeNpub(pubkeyHex)}")
+            if (tagged.add(pubkeyHex)) tags.add(listOf("p", pubkeyHex))
+        }
+        return text to tags
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -405,8 +405,14 @@ class MetadataManager(
         eventId: String,
         relayHints: List<String> = emptyList(),
         author: String? = null,
+        /** Group the reference was seen in. Some NIP-29 relays answer an ids-only REQ with
+         *  nothing and require the `#h` filter even for a lookup by id. */
+        groupId: String? = null,
         messageHandler: (String, NostrGroupClient) -> Unit,
     ) {
+        suspend fun NostrGroupClient.reqEvent() {
+            if (groupId != null) requestGroupMessageById(groupId, eventId) else requestEventById(eventId)
+        }
         // Skip if already cached or already in-flight
         if (_cachedEvents.value.containsKey(eventId)) return
         // Disk fallback: resolve a previously-seen event from the persistent cache before any
@@ -447,7 +453,7 @@ class MetadataManager(
             val connected = connectionManager.getAllConnectedClients()
             connected.forEach { client ->
                 try {
-                    client.requestEventById(eventId)
+                    client.reqEvent()
                 } catch (_: Exception) {
                 }
             }
@@ -463,7 +469,7 @@ class MetadataManager(
                     scope.launch {
                         if (client.awaitAuthOrTimeout(EVENT_FETCH_AUTH_TIMEOUT_MS) && !_cachedEvents.value.containsKey(eventId)) {
                             try {
-                                client.requestEventById(eventId)
+                                client.reqEvent()
                             } catch (_: Exception) {
                             }
                         }
@@ -481,7 +487,7 @@ class MetadataManager(
                     try {
                         val existing = connectionManager.getClientForRelay(hint)
                         if (existing == null || !existing.isConnected()) {
-                            connectionManager.getOrConnectRelay(hint, messageHandler)?.requestEventById(eventId)
+                            connectionManager.getOrConnectRelay(hint, messageHandler)?.reqEvent()
                         }
                     } catch (_: Exception) {
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
@@ -1,5 +1,7 @@
 package org.nostr.nostrord.nostr
 
+import org.nostr.nostrord.utils.LruCache
+
 /**
  * NIP-19: bech32-encoded entities
  * Supports npub, nsec, note, nprofile, nevent, naddr
@@ -161,7 +163,23 @@ object Nip19 {
     /**
      * Decode any NIP-19 bech32 entity
      */
+    /**
+     * Decoded entities for tokens seen before. Rendering a message re-decodes every reference it
+     * contains on each render, and a decode is base32 + checksum + TLV parsing; entities are
+     * immutable, so sharing them is safe. Secrets are never cached (see [decode]).
+     */
+    private val decodeCache = LruCache<String, Entity>(512)
+
     fun decode(bech32: String): Entity? {
+        decodeCache.get(bech32)?.let { return it }
+        val entity = decodeUncached(bech32) ?: return null
+        // An nsec stays out of any long-lived structure: the app zeroes key material on dispose
+        // and a cache would outlive that.
+        if (entity !is Entity.Nsec) decodeCache.put(bech32, entity)
+        return entity
+    }
+
+    private fun decodeUncached(bech32: String): Entity? {
         val result = Bech32.decode(bech32) ?: return null
         val (hrp, data) = result
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/mentions/MentionAutocomplete.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/mentions/MentionAutocomplete.kt
@@ -1,0 +1,100 @@
+package org.nostr.nostrord.ui.mentions
+
+import org.nostr.nostrord.utils.normalizeForSearch
+
+/**
+ * The mention being typed in a composer: the trigger character, the query after it, and the
+ * trigger's index in the text.
+ */
+data class MentionCtx(
+    val trigger: Char,
+    val query: String,
+    val start: Int,
+) {
+    /** Index just past the typed token: where a replacement ends. */
+    val end: Int get() = start + 1 + query.length
+}
+
+/** Text and caret position after a suggestion replaces the typed token. */
+data class MentionInsertion(
+    val text: String,
+    val cursor: Int,
+)
+
+/**
+ * Trigger detection, candidate filtering and insertion for the `@user` / `%group` autocomplete.
+ * Shared by every composer on both UIs (chat, thread reply, new thread) so the two render trees
+ * agree on when a mention is active and what typing a suggestion produces.
+ */
+object MentionAutocomplete {
+    /** Mentions a person; resolved to `nostr:npub…` plus a `p` tag when the event is built. */
+    const val USER = '@'
+
+    /** Mentions a group; resolved to `nostr:naddr…` in the content by the composer. */
+    const val GROUP = '%'
+
+    /** Rows a popup shows at once; also the keyboard-navigation range. */
+    const val MAX_SUGGESTIONS = 8
+
+    /**
+     * The mention active at [cursor]: the nearest trigger that starts a word and runs unbroken
+     * (no whitespace) up to the caret. Null when there is none.
+     */
+    fun detect(text: String, cursor: Int): MentionCtx? {
+        if (cursor <= 0 || cursor > text.length) return null
+        val before = text.substring(0, cursor)
+        val index = maxOf(before.lastIndexOf(USER), before.lastIndexOf(GROUP))
+        if (index < 0) return null
+        val charBefore = before.getOrNull(index - 1)
+        if (charBefore != null && !charBefore.isWhitespace()) return null
+        val query = before.substring(index + 1)
+        if (query.any { it.isWhitespace() }) return null
+        return MentionCtx(before[index], query, index)
+    }
+
+    /**
+     * Keep [previous] alive when its trigger still runs unbroken to the end of [text], re-reading
+     * the query from the text. The Android IME reports a stale cursor for a frame while composing,
+     * which makes [detect] miss a mention mid-word and flicker the popup closed.
+     */
+    fun sustain(text: String, previous: MentionCtx?): MentionCtx? {
+        val ctx = previous ?: return null
+        if (ctx.start < 0 || ctx.start >= text.length || text[ctx.start] != ctx.trigger) return null
+        val charBefore = text.getOrNull(ctx.start - 1)
+        if (charBefore != null && !charBefore.isWhitespace()) return null
+        val token = text.substring(ctx.start + 1)
+        if (token.any { it.isWhitespace() }) return null
+        return ctx.copy(query = token)
+    }
+
+    /** [detect] at the caret, falling back to [sustain] for the stale-cursor frame. */
+    fun track(text: String, cursor: Int, previous: MentionCtx?): MentionCtx? = detect(text, cursor) ?: sustain(text, previous)
+
+    /**
+     * Candidates matching [query], capped at [limit]. [keys] returns the searchable strings of an
+     * item (display name, pubkey, group id); an empty query offers the head of the list.
+     */
+    fun <T> filter(
+        items: List<T>,
+        query: String,
+        limit: Int = MAX_SUGGESTIONS,
+        keys: (T) -> List<String>,
+    ): List<T> {
+        if (query.isEmpty()) return items.take(limit)
+        val needle = query.normalizeForSearch()
+        return items
+            .filter { item -> keys(item).any { it.normalizeForSearch().contains(needle) } }
+            .take(limit)
+    }
+
+    /**
+     * Replace the typed token with `<trigger><label> `, leaving the caret after the space. The
+     * remainder is left-trimmed so completing mid-sentence never leaves a double space.
+     */
+    fun insert(text: String, ctx: MentionCtx, label: String): MentionInsertion {
+        val before = text.substring(0, ctx.start.coerceIn(0, text.length))
+        val after = text.substring(ctx.end.coerceIn(0, text.length)).trimStart()
+        val token = "${ctx.trigger}$label "
+        return MentionInsertion(before + token + after, before.length + token.length)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui.screens.group
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -39,6 +40,41 @@ data class MentionableGroup(
     val relayUrl: String,
     val meta: GroupMetadata,
 )
+
+/**
+ * Groups offered in the `%group` mention autocomplete: only the ones you're in plus the ones
+ * discovered through people you follow (their kind:10009 lists, and friends present in a group's
+ * member list) - not every group the relay ever served. Matches the friend-based discovery used on
+ * the Home page. Shared by every screen with a composer (chat, threads).
+ */
+@Suppress("UNCHECKED_CAST")
+fun mentionableGroupsFlow(
+    repo: NostrRepositoryApi,
+    scope: CoroutineScope,
+): StateFlow<List<MentionableGroup>> = combine(
+    listOf(
+        repo.groupsByRelay,
+        repo.joinedGroupsByRelay,
+        repo.following,
+        repo.userGroupLists,
+        repo.groupMembers,
+    ),
+) { arr ->
+    val byRelay = arr[0] as Map<String, List<GroupMetadata>>
+    val joinedByRelay = arr[1] as Map<String, Set<String>>
+    val following = arr[2] as Set<String>
+    val lists = arr[3] as Map<String, List<UserGroupRef>>
+    val members = arr[4] as Map<String, List<String>>
+
+    val wanted = HashSet<String>()
+    wanted.addAll(joinedByRelay.values.flatten())
+    following.forEach { f -> lists[f].orEmpty().forEach { wanted.add(it.groupId) } }
+    members.forEach { (gid, pks) -> if (pks.any { it in following }) wanted.add(gid) }
+
+    byRelay
+        .flatMap { (relay, list) -> list.filter { it.id in wanted }.map { MentionableGroup(relay, it) } }
+        .distinctBy { it.meta.id }
+}.stateIn(scope, SharingStarted.Eagerly, emptyList())
 
 /** A follow offered in the add-member friend picker. */
 data class FriendCandidate(
@@ -289,38 +325,8 @@ class GroupViewModel(
     val zaps = repo.zaps
     val cachedEvents = repo.cachedEvents
 
-    /**
-     * Groups offered in the `%group` mention autocomplete: only the ones you're in plus the
-     * ones discovered through people you follow (their kind:10009 lists, and friends present
-     * in a group's member list) - not every group the relay ever served. Matches the
-     * friend-based discovery used on the Home page.
-     */
-    @Suppress("UNCHECKED_CAST")
-    val mentionableGroups: StateFlow<List<MentionableGroup>> =
-        combine(
-            listOf(
-                repo.groupsByRelay,
-                repo.joinedGroupsByRelay,
-                repo.following,
-                repo.userGroupLists,
-                repo.groupMembers,
-            ),
-        ) { arr ->
-            val byRelay = arr[0] as Map<String, List<GroupMetadata>>
-            val joinedByRelay = arr[1] as Map<String, Set<String>>
-            val following = arr[2] as Set<String>
-            val lists = arr[3] as Map<String, List<UserGroupRef>>
-            val members = arr[4] as Map<String, List<String>>
-
-            val wanted = HashSet<String>()
-            wanted.addAll(joinedByRelay.values.flatten())
-            following.forEach { f -> lists[f].orEmpty().forEach { wanted.add(it.groupId) } }
-            members.forEach { (gid, pks) -> if (pks.any { it in following }) wanted.add(gid) }
-
-            byRelay
-                .flatMap { (relay, list) -> list.filter { it.id in wanted }.map { MentionableGroup(relay, it) } }
-                .distinctBy { it.meta.id }
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+    /** Groups offered in the `%group` mention autocomplete; see [mentionableGroupsFlow]. */
+    val mentionableGroups: StateFlow<List<MentionableGroup>> = mentionableGroupsFlow(repo, viewModelScope)
 
     /** The active account's standing in this group; derived once in [GroupMembershipModel]. */
     val membershipState: StateFlow<GroupMembershipState> = membershipModel.membershipState

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -233,6 +233,29 @@ class ThreadsViewModel(
     /** Optimistic-send status per event id (Sending / Failed) - shared with chat via the repo. */
     val messageStatus = repo.messageStatus
 
+    /**
+     * `@user` candidates for the thread composers: the group's kind:39002 member list, falling back
+     * to the authors seen in the group while that list is still empty (same rule as chat, where a
+     * relay that withholds 39002 must not leave the autocomplete blank).
+     */
+    val mentionableMembers: StateFlow<List<String>> =
+        combine(repo.groupMembers, repo.messages, repo.threadRoots, repo.threadReplies) { members, messages, roots, replies ->
+            members[groupId].orEmpty().ifEmpty {
+                (scoped(messages[groupId].orEmpty()) + scoped(roots[groupId].orEmpty()) + scoped(replies[groupId].orEmpty()))
+                    .map { it.pubkey }
+                    .distinct()
+            }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** Admins of this group, so the suggestion list can rank them first (chat parity). */
+    val groupAdmins: StateFlow<List<String>> =
+        repo.groupAdmins
+            .map { it[groupId].orEmpty() }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
+
+    /** `%group` candidates; see [mentionableGroupsFlow]. */
+    val mentionableGroups: StateFlow<List<MentionableGroup>> = mentionableGroupsFlow(repo, viewModelScope)
+
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading
 
@@ -299,11 +322,12 @@ class ThreadsViewModel(
         title: String,
         content: String,
         shareToChat: Boolean = false,
+        mentions: Map<String, String> = emptyMap(),
         onCreated: (rootId: String) -> Unit = {},
     ) {
         if (content.isBlank()) return
         viewModelScope.launch {
-            when (val result = repo.createThread(groupId, title.trim(), content.trim())) {
+            when (val result = repo.createThread(groupId, title.trim(), content.trim(), mentions)) {
                 is Result.Success -> {
                     onCreated(result.data)
                     if (shareToChat) announceThread(result.data, title.trim(), repo.getPublicKey())
@@ -341,13 +365,16 @@ class ThreadsViewModel(
     fun sendReply(
         content: String,
         parent: NostrGroupClient.NostrMessage? = null,
+        mentions: Map<String, String> = emptyMap(),
         onSuccess: () -> Unit = {},
         onFailure: () -> Unit = {},
     ) {
         if (content.isBlank()) return
         val root = openThread.value?.root ?: return
         viewModelScope.launch {
-            val result = withMinDuration { repo.sendThreadReply(groupId, root = root, parent = parent ?: root, content = content.trim()) }
+            val result = withMinDuration {
+                repo.sendThreadReply(groupId, root = root, parent = parent ?: root, content = content.trim(), mentions = mentions)
+            }
             when (result) {
                 is Result.Error -> onFailure()
                 is Result.Success -> onSuccess()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -596,7 +596,10 @@ class FakeNostrRepository : NostrRepositoryApi {
         eventId: String,
         relayHints: List<String>,
         author: String?,
-    ) {}
+        groupId: String?,
+    ) {
+        calls += "requestEventById:$eventId:${groupId ?: "-"}"
+    }
 
     override suspend fun requestAddressableEvent(
         kind: Int,

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -301,8 +301,13 @@ class FakeNostrRepository : NostrRepositoryApi {
         calls += "fetchThread:$groupId:$rootId"
     }
 
-    override suspend fun createThread(groupId: String, title: String, content: String): Result<String> {
-        calls += "createThread:$groupId:$title"
+    override suspend fun createThread(
+        groupId: String,
+        title: String,
+        content: String,
+        mentions: Map<String, String>,
+    ): Result<String> {
+        calls += "createThread:$groupId:$title:${mentions.keys.sorted().joinToString(",")}"
         // A real 32-byte hex id so callers can bech32-encode it (nevent).
         return Result.Success("ab".repeat(32))
     }
@@ -312,8 +317,9 @@ class FakeNostrRepository : NostrRepositoryApi {
         root: NostrGroupClient.NostrMessage,
         parent: NostrGroupClient.NostrMessage,
         content: String,
+        mentions: Map<String, String>,
     ): Result<Unit> {
-        calls += "sendThreadReply:$groupId:${root.id}:${parent.id}"
+        calls += "sendThreadReply:$groupId:${root.id}:${parent.id}:${mentions.keys.sorted().joinToString(",")}"
         return Result.Success(Unit)
     }
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadEventCacheMirrorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadEventCacheMirrorTest.kt
@@ -1,0 +1,74 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.toCachedEvent
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.cache.InMemoryCacheStore
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+private const val MIRROR_PUBKEY = "00000000000000000000000000000000000000000000000000000000cafebabe"
+private const val MIRROR_GROUP = "mirror-group"
+
+/**
+ * A quoted thread ("Share to chat") resolves through the generic by-id event cache, which the
+ * kind-keyed thread stores never reach. Without the mirror the card pays a network round-trip for
+ * an event already in memory, and reads as removed whenever the relay withholds it.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ThreadEventCacheMirrorTest {
+    @AfterTest
+    fun cleanup() = SecureStorage.clearAllMessagesForAccount(MIRROR_PUBKEY)
+
+    private fun manager(scope: TestScope, mirrored: MutableList<NostrGroupClient.NostrMessage>) = GroupManager(
+        connectionManager = ConnectionManager(scope),
+        scope = scope,
+        cacheStore = InMemoryCacheStore(),
+        onThreadEventCached = { mirrored += it },
+    ).apply { setCurrentPubkey(MIRROR_PUBKEY) }
+
+    private val sign: suspend (Event) -> Event = { it.copy(id = it.calculateId(), sig = "ff".repeat(64)) }
+
+    @Test
+    fun `a published thread root reaches the by-id event cache`() = runTest {
+        val scope = TestScope(testScheduler)
+        val mirrored = mutableListOf<NostrGroupClient.NostrMessage>()
+        val manager = manager(scope, mirrored)
+
+        manager.createThread(groupId = MIRROR_GROUP, title = "Release notes", content = "body", pubKey = MIRROR_PUBKEY, signEvent = sign)
+        advanceUntilIdle()
+
+        val root = mirrored.single()
+        assertEquals(11, root.kind)
+        // The card titles itself from the subject tag, so the mirrored copy has to carry the tags.
+        val cached = root.toCachedEvent()
+        assertEquals("Release notes", cached.tags.firstOrNull { it.size >= 2 && it[0] == "subject" }?.get(1))
+        assertEquals(root.id, cached.id)
+        assertEquals(11, cached.kind)
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a reply is mirrored too, so quoting one resolves the same way`() = runTest {
+        val scope = TestScope(testScheduler)
+        val mirrored = mutableListOf<NostrGroupClient.NostrMessage>()
+        val manager = manager(scope, mirrored)
+
+        manager.createThread(groupId = MIRROR_GROUP, title = "Root", content = "body", pubKey = MIRROR_PUBKEY, signEvent = sign)
+        advanceUntilIdle()
+        val root = mirrored.single()
+
+        manager.sendThreadReply(groupId = MIRROR_GROUP, root = root, parent = root, content = "re", pubKey = MIRROR_PUBKEY, signEvent = sign)
+        advanceUntilIdle()
+
+        assertEquals(listOf(11, 1111), mirrored.map { it.kind })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip19Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip19Test.kt
@@ -210,4 +210,17 @@ class Nip19Test {
         val entity = Nip19.Entity.Naddr("id", pubkeyHex, 30023)
         assertEquals(pubkeyHex, Nip19.getPrimaryId(entity))
     }
+
+    @Test
+    fun `decoding is memoized but never caches a secret key`() {
+        val npub = Nip19.encodeNpub("aa".repeat(32))
+        val first = Nip19.decode(npub)
+        assertEquals(first, Nip19.decode(npub))
+
+        // An nsec must not survive in any long-lived structure; it still decodes correctly.
+        val nsec = Nip19.encodeNsec("bb".repeat(32))
+        val secret = Nip19.decode(nsec)
+        assertTrue(secret is Nip19.Entity.Nsec)
+        assertEquals("bb".repeat(32), (secret as Nip19.Entity.Nsec).privkey)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -208,6 +209,55 @@ class ThreadsViewModelTest {
         vm.createThread("Quiet", "body", shareToChat = false)
         testDispatcher.scheduler.advanceUntilIdle()
         assertNull(announced)
+    }
+
+    // -------------------------------------------------------------------------
+    // Mentions
+    // -------------------------------------------------------------------------
+
+    @Test
+    fun `sendReply carries the composer mentions to the repo`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._threadRoots.value = mapOf("g1" to listOf(root("a", 100, "hello")))
+        val vm = ThreadsViewModel(fake, "g1")
+        // openThread is WhileSubscribed: without a collector its value never leaves null and
+        // sendReply would no-op.
+        val job = launch { vm.openThread.collect {} }
+        vm.openThread("a")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        vm.sendReply("hey @Alice", mentions = mapOf("Alice" to "pk_alice"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(fake.calls.any { it == "sendThreadReply:g1:a:a:Alice" }, fake.calls.toString())
+        job.cancel()
+    }
+
+    @Test
+    fun `createThread carries the composer mentions to the repo`() = runTest {
+        val fake = FakeNostrRepository()
+        val vm = ThreadsViewModel(fake, "g1")
+        vm.createThread("Title", "hey @Alice", mentions = mapOf("Alice" to "pk_alice"))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(fake.calls.any { it == "createThread:g1:Title:Alice" }, fake.calls.toString())
+    }
+
+    @Test
+    fun `mention candidates fall back to seen authors until the member list arrives`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._threadRoots.value = mapOf("g1" to listOf(root("a", 100, "hello")))
+        val vm = ThreadsViewModel(fake, "g1")
+        // Collect so the WhileSubscribed flow is live.
+        val job = launch { vm.mentionableMembers.collect {} }
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf("author_a"), vm.mentionableMembers.value)
+
+        // The relay's kind:39002 list supersedes the fallback.
+        fake._groupMembers.value = mapOf("g1" to listOf("pk1", "pk2"))
+        testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals(listOf("pk1", "pk2"), vm.mentionableMembers.value)
+        job.cancel()
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/mentions/MentionAutocompleteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/mentions/MentionAutocompleteTest.kt
@@ -1,0 +1,96 @@
+package org.nostr.nostrord.ui.mentions
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MentionAutocompleteTest {
+    private data class Member(val name: String, val pubkey: String)
+
+    @Test
+    fun `detects a user mention at the caret`() {
+        val ctx = MentionAutocomplete.detect("hey @ali", 8)
+        assertEquals(MentionCtx('@', "ali", 4), ctx)
+    }
+
+    @Test
+    fun `detects a group mention`() {
+        val ctx = MentionAutocomplete.detect("%dev", 4)
+        assertEquals(MentionCtx('%', "dev", 0), ctx)
+    }
+
+    @Test
+    fun `a bare trigger offers the full list`() {
+        assertEquals(MentionCtx('@', "", 0), MentionAutocomplete.detect("@", 1))
+    }
+
+    @Test
+    fun `mid-word trigger is not a mention`() {
+        assertNull(MentionAutocomplete.detect("mail@example", 12))
+        assertNull(MentionAutocomplete.detect("100%sure", 8))
+    }
+
+    @Test
+    fun `a space ends the mention`() {
+        assertNull(MentionAutocomplete.detect("@ali ce", 7))
+    }
+
+    @Test
+    fun `the nearest trigger wins`() {
+        assertEquals(MentionCtx('%', "de", 7), MentionAutocomplete.detect("@alice %de", 10))
+    }
+
+    @Test
+    fun `sustain keeps the mention alive when the IME reports a stale cursor`() {
+        val previous = MentionCtx('@', "al", 4)
+        assertEquals(MentionCtx('@', "ali", 4), MentionAutocomplete.sustain("hey @ali", previous))
+    }
+
+    @Test
+    fun `sustain drops the mention once the token is broken`() {
+        assertNull(MentionAutocomplete.sustain("hey @ali ce", MentionCtx('@', "ali", 4)))
+        assertNull(MentionAutocomplete.sustain("hey there", MentionCtx('@', "ali", 4)))
+    }
+
+    @Test
+    fun `filter matches display name or key and caps the list`() {
+        val members = listOf(
+            Member("Alice", "aa11"),
+            Member("Bob", "bb22"),
+            Member("Alfred", "cc33"),
+        )
+        val keys: (Member) -> List<String> = { listOf(it.name, it.pubkey) }
+
+        assertEquals(listOf("Alice", "Alfred"), MentionAutocomplete.filter(members, "al", keys = keys).map { it.name })
+        assertEquals(listOf("Bob"), MentionAutocomplete.filter(members, "bb2", keys = keys).map { it.name })
+        assertEquals(2, MentionAutocomplete.filter(members, "", limit = 2, keys = keys).size)
+    }
+
+    @Test
+    fun `filter folds decorative unicode like the member search`() {
+        val members = listOf(Member("𝐀lice", "aa11"))
+        assertEquals(1, MentionAutocomplete.filter(members, "ali", keys = { listOf(it.name) }).size)
+    }
+
+    @Test
+    fun `insert replaces the typed token and leaves the caret after it`() {
+        val ctx = MentionCtx('@', "ali", 4)
+        val result = MentionAutocomplete.insert("hey @ali", ctx, "Alice")
+        assertEquals("hey @Alice ", result.text)
+        assertEquals(result.text.length, result.cursor)
+    }
+
+    @Test
+    fun `insert mid-sentence keeps the rest without doubling the space`() {
+        val ctx = MentionCtx('@', "al", 4)
+        val result = MentionAutocomplete.insert("hey @al how are you", ctx, "Alice")
+        assertEquals("hey @Alice how are you", result.text)
+        assertEquals("hey @Alice ".length, result.cursor)
+    }
+
+    @Test
+    fun `insert handles a group label with spaces`() {
+        val ctx = MentionCtx('%', "no", 0)
+        assertEquals("%Nostr Devs ", MentionAutocomplete.insert("%no", ctx, "Nostr Devs").text)
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MentionField.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MentionField.kt
@@ -1,0 +1,157 @@
+package org.nostr.nostrord.ui.components.chat
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
+import org.nostr.nostrord.ui.mentions.MentionCtx
+import org.nostr.nostrord.ui.screens.group.components.GroupMentionPopup
+import org.nostr.nostrord.ui.screens.group.components.MentionPopup
+import org.nostr.nostrord.ui.screens.group.components.getFilteredGroups
+import org.nostr.nostrord.ui.screens.group.components.getFilteredMembers
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
+import org.nostr.nostrord.ui.screens.group.model.MemberInfo
+
+/**
+ * The `@user` / `%group` autocomplete attached to one text field: which mention is being typed and
+ * which suggestion is highlighted. Lives next to the field's [TextFieldValue]; the field feeds it
+ * through [onValueChange] and asks it to rewrite the text through [apply].
+ *
+ * Only one trigger is ever active at a caret, so a single context covers both kinds.
+ */
+@Stable
+class MentionFieldState {
+    var ctx by mutableStateOf<MentionCtx?>(null)
+        private set
+
+    var selectedIndex by mutableStateOf(0)
+        private set
+
+    val trigger: Char? get() = ctx?.trigger
+
+    val query: String get() = ctx?.query.orEmpty()
+
+    val isActive: Boolean get() = ctx != null
+
+    /** Re-track the mention after a text edit; a changed query resets the highlighted row. */
+    fun onValueChange(value: TextFieldValue) {
+        val next = MentionAutocomplete.track(value.text, value.selection.start, ctx)
+        if (next?.query != ctx?.query) selectedIndex = 0
+        ctx = next
+    }
+
+    fun dismiss() {
+        ctx = null
+        selectedIndex = 0
+    }
+
+    fun moveSelection(delta: Int, matchCount: Int) {
+        if (matchCount <= 0) return
+        selectedIndex = (selectedIndex + delta).coerceIn(0, matchCount - 1)
+    }
+
+    /** [value] with the typed token replaced by [label], caret after it. Null when idle. */
+    fun apply(value: TextFieldValue, label: String): TextFieldValue? {
+        val active = ctx ?: return null
+        val inserted = MentionAutocomplete.insert(value.text, active, label)
+        dismiss()
+        return TextFieldValue(inserted.text, TextRange(inserted.cursor))
+    }
+}
+
+@Composable
+fun rememberMentionFieldState(): MentionFieldState = remember { MentionFieldState() }
+
+/** Header + divider of a suggestion list, in dp: lets a floating popup offset itself above a field. */
+internal const val MENTION_POPUP_HEADER_DP = 30
+
+/** One suggestion row, in dp. */
+internal const val MENTION_POPUP_ROW_DP = 36
+
+/** Members offered for the active `@` mention; empty while a `%` (or no) mention is being typed. */
+fun MentionFieldState.memberMatches(members: List<MemberInfo>): List<MemberInfo> = if (trigger == MentionAutocomplete.USER) getFilteredMembers(members, query) else emptyList()
+
+/** Groups offered for the active `%` mention; empty while a `@` (or no) mention is being typed. */
+fun MentionFieldState.groupMatches(groups: List<GroupInfo>): List<GroupInfo> = if (trigger == MentionAutocomplete.GROUP) getFilteredGroups(groups, query) else emptyList()
+
+/**
+ * Popup keyboard handling for a composer: Esc closes, arrows move the highlight, Enter/Tab confirm.
+ * Returns true when the key was consumed, so the field's own Enter-sends stays out of the way while
+ * a suggestion list is open.
+ */
+fun MentionFieldState.handleKeyEvent(
+    event: KeyEvent,
+    matchCount: Int,
+    onConfirm: () -> Unit,
+): Boolean {
+    if (event.type != KeyEventType.KeyDown || !isActive) return false
+    return when (event.key) {
+        Key.Escape -> {
+            dismiss()
+            true
+        }
+        Key.DirectionUp -> if (matchCount > 0) {
+            moveSelection(-1, matchCount)
+            true
+        } else {
+            false
+        }
+        Key.DirectionDown -> if (matchCount > 0) {
+            moveSelection(1, matchCount)
+            true
+        } else {
+            false
+        }
+        Key.Enter, Key.Tab -> if (matchCount > 0) {
+            onConfirm()
+            true
+        } else {
+            false
+        }
+        else -> false
+    }
+}
+
+/**
+ * The suggestion list for whichever mention is active: members for `@`, groups for `%`, nothing
+ * when idle. Placement is the caller's (inline above the field on Android, a floating Popup
+ * elsewhere), so this renders only the list itself.
+ */
+@Composable
+fun MentionSuggestions(
+    state: MentionFieldState,
+    members: List<MemberInfo>,
+    groups: List<GroupInfo>,
+    onMemberSelect: (MemberInfo) -> Unit,
+    onGroupSelect: (GroupInfo) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (state.trigger) {
+        MentionAutocomplete.USER -> MentionPopup(
+            members = members,
+            query = state.query,
+            selectedIndex = state.selectedIndex,
+            onMemberSelect = onMemberSelect,
+            modifier = modifier,
+        )
+        MentionAutocomplete.GROUP -> GroupMentionPopup(
+            groups = groups,
+            query = state.query,
+            selectedIndex = state.selectedIndex,
+            onGroupSelect = onGroupSelect,
+            modifier = modifier,
+        )
+        else -> Unit
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
@@ -27,7 +29,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -36,12 +40,15 @@ import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.launch
+import org.nostr.nostrord.getPlatform
 import org.nostr.nostrord.network.upload.FileTooLargeException
 import org.nostr.nostrord.network.upload.MAX_UPLOAD_BYTES
 import org.nostr.nostrord.network.upload.PasteMediaEffect
@@ -52,10 +59,15 @@ import org.nostr.nostrord.network.upload.uploadMedia
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.ui.components.upload.MessageUploadButton
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
+import org.nostr.nostrord.ui.screens.group.components.MentionVisualTransformation
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
+import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.utils.Result
 
 /**
@@ -63,6 +75,11 @@ import org.nostr.nostrord.utils.Result
  * .composer parity): attach button, caret-aware text field (paste-image + emoji), and a send
  * button that swaps the glyph for a spinner while [isSending], matching the group MessageInput.
  * Callers own [value] so they can clear it on send; uploads/emoji append through [onValueChange].
+ *
+ * Passing [members] / [availableGroups] turns on the `@user` / `%group` autocomplete: picking a
+ * suggestion writes the token into the text and reports it through [onMentionsChange] /
+ * [onGroupMentionsChange], which the caller resolves at send time. Left empty (the DM page) the
+ * composer behaves as a plain field.
  */
 @Composable
 fun MessageComposer(
@@ -74,12 +91,68 @@ fun MessageComposer(
     modifier: Modifier = Modifier,
     // Lets a caller put the caret here (picking Reply focuses the composer to type into).
     focusRequester: FocusRequester? = null,
+    members: List<MemberInfo> = emptyList(),
+    availableGroups: List<GroupInfo> = emptyList(),
+    // displayName -> pubkey, resolved to nostr:npub + a p tag when the event is built.
+    mentions: Map<String, String> = emptyMap(),
+    onMentionsChange: (Map<String, String>) -> Unit = {},
+    // groupName -> the mentioned group, resolved to nostr:naddr in the content by the caller.
+    groupMentions: Map<String, GroupInfo> = emptyMap(),
+    onGroupMentionsChange: (Map<String, GroupInfo>) -> Unit = {},
 ) {
     var showEmojiPicker by remember { mutableStateOf(false) }
     var isUploadingPaste by remember { mutableStateOf(false) }
     var pasteError by remember { mutableStateOf<String?>(null) }
     val clipboardReader = rememberClipboardImageReader()
     val scope = rememberCoroutineScope()
+
+    val mentionState = rememberMentionFieldState()
+    val memberMatches = mentionState.memberMatches(members)
+    val groupMatches = mentionState.groupMatches(availableGroups)
+    val isAndroid = remember { getPlatform().name.startsWith("Android") }
+
+    // Keep a stable VisualTransformation instance: rebuilding it every recomposition restarts the
+    // Android IME session, which drops the character being typed while the popup is open.
+    val emojiFontFamily = rememberEmojiFontFamily()
+    val mentionVisualTransformation = remember(mentions.keys, groupMentions.keys, emojiFontFamily) {
+        MentionVisualTransformation(
+            mentionedNames = mentions.keys,
+            mentionColor = NostrordColors.MentionText,
+            emojiFontFamily = emojiFontFamily,
+            groupMentionedNames = groupMentions.keys,
+        )
+    }
+
+    fun changeText(newValue: TextFieldValue) {
+        onValueChange(newValue)
+        mentionState.onValueChange(newValue)
+    }
+
+    fun selectMember(member: MemberInfo) {
+        val updated = mentionState.apply(value, member.displayName) ?: return
+        onValueChange(updated)
+        if (!mentions.containsKey(member.displayName)) {
+            onMentionsChange(mentions + (member.displayName to member.pubkey))
+        }
+        focusRequester?.requestFocus()
+    }
+
+    fun selectGroup(group: GroupInfo) {
+        val updated = mentionState.apply(value, group.name) ?: return
+        onValueChange(updated)
+        if (!groupMentions.containsKey(group.name)) {
+            onGroupMentionsChange(groupMentions + (group.name to group))
+        }
+        focusRequester?.requestFocus()
+    }
+
+    fun confirmMention() {
+        memberMatches.getOrNull(mentionState.selectedIndex)?.let {
+            selectMember(it)
+            return
+        }
+        groupMatches.getOrNull(mentionState.selectedIndex)?.let { selectGroup(it) }
+    }
 
     val canSend = value.text.isNotBlank() && !isSending && !isUploadingPaste
 
@@ -107,151 +180,228 @@ fun MessageComposer(
         }
     }
 
-    Box(modifier = modifier.fillMaxWidth()) {
-        Row(
-            modifier =
-            Modifier
-                .fillMaxWidth()
-                .clip(NostrordShapes.inputShape)
-                .background(NostrordColors.SurfaceVariant)
-                .padding(horizontal = Spacing.md, vertical = Spacing.sm),
-            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            MessageUploadButton(
-                externalBusy = isUploadingPaste,
-                onUploadComplete = { uploadResult -> appendUploadedUrl(uploadResult.url) },
-            )
-            BasicTextField(
-                value = value,
-                onValueChange = onValueChange,
-                cursorBrush = SolidColor(NostrordColors.TextContent),
-                textStyle = NostrordTypography.Input.copy(color = NostrordColors.TextContent),
-                maxLines = 7,
-                modifier =
-                Modifier
-                    .weight(1f)
-                    .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
-                    .onPreviewKeyEvent { event ->
-                        when {
-                            event.type == KeyEventType.KeyDown && event.key == Key.Escape && showEmojiPicker -> {
-                                showEmojiPicker = false
-                                true
-                            }
-                            // Ctrl+V media: read the clipboard image and upload it.
-                            event.type == KeyEventType.KeyDown && event.key == Key.V && event.isCtrlPressed && !isUploadingPaste -> {
-                                val hasMedia = runCatching { clipboardReader.hasImage() }.getOrDefault(false)
-                                if (hasMedia) {
-                                    isUploadingPaste = true
-                                    scope.launch {
-                                        val image =
-                                            try {
-                                                clipboardReader.read()
-                                            } catch (e: FileTooLargeException) {
-                                                isUploadingPaste = false
-                                                pasteError = e.message
-                                                return@launch
-                                            } catch (e: UnsupportedFileTypeException) {
-                                                isUploadingPaste = false
-                                                pasteError = e.message
-                                                return@launch
-                                            }
-                                        if (image == null) {
-                                            isUploadingPaste = false
-                                            return@launch
-                                        }
-                                        handlePastedMedia(image.first, image.second)
-                                    }
-                                    true
-                                } else {
-                                    false
-                                }
-                            }
-                            event.type == KeyEventType.KeyDown && event.key == Key.Enter && event.isShiftPressed -> {
-                                val sel = value.selection
-                                val t = value.text
-                                val newText = t.substring(0, sel.start) + "\n" + t.substring(sel.end)
-                                onValueChange(TextFieldValue(newText, TextRange(sel.start + 1)))
-                                true
-                            }
-                            event.type == KeyEventType.KeyDown && event.key == Key.Enter && !event.isShiftPressed -> {
-                                if (canSend) onSend()
-                                true
-                            }
-                            else -> false
-                        }
-                    },
-                decorationBox = { innerTextField ->
-                    Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.padding(vertical = 4.dp)) {
-                        if (value.text.isEmpty()) {
-                            Text(
-                                placeholder,
-                                style = NostrordTypography.InputPlaceholder,
-                                color = NostrordColors.TextMuted,
-                            )
-                        }
-                        innerTextField()
-                    }
-                },
-            )
-            IconButton(
-                onClick = { showEmojiPicker = !showEmojiPicker },
-                modifier = Modifier.size(width = 26.dp, height = 32.dp),
+    Column(modifier = modifier.fillMaxWidth()) {
+        // Android renders the suggestions inline (same window): a Popup is a separate Android
+        // window whose add/remove restarts the IME InputConnection and eats the character being
+        // typed. canFocus = false keeps the clickable rows from stealing focus from the field.
+        if (isAndroid && (memberMatches.isNotEmpty() || groupMatches.isNotEmpty())) {
+            Box(
+                modifier = Modifier
+                    .focusProperties { canFocus = false }
+                    .fillMaxWidth()
+                    .heightIn(max = 240.dp)
+                    .padding(bottom = Spacing.sm),
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.EmojiEmotions,
-                    contentDescription = "Emoji",
-                    tint = if (showEmojiPicker) NostrordColors.Primary else NostrordColors.TextMuted,
-                    modifier = Modifier.size(20.dp),
+                MentionSuggestions(
+                    state = mentionState,
+                    members = members,
+                    groups = availableGroups,
+                    onMemberSelect = { selectMember(it) },
+                    onGroupSelect = { selectGroup(it) },
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
-            IconButton(
-                onClick = onSend,
-                enabled = canSend,
-                modifier = Modifier.size(width = 26.dp, height = 32.dp),
+        }
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .clip(NostrordShapes.inputShape)
+                    .background(NostrordColors.SurfaceVariant)
+                    .padding(horizontal = Spacing.md, vertical = Spacing.sm),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                if (isSending) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        color = NostrordColors.Primary,
-                        strokeWidth = 2.dp,
-                    )
-                } else {
+                MessageUploadButton(
+                    externalBusy = isUploadingPaste,
+                    onUploadComplete = { uploadResult -> appendUploadedUrl(uploadResult.url) },
+                )
+                BasicTextField(
+                    value = value,
+                    onValueChange = { changeText(it) },
+                    cursorBrush = SolidColor(NostrordColors.TextContent),
+                    textStyle = NostrordTypography.Input.copy(color = NostrordColors.TextContent),
+                    visualTransformation = mentionVisualTransformation,
+                    maxLines = 7,
+                    modifier =
+                    Modifier
+                        .weight(1f)
+                        .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
+                        .onFocusChanged { focusState ->
+                            // Android drops focus transiently while the IME composes; dismissing there
+                            // would flicker the inline list. Typing or Esc closes it instead.
+                            if (!isAndroid && !focusState.isFocused) mentionState.dismiss()
+                        }
+                        .onPreviewKeyEvent { event ->
+                            // The popup owns Esc / arrows / Enter / Tab while it is open, so Enter
+                            // completes the highlighted suggestion instead of sending.
+                            if (mentionState.handleKeyEvent(
+                                    event,
+                                    maxOf(memberMatches.size, groupMatches.size),
+                                ) { confirmMention() }
+                            ) {
+                                return@onPreviewKeyEvent true
+                            }
+                            when {
+                                event.type == KeyEventType.KeyDown && event.key == Key.Escape && showEmojiPicker -> {
+                                    showEmojiPicker = false
+                                    true
+                                }
+                                // Ctrl+V media: read the clipboard image and upload it.
+                                event.type == KeyEventType.KeyDown && event.key == Key.V && event.isCtrlPressed && !isUploadingPaste -> {
+                                    val hasMedia = runCatching { clipboardReader.hasImage() }.getOrDefault(false)
+                                    if (hasMedia) {
+                                        isUploadingPaste = true
+                                        scope.launch {
+                                            val image =
+                                                try {
+                                                    clipboardReader.read()
+                                                } catch (e: FileTooLargeException) {
+                                                    isUploadingPaste = false
+                                                    pasteError = e.message
+                                                    return@launch
+                                                } catch (e: UnsupportedFileTypeException) {
+                                                    isUploadingPaste = false
+                                                    pasteError = e.message
+                                                    return@launch
+                                                }
+                                            if (image == null) {
+                                                isUploadingPaste = false
+                                                return@launch
+                                            }
+                                            handlePastedMedia(image.first, image.second)
+                                        }
+                                        true
+                                    } else {
+                                        false
+                                    }
+                                }
+                                event.type == KeyEventType.KeyDown && event.key == Key.Enter && event.isShiftPressed -> {
+                                    val sel = value.selection
+                                    val t = value.text
+                                    val newText = t.substring(0, sel.start) + "\n" + t.substring(sel.end)
+                                    changeText(TextFieldValue(newText, TextRange(sel.start + 1)))
+                                    true
+                                }
+                                event.type == KeyEventType.KeyDown && event.key == Key.Enter && !event.isShiftPressed -> {
+                                    if (canSend) onSend()
+                                    true
+                                }
+                                else -> false
+                            }
+                        },
+                    decorationBox = { innerTextField ->
+                        Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.padding(vertical = 4.dp)) {
+                            if (value.text.isEmpty()) {
+                                Text(
+                                    placeholder,
+                                    style = NostrordTypography.InputPlaceholder,
+                                    color = NostrordColors.TextMuted,
+                                )
+                            }
+                            innerTextField()
+                        }
+                    },
+                )
+                IconButton(
+                    onClick = { showEmojiPicker = !showEmojiPicker },
+                    modifier = Modifier.size(width = 26.dp, height = 32.dp),
+                ) {
                     Icon(
-                        imageVector = Icons.AutoMirrored.Filled.Send,
-                        contentDescription = "Send",
-                        tint = if (value.text.isNotBlank()) NostrordColors.Primary else NostrordColors.TextMuted,
+                        imageVector = Icons.Outlined.EmojiEmotions,
+                        contentDescription = "Emoji",
+                        tint = if (showEmojiPicker) NostrordColors.Primary else NostrordColors.TextMuted,
                         modifier = Modifier.size(20.dp),
                     )
                 }
-            }
-        }
-
-        if (showEmojiPicker) {
-            Popup(
-                alignment = Alignment.BottomEnd,
-                onDismissRequest = { showEmojiPicker = false },
-                properties = PopupProperties(focusable = true),
-            ) {
-                Box(
-                    modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null,
-                            onClick = { showEmojiPicker = false },
-                        ),
+                IconButton(
+                    onClick = onSend,
+                    enabled = canSend,
+                    modifier = Modifier.size(width = 26.dp, height = 32.dp),
                 ) {
-                    EmojiPicker(
-                        onEmojiSelect = { emoji ->
-                            val t = value.text
-                            val cursor = value.selection.start
-                            val newText = t.substring(0, cursor) + emoji + t.substring(cursor)
-                            onValueChange(TextFieldValue(newText, TextRange(cursor + emoji.length)))
-                        },
-                        onDismiss = { showEmojiPicker = false },
-                        modifier = Modifier.align(Alignment.BottomEnd).padding(end = Spacing.lg, bottom = 56.dp),
+                    if (isSending) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            color = NostrordColors.Primary,
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.Send,
+                            contentDescription = "Send",
+                            tint = if (value.text.isNotBlank()) NostrordColors.Primary else NostrordColors.TextMuted,
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
+            }
+
+            if (showEmojiPicker) {
+                Popup(
+                    alignment = Alignment.BottomEnd,
+                    onDismissRequest = { showEmojiPicker = false },
+                    properties = PopupProperties(focusable = true),
+                ) {
+                    Box(
+                        modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = { showEmojiPicker = false },
+                            ),
+                    ) {
+                        EmojiPicker(
+                            onEmojiSelect = { emoji ->
+                                val t = value.text
+                                val cursor = value.selection.start
+                                val newText = t.substring(0, cursor) + emoji + t.substring(cursor)
+                                changeText(TextFieldValue(newText, TextRange(cursor + emoji.length)))
+                            },
+                            onDismiss = { showEmojiPicker = false },
+                            modifier = Modifier.align(Alignment.BottomEnd).padding(end = Spacing.lg, bottom = 56.dp),
+                        )
+                    }
+                }
+            }
+
+            // Desktop / iOS float the list over the page; the transparent scrim above it closes on an
+            // outside tap (dismissOnClickOutside stays off so soft-keyboard taps never close it).
+            if (!isAndroid && (memberMatches.isNotEmpty() || groupMatches.isNotEmpty())) {
+                val density = LocalDensity.current
+                val rows = maxOf(memberMatches.size, groupMatches.size).coerceAtMost(MentionAutocomplete.MAX_SUGGESTIONS)
+                val popupHeightPx = with(density) { (MENTION_POPUP_HEADER_DP + rows * MENTION_POPUP_ROW_DP).dp.roundToPx() }
+
+                Popup(
+                    alignment = Alignment.Center,
+                    onDismissRequest = { mentionState.dismiss() },
+                    properties = PopupProperties(focusable = false, dismissOnClickOutside = false),
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null,
+                                onClick = { mentionState.dismiss() },
+                            ),
+                    )
+                }
+
+                Popup(
+                    alignment = Alignment.TopStart,
+                    offset = IntOffset(x = 0, y = -popupHeightPx),
+                    onDismissRequest = { mentionState.dismiss() },
+                    properties = PopupProperties(focusable = false, dismissOnClickOutside = false, dismissOnBackPress = true),
+                ) {
+                    MentionSuggestions(
+                        state = mentionState,
+                        members = members,
+                        groups = availableGroups,
+                        onMemberSelect = { selectMember(it) },
+                        onGroupSelect = { selectGroup(it) },
                     )
                 }
             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -1789,7 +1789,7 @@ private fun QuotedEvent(
     LaunchedEffect(eventId, relayHints, author, retryTick) {
         if (!cachedEvents.containsKey(eventId)) {
             eventNotFound = false
-            AppModule.nostrRepository.requestEventById(eventId, relayHints, author)
+            AppModule.nostrRepository.requestEventById(eventId, relayHints, author, currentGroupId)
             // Poll every 500ms up to 5s — yields the coroutine instead of blocking 5s solid
             repeat(10) {
                 kotlinx.coroutines.delay(500)
@@ -1924,8 +1924,9 @@ private fun QuotedEvent(
                     )
                     Text(
                         // Deleted and unreachable look identical from here (the relay just does
-                        // not serve it), so the copy must not claim either one.
-                        text = "Event removed or unavailable",
+                        // not serve it), so the copy must not claim either one. The nevent's kind
+                        // hint names what is missing even though the event never resolved.
+                        text = if (kind == 11) "Thread removed or unavailable" else "Event removed or unavailable",
                         color = NostrordColors.TextMuted,
                         style = NostrordTypography.Caption,
                     )
@@ -2014,7 +2015,7 @@ private fun QuotedEvent(
                 .padding(Spacing.md),
         ) {
             Text(
-                text = "Loading event...",
+                text = if (kind == 11) "Loading thread..." else "Loading event...",
                 color = NostrordColors.TextMuted,
                 style = NostrordTypography.Caption,
             )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -1367,8 +1367,12 @@ private fun ThreadQuoteCard(
     val groupId = extractGroupFromEvent(event)?.first ?: currentGroupId
     val navigate = LocalFrameNavigator.current
     val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
-    val groupName = groupId?.let { gid -> groupsByRelay.values.flatten().firstOrNull { it.id == gid }?.name }
-        ?.takeIf { it.isNotBlank() }
+    // Flattening every relay's group list is an allocation plus a linear scan, and this card sits
+    // in a scrolling list: keyed so it runs when the lists change, not on every recomposition.
+    val groupName = remember(groupsByRelay, groupId) {
+        groupId?.let { gid -> groupsByRelay.values.flatten().firstOrNull { it.id == gid }?.name }
+            ?.takeIf { it.isNotBlank() }
+    }
 
     val title = event.tags.firstOrNull { it.size >= 2 && (it[0] == "subject" || it[0] == "title") }
         ?.get(1)?.trim()?.takeIf { it.isNotEmpty() }
@@ -1867,8 +1871,10 @@ private fun QuotedEvent(
                 // cross-relay forwarded group still shows its name + avatar; fetch a preview from
                 // the relay hint when we don't know it yet (parity with web / GroupLinkCard).
                 val sourceGroup =
-                    groupsByRelay.values.flatten().find { it.id == sourceGroupId }
-                        ?: groups.find { it.id == sourceGroupId }
+                    remember(groupsByRelay, groups, sourceGroupId) {
+                        groupsByRelay.values.flatten().find { it.id == sourceGroupId }
+                            ?: groups.find { it.id == sourceGroupId }
+                    }
                 val previewRelay = sourceRelayUrl ?: relayHints.firstOrNull()
                 LaunchedEffect(sourceGroupId, previewRelay, sourceGroup?.name) {
                     if (sourceGroup?.name == null && previewRelay != null) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt
@@ -53,10 +53,12 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
@@ -150,7 +152,6 @@ fun AppField(
             lineHeight = TextUnit.Unspecified,
         )
     val visual = if (masked) PasswordVisualTransformation() else VisualTransformation.None
-    val colors = appFieldColors(containerColor)
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
@@ -173,40 +174,126 @@ fun AppField(
         ),
         interactionSource = interactionSource,
         decorationBox = { innerTextField ->
-            OutlinedTextFieldDefaults.DecorationBox(
-                value = value,
-                innerTextField = innerTextField,
+            AppFieldDecoration(
+                text = value,
+                placeholder = placeholder,
                 enabled = enabled,
                 singleLine = singleLine,
-                visualTransformation = visual,
+                visual = visual,
                 interactionSource = interactionSource,
-                placeholder =
-                placeholder?.let {
-                    {
-                        Text(
-                            it,
-                            // Same TextStyle as the value (only the color differs) so the field
-                            // is the exact same height empty or filled; a placeholder with a
-                            // different line height made the box grow/shrink as you typed.
-                            style = textStyle.copy(color = NostrordColors.TextMuted),
-                            maxLines = if (singleLine) 1 else Int.MAX_VALUE,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
-                },
                 leadingIcon = leadingIcon,
                 trailingIcon = trailingIcon,
+                containerColor = containerColor,
+                textStyle = textStyle,
+                innerTextField = innerTextField,
+            )
+        },
+    )
+}
+
+/**
+ * [AppField] over a [TextFieldValue], for callers that need the caret position (mention
+ * autocomplete). Same chrome as the String overload; masking and IME actions stay there since no
+ * caret-aware field wants them.
+ */
+@Composable
+fun AppField(
+    value: TextFieldValue,
+    onValueChange: (TextFieldValue) -> Unit,
+    modifier: Modifier = Modifier,
+    placeholder: String? = null,
+    enabled: Boolean = true,
+    singleLine: Boolean = true,
+    minLines: Int = 1,
+    maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    containerColor: Color = NostrordColors.BackgroundFloating,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    val textStyle =
+        LocalTextStyle.current.copy(
+            color = NostrordColors.TextContent,
+            fontSize = 14.sp,
+            lineHeight = TextUnit.Unspecified,
+        )
+    BasicTextField(
+        value = value,
+        onValueChange = onValueChange,
+        modifier = modifier,
+        enabled = enabled,
+        textStyle = textStyle,
+        cursorBrush = SolidColor(NostrordColors.Primary),
+        visualTransformation = visualTransformation,
+        singleLine = singleLine,
+        minLines = minLines,
+        maxLines = maxLines,
+        interactionSource = interactionSource,
+        decorationBox = { innerTextField ->
+            AppFieldDecoration(
+                text = value.text,
+                placeholder = placeholder,
+                enabled = enabled,
+                singleLine = singleLine,
+                visual = visualTransformation,
+                interactionSource = interactionSource,
+                leadingIcon = null,
+                trailingIcon = null,
+                containerColor = containerColor,
+                textStyle = textStyle,
+                innerTextField = innerTextField,
+            )
+        },
+    )
+}
+
+/** The bordered box, placeholder and icons both [AppField] overloads wrap their field in. */
+@Composable
+private fun AppFieldDecoration(
+    text: String,
+    placeholder: String?,
+    enabled: Boolean,
+    singleLine: Boolean,
+    visual: VisualTransformation,
+    interactionSource: MutableInteractionSource,
+    leadingIcon: (@Composable () -> Unit)?,
+    trailingIcon: (@Composable () -> Unit)?,
+    containerColor: Color,
+    textStyle: TextStyle,
+    innerTextField: @Composable () -> Unit,
+) {
+    val colors = appFieldColors(containerColor)
+    OutlinedTextFieldDefaults.DecorationBox(
+        value = text,
+        innerTextField = innerTextField,
+        enabled = enabled,
+        singleLine = singleLine,
+        visualTransformation = visual,
+        interactionSource = interactionSource,
+        placeholder =
+        placeholder?.let {
+            {
+                Text(
+                    it,
+                    // Same TextStyle as the value (only the color differs) so the field is the
+                    // exact same height empty or filled; a placeholder with a different line
+                    // height made the box grow/shrink as you typed.
+                    style = textStyle.copy(color = NostrordColors.TextMuted),
+                    maxLines = if (singleLine) 1 else Int.MAX_VALUE,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        },
+        leadingIcon = leadingIcon,
+        trailingIcon = trailingIcon,
+        colors = colors,
+        contentPadding = AppFieldContentPadding,
+        container = {
+            OutlinedTextFieldDefaults.Container(
+                enabled = enabled,
+                isError = false,
+                interactionSource = interactionSource,
                 colors = colors,
-                contentPadding = AppFieldContentPadding,
-                container = {
-                    OutlinedTextFieldDefaults.Container(
-                        enabled = enabled,
-                        isError = false,
-                        interactionSource = interactionSource,
-                        colors = colors,
-                        shape = AppFieldShape,
-                    )
-                },
+                shape = AppFieldShape,
             )
         },
     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -56,6 +57,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
@@ -97,6 +99,8 @@ import org.nostr.nostrord.ui.screens.group.components.CreateThreadDialog
 import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
 import org.nostr.nostrord.ui.screens.group.components.JoinGroupConfirmDialog
 import org.nostr.nostrord.ui.screens.group.components.UserProfileModal
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
+import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
@@ -217,6 +221,45 @@ fun ThreadsScreen(
     var deleteTarget by remember { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
     var reply by remember { mutableStateOf(TextFieldValue("")) }
     var sending by remember { mutableStateOf(false) }
+
+    // Composer mentions: displayName -> pubkey for @user (resolved to nostr:npub + a p tag by the
+    // repo), name -> group for %group (resolved to nostr:naddr here, at send).
+    var replyMentions by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var replyGroupMentions by remember { mutableStateOf<Map<String, GroupInfo>>(emptyMap()) }
+    val memberPubkeys by vm.mentionableMembers.collectAsState()
+    val adminPubkeys by vm.groupAdmins.collectAsState()
+    val mentionableGroups by vm.mentionableGroups.collectAsState()
+    val relayMetadata by AppModule.nostrRepository.relayMetadata.collectAsState()
+    val mentionMembers by remember(memberPubkeys, adminPubkeys, userMetadata) {
+        derivedStateOf {
+            memberPubkeys
+                .map { pubkey ->
+                    val metadata = userMetadata[pubkey]
+                    MemberInfo(
+                        pubkey = pubkey,
+                        displayName = metadata?.displayName ?: metadata?.name ?: shortNpub(pubkey),
+                        picture = metadata?.picture,
+                        isAdmin = pubkey in adminPubkeys,
+                    )
+                }.sortedWith(compareByDescending<MemberInfo> { it.isAdmin }.thenBy { it.displayName.lowercase() })
+        }
+    }
+    val mentionGroups by remember(mentionableGroups) {
+        derivedStateOf {
+            mentionableGroups.map { GroupInfo(it.meta.id, it.meta.name ?: it.meta.id, it.meta.picture, it.relayUrl) }
+        }
+    }
+
+    /** Swap each `%name` for the mentioned group's naddr, carrying its own hosting relay. */
+    fun resolveGroupMentions(text: String, chosen: Map<String, GroupInfo>): String {
+        var content = text
+        chosen.forEach { (name, group) ->
+            val relayPubkey = relayMetadata[group.relay]?.groupNaddrAuthor
+            val naddr = Nip19.encodeNaddr(group.id, group.relay, pubkeyHex = relayPubkey)
+            content = content.replace("%$name", "nostr:$naddr")
+        }
+        return content
+    }
     // Shared with MessageContent via LocalImageViewerUrl: tap an inline image -> fullscreen viewer.
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
 
@@ -402,10 +445,13 @@ fun ThreadsScreen(
                             if (reply.text.isNotBlank() && !sending) {
                                 sending = true
                                 vm.sendReply(
-                                    reply.text.trim(),
+                                    resolveGroupMentions(reply.text.trim(), replyGroupMentions),
                                     parent = replyingTo,
+                                    mentions = replyMentions,
                                     onSuccess = {
                                         reply = TextFieldValue("")
+                                        replyMentions = emptyMap()
+                                        replyGroupMentions = emptyMap()
                                         replyingTo = null
                                         sending = false
                                     },
@@ -416,6 +462,12 @@ fun ThreadsScreen(
                         placeholder = "Write a reply...",
                         isSending = sending,
                         focusRequester = composerFocus,
+                        members = mentionMembers,
+                        availableGroups = mentionGroups,
+                        mentions = replyMentions,
+                        onMentionsChange = { replyMentions = it },
+                        groupMentions = replyGroupMentions,
+                        onGroupMentionsChange = { replyGroupMentions = it },
                         modifier = Modifier.padding(Spacing.md),
                     )
                 }
@@ -514,13 +566,15 @@ fun ThreadsScreen(
     if (showCompose) {
         CreateThreadDialog(
             onDismiss = { showCompose = false },
-            onCreate = { title, content, shareToChat ->
+            onCreate = { title, content, shareToChat, mentions, groupMentions ->
                 // Open the new thread right away (Discord parity; the optimistic root is
                 // already in the store, so the detail renders instantly).
-                vm.createThread(title, content, shareToChat) { rootId ->
+                vm.createThread(title, resolveGroupMentions(content, groupMentions), shareToChat, mentions) { rootId ->
                     onNavigate(route.copy(threadRootId = rootId))
                 }
             },
+            members = mentionMembers,
+            availableGroups = mentionGroups,
         )
     }
 
@@ -591,6 +645,14 @@ fun ThreadsScreen(
             pubkey = pk,
             metadata = userMetadata[pk],
             userMetadata = userMetadata,
+            // Mention drops the name into the reply composer, chat parity.
+            onMention = { name ->
+                val separator = if (reply.text.isEmpty() || reply.text.endsWith(" ")) "" else " "
+                val appended = reply.text + separator + "@$name "
+                reply = TextFieldValue(appended, TextRange(appended.length))
+                replyMentions = replyMentions + (name to pk)
+                selectedUserPubkey = null
+            },
             onDismiss = { selectedUserPubkey = null },
         )
     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateThreadDialog.kt
@@ -24,31 +24,78 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.nostr.nostrord.ui.components.buttons.AppButton
 import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.components.chat.MentionSuggestions
+import org.nostr.nostrord.ui.components.chat.groupMatches
+import org.nostr.nostrord.ui.components.chat.handleKeyEvent
+import org.nostr.nostrord.ui.components.chat.memberMatches
+import org.nostr.nostrord.ui.components.chat.rememberMentionFieldState
 import org.nostr.nostrord.ui.components.forms.AppField
 import org.nostr.nostrord.ui.components.upload.MessageUploadButton
+import org.nostr.nostrord.ui.screens.group.model.GroupInfo
+import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 
 /**
  * Compose-a-new-thread dialog (kind:11 root): native mirror of the web CreateThreadModal. Title is
- * the thread headline (required), then the body. Logic stays in [org.nostr.nostrord.ui.screens.group.ThreadsViewModel];
- * this is pure UI and reports back through [onCreate].
+ * the thread headline (required), then the body, which takes the same `@user` / `%group`
+ * autocomplete as the chat and reply composers. Logic stays in
+ * [org.nostr.nostrord.ui.screens.group.ThreadsViewModel]; this is pure UI and reports back through
+ * [onCreate], which receives the chosen mentions so the caller can resolve them at publish.
  */
 @Composable
 fun CreateThreadDialog(
     onDismiss: () -> Unit,
-    onCreate: (title: String, content: String, shareToChat: Boolean) -> Unit,
+    onCreate: (
+        title: String,
+        content: String,
+        shareToChat: Boolean,
+        mentions: Map<String, String>,
+        groupMentions: Map<String, GroupInfo>,
+    ) -> Unit,
+    members: List<MemberInfo> = emptyList(),
+    availableGroups: List<GroupInfo> = emptyList(),
 ) {
     var title by remember { mutableStateOf("") }
-    var body by remember { mutableStateOf("") }
+    var body by remember { mutableStateOf(TextFieldValue("")) }
+    var mentions by remember { mutableStateOf<Map<String, String>>(emptyMap()) }
+    var groupMentions by remember { mutableStateOf<Map<String, GroupInfo>>(emptyMap()) }
+
+    val emojiFontFamily = rememberEmojiFontFamily()
+    val mentionVisualTransformation = remember(mentions.keys, groupMentions.keys, emojiFontFamily) {
+        MentionVisualTransformation(
+            mentionedNames = mentions.keys,
+            mentionColor = NostrordColors.MentionText,
+            emojiFontFamily = emojiFontFamily,
+            groupMentionedNames = groupMentions.keys,
+        )
+    }
+
+    val mentionState = rememberMentionFieldState()
+    val memberMatches = mentionState.memberMatches(members)
+    val groupMatches = mentionState.groupMatches(availableGroups)
+
+    fun selectMember(member: MemberInfo) {
+        body = mentionState.apply(body, member.displayName) ?: return
+        mentions = mentions + (member.displayName to member.pubkey)
+    }
+
+    fun selectGroup(group: GroupInfo) {
+        body = mentionState.apply(body, group.name) ?: return
+        groupMentions = groupMentions + (group.name to group)
+    }
 
     // Default on: announcing the new thread in chat is the common case; one click opts out.
     var shareToChat by remember { mutableStateOf(true) }
@@ -95,19 +142,46 @@ fun CreateThreadDialog(
                         // Attach media to the thread body (rendered inline like chat).
                         MessageUploadButton(
                             onUploadComplete = { result ->
-                                body = if (body.isBlank()) result.url else "$body ${result.url}"
+                                val current = body.text
+                                val appended = if (current.isBlank()) result.url else "$current ${result.url}"
+                                body = TextFieldValue(appended, TextRange(appended.length))
                             },
                         )
                     }
                     Spacer(Modifier.height(Spacing.xs))
                     AppField(
                         value = body,
-                        onValueChange = { body = it },
+                        onValueChange = {
+                            body = it
+                            mentionState.onValueChange(it)
+                        },
                         placeholder = "Start a discussion...",
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .onPreviewKeyEvent { event ->
+                                mentionState.handleKeyEvent(event, maxOf(memberMatches.size, groupMatches.size)) {
+                                    memberMatches.getOrNull(mentionState.selectedIndex)?.let { selectMember(it) }
+                                        ?: groupMatches.getOrNull(mentionState.selectedIndex)?.let { selectGroup(it) }
+                                }
+                            },
                         singleLine = false,
                         minLines = 4,
+                        visualTransformation = mentionVisualTransformation,
                     )
+
+                    // Inline below the field: a floating Popup inside a Dialog lands in its own
+                    // window and would sit behind the scrim on desktop.
+                    if (memberMatches.isNotEmpty() || groupMatches.isNotEmpty()) {
+                        Spacer(Modifier.height(Spacing.xs))
+                        MentionSuggestions(
+                            state = mentionState,
+                            members = members,
+                            groups = availableGroups,
+                            onMemberSelect = { selectMember(it) },
+                            onGroupSelect = { selectGroup(it) },
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
 
                     Spacer(Modifier.height(Spacing.sm))
                     // Announce the new thread in the group chat (kind:9 with the root's nevent).
@@ -125,10 +199,10 @@ fun CreateThreadDialog(
                         AppButton(
                             text = "Publish thread",
                             onClick = {
-                                onCreate(title, body, shareToChat)
+                                onCreate(title, body.text, shareToChat, mentions, groupMentions)
                                 onDismiss()
                             },
-                            enabled = title.isNotBlank() && body.isNotBlank(),
+                            enabled = title.isNotBlank() && body.text.isNotBlank(),
                         )
                     }
                 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupMentionPopup.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/GroupMentionPopup.kt
@@ -30,27 +30,19 @@ import coil3.compose.LocalPlatformContext
 import coil3.request.CachePolicy
 import coil3.request.ImageRequest
 import coil3.request.crossfade
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
 import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.util.generateColorFromString
-import org.nostr.nostrord.utils.normalizeForSearch
 
+/** Groups offered for `%query`; the count also drives keyboard navigation in the composers. */
 fun getFilteredGroups(
     groups: List<GroupInfo>,
     query: String,
-): List<GroupInfo> = if (query.isEmpty()) {
-    groups.take(8)
-} else {
-    val normalizedQuery = query.normalizeForSearch()
-    groups
-        .filter { group ->
-            group.name.normalizeForSearch().contains(normalizedQuery) ||
-                group.id.contains(query, ignoreCase = true)
-        }.take(8)
-}
+): List<GroupInfo> = MentionAutocomplete.filter(groups, query) { listOf(it.name, it.id) }
 
 @Composable
 fun GroupMentionPopup(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MentionPopup.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MentionPopup.kt
@@ -19,31 +19,22 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
-import org.nostr.nostrord.utils.normalizeForSearch
 import org.nostr.nostrord.utils.shortNpub
 
 /**
- * Get filtered members based on query for mention popup.
- * Used by MessageInput to know the count for keyboard navigation.
+ * Members offered for `@query`. Also used by the composers to know the count for keyboard
+ * navigation, so the highlighted row and the rendered list can never disagree.
  */
 fun getFilteredMembers(
     members: List<MemberInfo>,
     query: String,
-): List<MemberInfo> = if (query.isEmpty()) {
-    members.take(8)
-} else {
-    val normalizedQuery = query.normalizeForSearch()
-    members
-        .filter { member ->
-            member.displayName.normalizeForSearch().contains(normalizedQuery) ||
-                member.pubkey.contains(query, ignoreCase = true)
-        }.take(8)
-}
+): List<MemberInfo> = MentionAutocomplete.filter(members, query) { listOf(it.displayName, it.pubkey) }
 
 @Composable
 fun MentionPopup(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -75,6 +75,8 @@ import org.nostr.nostrord.network.upload.uploadMedia
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.ui.components.upload.MessageUploadButton
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
+import org.nostr.nostrord.ui.mentions.MentionCtx
 import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
 import org.nostr.nostrord.ui.theme.NostrordColors
@@ -231,28 +233,14 @@ fun MessageInput(
         }
     }
 
+    // Only one trigger can be active at a caret, so each state block asks for its own.
     fun findMentionContext(text: String, cursorPosition: Int, trigger: Char): Pair<Int, String> {
-        if (cursorPosition <= 0 || cursorPosition > text.length) return Pair(-1, "")
-        val triggerIndex = text.substring(0, cursorPosition).lastIndexOf(trigger)
-        if (triggerIndex == -1) return Pair(-1, "")
-        val charBefore = text.getOrNull(triggerIndex - 1)
-        if (charBefore != null && !charBefore.isWhitespace()) return Pair(-1, "")
-        val queryPart = text.substring(triggerIndex + 1, cursorPosition)
-        if (queryPart.contains(' ') || queryPart.contains('\n')) return Pair(-1, "")
-        return Pair(triggerIndex, queryPart)
+        val ctx = MentionAutocomplete.detect(text, cursorPosition)?.takeIf { it.trigger == trigger }
+            ?: return Pair(-1, "")
+        return Pair(ctx.start, ctx.query)
     }
 
-    // The Android IME can briefly report a stale/zeroed cursor while composing,
-    // which makes findMentionContext fail for one frame. As long as the trigger
-    // token still runs unbroken to the end of the text, treat the mention as
-    // active so the popup doesn't flicker closed mid-typing.
-    fun triggerStillActive(text: String, startIndex: Int, trigger: Char): Boolean {
-        if (startIndex < 0 || startIndex >= text.length || text[startIndex] != trigger) return false
-        val charBefore = text.getOrNull(startIndex - 1)
-        if (charBefore != null && !charBefore.isWhitespace()) return false
-        val token = text.substring(startIndex + 1)
-        return !token.contains(' ') && !token.contains('\n')
-    }
+    fun triggerStillActive(text: String, startIndex: Int, trigger: Char): Boolean = MentionAutocomplete.sustain(text, MentionCtx(trigger, "", startIndex)) != null
 
     fun updateMentionState(value: TextFieldValue) {
         val (index, query) = findMentionContext(value.text, value.selection.start, '@')
@@ -348,21 +336,12 @@ fun MessageInput(
     }
 
     fun handleMemberSelect(member: MemberInfo) {
-        val currentText = textFieldValue.text
-        val beforeMention = currentText.substring(0, mentionStartIndex)
-        val afterMention = if (mentionStartIndex + 1 + mentionQuery.length < currentText.length) {
-            currentText.substring(mentionStartIndex + 1 + mentionQuery.length).trimStart()
-        } else {
-            ""
-        }
-        val mentionPart = "@${member.displayName} "
-        val newText = if (afterMention.isEmpty()) {
-            "$beforeMention$mentionPart"
-        } else {
-            "$beforeMention$mentionPart$afterMention"
-        }
-        val cursorPosition = beforeMention.length + mentionPart.length
-        textFieldValue = TextFieldValue(newText, TextRange(cursorPosition))
+        val inserted = MentionAutocomplete.insert(
+            textFieldValue.text,
+            MentionCtx(MentionAutocomplete.USER, mentionQuery, mentionStartIndex),
+            member.displayName,
+        )
+        textFieldValue = TextFieldValue(inserted.text, TextRange(inserted.cursor))
         if (!mentions.containsKey(member.displayName)) {
             onMentionsChange(mentions + (member.displayName to member.pubkey))
         }
@@ -373,21 +352,12 @@ fun MessageInput(
     }
 
     fun handleGroupSelect(group: GroupInfo) {
-        val currentText = textFieldValue.text
-        val beforeMention = currentText.substring(0, groupMentionStartIndex)
-        val afterMention = if (groupMentionStartIndex + 1 + groupMentionQuery.length < currentText.length) {
-            currentText.substring(groupMentionStartIndex + 1 + groupMentionQuery.length).trimStart()
-        } else {
-            ""
-        }
-        val mentionPart = "%${group.name} "
-        val newText = if (afterMention.isEmpty()) {
-            "$beforeMention$mentionPart"
-        } else {
-            "$beforeMention$mentionPart$afterMention"
-        }
-        val cursorPosition = beforeMention.length + mentionPart.length
-        textFieldValue = TextFieldValue(newText, TextRange(cursorPosition))
+        val inserted = MentionAutocomplete.insert(
+            textFieldValue.text,
+            MentionCtx(MentionAutocomplete.GROUP, groupMentionQuery, groupMentionStartIndex),
+            group.name,
+        )
+        textFieldValue = TextFieldValue(inserted.text, TextRange(inserted.cursor))
         if (!groupMentions.containsKey(group.name)) {
             onGroupMentionsChange(groupMentions + (group.name to group))
         }
@@ -1425,7 +1395,9 @@ private val emojiRegex = Regex(
         "]+",
 )
 
-private class MentionVisualTransformation(
+/** Tints the resolved `@user` / `%group` tokens in a composer (and shapes emoji with the emoji
+ *  font). Shared by the chat and thread composers so a chosen mention reads the same everywhere. */
+internal class MentionVisualTransformation(
     private val mentionedNames: Set<String>,
     private val mentionColor: Color,
     private val emojiFontFamily: FontFamily? = null,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/MentionPopup.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/MentionPopup.kt
@@ -1,0 +1,183 @@
+package org.nostr.nostrord.web.components
+
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
+import org.nostr.nostrord.ui.mentions.MentionCtx
+import org.nostr.nostrord.ui.screens.group.MentionableGroup
+import org.nostr.nostrord.utils.shortNpub
+import react.ChildrenBuilder
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.span
+import web.cssom.ClassName
+
+/** Profile name for [pubkey], else a short npub. The label a mention is typed and rendered as. */
+fun mentionDisplayName(pubkey: String, meta: UserMetadata?): String = meta?.displayName?.takeIf { it.isNotBlank() }
+    ?: meta?.name?.takeIf { it.isNotBlank() }
+    ?: shortNpub(pubkey)
+
+/** A single autocomplete row: how to show it, its subtitle, and the `nostr:` ref it resolves to. */
+data class MentionMatch(
+    val label: String,
+    val picture: String?,
+    val seed: String,
+    val group: Boolean,
+    val ref: String,
+    val sub: String,
+)
+
+/** Rows a web composer popup shows at once. */
+const val MENTION_MATCH_LIMIT = 6
+
+/**
+ * Suggestions for the mention being typed: members for `@`, groups for `%`, empty when idle.
+ * Shared by every web composer (chat, thread reply, new thread) so all three rank and label alike.
+ */
+fun mentionMatches(
+    ctx: MentionCtx?,
+    members: List<String>,
+    userMetadata: Map<String, UserMetadata>,
+    groups: List<MentionableGroup>,
+    relayPubkeyOf: (String) -> String?,
+): List<MentionMatch> = when (ctx?.trigger) {
+    MentionAutocomplete.USER ->
+        MentionAutocomplete
+            .filter(members, ctx.query, MENTION_MATCH_LIMIT) { pk -> listOf(mentionDisplayName(pk, userMetadata[pk]), pk) }
+            .map { pk ->
+                MentionMatch(
+                    label = mentionDisplayName(pk, userMetadata[pk]),
+                    picture = userMetadata[pk]?.picture,
+                    seed = pk,
+                    group = false,
+                    ref = "nostr:" + Nip19.encodeNpub(pk),
+                    sub = shortNpub(pk) + pk.takeLast(4),
+                )
+            }
+
+    MentionAutocomplete.GROUP ->
+        MentionAutocomplete
+            .filter(groups, ctx.query, MENTION_MATCH_LIMIT) { listOf(it.meta.name ?: it.meta.id, it.meta.id) }
+            .map { mg ->
+                // The naddr carries the mentioned group's OWN hosting relay (and that relay's
+                // pubkey), not the current one, so following the mention navigates correctly.
+                val host = mg.relayUrl.removePrefix("wss://").removePrefix("ws://").trimEnd('/')
+                MentionMatch(
+                    label = mg.meta.name ?: mg.meta.id,
+                    picture = mg.meta.picture,
+                    seed = mg.meta.id,
+                    group = true,
+                    ref = "nostr:" + Nip19.encodeNaddr(mg.meta.id, mg.relayUrl, 39000, relayPubkeyOf(mg.relayUrl)),
+                    sub = host,
+                )
+            }
+
+    else -> emptyList()
+}
+
+/** A run of composer text, flagged as a resolved mention (tinted) or plain. */
+data class MentionSegment(
+    val text: String,
+    val mention: Boolean,
+)
+
+/**
+ * Split [text] into plain / mention runs for a composer's colored mirror. Only the literal [tokens]
+ * (`@alice`, `%my group`) that are resolved mentions are tinted, the same rule as native's
+ * MentionVisualTransformation: it colors the chosen mentions, not every "@word".
+ */
+fun mentionSegments(text: String, tokens: Collection<String>): List<MentionSegment> {
+    if (text.isEmpty()) return emptyList()
+    val colored = BooleanArray(text.length)
+    tokens.forEach { token ->
+        if (token.isEmpty()) return@forEach
+        var i = text.indexOf(token)
+        while (i >= 0) {
+            for (j in i until i + token.length) colored[j] = true
+            i = text.indexOf(token, i + token.length)
+        }
+    }
+    val segments = mutableListOf<MentionSegment>()
+    var start = 0
+    for (k in 1..text.length) {
+        if (k == text.length || colored[k] != colored[start]) {
+            segments.add(MentionSegment(text.substring(start, k), colored[start]))
+            start = k
+        }
+    }
+    return segments
+}
+
+/** The mirror's content: the draft with its resolved mentions wrapped in `.msg-mention`. */
+fun ChildrenBuilder.mentionHighlight(text: String, tokens: Collection<String>) {
+    mentionSegments(text, tokens).forEach { seg ->
+        if (seg.mention) {
+            span {
+                className = ClassName("msg-mention")
+                +seg.text
+            }
+        } else {
+            +seg.text
+        }
+    }
+}
+
+external interface MentionPopupProps : Props {
+    var matches: List<MentionMatch>
+
+    /** Trigger being completed; picks the MEMBERS / GROUPS header. */
+    var trigger: Char
+
+    /** Highlighted row, driven by the composer's arrow keys and hover. */
+    var selected: Int
+    var onPick: (MentionMatch) -> Unit
+    var onHover: (Int) -> Unit
+}
+
+/**
+ * The `@user` / `%group` suggestion list. Absolutely positioned against the nearest positioned
+ * ancestor (the composer area), so it floats above the composer instead of being clipped by it.
+ */
+val MentionPopup =
+    FC<MentionPopupProps> { props ->
+        if (props.matches.isEmpty()) return@FC
+        div {
+            className = ClassName("mention-popup")
+            div {
+                className = ClassName("mention-header")
+                +(if (props.trigger == MentionAutocomplete.GROUP) "GROUPS" else "MEMBERS")
+            }
+            val sel = props.selected.coerceIn(0, props.matches.size - 1)
+            props.matches.forEachIndexed { idx, mm ->
+                div {
+                    key = mm.ref
+                    className = ClassName(if (idx == sel) "mention-row selected" else "mention-row")
+                    // Keep the composer's focus and caret: the click must not blur the field.
+                    onMouseDown = { e ->
+                        e.preventDefault()
+                        props.onPick(mm)
+                    }
+                    onMouseEnter = { props.onHover(idx) }
+                    WebAvatar {
+                        url = mm.picture
+                        seed = mm.seed
+                        this.name = mm.label
+                        kind = if (mm.group) AvatarKind.GROUP else AvatarKind.USER
+                        cls = "mention-avatar"
+                    }
+                    div {
+                        className = ClassName("mention-text")
+                        span {
+                            className = ClassName("mention-name")
+                            +mm.label
+                        }
+                        span {
+                            className = ClassName("mention-key")
+                            +mm.sub
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt
@@ -1,8 +1,15 @@
 package org.nostr.nostrord.web.modals
 
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
+import org.nostr.nostrord.ui.mentions.MentionCtx
+import org.nostr.nostrord.ui.screens.group.MentionableGroup
 import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.MentionMatch
+import org.nostr.nostrord.web.components.MentionPopup
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.mentionMatches
 import org.nostr.nostrord.web.components.useEscClose
 import react.FC
 import react.Props
@@ -19,8 +26,20 @@ import web.html.checkbox
 external interface CreateThreadModalProps : Props {
     var onClose: () -> Unit
 
-    /** Publish a new thread: (title, content, shareToChat). Title becomes the subject/title tags. */
-    var onCreate: (String, String, Boolean) -> Unit
+    /**
+     * Publish a new thread: (title, content, shareToChat, mentions). Title becomes the
+     * subject/title tags; mentions maps each typed `@displayName` to its pubkey. `%group`
+     * mentions are already resolved to their `nostr:naddr` inside content.
+     */
+    var onCreate: (String, String, Boolean, Map<String, String>) -> Unit
+
+    /** `@user` candidates (the group's members) and `%group` candidates, as in the composers. */
+    var members: List<String>
+    var allGroups: List<MentionableGroup>
+    var userMetadata: Map<String, UserMetadata>
+
+    /** Relay's NIP-11 pubkey, the naddr author of a `%group` mention on that relay. */
+    var relayPubkeyOf: (String) -> String?
 }
 
 /**
@@ -36,7 +55,22 @@ val CreateThreadModal =
         // Default on: announcing the new thread in chat is the common case; one click opts out.
         val (shareToChat, setShareToChat) = useState { true }
 
-        useEscClose { props.onClose() }
+        // Same @user / %group autocomplete the chat and reply composers carry.
+        val (mention, setMention) = useState<MentionCtx?> { null }
+        val (mentions, setMentions) = useState<Map<String, String>> { emptyMap() }
+        val (groupMentions, setGroupMentions) = useState<Map<String, String>> { emptyMap() }
+        val (mentionSelected, setMentionSelected) = useState { 0 }
+        val suggestions = mentionMatches(mention, props.members, props.userMetadata, props.allGroups, props.relayPubkeyOf)
+
+        fun insertMention(mm: MentionMatch) {
+            val ctx = mention ?: return
+            setBody(MentionAutocomplete.insert(body, ctx, mm.label).text)
+            if (mm.group) setGroupMentions { it + (mm.label to mm.ref) } else setMentions { it + (mm.label to mm.seed) }
+            setMention(null)
+            setMentionSelected(0)
+        }
+
+        useEscClose { if (mention != null) setMention(null) else props.onClose() }
 
         div {
             className = ClassName("modal-overlay")
@@ -89,11 +123,51 @@ val CreateThreadModal =
                         onError = { setUploadError(it) }
                     }
                 }
-                textarea {
-                    className = ClassName("modal-textarea")
-                    placeholder = "Start a discussion..."
-                    value = body
-                    onChange = { event -> setBody(event.currentTarget.value) }
+                div {
+                    className = ClassName("mention-anchor")
+                    // Stable keys: without them, mounting the popup shifts the textarea's position
+                    // among its siblings and React remounts it, dropping the caret mid-word.
+                    if (mention != null && suggestions.isNotEmpty()) {
+                        MentionPopup {
+                            key = "mention-popup"
+                            matches = suggestions
+                            trigger = mention.trigger
+                            selected = mentionSelected
+                            onPick = { insertMention(it) }
+                            onHover = { setMentionSelected(it) }
+                        }
+                    }
+                    textarea {
+                        key = "thread-body"
+                        className = ClassName("modal-textarea")
+                        placeholder = "Start a discussion..."
+                        value = body
+                        onChange = { event ->
+                            val v = event.currentTarget.value
+                            setBody(v)
+                            val cursor = (event.currentTarget.asDynamic().selectionStart as? Int) ?: v.length
+                            setMention(MentionAutocomplete.detect(v, cursor))
+                            setMentionSelected(0)
+                        }
+                        onKeyDown = { e ->
+                            val hasMatches = mention != null && suggestions.isNotEmpty()
+                            when {
+                                hasMatches && e.key == "ArrowDown" -> {
+                                    e.preventDefault()
+                                    setMentionSelected { (it + 1).coerceAtMost(suggestions.size - 1) }
+                                }
+                                hasMatches && e.key == "ArrowUp" -> {
+                                    e.preventDefault()
+                                    setMentionSelected { (it - 1).coerceAtLeast(0) }
+                                }
+                                hasMatches && (e.key == "Enter" || e.key == "Tab") -> {
+                                    e.preventDefault()
+                                    insertMention(suggestions[mentionSelected.coerceIn(0, suggestions.size - 1)])
+                                }
+                            }
+                        }
+                        onBlur = { setMention(null) }
+                    }
                 }
                 uploadError?.let {
                     div {
@@ -123,7 +197,11 @@ val CreateThreadModal =
                         className = ClassName("btn-primary")
                         disabled = title.isBlank() || body.isBlank()
                         onClick = {
-                            props.onCreate(title, body, shareToChat)
+                            // %group mentions resolve to their naddr here; @user mentions ride the
+                            // map so the event also carries their p tags.
+                            var content = body
+                            groupMentions.forEach { (name, ref) -> content = content.replace("%$name", ref) }
+                            props.onCreate(title, content, shareToChat, mentions)
                             props.onClose()
                         }
                         +"Publish thread"

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -24,6 +24,8 @@ import org.nostr.nostrord.nostr.Nip68
 import org.nostr.nostrord.nostr.Nip84
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.keyboard.VirtualKeyboardPolicy
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
+import org.nostr.nostrord.ui.mentions.MentionCtx
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.GroupView
 import org.nostr.nostrord.ui.screens.group.GroupMembership
@@ -57,6 +59,8 @@ import org.nostr.nostrord.web.components.ChatVideo
 import org.nostr.nostrord.web.components.EmojiPicker
 import org.nostr.nostrord.web.components.Ic
 import org.nostr.nostrord.web.components.LiveSpaceBar
+import org.nostr.nostrord.web.components.MentionMatch
+import org.nostr.nostrord.web.components.MentionPopup
 import org.nostr.nostrord.web.components.Spoiler
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
@@ -66,6 +70,9 @@ import org.nostr.nostrord.web.components.confirmDialog
 import org.nostr.nostrord.web.components.copyToClipboard
 import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.memberSkeleton
+import org.nostr.nostrord.web.components.mentionDisplayName
+import org.nostr.nostrord.web.components.mentionHighlight
+import org.nostr.nostrord.web.components.mentionMatches
 import org.nostr.nostrord.web.components.messageSendStatus
 import org.nostr.nostrord.web.components.messageSkeleton
 import org.nostr.nostrord.web.components.reactionBadges
@@ -200,74 +207,14 @@ private fun processMentions(content: String, userMetadata: Map<String, UserMetad
     }.getOrDefault(match.value)
 }
 
-private fun displayName(pubkey: String, meta: UserMetadata?): String = meta?.displayName?.takeIf { it.isNotBlank() }
-    ?: meta?.name?.takeIf { it.isNotBlank() }
-    ?: shortNpub(pubkey)
-
-/** Active mention being typed in the composer: the trigger (@ or %), its query, and start index. */
-private data class MentionCtx(val trigger: Char, val query: String, val start: Int)
-
-/** A single autocomplete suggestion: how to show it, a subtitle, and the `nostr:` ref to insert. */
-private data class MentionMatch(
-    val label: String,
-    val picture: String?,
-    val seed: String,
-    val group: Boolean,
-    val ref: String,
-    val sub: String,
-)
-
-/**
- * Find the mention being typed at [cursor]: the nearest `@`/`%` that starts a word and runs
- * unbroken (no whitespace) up to the cursor. Returns null when there's no active mention.
- */
-private fun detectMention(text: String, cursor: Int): MentionCtx? {
-    val before = text.take(cursor)
-    val idx = maxOf(before.lastIndexOf('@'), before.lastIndexOf('%'))
-    if (idx < 0) return null
-    val boundary = idx == 0 || before[idx - 1].isWhitespace()
-    if (!boundary) return null
-    val query = before.substring(idx + 1)
-    if (query.any { it.isWhitespace() }) return null
-    return MentionCtx(before[idx], query, idx)
-}
+private fun displayName(pubkey: String, meta: UserMetadata?): String = mentionDisplayName(pubkey, meta)
 
 /** A mention requested from the profile modal, inserted into the composer draft. */
 private data class MentionRequest(val name: String, val pubkey: String, val nonce: Int)
 
-/** A run of composer text, flagged as a resolved @mention (gold) or plain. */
-private data class HlSeg(val text: String, val mention: Boolean)
-
 /** Per-message values that depend only on the message (+ group/relay), precomputed once per
  *  message-list change so the row list doesn't re-encode bech32 + re-serialize JSON every render. */
 private data class RowMeta(val nevent: String, val eventJson: String, val link: String)
-
-/**
- * Split [text] into plain / mention runs for the composer's colored mirror. Only the literal
- * [tokens] (e.g. "@alice", "%my group") that are resolved mentions are tinted — same rule as
- * native's MentionVisualTransformation (it colors the chosen mentions, not every "@word").
- */
-private fun highlightSegments(text: String, tokens: Collection<String>): List<HlSeg> {
-    if (text.isEmpty()) return emptyList()
-    val colored = BooleanArray(text.length)
-    tokens.forEach { token ->
-        if (token.isEmpty()) return@forEach
-        var i = text.indexOf(token)
-        while (i >= 0) {
-            for (j in i until i + token.length) colored[j] = true
-            i = text.indexOf(token, i + token.length)
-        }
-    }
-    val segs = mutableListOf<HlSeg>()
-    var start = 0
-    for (k in 1..text.length) {
-        if (k == text.length || colored[k] != colored[start]) {
-            segs.add(HlSeg(text.substring(start, k), colored[start]))
-            start = k
-        }
-    }
-    return segs
-}
 
 /** Markdown-toolbar button (prototype FmtBtn). Unsupported tokens render disabled. */
 private fun ChildrenBuilder.fmtBtn(ic: Ic, label: String, disabled: Boolean = false, onSelect: () -> Unit) {
@@ -399,52 +346,12 @@ private val ChatComposer =
         }
 
         // Autocomplete suggestions for the active mention (members for @, groups for %).
-        val mentionMatches: List<MentionMatch> =
-            when (mention?.trigger) {
-                '@' -> {
-                    val normalizedQuery = mention.query.normalizeForSearch()
-                    members.asSequence()
-                        .map { pk -> pk to displayName(pk, userMetadata[pk]) }
-                        .filter { (_, nm) -> mention.query.isBlank() || nm.normalizeForSearch().contains(normalizedQuery) }
-                        .take(6)
-                        .map { (pk, nm) ->
-                            MentionMatch(
-                                nm,
-                                userMetadata[pk]?.picture,
-                                pk,
-                                group = false,
-                                ref = "nostr:" + Nip19.encodeNpub(pk),
-                                sub = shortNpub(pk) + pk.takeLast(4),
-                            )
-                        }
-                        .toList()
-                }
-                '%' -> {
-                    val normalizedQuery = mention.query.normalizeForSearch()
-                    allGroups.asSequence()
-                        .filter { mg ->
-                            mention.query.isBlank() ||
-                                (mg.meta.name ?: mg.meta.id).normalizeForSearch().contains(normalizedQuery)
-                        }
-                        .take(6)
-                        .map { mg ->
-                            // Encode the naddr with the group's OWN hosting relay (and that relay's
-                            // pubkey), not the current chat relay, so the mention navigates correctly.
-                            val gRelayHost = mg.relayUrl.removePrefix("wss://").removePrefix("ws://").trimEnd('/')
-                            val ref = "nostr:" + Nip19.encodeNaddr(mg.meta.id, mg.relayUrl, 39000, props.relayPubkeyOf(mg.relayUrl))
-                            MentionMatch(mg.meta.name ?: mg.meta.id, mg.meta.picture, mg.meta.id, group = true, ref = ref, sub = gRelayHost)
-                        }
-                        .toList()
-                }
-                else -> emptyList()
-            }
+        val mentionMatches = mentionMatches(mention, members, userMetadata, allGroups, props.relayPubkeyOf)
 
         // Replace the typed "@query"/"%query" with the chosen suggestion.
         fun insertMention(mm: MentionMatch) {
             val m = mention ?: return
-            val cursorEnd = (m.start + 1 + m.query.length).coerceAtMost(draft.length)
-            val inserted = if (mm.group) "%${mm.label}" else "@${mm.label}"
-            setDraft(draft.take(m.start) + inserted + " " + draft.substring(cursorEnd))
+            setDraft(MentionAutocomplete.insert(draft, m, mm.label).text)
             if (mm.group) {
                 setGroupMentions { it + (mm.label to mm.ref) }
             } else {
@@ -736,43 +643,13 @@ private val ChatComposer =
                 // Mention popup floats above the frame (anchored to the area, the
                 // frame's overflow:hidden would clip it inside the input row).
                 if (mention != null && mentionMatches.isNotEmpty()) {
-                    div {
+                    MentionPopup {
                         key = "mention-popup"
-                        className = ClassName("mention-popup")
-                        div {
-                            className = ClassName("mention-header")
-                            +(if (mention.trigger == '%') "GROUPS" else "MEMBERS")
-                        }
-                        val sel = mentionSelected.coerceIn(0, mentionMatches.size - 1)
-                        mentionMatches.forEachIndexed { idx, mm ->
-                            div {
-                                key = mm.ref
-                                className = ClassName(if (idx == sel) "mention-row selected" else "mention-row")
-                                onMouseDown = { e ->
-                                    e.preventDefault()
-                                    insertMention(mm)
-                                }
-                                onMouseEnter = { setMentionSelected(idx) }
-                                WebAvatar {
-                                    url = mm.picture
-                                    seed = mm.seed
-                                    this.name = mm.label
-                                    kind = if (mm.group) AvatarKind.GROUP else AvatarKind.USER
-                                    cls = "mention-avatar"
-                                }
-                                div {
-                                    className = ClassName("mention-text")
-                                    span {
-                                        className = ClassName("mention-name")
-                                        +mm.label
-                                    }
-                                    span {
-                                        className = ClassName("mention-key")
-                                        +mm.sub
-                                    }
-                                }
-                            }
-                        }
+                        matches = mentionMatches
+                        trigger = mention.trigger
+                        selected = mentionSelected
+                        onPick = { insertMention(it) }
+                        onHover = { setMentionSelected(it) }
                     }
                 }
 
@@ -879,17 +756,7 @@ private val ChatComposer =
                             div {
                                 className = ClassName("composer-highlight")
                                 ref = composerHighlightRef
-                                val tokens = mentions.keys.map { "@$it" } + groupMentions.keys.map { "%$it" }
-                                highlightSegments(draft, tokens).forEach { seg ->
-                                    if (seg.mention) {
-                                        span {
-                                            className = ClassName("msg-mention")
-                                            +seg.text
-                                        }
-                                    } else {
-                                        +seg.text
-                                    }
-                                }
+                                mentionHighlight(draft, mentions.keys.map { "@$it" } + groupMentions.keys.map { "%$it" })
                             }
                             textarea {
                                 ref = composerInputRef
@@ -912,7 +779,7 @@ private val ChatComposer =
                                     if (showHints) setShowHints(false)
                                     setDraft(v)
                                     val cursor = (event.currentTarget.asDynamic().selectionStart as? Int) ?: v.length
-                                    setMention(detectMention(v, cursor))
+                                    setMention(MentionAutocomplete.detect(v, cursor))
                                     setMentionSelected(0)
                                 }
                                 onKeyDown = { event ->

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -2142,6 +2142,7 @@ val ChatScreen =
                                                 this.myPubkey = myPubkey
                                                 this.userMetadata = userMetadata
                                                 this.messagesById = messagesById
+                                                this.groupId = group.id
                                                 onEventRef = { id -> scrollToMessage(id) }
                                                 onGroupRef = { gid, relay -> props.onNavigateGroup(gid, relay) }
                                                 canZap =
@@ -2746,6 +2747,9 @@ external interface MessageRowProps : Props {
     var myPubkey: String?
     var userMetadata: Map<String, UserMetadata>
     var messagesById: Map<String, NostrGroupClient.NostrMessage>
+
+    /** Group this row belongs to; scopes a quoted event's by-id REQ with `#h`. */
+    var groupId: String
     var onEventRef: (String) -> Unit
     var onGroupRef: (String, String?) -> Unit
     var replyTo: ReplyPreviewData?
@@ -3087,6 +3091,7 @@ private val MessageRow =
                         props.onUser,
                         props.onEventRef,
                         props.onGroupRef,
+                        props.groupId,
                     )
                     // Send-state icon (own messages: clock while sending, check when
                     // delivered) flows inline after the content so no extra line shifts
@@ -3439,6 +3444,9 @@ internal fun ChildrenBuilder.renderMessageContent(
     onUser: (String) -> Unit,
     onEventRef: (String) -> Unit,
     onGroupRef: (String, String?) -> Unit,
+    /** Group this message was read in: a quoted event is looked up with `#h`, which some
+     *  NIP-29 relays require even for a lookup by id. */
+    groupId: String?,
 ) {
     // Markdown image embeds collapse to their bare url so URL_REGEX sees a plain link; the
     // surrounding `![alt](` / `)` would otherwise render as literal text. Mirrors native.
@@ -3451,16 +3459,16 @@ internal fun ChildrenBuilder.renderMessageContent(
     var qLast = 0
     for (q in BLOCKQUOTE_REGEX.findAll(content)) {
         if (q.range.first > qLast) {
-            renderBody(content.substring(qLast, q.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+            renderBody(content.substring(qLast, q.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
         }
         div {
             className = ClassName("msg-quote")
-            renderBody(q.value.replace(BLOCKQUOTE_LINE_PREFIX, ""), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+            renderBody(q.value.replace(BLOCKQUOTE_LINE_PREFIX, ""), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
         }
         qLast = q.range.last + 1
     }
     if (qLast < content.length) {
-        renderBody(content.substring(qLast), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+        renderBody(content.substring(qLast), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
     }
 }
 
@@ -3475,11 +3483,14 @@ private fun ChildrenBuilder.renderBody(
     onUser: (String) -> Unit,
     onEventRef: (String) -> Unit,
     onGroupRef: (String, String?) -> Unit,
+    /** Group this message was read in: a quoted event is looked up with `#h`, which some
+     *  NIP-29 relays require even for a lookup by id. */
+    groupId: String?,
 ) {
     var last = 0
     for (block in CODE_BLOCK_REGEX.findAll(content)) {
         if (block.range.first > last) {
-            renderInline(content.substring(last, block.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+            renderInline(content.substring(last, block.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
         }
         val lang = block.groupValues[1].takeIf { it.isNotBlank() }
         div {
@@ -3498,7 +3509,7 @@ private fun ChildrenBuilder.renderBody(
         last = block.range.last + 1
     }
     if (last < content.length) {
-        renderInline(content.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+        renderInline(content.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
     }
 }
 
@@ -3513,11 +3524,14 @@ private fun ChildrenBuilder.renderInline(
     onUser: (String) -> Unit,
     onEventRef: (String) -> Unit,
     onGroupRef: (String, String?) -> Unit,
+    /** Group this message was read in: a quoted event is looked up with `#h`, which some
+     *  NIP-29 relays require even for a lookup by id. */
+    groupId: String?,
 ) {
     var last = 0
     for (m in INLINE_CODE_REGEX.findAll(text)) {
         if (m.range.first > last) {
-            renderEntities(text.substring(last, m.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+            renderEntities(text.substring(last, m.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
         }
         code {
             className = ClassName("msg-code")
@@ -3526,7 +3540,7 @@ private fun ChildrenBuilder.renderInline(
         last = m.range.last + 1
     }
     if (last < text.length) {
-        renderEntities(text.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef)
+        renderEntities(text.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
     }
 }
 
@@ -3540,6 +3554,9 @@ private fun ChildrenBuilder.renderEntities(
     onUser: (String) -> Unit,
     onEventRef: (String) -> Unit,
     onGroupRef: (String, String?) -> Unit,
+    /** Group this message was read in: a quoted event is looked up with `#h`, which some
+     *  NIP-29 relays require even for a lookup by id. */
+    groupId: String?,
 ) {
     var last = 0
     for (match in URL_REGEX.findAll(content)) {
@@ -3623,6 +3640,7 @@ private fun ChildrenBuilder.renderEntities(
                         author = entity.author
                         kind = entity.kind
                         localById = messagesById
+                        this.groupId = groupId
                         onScrollTo = onEventRef
                         this.onUser = onUser
                         this.onGroupRef = onGroupRef
@@ -3634,6 +3652,7 @@ private fun ChildrenBuilder.renderEntities(
                         author = null
                         kind = null
                         localById = messagesById
+                        this.groupId = groupId
                         onScrollTo = onEventRef
                         this.onUser = onUser
                         this.onGroupRef = onGroupRef
@@ -3642,13 +3661,13 @@ private fun ChildrenBuilder.renderEntities(
                     if (entity.kind == 39000) {
                         if (standalone) {
                             GroupLinkCard {
-                                groupId = entity.identifier
+                                this.groupId = entity.identifier
                                 relayUrl = entity.relays.firstOrNull()
                                 onNavigate = onGroupRef
                             }
                         } else {
                             GroupMentionChip {
-                                groupId = entity.identifier
+                                this.groupId = entity.identifier
                                 relayUrl = entity.relays.firstOrNull()
                                 onNavigate = onGroupRef
                             }
@@ -3731,6 +3750,9 @@ private external interface QuotedEventProps : Props {
     /** nevent kind hint (null for a bare note) — shown on the not-found card. */
     var kind: Int?
     var localById: Map<String, NostrGroupClient.NostrMessage>
+
+    /** Group the reference was read in; scopes the by-id REQ with `#h`. */
+    var groupId: String?
     var onScrollTo: (String) -> Unit
     var onUser: (String) -> Unit
     var onGroupRef: (String, String?) -> Unit
@@ -3766,7 +3788,7 @@ private val QuotedEvent =
         useEffect(props.eventId, retryTick) {
             setNotFound(false)
             if (props.eventId !in cached && local == null) {
-                launchApp { repo.requestEventById(props.eventId, props.relays, props.author) }
+                launchApp { repo.requestEventById(props.eventId, props.relays, props.author, props.groupId) }
             }
         }
         // Give up after 5s of no resolution. Re-runs when content arrives (cancels the timer).
@@ -3839,7 +3861,7 @@ private val QuotedEvent =
         useEffect(replyParentId) {
             val pid = replyParentId ?: return@useEffect
             if (pid !in cached && replyLocal == null) {
-                launchApp { repo.requestEventById(pid, props.relays, null) }
+                launchApp { repo.requestEventById(pid, props.relays, null, props.groupId) }
             }
         }
         useEffect(replyPubkey) {
@@ -4027,6 +4049,7 @@ private val QuotedEvent =
                                 props.onUser,
                                 props.onScrollTo,
                                 props.onGroupRef,
+                                props.groupId,
                             )
                         }
                     }
@@ -4062,6 +4085,7 @@ private val QuotedEvent =
                             props.onUser,
                             props.onScrollTo,
                             props.onGroupRef,
+                            props.groupId,
                         )
                     }
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -430,6 +430,8 @@ val DmPage =
                                             { props.onOpenProfile(UserRoute(it)) },
                                             {},
                                             { gid, relay -> relay?.let { props.onOpenGroup(GroupRoute(it, gid)) } },
+                                            // A DM is not in a group: the by-id REQ stays unscoped.
+                                            null,
                                         )
                                     }
                                     if (invite != null) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -1100,6 +1100,8 @@ private fun ChildrenBuilder.threadMessage(
                     onUser = onUser,
                     onEventRef = {},
                     onGroupRef = onGroupRef,
+                    // The event's own NIP-29 `h` tag scopes a quoted reference's by-id REQ.
+                    groupId = msg.tags.firstOrNull { it.size >= 2 && it[0] == "h" }?.get(1),
                 )
                 // Inline send-state icon (clock/check) so no extra line shifts the list.
                 if (myPubkey != null && myPubkey == msg.pubkey) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -10,9 +10,12 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
+import org.nostr.nostrord.ui.mentions.MentionAutocomplete
+import org.nostr.nostrord.ui.mentions.MentionCtx
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.threadShareLink
 import org.nostr.nostrord.ui.screens.group.GroupMembership
+import org.nostr.nostrord.ui.screens.group.MentionableGroup
 import org.nostr.nostrord.ui.screens.group.ThreadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.canDeleteThreadMessage
@@ -24,7 +27,7 @@ import org.nostr.nostrord.ui.screens.group.threadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.getDateLabel
-import org.nostr.nostrord.utils.shortNpub
+import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.VirtualKeyboard
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
@@ -32,12 +35,17 @@ import org.nostr.nostrord.web.bridge.useViewModel
 import org.nostr.nostrord.web.components.AvatarKind
 import org.nostr.nostrord.web.components.EmojiPicker
 import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.MentionMatch
+import org.nostr.nostrord.web.components.MentionPopup
 import org.nostr.nostrord.web.components.Portal
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.confirmDialog
 import org.nostr.nostrord.web.components.copyToClipboard
 import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.mentionDisplayName
+import org.nostr.nostrord.web.components.mentionHighlight
+import org.nostr.nostrord.web.components.mentionMatches
 import org.nostr.nostrord.web.components.messageSendStatus
 import org.nostr.nostrord.web.components.reactionBadges
 import org.nostr.nostrord.web.components.sendStateIcon
@@ -79,10 +87,7 @@ private fun ChildrenBuilder.threadsLockedState(title: String, body: String) {
     }
 }
 
-// Mirrors ChatScreen.displayName (private there): profile name, else a short npub.
-private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = meta?.displayName?.takeIf { it.isNotBlank() }
-    ?: meta?.name?.takeIf { it.isNotBlank() }
-    ?: shortNpub(pubkey)
+private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = mentionDisplayName(pubkey, meta)
 
 private fun relativeTime(createdAtSeconds: Long): String {
     val nowSec = (Date.now() / 1000).toLong()
@@ -105,6 +110,296 @@ private data class ThreadCtxMenu(
     val x: Double,
     val y: Double,
 )
+
+private external interface ThreadComposerProps : Props {
+    /** The screen's ThreadsViewModel (shared, not a second instance). */
+    var vm: ThreadsViewModel
+
+    /** Message being answered (null posts top-level), plus the banner's name and preview. */
+    var replyingTo: NostrGroupClient.NostrMessage?
+
+    /** Bumped on EVERY reply pick so re-replying to the same message still refocuses. */
+    var replyNonce: Int
+    var replyParentName: String?
+    var replyParentPreview: String?
+    var onCancelReply: () -> Unit
+
+    /** Cleared after a successful publish so the screen can drop the reply target. */
+    var onSent: () -> Unit
+    var members: List<String>
+    var allGroups: List<MentionableGroup>
+    var userMetadata: Map<String, UserMetadata>
+
+    /** Relay's NIP-11 pubkey, the naddr author of a `%group` mention on that relay. */
+    var relayPubkeyOf: (String) -> String?
+    var onUploadError: (String) -> Unit
+}
+
+/**
+ * The thread reply composer: the DM pill (.dm-composer) plus the `@user` / `%group` autocomplete
+ * and the colored mention mirror the chat composer has. Split out of [ThreadsScreen] so typing
+ * re-renders only this subtree, not the whole thread.
+ */
+private val ThreadComposer =
+    FC<ThreadComposerProps> { props ->
+        val vm = props.vm
+        val (reply, setReply) = useState { "" }
+        val (sending, setSending) = useState { false }
+        val (emojiOpen, setEmojiOpen) = useState { false }
+        val (uploadCount, setUploadCount) = useState { 0 }
+
+        // Active @user / %group mention being typed, and the ones already chosen: displayName ->
+        // pubkey for users (resolved to nostr:npub + a p tag by the repo), name -> nostr:naddr for
+        // groups (spliced into the content at send).
+        val (mention, setMention) = useState<MentionCtx?> { null }
+        val (mentions, setMentions) = useState<Map<String, String>> { emptyMap() }
+        val (groupMentions, setGroupMentions) = useState<Map<String, String>> { emptyMap() }
+        val (mentionSelected, setMentionSelected) = useState { 0 }
+
+        val composerInputRef = useRef<HTMLTextAreaElement>(null)
+        val composerHighlightRef = useRef<HTMLDivElement>(null)
+
+        val suggestions = mentionMatches(mention, props.members, props.userMetadata, props.allGroups, props.relayPubkeyOf)
+
+        useEffect(props.replyingTo?.id, props.replyNonce) {
+            if (props.replyingTo == null) return@useEffect
+            val ta = composerInputRef.current ?: return@useEffect
+            // Re-focusing an already-focused field does not re-open a keyboard the user
+            // dismissed, so blur first in exactly that case (mirrors ChatScreen).
+            if (!VirtualKeyboard.isOpen && document.asDynamic().activeElement === ta.asDynamic()) {
+                ta.blur()
+            }
+            ta.focus()
+        }
+
+        // Keep the mirror's box in step with the auto-growing textarea.
+        useEffect(reply) {
+            val el = composerInputRef.current ?: return@useEffect
+            el.style.height = "auto"
+            el.style.height = "${el.scrollHeight}px"
+        }
+
+        fun isMediaMime(type: String?): Boolean = type != null && (type.startsWith("image/") || type.startsWith("video/") || type.startsWith("audio/"))
+
+        // Upload a pasted / dropped file and append its URL to the reply draft (parity with DM / group).
+        fun handleMediaFile(file: dynamic) {
+            setUploadCount { it + 1 }
+            launchApp {
+                try {
+                    when (val r = uploadBlob(file)) {
+                        is Result.Success -> setReply { prev -> if (prev.isBlank()) r.data.url else "$prev ${r.data.url}" }
+                        is Result.Error -> props.onUploadError(r.error.message)
+                    }
+                } finally {
+                    setUploadCount { it - 1 }
+                }
+            }
+        }
+
+        /** Replace the typed "@query" / "%query" with the chosen suggestion. */
+        fun insertMention(mm: MentionMatch) {
+            val ctx = mention ?: return
+            setReply(MentionAutocomplete.insert(reply, ctx, mm.label).text)
+            if (mm.group) setGroupMentions { it + (mm.label to mm.ref) } else setMentions { it + (mm.label to mm.seed) }
+            setMention(null)
+            setMentionSelected(0)
+        }
+
+        fun sendReply() {
+            if (reply.isBlank() || sending) return
+            // Resolve %group mentions to their nostr:naddr inline (native does this at send too);
+            // @user mentions are resolved by the repo from the mentions map (+ p tag).
+            var text = reply
+            groupMentions.forEach { (name, ref) -> text = text.replace("%$name", ref) }
+            setSending(true)
+            vm.sendReply(
+                text,
+                parent = props.replyingTo,
+                mentions = mentions,
+                onSuccess = {
+                    setReply("")
+                    setMentions(emptyMap())
+                    setGroupMentions(emptyMap())
+                    setSending(false)
+                    props.onSent()
+                },
+                onFailure = { setSending(false) },
+            )
+        }
+
+        // execCommand keeps the cursor position so an emoji lands where the caret is, not appended.
+        fun insertAtCursor(s: String) {
+            val ta = composerInputRef.current
+            if (ta == null) {
+                setReply { it + s }
+                return
+            }
+            ta.focus()
+            document.asDynamic().execCommand("insertText", false, s)
+        }
+
+        // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
+        div {
+            className = ClassName("dm-composer-wrap")
+            // Floats above the pill; .dm-composer-wrap is the positioned ancestor it anchors to.
+            // Every child here carries a stable key: without them, mounting the popup shifts the
+            // siblings after it and React remounts the textarea, which drops the caret mid-word.
+            if (mention != null && suggestions.isNotEmpty()) {
+                MentionPopup {
+                    key = "mention-popup"
+                    matches = suggestions
+                    trigger = mention.trigger
+                    selected = mentionSelected
+                    onPick = { insertMention(it) }
+                    onHover = { setMentionSelected(it) }
+                }
+            }
+            // Reply chip above the composer while answering a specific message.
+            props.replyParentName?.let { parentName ->
+                div {
+                    key = "composer-reply"
+                    className = ClassName("composer-reply")
+                    icon(Ic.Reply)
+                    span {
+                        className = ClassName("composer-reply-label")
+                        +"Replying to"
+                    }
+                    span {
+                        className = ClassName("composer-reply-name")
+                        +parentName
+                    }
+                    props.replyParentPreview?.let { preview ->
+                        span {
+                            className = ClassName("composer-reply-text")
+                            +preview
+                        }
+                    }
+                    button {
+                        className = ClassName("composer-reply-close")
+                        onClick = { props.onCancelReply() }
+                        icon(Ic.Close)
+                    }
+                }
+            }
+            div {
+                key = "composer-pill"
+                className = ClassName("dm-composer")
+                UploadButton {
+                    cls = "dm-composer-btn"
+                    icon = Ic.AttachFile
+                    busy = uploadCount > 0
+                    onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
+                    onPickerClosed = { composerInputRef.current?.focus() }
+                    onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
+                    onError = { props.onUploadError(it) }
+                }
+                div {
+                    className = ClassName("composer-input-wrap")
+                    // Colored mirror painted behind the transparent textarea: same text, with the
+                    // resolved @user / %group mentions tinted (native parity).
+                    div {
+                        className = ClassName("composer-highlight")
+                        ref = composerHighlightRef
+                        mentionHighlight(reply, mentions.keys.map { "@$it" } + groupMentions.keys.map { "%$it" })
+                    }
+                    textarea {
+                        ref = composerInputRef
+                        className = ClassName("composer-input")
+                        rows = 1
+                        value = reply
+                        placeholder = "Write a reply..."
+                        onScroll = {
+                            composerHighlightRef.current?.scrollTop = composerInputRef.current?.scrollTop ?: 0.0
+                        }
+                        onChange = { event ->
+                            val v = (event.target as HTMLTextAreaElement).value
+                            setReply(v)
+                            val cursor = (event.currentTarget.asDynamic().selectionStart as? Int) ?: v.length
+                            setMention(MentionAutocomplete.detect(v, cursor))
+                            setMentionSelected(0)
+                        }
+                        onKeyDown = { e ->
+                            val hasMatches = mention != null && suggestions.isNotEmpty()
+                            when {
+                                hasMatches && e.key == "ArrowDown" -> {
+                                    e.preventDefault()
+                                    setMentionSelected { (it + 1).coerceAtMost(suggestions.size - 1) }
+                                }
+                                hasMatches && e.key == "ArrowUp" -> {
+                                    e.preventDefault()
+                                    setMentionSelected { (it - 1).coerceAtLeast(0) }
+                                }
+                                hasMatches && (e.key == "Enter" || e.key == "Tab") -> {
+                                    e.preventDefault()
+                                    insertMention(suggestions[mentionSelected.coerceIn(0, suggestions.size - 1)])
+                                }
+                                mention != null && e.key == "Escape" -> {
+                                    e.preventDefault()
+                                    setMention(null)
+                                }
+                                e.key == "Enter" && !e.shiftKey -> {
+                                    e.preventDefault()
+                                    sendReply()
+                                }
+                            }
+                        }
+                        onBlur = { window.setTimeout({ setMention(null) }, 150) }
+                        onPaste = { event ->
+                            val items = event.asDynamic().clipboardData?.items
+                            val count = (items?.length as? Int) ?: 0
+                            for (i in 0 until count) {
+                                val item = items[i]
+                                val type = item.type.unsafeCast<String?>()
+                                if (item.kind == "file" && isMediaMime(type)) {
+                                    val file = item.getAsFile()
+                                    if (file != null) {
+                                        event.preventDefault()
+                                        handleMediaFile(file)
+                                    }
+                                }
+                            }
+                        }
+                        onDragOver = { it.preventDefault() }
+                        onDrop = { event ->
+                            val files = event.asDynamic().dataTransfer?.files
+                            val count = (files?.length as? Int) ?: 0
+                            if (count > 0) event.preventDefault()
+                            for (i in 0 until count) {
+                                val file = files[i]
+                                if (isMediaMime(file.type.unsafeCast<String?>())) handleMediaFile(file)
+                            }
+                        }
+                    }
+                }
+                button {
+                    className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
+                    title = "Emoji"
+                    onClick = { setEmojiOpen(!emojiOpen) }
+                    icon(Ic.EmojiEmotions)
+                }
+                button {
+                    className = ClassName("dm-composer-btn send")
+                    title = "Send"
+                    disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
+                    onMouseDown = { e -> e.preventDefault() }
+                    onClick = { sendReply() }
+                    if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
+                }
+                if (emojiOpen) {
+                    div {
+                        className = ClassName("emoji-overlay")
+                        onClick = { setEmojiOpen(false) }
+                        EmojiPicker {
+                            onPick = { emoji ->
+                                insertAtCursor(emoji)
+                                setEmojiOpen(false)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 
 external interface ThreadsScreenProps : Props {
     var route: GroupRoute
@@ -208,68 +503,24 @@ val ThreadsScreen =
         }
 
         val (composing, setComposing) = useState { false }
-        val (reply, setReply) = useState { "" }
-        val (sending, setSending) = useState { false }
-        val (emojiOpen, setEmojiOpen) = useState { false }
-        val (uploadCount, setUploadCount) = useState { 0 }
         val (uploadError, setUploadError) = useState<String?> { null }
-        val composerInputRef = useRef<HTMLTextAreaElement>(null)
 
         // Picking Reply should leave the caret in the composer, ready to type (chat parity).
         // Bumped per pick so replying twice to the same message re-focuses.
         val (replyFocusNonce, setReplyFocusNonce) = useState { 0 }
-        useEffect(replyingTo?.id, replyFocusNonce) {
-            if (replyingTo == null) return@useEffect
-            val ta = composerInputRef.current ?: return@useEffect
-            // Re-focusing an already-focused field does not re-open a keyboard the user
-            // dismissed, so blur first in exactly that case (mirrors ChatScreen).
-            if (!VirtualKeyboard.isOpen && document.asDynamic().activeElement === ta.asDynamic()) {
-                ta.blur()
-            }
-            ta.focus()
-        }
 
-        fun isMediaMime(type: String?): Boolean = type != null && (type.startsWith("image/") || type.startsWith("video/") || type.startsWith("audio/"))
-
-        // Upload a pasted / dropped file and append its URL to the reply draft (parity with DM / group).
-        fun handleMediaFile(file: dynamic) {
-            setUploadCount { it + 1 }
-            launchApp {
-                try {
-                    when (val r = uploadBlob(file)) {
-                        is Result.Success -> setReply { prev -> if (prev.isBlank()) r.data.url else "$prev ${r.data.url}" }
-                        is Result.Error -> setUploadError(r.error.message)
-                    }
-                } finally {
-                    setUploadCount { it - 1 }
-                }
-            }
-        }
-
-        fun sendReply() {
-            if (reply.isBlank() || sending) return
-            setSending(true)
-            vm.sendReply(
-                reply,
-                parent = replyingTo,
-                onSuccess = {
-                    setReply("")
-                    setReplyingTo(null)
-                    setSending(false)
-                },
-                onFailure = { setSending(false) },
-            )
-        }
-
-        // execCommand keeps the cursor position so an emoji lands where the caret is, not appended.
-        fun insertAtCursor(s: String) {
-            val ta = composerInputRef.current
-            if (ta == null) {
-                setReply { it + s }
-                return
-            }
-            ta.focus()
-            document.asDynamic().execCommand("insertText", false, s)
+        // Mention candidates, shared with the new-thread modal: the group's members (admins first,
+        // chat parity) and the groups reachable through your follows.
+        val mentionableMembers = useStateFlow(vm.mentionableMembers)
+        val threadAdmins = useStateFlow(vm.groupAdmins)
+        val mentionableGroups = useStateFlow(vm.mentionableGroups)
+        val relayMetadata = useStateFlow(AppModule.nostrRepository.relayMetadata)
+        val mentionMembers = mentionableMembers.sortedWith(
+            compareByDescending<String> { it in threadAdmins }
+                .thenBy { mentionDisplayName(it, userMetadata[it]).lowercase() },
+        )
+        val relayPubkeyOf: (String) -> String? = { r ->
+            relayMetadata[r]?.groupNaddrAuthor ?: relayMetadata[r.normalizeRelayUrl()]?.groupNaddrAuthor
         }
 
         div {
@@ -434,13 +685,17 @@ val ThreadsScreen =
                     Portal {
                         CreateThreadModal {
                             onClose = { setComposing(false) }
-                            onCreate = { title, content, shareToChat ->
+                            onCreate = { title, content, shareToChat, mentions ->
                                 // Open the new thread right away (Discord parity; the optimistic
                                 // root is already in the store, so the detail renders instantly).
-                                vm.createThread(title, content, shareToChat) { rootId ->
+                                vm.createThread(title, content, shareToChat, mentions) { rootId ->
                                     props.onNavigate(route.copy(threadRootId = rootId))
                                 }
                             }
+                            members = mentionMembers
+                            allGroups = mentionableGroups
+                            this.userMetadata = userMetadata
+                            this.relayPubkeyOf = relayPubkeyOf
                         }
                     }
                 }
@@ -525,111 +780,20 @@ val ThreadsScreen =
                                 }
                                 detail.replies.forEach { r -> renderThreadMessage(r, isRoot = false) }
                             }
-                            // Same composer as DM (.dm-composer): rounded bar, Enter to send, emoji picker.
-                            div {
-                                className = ClassName("dm-composer-wrap")
-                                // Reply chip above the composer while answering a specific message.
-                                replyingTo?.let { target ->
-                                    div {
-                                        className = ClassName("composer-reply")
-                                        icon(Ic.Reply)
-                                        span {
-                                            className = ClassName("composer-reply-label")
-                                            +"Replying to"
-                                        }
-                                        span {
-                                            className = ClassName("composer-reply-name")
-                                            +threadDisplayName(target.pubkey, userMetadata[target.pubkey])
-                                        }
-                                        target.content.lineSequence().map { it.trim() }.firstOrNull { it.isNotEmpty() }?.let { preview ->
-                                            span {
-                                                className = ClassName("composer-reply-text")
-                                                +preview
-                                            }
-                                        }
-                                        button {
-                                            className = ClassName("composer-reply-close")
-                                            onClick = { setReplyingTo(null) }
-                                            icon(Ic.Close)
-                                        }
-                                    }
-                                }
-                                div {
-                                    className = ClassName("dm-composer")
-                                    UploadButton {
-                                        cls = "dm-composer-btn"
-                                        icon = Ic.AttachFile
-                                        busy = uploadCount > 0
-                                        onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
-                                        onPickerClosed = { composerInputRef.current?.focus() }
-                                        onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
-                                        onError = { setUploadError(it) }
-                                    }
-                                    textarea {
-                                        ref = composerInputRef
-                                        rows = 1
-                                        value = reply
-                                        placeholder = "Write a reply..."
-                                        onChange = { setReply((it.target as HTMLTextAreaElement).value) }
-                                        onKeyDown = { e ->
-                                            if (e.key == "Enter" && !e.shiftKey) {
-                                                e.preventDefault()
-                                                sendReply()
-                                            }
-                                        }
-                                        onPaste = { event ->
-                                            val items = event.asDynamic().clipboardData?.items
-                                            val count = (items?.length as? Int) ?: 0
-                                            for (i in 0 until count) {
-                                                val item = items[i]
-                                                val type = item.type.unsafeCast<String?>()
-                                                if (item.kind == "file" && isMediaMime(type)) {
-                                                    val file = item.getAsFile()
-                                                    if (file != null) {
-                                                        event.preventDefault()
-                                                        handleMediaFile(file)
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        onDragOver = { it.preventDefault() }
-                                        onDrop = { event ->
-                                            val files = event.asDynamic().dataTransfer?.files
-                                            val count = (files?.length as? Int) ?: 0
-                                            if (count > 0) event.preventDefault()
-                                            for (i in 0 until count) {
-                                                val file = files[i]
-                                                if (isMediaMime(file.type.unsafeCast<String?>())) handleMediaFile(file)
-                                            }
-                                        }
-                                    }
-                                    button {
-                                        className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
-                                        title = "Emoji"
-                                        onClick = { setEmojiOpen(!emojiOpen) }
-                                        icon(Ic.EmojiEmotions)
-                                    }
-                                    button {
-                                        className = ClassName("dm-composer-btn send")
-                                        title = "Send"
-                                        disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
-                                        onMouseDown = { e -> e.preventDefault() }
-                                        onClick = { sendReply() }
-                                        if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
-                                    }
-                                    if (emojiOpen) {
-                                        div {
-                                            className = ClassName("emoji-overlay")
-                                            onClick = { setEmojiOpen(false) }
-                                            EmojiPicker {
-                                                onPick = { emoji ->
-                                                    insertAtCursor(emoji)
-                                                    setEmojiOpen(false)
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
+                            ThreadComposer {
+                                this.vm = vm
+                                this.replyingTo = replyingTo
+                                this.replyNonce = replyFocusNonce
+                                this.replyParentName = replyingTo?.let { threadDisplayName(it.pubkey, userMetadata[it.pubkey]) }
+                                this.replyParentPreview = replyingTo?.content
+                                    ?.lineSequence()?.map { it.trim() }?.firstOrNull { it.isNotEmpty() }
+                                this.onCancelReply = { setReplyingTo(null) }
+                                this.onSent = { setReplyingTo(null) }
+                                this.members = mentionMembers
+                                this.allGroups = mentionableGroups
+                                this.userMetadata = userMetadata
+                                this.relayPubkeyOf = relayPubkeyOf
+                                this.onUploadError = { setUploadError(it) }
                             }
                         }
                     }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3489,8 +3489,19 @@ body {
 }
 
 .dm-composer-wrap {
+    /* Positioned ancestor for the .mention-popup, which floats above the pill. */
+    position: relative;
     flex-shrink: 0;
     padding: var(--space-xs) var(--space-lg) var(--space-xl);
+}
+
+/* The thread reply composer uses the chat composer's mirror (.composer-highlight paints the
+   text, tinting resolved mentions), so its textarea must stay transparent. Two classes beat
+   `.dm-composer textarea`, which otherwise repaints the text over the mirror. */
+.dm-composer .composer-input {
+    color: transparent;
+    caret-color: var(--color-text-primary);
+    font-size: 15px;
 }
 
 .dm-composer {
@@ -7374,6 +7385,12 @@ body {
     cursor: pointer;
     user-select: none;
 }
+/* Positioned ancestor for a .mention-popup over a field that is not a composer bar
+   (the new-thread modal's body). */
+.mention-anchor {
+    position: relative;
+}
+
 /* @user / %group mention autocomplete popover, floating above the composer
    frame (anchored to .composer-area; prototype: bottom-full left-4 w-[300px]). */
 .mention-popup {

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -13,6 +13,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `AccountChooserDialog` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/AccountChooserDialog.kt | Centered modal shown when the user signs out of the active account while other |
 | `AddAccountSheet` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/AddAccountSheet.kt | Modal that adds a new signed-in account. Centered dialog matching the web |
 | `AppButton` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/buttons/AppButton.kt | — |
+| `AppField` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt | [AppField] over a [TextFieldValue], for callers that need the caret position (mention |
 | `AppField` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt | The single standardized form field (web `.modal-input` / `.modal-textarea` / `.modal-select` |
 | `AppFrame` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt | New-design logged-in frame (prototype AppShell): the 72px groups rail (home, |
 | `AppSearchField` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/forms/AppForms.kt | Standardized search / filter input (web `searchInput` over `.input-group`): floating surface with |
@@ -61,6 +62,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `MemberSidebar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/sidebars/MemberSidebar.kt | Enhanced member sidebar with online/offline status, avatars, role badges, and search. |
 | `MemberSkeleton` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/loading/SkeletonLoader.kt | Skeleton loader for member list items. |
 | `MeMenu` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt | Sheet/popup that opens from the user avatar. Lists every signed-in account |
+| `MentionSuggestions` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MentionField.kt | The suggestion list for whichever mention is active: members for `@`, groups for `%`, nothing |
 | `MessageComposer` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt | Single rounded "pill" composer shared by the DM page and the individual thread view (web |
 | `MessageContent` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt | # MessageContent - Robust Inline Text Rendering |
 | `MessageContextMenu` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt | Message context menu - appears on right-click (desktop) or long-press (mobile). |
@@ -89,6 +91,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `StepLabel` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/onboarding/OnboardingPieces.kt | Uppercase step label under the bars: "Step 1 of 2 · Welcome". |
 | `StepProgress` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/onboarding/OnboardingPieces.kt | Onboarding building blocks — Compose counterpart of the web's `.onb-*` / |
 | `SystemEventItem` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/SystemEventItem.kt | Enhanced system event item with avatars and grouping support. |
+| `SystemMessageHost` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/SystemMessageHost.kt | Renders [AppModule.systemMessages] as a transient toast at the bottom of the app. |
 | `TagBadge` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/GroupTypeBadges.kt | Tone-tinted access pill (Public/Private, Open/Closed, Joined). 10sp semibold, |
 | `ThreadMessageContextMenu` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt | Compact context menu for thread messages (right-click / long-press): the quick-reactions |
 | `UnreadBadge` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/badges/UnreadBadge.kt | Unread message count badge. |
@@ -140,11 +143,13 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `LiveSpaceBar` | webMain/kotlin/org/nostr/nostrord/web/components/LiveSpaceBar.kt | In-chat banner for a NIP-29 AV space: participant count, a stack of the first few faces and |
 | `ManageGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ManageGroupModal.kt | Unified admin "Manage group" modal (port of the prototype GroupManage): a left tab |
 | `MembersModal` | webMain/kotlin/org/nostr/nostrord/web/modals/MembersModal.kt | Read-only member roster (port of the prototype GroupPanels "Members" panel): avatar + |
+| `MentionPopup` | webMain/kotlin/org/nostr/nostrord/web/components/MentionPopup.kt | The `@user` / `%group` suggestion list. Absolutely positioned against the nearest positioned |
 | `PomegranateDisconnectModal` | webMain/kotlin/org/nostr/nostrord/web/modals/PomegranateDisconnectModal.kt | Confirmation for unlinking a Login-with-Google account from its central server. The |
 | `Portal` | webMain/kotlin/org/nostr/nostrord/web/components/Portal.kt | Renders its children into `<body>` through a React portal, so they escape any ancestor that |
 | `ReportUserModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ReportUserModal.kt | NIP-56 report modal (prototype ReportModal): reason radio cards, optional note, |
 | `ShareGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt | Share-group modal — real port of the Compose ShareGroupModal: a single cycling identifier field |
 | `Spoiler` | webMain/kotlin/org/nostr/nostrord/web/components/Spoiler.kt | Discord-style spoiler (//text//): blurred until clicked, click toggles. Mirrors the |
+| `SystemMessageHost` | webMain/kotlin/org/nostr/nostrord/web/components/SystemMessageHost.kt | Renders [AppModule.systemMessages] as a transient toast at the bottom of the page. |
 | `UnlockModal` | webMain/kotlin/org/nostr/nostrord/web/modals/UnlockModal.kt | Startup unlock for a NIP-49 password-protected account (web counterpart of the |
 | `UploadButton` | webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt | Upload button — a styled `<label>` wrapping a hidden file input. On pick it validates |
 | `UserProfileModal` | webMain/kotlin/org/nostr/nostrord/web/modals/UserProfileModal.kt | Quick user profile modal (prototype UserProfileCard): clickable header row to the |


### PR DESCRIPTION
The @ / % autocomplete only existed in the chat composer, so a thread reply could name someone but never notify them: `sendThreadReply` had no `mentions` parameter and neither did `createThread`. Both thread composers and both new-thread dialogs now carry it, on Compose and on the web.

Trigger detection, filtering and insertion existed four times and had already drifted (the web matched only display names, native also matched the key). They now live once in `MentionAutocomplete`, and every composer delegates to it. Mention resolution (`@name` -> `nostr:npub` plus the `p` tag) moves out of `sendMessage` into `MentionTags`, shared by kinds 9, 11 and 1111; it skips a pubkey the event already tags, which matters on a reply, since `ThreadTags.reply` p-tags the parent author and a duplicate would only inflate the indexable-tag count some NIP-29 relays reject.

Riding along is the fix for the quoted-thread card, which reported "removed or unavailable" with a Retry that repeated the same failing request. Three causes: the card resolves an nevent through the generic by-id event cache, which thread events never reached; the by-id REQ carried only `ids`, and some NIP-29 relays require `#h` even for a lookup by id; and `fetchThread`'s answer lands under an `e_` subscription, so the card worked only for a thread already opened, which is what made it look intermittent.

| Area | Change |
|---|---|
| commonMain | `MentionAutocomplete` (detect / sustain / filter / insert) + `MentionTags`; `mentions` on `createThread` and `sendThreadReply`; `ThreadsViewModel` exposes the member and group candidates; `mentionableGroupsFlow` shared with `GroupViewModel` |
| Compose | `MentionField` state holder + `MentionSuggestions`; mention support on `MessageComposer` and `CreateThreadDialog`; `AppField` overload over `TextFieldValue` |
| Web | `web/components/MentionPopup.kt` (popup, match building, highlight mirror); `ThreadComposer` extracted from `ThreadsScreen`; popup in `CreateThreadModal` |
| Quote card | thread events mirrored into the by-id event cache; `#h` on the by-id REQ where the group is known; thread-shaped placeholder copy on Compose |
| Perf | decoded bech32 entities cached (nsec excluded); the quote cards' group lookup keyed instead of re-scanning every relay per recomposition |

The web popup is a sibling of the textarea, so every child there carries a stable `key`: without them React remounts the field on the first `@` and the caret is lost mid-word. `MessageComposer` keeps the chat's Android split (inline list, never a `Popup`), since a `Popup` window restarts the IME and eats the character being typed.

Tests: `MentionAutocompleteTest`, `ThreadEventCacheMirrorTest`, the mention cases in `ThreadsViewModelTest`, and the decode-cache case in `Nip19Test`. `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid`, `jvmTest` and `spotlessCheck` pass. Not yet validated on a device.

- `refactor(mentions): one @ / % autocomplete for both UIs`
- `feat(threads): mention users and groups from the thread pages`
- `fix(chat): resolve a quoted thread from memory instead of refetching it`
- `perf(render): cache decoded bech32 entities`
- `perf(chat): key the quote cards' group lookup`