### PR TITLE
Announce a notification once, not once per redelivery

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.Serializable
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.getAnnouncedNotificationIds
 import org.nostr.nostrord.storage.getPersistedNotifications
+import org.nostr.nostrord.storage.saveAnnouncedNotificationIds
 import org.nostr.nostrord.storage.savePersistedNotifications
 
 @Serializable
@@ -43,25 +45,45 @@ class NotificationHistoryStore {
 
     private var currentPubkey: String? = null
 
+    /**
+     * Ids already announced, oldest first. The feed keeps only [MAX_ENTRIES], while the thread and
+     * chat subscriptions re-serve their whole window on every pane open, re-AUTH and restart: an id
+     * that fell off the feed's tail would come back as unread every time. This outlives the feed and
+     * the session, so an event notifies exactly once.
+     */
+    private val announced = LinkedHashSet<String>()
+
     fun initialize(pubkey: String?) {
         currentPubkey = pubkey
-        _entries.value =
-            if (pubkey == null) {
-                emptyList()
-            } else {
-                SecureStorage.getPersistedNotifications(pubkey)
-            }
+        announced.clear()
+        if (pubkey == null) {
+            _entries.value = emptyList()
+            return
+        }
+        val persisted = SecureStorage.getPersistedNotifications(pubkey)
+        _entries.value = persisted
+        announced.addAll(SecureStorage.getAnnouncedNotificationIds(pubkey))
+        // Seed from the feed so an install upgrading into this does not re-announce what it
+        // is already showing.
+        announced.addAll(persisted.map { it.id }.asReversed())
+        trimAnnounced()
     }
 
+    /**
+     * Record a notification, unless its event already announced once. Silently dropping a repeat is
+     * the point: the relay re-delivering old events must not resurface them as unread.
+     */
     fun add(entry: NotificationEntry) {
-        _entries.update { current ->
-            if (current.any { it.id == entry.id }) {
-                current
-            } else {
-                (listOf(entry) + current).take(MAX_ENTRIES)
-            }
-        }
+        if (!announced.add(entry.id)) return
+        trimAnnounced()
+        _entries.update { current -> (listOf(entry) + current).take(MAX_ENTRIES) }
         persist()
+    }
+
+    private fun trimAnnounced() {
+        while (announced.size > MAX_ANNOUNCED) {
+            announced.remove(announced.first())
+        }
     }
 
     fun markRead(id: String) {
@@ -122,7 +144,10 @@ class NotificationHistoryStore {
         persist()
     }
 
-    /** Drop every entry from the in-memory feed and erase the persisted blob. */
+    /**
+     * Drop every entry from the in-memory feed and erase the persisted blob. The announced ids
+     * stay: emptying the feed is not a request to be told about those events again.
+     */
     fun clearHistory() {
         _entries.value = emptyList()
         persist()
@@ -131,11 +156,13 @@ class NotificationHistoryStore {
     fun clear() {
         currentPubkey = null
         _entries.value = emptyList()
+        announced.clear()
     }
 
     private fun persist() {
         val pubkey = currentPubkey ?: return
         SecureStorage.savePersistedNotifications(pubkey, _entries.value)
+        SecureStorage.saveAnnouncedNotificationIds(pubkey, announced)
     }
 
     /**
@@ -156,5 +183,9 @@ class NotificationHistoryStore {
 
     companion object {
         private const val MAX_ENTRIES = 50
+
+        // Well above the widest re-served window (the thread replies REQ asks for 500 per group),
+        // so a repeat is still recognised after several groups' worth of history is replayed.
+        internal const val MAX_ANNOUNCED = 2_000
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1190,6 +1190,30 @@ fun SecureStorage.savePersistedNotifications(
     }
 }
 
+// Ids of events already announced in the feed, kept apart from the feed itself: the feed is
+// capped at the last few entries, so its ids alone cannot answer "did this already notify?"
+// once an entry falls off the tail.
+private fun announcedNotificationsKey(pubkey: String): String = "notification_announced_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.getAnnouncedNotificationIds(pubkey: String): List<String> {
+    val raw = getStringPref(announcedNotificationsKey(pubkey), "").ifBlank { return emptyList() }
+    return try {
+        Json.decodeFromString(raw)
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
+fun SecureStorage.saveAnnouncedNotificationIds(
+    pubkey: String,
+    ids: Collection<String>,
+) {
+    try {
+        saveStringPref(announcedNotificationsKey(pubkey), Json.encodeToString(ids.toList()))
+    } catch (_: Exception) {
+    }
+}
+
 // Per-account, per-group notification level overrides (issue #70). Stored as a
 // groupId -> NotificationLevel.name map so each account keeps its own muting /
 // "mentions & replies only" choices. The settings layer maps the names back to

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStoreTest.kt
@@ -1,0 +1,76 @@
+package org.nostr.nostrord.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class NotificationHistoryStoreTest {
+    // initialize(null) keeps the store off SecureStorage: persist() is a no-op without an account,
+    // so these exercise the in-memory dedup without touching a platform backend.
+    private fun store() = NotificationHistoryStore().apply { initialize(null) }
+
+    private fun entry(id: String, rootId: String? = "root1") = NotificationEntry(
+        id = id,
+        type = NotificationType.REPLY,
+        groupId = "g1",
+        relayUrl = "wss://relay.example",
+        actorPubkey = "pk_other",
+        createdAt = 1_700_000_000,
+        preview = "hey",
+        threadRootId = rootId,
+    )
+
+    @Test
+    fun `the same event announces once`() {
+        val store = store()
+        store.add(entry("e1"))
+        store.add(entry("e1"))
+        assertEquals(1, store.entries.value.size)
+    }
+
+    @Test
+    fun `an event re-served after falling off the feed does not come back`() {
+        val store = store()
+        store.add(entry("old"))
+        // Push it past the feed cap: the relay re-serving it must still be recognised as a repeat.
+        repeat(60) { store.add(entry("e$it")) }
+        assertTrue(store.entries.value.none { it.id == "old" }, "setup: the entry should have aged out")
+
+        store.add(entry("old"))
+        assertTrue(store.entries.value.none { it.id == "old" })
+    }
+
+    @Test
+    fun `a read entry re-served stays gone instead of returning unread`() {
+        val store = store()
+        store.add(entry("e1"))
+        store.markReadForThread("root1")
+        assertTrue(store.entries.value.single().read)
+
+        store.add(entry("e1"))
+        assertTrue(store.entries.value.single().read)
+        assertEquals(1, store.entries.value.size)
+    }
+
+    @Test
+    fun `clearing the feed does not re-open the gate`() {
+        val store = store()
+        store.add(entry("e1"))
+        store.clearHistory()
+        store.add(entry("e1"))
+        assertTrue(store.entries.value.isEmpty())
+    }
+
+    @Test
+    fun `the announced set is bounded`() {
+        val store = store()
+        repeat(NotificationHistoryStore.MAX_ANNOUNCED + 10) { store.add(entry("e$it")) }
+        // The oldest ids are forgotten, so that event may announce again; the newest are still held.
+        store.add(entry("e0"))
+        assertEquals("e0", store.entries.value.first().id)
+
+        val newest = "e${NotificationHistoryStore.MAX_ANNOUNCED + 9}"
+        store.add(entry(newest))
+        assertEquals(1, store.entries.value.count { it.id == newest })
+    }
+}


### PR DESCRIPTION
Old thread replies were arriving as a batch of unread notifications, 41 days and 10 days after the fact. The thread subscriptions carry no `since` cursor, so the relay re-serves its whole window on every pane open, every re-AUTH and every restart, and each redelivered reply created a fresh unread entry.

`UnreadManager` deliberately has no lastRead anchor for thread replies (an anchor would swallow every reply landing in the same second as a chat read) and leans instead on the feed deduping by event id. That dedup could not hold: the feed keeps 50 entries, so an id that fell off the tail was unknown again, and every upstream dedup (`EventDeduplicator`, the `applyThreadEvent` list) is session-scoped, so a restart re-processed everything.

The announced ids now live in their own persisted slot, apart from the feed and outliving the session, so an event notifies exactly once. Clearing the feed keeps them: emptying a list is not a request to be told again. On upgrade the set is seeded from the entries already on screen, so what is currently visible never repeats.

| Area | Change |
|---|---|
| `NotificationHistoryStore` | announced-id set consulted before an entry is created; seeded on `initialize` from the persisted feed; cleared on logout, kept by `clearHistory` |
| `SecureStorage` | new per-account `notification_announced_*` slot |
| Tests | `NotificationHistoryStoreTest`, incl. the regression: an event pushed past the 50-entry cap and re-served must not come back |

Scope note: this stops the re-announcing, which is what produced the batch. It does not add an age floor on entry creation, so an old event that is not currently in the feed can still surface once after the upgrade and then never again. Nor does it prune entries whose thread was deleted, or bound the thread REQs with a `since`. Those were considered and deliberately left out.

Trade-off: the id set is capped at 2000 per account (~135 KB of JSON worst case), rewritten when a new notification arrives. At human pace that is irrelevant; if it ever shows up on Android the levers are a smaller cap or storing an id prefix.

`compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid`, `jvmTest` and `spotlessCheck` pass. Not yet validated on a device.

- `fix(notifications): announce an event once, not once per redelivery`