### PR TITLE
feat(dm): export and import chat history as a backup file

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.android.kt
@@ -1,0 +1,42 @@
+package org.nostr.nostrord.utils
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
+
+actual val supportsTextFilePick: Boolean = true
+
+actual class TextFilePicker(
+    private val doLaunch: () -> Unit,
+) {
+    actual fun launch() = doLaunch()
+}
+
+@Composable
+actual fun rememberTextFilePicker(
+    onError: (String) -> Unit,
+    onPicked: (content: String) -> Unit,
+): TextFilePicker {
+    val context = LocalContext.current
+    val currentOnError = rememberUpdatedState(onError)
+    val currentOnPicked = rememberUpdatedState(onPicked)
+    val launcher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            if (uri == null) return@rememberLauncherForActivityResult // cancelled
+            val content =
+                try {
+                    context.contentResolver.openInputStream(uri)?.use { it.readBytes().decodeToString() }
+                } catch (_: Exception) {
+                    null
+                }
+            if (content == null) currentOnError.value("Couldn't read that file.") else currentOnPicked.value(content)
+        }
+    return remember(launcher) {
+        // Backups are written as application/jsonl, which many file providers do not recognise;
+        // the wildcard keeps the file selectable instead of greying it out.
+        TextFilePicker { launcher.launch(arrayOf("application/jsonl", "application/json", "text/*", "*/*")) }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -45,6 +45,7 @@ import org.nostr.nostrord.network.managers.ConnectionStats
 import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmHistoryFile
 import org.nostr.nostrord.network.managers.DmManager
 import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.network.managers.DmPairingManager
@@ -2372,6 +2373,38 @@ class NostrRepository(
             )
         }
         return Result.Success(Unit)
+    }
+
+    override suspend fun exportDmHistory(): String {
+        val myPub = sessionManager.getPublicKey() ?: return ""
+        val cached =
+            try {
+                cacheStore.loadByKind(myPub, DM_CACHE_KIND)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                return ""
+            }
+        return DmHistoryFile.render(cached.mapNotNull { it.toDmMessage(myPub).rumorJson })
+    }
+
+    override suspend fun importDmHistory(text: String): Result<DmImportSummary> {
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val parsed = DmHistoryFile.parse(text)
+        if (parsed.rumors.isEmpty()) {
+            return Result.Error(AppError.Unknown("No messages this account can restore were found in that file."))
+        }
+        // Filing goes through DmManager, so the persistence collector writes the restored rumors to
+        // the cache exactly like relay-delivered ones. Nothing is published.
+        var imported = 0
+        parsed.rumors.forEach { if (dmManager.importRumor(it, myPub)) imported++ }
+        return Result.Success(
+            DmImportSummary(
+                imported = imported,
+                duplicates = parsed.rumors.size - imported,
+                skipped = parsed.skipped,
+            ),
+        )
     }
 
     override fun cancelDmArchive() {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -234,6 +234,15 @@ interface NostrRepositoryApi {
     /** The current encryption private key, for moving it to another device. */
     fun exportDmEncryptionKey(): String?
 
+    /**
+     * The whole DM history as a backup file body (JSONL, one decrypted rumor per line). Empty when
+     * there is nothing stored. The file is NOT encrypted; callers must say so before writing it.
+     */
+    suspend fun exportDmHistory(): String
+
+    /** Restore rumors from a backup file body. See [DmImportSummary] for the partial-restore case. */
+    suspend fun importDmHistory(text: String): Result<DmImportSummary>
+
     /** Progress of the self-archive republish (see DmArchiveManager). */
     val dmArchiveProgress: StateFlow<DmArchiveManager.Progress>
 
@@ -893,3 +902,14 @@ interface NostrRepositoryApi {
         explicitRelays: List<String> = emptyList(),
     ): List<String>
 }
+
+/**
+ * Outcome of restoring a backup file. [skipped] counts lines that were not a usable rumor and
+ * [duplicates] ones already in this account's history, so a restore that filed less than the file
+ * held can say why instead of looking like a silent loss.
+ */
+data class DmImportSummary(
+    val imported: Int,
+    val duplicates: Int,
+    val skipped: Int,
+)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmHistoryFile.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmHistoryFile.kt
@@ -1,0 +1,82 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.Nip17
+import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.timestampToDateTime
+
+/**
+ * The DM backup file: one decrypted rumor per line (JSONL).
+ *
+ * Byte-compatible with Jumble's export (`jumble-dm-<date>.jsonl`), so a file written by either
+ * client restores in the other. Nothing is encrypted here: the file holds the conversations in
+ * the clear, which is why the UI has to say so before writing it.
+ */
+object DmHistoryFile {
+    const val MIME_TYPE = "application/jsonl"
+
+    /** Kinds a backup carries: chat, file message, reaction. Anything else is a skipped line. */
+    private val IMPORTABLE_KINDS = setOf(Nip17.KIND_CHAT, KIND_FILE_MESSAGE, KIND_REACTION)
+
+    private const val KIND_FILE_MESSAGE = 15
+    private const val KIND_REACTION = 7
+
+    data class Parsed(
+        val rumors: List<Event>,
+        /** Lines that were not a valid rumor, reported so a partial restore is never silent. */
+        val skipped: Int,
+    )
+
+    /** `nostrord-dm-YYYY-MM-DD.jsonl`, mirroring Jumble's naming. */
+    fun fileName(): String {
+        val now = timestampToDateTime(epochSeconds())
+        val month = now.month.toString().padStart(2, '0')
+        val day = now.day.toString().padStart(2, '0')
+        return "nostrord-dm-${now.year}-$month-$day.jsonl"
+    }
+
+    fun render(rumorJson: List<String>): String = rumorJson.joinToString("\n")
+
+    /**
+     * Read a backup. Malformed and out-of-scope lines are counted rather than aborting the run:
+     * a file with one bad line still restores everything else, which is the point of a backup.
+     */
+    fun parse(text: String): Parsed {
+        val rumors = mutableListOf<Event>()
+        var skipped = 0
+        text.lineSequence().forEach { line ->
+            if (line.isBlank()) return@forEach
+            val rumor = parseLine(line)
+            if (rumor == null) skipped++ else rumors.add(rumor)
+        }
+        return Parsed(rumors, skipped)
+    }
+
+    private fun parseLine(line: String): Event? {
+        val obj = runCatching { Json.parseToJsonElement(line).jsonObject }.getOrNull() ?: return null
+        val kind = obj["kind"]?.jsonPrimitive?.content?.toIntOrNull() ?: return null
+        if (kind !in IMPORTABLE_KINDS) return null
+        val id = obj["id"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: return null
+        val pubkey = obj["pubkey"]?.jsonPrimitive?.content?.takeIf { it.isNotBlank() } ?: return null
+        val createdAt = obj["created_at"]?.jsonPrimitive?.content?.toLongOrNull() ?: return null
+        val tags = obj["tags"] as? JsonArray ?: return null
+        // Present-but-empty is valid content; absent is not.
+        val content = obj["content"]?.jsonPrimitive?.content ?: return null
+        val parsedTags =
+            tags.mapNotNull { tag ->
+                (tag as? JsonArray)?.map { it.jsonPrimitive.content }
+            }
+        return Event(
+            id = id,
+            pubkey = pubkey,
+            createdAt = createdAt,
+            kind = kind,
+            tags = parsedTags,
+            content = content,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -248,6 +248,39 @@ class DmManager(
         return true
     }
 
+    /**
+     * File a rumor restored from a backup file. Same shape as an unwrapped one, minus everything
+     * that only a relay delivery can mean: no delivery status, no wrap link, no seen-on relay.
+     * Returns false when the rumor is not a chat message for this account, or is already known.
+     */
+    fun importRumor(rumor: Event, myPubkey: String): Boolean {
+        if (rumor.kind != Nip17.KIND_CHAT) return false
+        val rumorId = rumor.id ?: return false
+        val recipient = rumor.getTag("p")?.getOrNull(1)
+        // The peer is the other party, and one side of the pair must be us, or the file is
+        // someone else's history and filing it would invent conversations.
+        val peer =
+            when (myPubkey) {
+                rumor.pubkey -> recipient
+                recipient -> rumor.pubkey
+                else -> null
+            } ?: return false
+        if (!markRumorSeen(rumorId)) return false
+        addMessage(
+            peer,
+            DmMessage(
+                id = rumorId,
+                peerPubkey = peer,
+                senderPubkey = rumor.pubkey,
+                content = rumor.content,
+                createdAt = rumor.createdAt,
+                mine = rumor.pubkey == myPubkey,
+                rumorJson = rumor.toJsonString(),
+            ),
+        )
+        return true
+    }
+
     /** Optimistically add a just-sent message so the UI shows it before the self-wrap echoes back. */
     fun addOptimistic(rumor: Event, recipientPubkey: String, myPubkey: String) {
         val rumorId = rumor.id ?: return

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
@@ -208,6 +208,67 @@ class DmEncryptionViewModel(
         repo.dismissDmPairing()
     }
 
+    // ── Chat history backup file (JSONL, interchangeable with Jumble's export) ───────────────
+
+    private val _historyBusy = MutableStateFlow(false)
+    val historyBusy: StateFlow<Boolean> = _historyBusy.asStateFlow()
+
+    /** Outcome of the last export/import, for the status line under the buttons. */
+    private val _historyStatus = MutableStateFlow<String?>(null)
+    val historyStatus: StateFlow<String?> = _historyStatus.asStateFlow()
+
+    fun clearHistoryStatus() {
+        _historyStatus.value = null
+    }
+
+    /**
+     * Hand the backup body to [write], which returns whether the file was actually written (the
+     * user can cancel a save dialog). The file is plaintext, which the UI states up front.
+     */
+    fun export(write: suspend (content: String) -> Boolean) {
+        if (_historyBusy.value) return
+        _historyBusy.value = true
+        _historyStatus.value = null
+        viewModelScope.launch {
+            val body = repo.exportDmHistory()
+            val lines = if (body.isBlank()) 0 else body.count { it == '\n' } + 1
+            _historyStatus.value =
+                when {
+                    lines == 0 -> "There are no messages to export."
+                    write(body) -> "Exported $lines messages."
+                    else -> null
+                }
+            _historyBusy.value = false
+        }
+    }
+
+    /** [read] returns the chosen file's text, or null when the user cancelled. */
+    fun import(read: suspend () -> String?) {
+        if (_historyBusy.value) return
+        _historyBusy.value = true
+        _historyStatus.value = null
+        viewModelScope.launch {
+            val text = read()
+            if (text == null) {
+                _historyBusy.value = false
+                return@launch
+            }
+            _historyStatus.value =
+                when (val result = repo.importDmHistory(text)) {
+                    is Result.Error -> result.error.message
+                    is Result.Success -> {
+                        val s = result.data
+                        buildString {
+                            append("Restored ${s.imported} messages.")
+                            if (s.duplicates > 0) append(" ${s.duplicates} were already here.")
+                            if (s.skipped > 0) append(" ${s.skipped} lines skipped.")
+                        }
+                    }
+                }
+            _historyBusy.value = false
+        }
+    }
+
     fun importKey() {
         val input = _importInput.value.trim()
         if (input.isEmpty()) return

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -172,6 +172,21 @@ class FakeNostrRepository : NostrRepositoryApi {
         return rotateDmEncryptionKeyResult
     }
 
+    var exportedDmHistory: String = ""
+    var importDmHistoryResult: Result<DmImportSummary> = Result.Success(DmImportSummary(0, 0, 0))
+    var importedDmHistoryText: String? = null
+
+    override suspend fun exportDmHistory(): String {
+        calls += "exportDmHistory"
+        return exportedDmHistory
+    }
+
+    override suspend fun importDmHistory(text: String): Result<DmImportSummary> {
+        calls += "importDmHistory"
+        importedDmHistoryText = text
+        return importDmHistoryResult
+    }
+
     var resetDmEncryptionKeyResult: Result<Unit> = Result.Success(Unit)
 
     override suspend fun resetDmEncryptionKey(): Result<Unit> {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmHistoryFileTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmHistoryFileTest.kt
@@ -1,0 +1,75 @@
+package org.nostr.nostrord.network.managers
+
+import org.nostr.nostrord.nostr.Event
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DmHistoryFileTest {
+    private val me = "a".repeat(64)
+    private val peer = "b".repeat(64)
+
+    private fun rumor(id: String, author: String = me, recipient: String = peer, content: String = "hi") = Event(
+        id = id,
+        pubkey = author,
+        createdAt = 1_700_000_000L,
+        kind = 14,
+        tags = listOf(listOf("p", recipient)),
+        content = content,
+    )
+
+    @Test
+    fun `a rendered file round-trips through the parser`() {
+        val body = DmHistoryFile.render(listOf(rumor("1".repeat(64)), rumor("2".repeat(64))).map { it.toJsonString() })
+
+        val parsed = DmHistoryFile.parse(body)
+
+        assertEquals(2, parsed.rumors.size)
+        assertEquals(0, parsed.skipped)
+        assertEquals(listOf("1".repeat(64), "2".repeat(64)), parsed.rumors.map { it.id })
+        assertEquals(listOf("p", peer), parsed.rumors.first().tags.first())
+    }
+
+    @Test
+    fun `a Jumble export parses`() {
+        // Shape taken from Jumble's exporter: one JSON.stringify'd rumor per line, no wrapper.
+        val body =
+            """
+            {"id":"${"c".repeat(64)}","pubkey":"$peer","created_at":1700000001,"kind":14,"tags":[["p","$me"]],"content":"hey"}
+            {"id":"${"d".repeat(64)}","pubkey":"$me","created_at":1700000002,"kind":15,"tags":[["p","$peer"]],"content":"file"}
+            """.trimIndent()
+
+        val parsed = DmHistoryFile.parse(body)
+
+        assertEquals(2, parsed.rumors.size)
+        assertEquals(0, parsed.skipped)
+    }
+
+    @Test
+    fun `bad lines are counted instead of aborting the restore`() {
+        val good = rumor("1".repeat(64)).toJsonString()
+        val body =
+            listOf(
+                good,
+                "not json at all",
+                """{"id":"x","pubkey":"$me","created_at":1,"kind":1,"tags":[],"content":"a note"}""",
+                """{"pubkey":"$me","created_at":1,"kind":14,"tags":[],"content":"no id"}""",
+                "",
+            ).joinToString("\n")
+
+        val parsed = DmHistoryFile.parse(body)
+
+        // A backup with a damaged line still restores everything else; blank lines are not damage.
+        assertEquals(1, parsed.rumors.size)
+        assertEquals(3, parsed.skipped)
+    }
+
+    @Test
+    fun `the file name carries the date and the jsonl extension`() {
+        val name = DmHistoryFile.fileName()
+        assertTrue(name.startsWith("nostrord-dm-"), name)
+        assertTrue(name.endsWith(".jsonl"), name)
+        // nostrord-dm-YYYY-MM-DD.jsonl: zero-padded, so the date sorts lexicographically.
+        assertTrue(Regex("""nostrord-dm-\d{4}-\d{2}-\d{2}\.jsonl""").matches(name), name)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
@@ -286,4 +286,29 @@ class DmManagerTest {
         dm.markFailed(other.id!!, "no DM relay accepted it")
         assertEquals(GroupManager.MessageStatus.Delivered, dm.messageStatus.value[other.id])
     }
+
+    @Test
+    fun `an imported rumor is filed under the peer, and only for this account`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val me = "a".repeat(64)
+        val peer = "b".repeat(64)
+        val stranger = "c".repeat(64)
+        fun rumor(id: String, author: String, recipient: String) = org.nostr.nostrord.nostr.Event(
+            id = id,
+            pubkey = author,
+            createdAt = 1L,
+            kind = 14,
+            tags = listOf(listOf("p", recipient)),
+            content = "hi",
+        )
+
+        assertEquals(true, dm.importRumor(rumor("1".repeat(64), peer, me), me))
+        assertEquals(true, dm.importRumor(rumor("2".repeat(64), me, peer), me))
+        // Same file imported twice must not double the conversation.
+        assertEquals(false, dm.importRumor(rumor("1".repeat(64), peer, me), me))
+        // Someone else's history would invent a conversation this account was never part of.
+        assertEquals(false, dm.importRumor(rumor("3".repeat(64), stranger, peer), me))
+
+        assertEquals(2, dm.messagesByPeer.value[peer]?.size)
+    }
 }

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.ios.kt
@@ -1,0 +1,21 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+
+// Choosing a file on iOS needs a UIDocumentPickerViewController presented from the root view
+// controller, the same plumbing TextFileSaver.ios.kt is waiting on. Until that lands the import
+// button is hidden here rather than opening a picker that resolves to nothing.
+actual val supportsTextFilePick: Boolean = false
+
+@Composable
+actual fun rememberTextFilePicker(
+    onError: (String) -> Unit,
+    onPicked: (content: String) -> Unit,
+): TextFilePicker = remember { TextFilePicker { } }
+
+actual class TextFilePicker(
+    private val doLaunch: () -> Unit,
+) {
+    actual fun launch() = doLaunch()
+}

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.jvm.kt
@@ -1,0 +1,60 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.lwjgl.system.MemoryStack
+import org.lwjgl.util.tinyfd.TinyFileDialogs
+import java.io.File
+
+actual val supportsTextFilePick: Boolean = true
+
+actual class TextFilePicker(
+    private val doLaunch: () -> Unit,
+) {
+    actual fun launch() = doLaunch()
+}
+
+/**
+ * tinyfd rather than java.awt.FileDialog: it shells out to zenity/kdialog, whose window the WM
+ * raises on its own, so focus returns to the app on close without any AWT focus handling.
+ */
+@Composable
+actual fun rememberTextFilePicker(
+    onError: (String) -> Unit,
+    onPicked: (content: String) -> Unit,
+): TextFilePicker {
+    val scope = rememberCoroutineScope()
+    val currentOnError = rememberUpdatedState(onError)
+    val currentOnPicked = rememberUpdatedState(onPicked)
+    return remember {
+        TextFilePicker {
+            // tinyfd blocks on the dialog subprocess, so it cannot run on the UI thread.
+            scope.launch(Dispatchers.IO) {
+                val path = openTextFileDialog() ?: return@launch // cancelled
+                val content =
+                    try {
+                        File(path).readText()
+                    } catch (_: Exception) {
+                        withContext(Dispatchers.Main) { currentOnError.value("Couldn't read that file.") }
+                        return@launch
+                    }
+                withContext(Dispatchers.Main) { currentOnPicked.value(content) }
+            }
+        }
+    }
+}
+
+private fun openTextFileDialog(): String? {
+    MemoryStack.stackPush().use { stack ->
+        val patterns = stack.mallocPointer(2)
+        patterns.put(stack.UTF8("*.jsonl"))
+        patterns.put(stack.UTF8("*.json"))
+        patterns.flip()
+        return TinyFileDialogs.tinyfd_openFileDialog("Select backup file", null, patterns, "Backup file", false)
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -55,6 +55,7 @@ import org.nostr.nostrord.auth.AuthMethod
 import org.nostr.nostrord.auth.logoutConfirmBody
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmHistoryFile
 import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
@@ -81,6 +82,10 @@ import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.utils.rememberTextFilePicker
+import org.nostr.nostrord.utils.rememberTextFileSaver
+import org.nostr.nostrord.utils.supportsTextFilePick
+import org.nostr.nostrord.utils.supportsTextFileSave
 
 enum class SettingsSection(val label: String) {
     Profile("Profile"),
@@ -1335,7 +1340,74 @@ private fun DmSettingsPanelContent(
         // Relay editor only matters while DMs are on; hidden with the rest of the feature when off.
         if (dmEnabled) {
             DmEncryptionPanelContent()
+            DmChatHistoryPanelContent()
             DmRelayPanelContent()
+        }
+    }
+}
+
+/**
+ * Backup file for the decrypted history: plain JSONL, one rumor per line, interchangeable with
+ * Jumble's export. Offered to every account, not only the ones that can hold an encryption key.
+ */
+@Composable
+private fun DmChatHistoryPanelContent() {
+    if (!supportsTextFileSave && !supportsTextFilePick) return
+    val activeAccountId by AppModule.accountStore.activeId.collectAsState()
+    val vm = viewModel(key = activeAccountId) { DmEncryptionViewModel(AppModule.nostrRepository) }
+    val busy by vm.historyBusy.collectAsState()
+    val status by vm.historyStatus.collectAsState()
+    val saveFile = rememberTextFileSaver()
+    val picker = rememberTextFilePicker(onError = { vm.clearHistoryStatus() }) { content -> vm.import { content } }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = NostrordShapes.cardShape,
+        colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(Spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(Spacing.lg),
+        ) {
+            Text(text = "Chat history", style = NostrordTypography.Button, color = NostrordColors.TextPrimary)
+            Text(
+                text = "Export your messages as a backup file, or import one to restore them on this " +
+                    "device. Importing never publishes anything.",
+                style = NostrordTypography.Caption,
+                color = NostrordColors.TextSecondary,
+            )
+            Text(
+                text = "The file is not encrypted: anyone who opens it reads your conversations. Keep it " +
+                    "somewhere you would keep your private key.",
+                style = NostrordTypography.Caption,
+                color = NostrordColors.Warning,
+            )
+            status?.let {
+                Text(text = it, style = NostrordTypography.Caption, color = NostrordColors.Success)
+            }
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                if (supportsTextFilePick) {
+                    TextButton(onClick = { picker.launch() }, enabled = !busy) {
+                        Text("Import", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                    }
+                }
+                if (supportsTextFileSave) {
+                    TextButton(
+                        onClick = {
+                            vm.export { content ->
+                                saveFile(content, DmHistoryFile.fileName())
+                            }
+                        },
+                        enabled = !busy,
+                    ) {
+                        Text(
+                            if (busy) "Working…" else "Export",
+                            color = NostrordColors.Primary,
+                            style = NostrordTypography.Button,
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/utils/TextFilePicker.kt
@@ -1,0 +1,20 @@
+package org.nostr.nostrord.utils
+
+import androidx.compose.runtime.Composable
+
+/** True on platforms that can let the user choose a text file to read. */
+expect val supportsTextFilePick: Boolean
+
+/**
+ * Picks one text file and hands its whole content to [onPicked]. Cancelling calls nothing.
+ * Reading is bounded by the caller's use: only small backup files go through here.
+ */
+expect class TextFilePicker {
+    fun launch()
+}
+
+@Composable
+expect fun rememberTextFilePicker(
+    onError: (String) -> Unit = {},
+    onPicked: (content: String) -> Unit,
+): TextFilePicker

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -5,6 +5,7 @@ import org.nostr.nostrord.auth.logoutConfirmBody
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmHistoryFile
 import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
@@ -43,6 +44,9 @@ import org.nostr.nostrord.web.components.icon
 import org.nostr.nostrord.web.components.noticeCard
 import org.nostr.nostrord.web.components.useEscClose
 import org.nostr.nostrord.web.navigation.pushRoute
+import org.w3c.dom.url.URL
+import org.w3c.files.Blob
+import org.w3c.files.BlobPropertyBag
 import react.FC
 import react.Props
 import react.dom.html.ReactHTML.button
@@ -54,12 +58,20 @@ import react.dom.html.ReactHTML.select
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.textarea
 import react.useEffect
+import react.useRef
 import react.useState
 import web.cssom.ClassName
+import web.dom.document
+import web.file.File
+import web.html.HTMLAnchorElement
+import web.html.HTMLInputElement
 import web.html.InputType
 import web.html.checkbox
+import web.html.file
 import web.html.password
 import web.html.text
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
 external interface SettingsScreenProps : Props {
     var onClose: () -> Unit
@@ -692,6 +704,7 @@ private val DmRelaysPanel =
 
         if (dmEnabled) {
             DmEncryptionPanel()
+            DmChatHistoryPanel()
         }
 
         // Relay editor only matters while DMs are on; hidden with the rest of the feature when off.
@@ -1827,4 +1840,111 @@ private fun react.ChildrenBuilder.levelRadio(
             }
         }
     }
+}
+
+// ── Chat history backup file ─────────────────────────────────────────────────
+
+/**
+ * Export/import of the decrypted history as a JSONL file, interchangeable with Jumble's backup.
+ * Available to every account: unlike the encryption key, a backup helps a local signer too.
+ */
+private val DmChatHistoryPanel =
+    FC<Props> {
+        val vm = useViewModel { DmEncryptionViewModel(AppModule.nostrRepository) }
+        val busy = useStateFlow(vm.historyBusy)
+        val status = useStateFlow(vm.historyStatus)
+        val fileInput = useRef<HTMLInputElement>(null)
+
+        div {
+            className = ClassName("settings-card")
+            div {
+                className = ClassName("settings-section-head")
+                +"CHAT HISTORY"
+            }
+            div {
+                className = ClassName("settings-tip")
+                +(
+                    "Export your messages as a backup file, or import one to restore them on this " +
+                        "device. Importing never publishes anything."
+                    )
+            }
+            div {
+                className = ClassName("settings-tip warning")
+                +(
+                    "The file is not encrypted: anyone who opens it reads your conversations. Keep it " +
+                        "somewhere you would keep your private key."
+                    )
+            }
+            status?.let {
+                div {
+                    className = ClassName("settings-success")
+                    +it
+                }
+            }
+            // Hidden input: the visible button drives it, so the control matches the rest of the page.
+            input {
+                ref = fileInput
+                className = ClassName("upload-file-input")
+                type = InputType.file
+                accept = ".jsonl,.json,application/jsonl,application/json"
+                onChange = { event ->
+                    val picked = event.target.files?.item(0)
+                    event.target.value = "" // so re-picking the same file fires onChange again
+                    if (picked != null) vm.import { readTextFile(picked) }
+                }
+            }
+            div {
+                className = ClassName("settings-form-actions")
+                button {
+                    className = ClassName("btn-text btn-sm accent")
+                    disabled = busy
+                    onClick = { fileInput.current?.click() }
+                    +"Import"
+                }
+                button {
+                    className = ClassName("btn-text btn-sm accent")
+                    disabled = busy
+                    onClick = {
+                        vm.export { content ->
+                            downloadTextFile(content, DmHistoryFile.fileName(), DmHistoryFile.MIME_TYPE)
+                            true
+                        }
+                    }
+                    +(if (busy) "Working…" else "Export")
+                }
+            }
+        }
+    }
+
+/**
+ * Reads the picked file as text. Plain `FileReader` over dynamic rather than the wrappers' typed
+ * handler: its `EventHandler` needs generic parameters this call site cannot name.
+ */
+private suspend fun readTextFile(file: File): String? = suspendCoroutine { cont ->
+    val reader: dynamic = js("new FileReader()")
+    var settled = false
+    reader.onload = {
+        if (!settled) {
+            settled = true
+            cont.resume(reader.result as? String)
+        }
+    }
+    reader.onerror = {
+        if (!settled) {
+            settled = true
+            cont.resume(null)
+        }
+    }
+    reader.readAsText(file)
+}
+
+/** Saves [content] through an object-URL anchor, the browser's only "write a file" affordance. */
+private fun downloadTextFile(content: String, fileName: String, mimeType: String) {
+    val blob = Blob(arrayOf(content), BlobPropertyBag(type = mimeType))
+    val url = URL.createObjectURL(blob)
+    val anchor = document.createElement("a") as HTMLAnchorElement
+    anchor.href = url
+    anchor.download = fileName
+    anchor.click()
+    URL.revokeObjectURL(url)
 }


### PR DESCRIPTION
Stacked on #259.

A decrypted history that lives only in one device's cache is one wipe away from gone, and rotating or resetting the encryption key takes the relay copies with it. The backup is plain JSONL, one rumor per line, byte-compatible with Jumble's export, so a file written by either client restores in the other.

Import files rumors through DmManager, so they persist exactly like relay-delivered ones and nothing is published. Rumors where neither side is this account are rejected: someone else's file would invent conversations.

| | |
|---|---|
| Format | JSONL, kinds 14/15/7, same validation as Jumble's importer |
| File | `nostrord-dm-YYYY-MM-DD.jsonl` |
| Encryption | none, and the card says so in warning colour |
| Picker | new expect/actual: `OpenDocument` on Android, tinyfd on desktop (same reason as the media picker), documented stub on iOS alongside TextFileSaver's |

The card hides itself where neither saving nor picking is available, so iOS shows nothing rather than a dead button.

- af647222 feat(dm): export and import chat history as a backup file