### PR TITLE
feat(dm): announce a NIP-4e encryption key, pair devices, and archive history

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/Account.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/Account.kt
@@ -97,12 +97,21 @@ fun removeAccountDialogBody(
     accountLabel: String,
     fallbackLabel: String?,
     method: AuthMethod,
+    holdsDmEncryptionKey: Boolean = false,
 ): String {
     val erased = "${erasedSubject(method, accountLabel)} will be erased on this device."
-    return when {
-        isActive && fallbackLabel != null -> "$erased You'll switch to \"$fallbackLabel\"."
-        isActive -> "$erased ${signInAgainHint(method)}"
-        else -> erased
+    val base =
+        when {
+            isActive && fallbackLabel != null -> "$erased You'll switch to \"$fallbackLabel\"."
+            isActive -> "$erased ${signInAgainHint(method)}"
+            else -> erased
+        }
+    // Unlike the identity key, this one is not recoverable from a backup phrase or a signer:
+    // messages already sent to it can only ever be opened with it.
+    return if (holdsDmEncryptionKey) {
+        "$base This device also holds this account's DM encryption key. Export it first or messages sent to it become unreadable."
+    } else {
+        base
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -42,10 +42,14 @@ import org.nostr.nostrord.network.livekit.LiveKitCredentials
 import org.nostr.nostrord.network.livekit.LiveKitTokenClient
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.ConnectionStats
+import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmConversation
+import org.nostr.nostrord.network.managers.DmEncryptionManager
 import org.nostr.nostrord.network.managers.DmManager
 import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.managers.LegacySealVerifier
 import org.nostr.nostrord.network.managers.LiveCursorStore
 import org.nostr.nostrord.network.managers.MetadataManager
 import org.nostr.nostrord.network.managers.OutboxManager
@@ -58,9 +62,11 @@ import org.nostr.nostrord.network.managers.UnreadManager
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip44
 import org.nostr.nostrord.nostr.Nip4e
 import org.nostr.nostrord.nostr.Nip78
 import org.nostr.nostrord.settings.NotificationLevel
@@ -73,6 +79,7 @@ import org.nostr.nostrord.storage.getLastActiveAt
 import org.nostr.nostrord.storage.isDmCacheMigratedFor
 import org.nostr.nostrord.storage.isGroupFetchLazy
 import org.nostr.nostrord.storage.isKind10009RepublishPendingFor
+import org.nostr.nostrord.storage.loadDmArchivedRumorIdsFor
 import org.nostr.nostrord.storage.loadDmEncKeys
 import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
@@ -87,6 +94,7 @@ import org.nostr.nostrord.storage.loadKind30078TimestampFor
 import org.nostr.nostrord.storage.loadMuteListSnapshotFor
 import org.nostr.nostrord.storage.loadRelayListFor
 import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
+import org.nostr.nostrord.storage.saveDmArchivedRumorIdsFor
 import org.nostr.nostrord.storage.saveDmEncKeys
 import org.nostr.nostrord.storage.saveDmLastRead
 import org.nostr.nostrord.storage.saveDmProcessedWrapIds
@@ -101,6 +109,7 @@ import org.nostr.nostrord.storage.saveKind30078TimestampFor
 import org.nostr.nostrord.storage.saveMuteListSnapshotFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
+import org.nostr.nostrord.ui.screens.dm.eventJson
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
@@ -245,6 +254,16 @@ class NostrRepository(
     // quiet gaps), wasting the work and stalling progress. 90s rides out a quiet gap while still
     // freeing the permit for the periodic retry when the signer is genuinely gone.
     private val DM_DECRYPT_TIMEOUT_MS = 90_000L
+
+    // How long to wait for a peer's kind:10044 after asking for it, when authenticating a NIP-4e
+    // legacy seal. Short: on a miss the wrap stays unhandled and the pipeline retries it later.
+    private val DM_ENC_KEY_FETCH_WAIT_MS = 3_000L
+
+    // Publish the legacy (encryption-key-signed) copy alongside the modern one, mirroring Jumble's
+    // migration. It is the only shape Coop and pre-migration builds read, it is signed locally so
+    // it costs no signer time, and the modern copy stays the delivery-tracked primary. Flip off
+    // once the deployed clients have dropped their legacy readers.
+    private val NIP4E_DUAL_SEND = true
 
     // Per-relay budget for a background event publish (connect + send). Bounds a dead socket so it
     // can't leak the publish job; delivery is best-effort and swallows failures anyway.
@@ -1215,6 +1234,16 @@ class NostrRepository(
             }
         }
 
+        // NIP-4e keys follow the session, not the DM inbox: whether the account signs remotely is
+        // only knowable once its signer is installed, which can land after the inbox opens.
+        scope.launch {
+            ActiveAccountManager.session.collect { session ->
+                dmPairingManager.clear()
+                pendingPairingRequestId = null
+                if (session == null) dmEncryptionManager.clear() else dmEncryptionManager.loadFor(session.pubkey, session.signer.isRemote)
+            }
+        }
+
         // Auto-forget confirmed orphan pins. A joined group still missing its kind:39000
         // after the hosting relay finished its group list (EOSE) was deleted, or was filed
         // under the wrong relay — it can never resolve, shows as a broken "No description"
@@ -1914,6 +1943,39 @@ class NostrRepository(
 
     private val dmManager = DmManager(scope, mutedPubkeys)
 
+    private val dmEncryptionManager = DmEncryptionManager()
+
+    private val dmArchiveManager = DmArchiveManager()
+
+    private val dmPairingManager = DmPairingManager()
+
+    /** Our own outstanding kind:4454, deleted once a device answers it. */
+    private var pendingPairingRequestId: String? = null
+
+    override val dmPairingState: StateFlow<DmPairingManager.State> = dmPairingManager.state
+
+    override val dmArchiveProgress: StateFlow<DmArchiveManager.Progress> = dmArchiveManager.progress
+
+    override val dmEncryptionState: StateFlow<DmEncryptionManager.State> = dmEncryptionManager.state
+
+    /**
+     * Decryptors for inbound wraps, held NIP-4e keys first: they fail in microseconds on a bad
+     * HMAC, so trying them costs nothing when the wrap is not ours, and it removes the signer from
+     * the read path entirely when it is.
+     */
+    private fun dmDecryptors(signer: NostrSigner): List<Nip17.Nip44Decryptor> = dmEncryptionManager.heldKeys().map { kp ->
+        Nip17.Nip44Decryptor { peer, ciphertext -> Nip44.decrypt(ciphertext, kp.privateKeyHex, peer) }
+    } + Nip17.Nip44Decryptor { peer, ciphertext -> signer.nip44Decrypt(peer, ciphertext) }
+
+    private val legacySealVerifier =
+        LegacySealVerifier(
+            fetchWaitMs = DM_ENC_KEY_FETCH_WAIT_MS,
+            announcedKeyFor = { author -> dmManager.encryptionKeyFor(author) },
+            requestAnnouncement = { author -> fetchDmRelays(author) },
+        )
+
+    private suspend fun verifyLegacyDmSender(authorPubkey: String, sealPubkey: String): Boolean = legacySealVerifier.verify(authorPubkey, sealPubkey)
+
     /** Conversations (most-recent first), derived from decrypted NIP-17 messages. */
     override val dmConversations: StateFlow<List<DmConversation>> get() = dmManager.conversations
 
@@ -1973,19 +2035,46 @@ class NostrRepository(
         return try {
             val rumor = Nip17.buildRumor(myPub, recipientPubkey, content)
             // NIP-4e: a recipient who announced an encryption key gets both NIP-44 layers addressed
-            // to it, tagged with the key they must ECDH the seal against. We hold no encryption key
-            // of our own yet, so that key is our identity pubkey, which is what makes this readable
-            // and verified by adopters without us publishing any state.
+            // to it, tagged with the key they must ECDH the seal against. Until we hold an
+            // encryption key of our own that key is our identity pubkey, which is what makes this
+            // readable by adopters without us publishing any state yet.
             val recipientEncKey = dmManager.encryptionKeyFor(recipientPubkey)
+            // Our own encryption key, when we hold one AND it is the announced one. It makes both
+            // seals a local NIP-44 op, so a send costs two signatures instead of two signatures
+            // plus two remote encrypts.
+            val myEncKey =
+                (dmEncryptionManager.state.value as? DmEncryptionManager.State.Active)
+                    ?.let { dmEncryptionManager.heldKeys().firstOrNull() }
             val recipientWrap =
                 if (recipientEncKey != null) {
-                    Nip17.wrap(rumor, recipientPubkey, signer, encryptTo = recipientEncKey, senderEncTag = myPub)
+                    Nip17.wrap(
+                        rumor,
+                        recipientPubkey,
+                        signer,
+                        encryptTo = recipientEncKey,
+                        // Until we hold a key of our own, our encryption key IS our identity key,
+                        // which is what makes this readable and verified without announcing state.
+                        senderEncTag = myEncKey?.publicKeyHex ?: myPub,
+                        encryptWith = myEncKey?.privateKeyHex,
+                    )
                 } else {
                     Nip17.wrap(rumor, recipientPubkey, signer)
                 }
-            // The self-copy stays identity-addressed: our own inbox path is unchanged and other
-            // devices on this account read it exactly as before.
-            val selfWrap = Nip17.wrap(rumor, myPub, signer)
+            // Self-copy: addressed to our encryption key once we hold one, so our other devices
+            // read it without the signer too; identity-addressed otherwise, exactly as before.
+            val selfWrap =
+                if (myEncKey != null) {
+                    Nip17.wrap(
+                        rumor,
+                        myPub,
+                        signer,
+                        encryptTo = myEncKey.publicKeyHex,
+                        senderEncTag = myEncKey.publicKeyHex,
+                        encryptWith = myEncKey.privateKeyHex,
+                    )
+                } else {
+                    Nip17.wrap(rumor, myPub, signer)
+                }
             dmManager.addOptimistic(rumor, recipientPubkey, myPub)
             val rumorId = rumor.id ?: return Result.Error(AppError.Unknown("Failed to build the message"))
             // Enqueue both wraps (recipient + self-copy) in the persisted send queue, then publish.
@@ -2000,6 +2089,35 @@ class NostrRepository(
                     PendingDmWrap(rumorId, selfWrap.id ?: "", selfWrap.toJsonObject().toString(), dmRelaysWithDefaults(myPub), now),
                 ),
             )
+            if (NIP4E_DUAL_SEND && myEncKey != null && recipientEncKey != null) {
+                // Best-effort copies in the encryption-key-signed shape, the only one deployed
+                // readers that predate the identity-signed seal accept. Both are signed locally,
+                // and the modern wraps above remain the delivery-tracked primaries, so a failure
+                // here never affects the message's state.
+                scope.launch {
+                    try {
+                        publishEventToRelays(
+                            dmRelaysWithDefaults(recipientPubkey),
+                            Nip17.giftWrap(
+                                Nip17.legacySeal(rumor, myEncKey.privateKeyHex, recipientEncKey),
+                                recipientPubkey,
+                                encryptTo = recipientEncKey,
+                            ),
+                        )
+                        publishEventToRelays(
+                            dmRelaysWithDefaults(myPub),
+                            Nip17.giftWrap(
+                                Nip17.legacySeal(rumor, myEncKey.privateKeyHex, myEncKey.publicKeyHex),
+                                myPub,
+                                encryptTo = myEncKey.publicKeyHex,
+                            ),
+                        )
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                    }
+                }
+            }
             Result.Success(Unit)
         } catch (e: NostrSigner.SigningException) {
             Result.Error(AppError.Unknown("Your signer could not encrypt this message (NIP-44). It may not support direct messages."))
@@ -2007,6 +2125,290 @@ class NostrRepository(
             Result.Error(AppError.Unknown(e.message ?: "Failed to send the message"))
         }
     }
+
+    /**
+     * Announce a NIP-4e encryption key so senders address it and inbound DMs decrypt in-process.
+     * Reuses the held key when there is one, so re-enabling does not strand history behind a key
+     * nobody is told about any more.
+     */
+    override suspend fun enableDmEncryption(): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val state = dmEncryptionManager.state.value
+        if (state is DmEncryptionManager.State.AnnouncedElsewhere) {
+            return Result.Error(
+                AppError.Unknown("This account already announced an encryption key from another device. Import that key here first."),
+            )
+        }
+        val encPubkey = dmEncryptionManager.currentEncPubkeyOrNull() ?: dmEncryptionManager.generateKey()
+        return publishEncryptionAnnouncement(signer, myPub, encPubkey).also {
+            if (it is Result.Success) dmEncryptionManager.setAnnounced(true)
+        }
+    }
+
+    /**
+     * Replace the advertised key with a fresh one. The previous key stays held and keeps being
+     * tried on receive, both for its own history and for contacts who have not re-read our
+     * announcement yet and are still addressing it.
+     */
+    override suspend fun rotateDmEncryptionKey(): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        if (dmEncryptionManager.state.value !is DmEncryptionManager.State.Active) {
+            return Result.Error(AppError.Unknown("Turn on the fast decryption key first."))
+        }
+        val fresh = dmEncryptionManager.generateKey()
+        return publishEncryptionAnnouncement(signer, myPub, fresh).also {
+            if (it is Result.Success) dmEncryptionManager.setAnnounced(true)
+        }
+    }
+
+    /**
+     * Stop advertising our encryption key. The key itself is kept: messages already addressed to
+     * it can only ever be opened with it, so deleting it would destroy that history.
+     */
+    override suspend fun disableDmEncryption(): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        return publishEncryptionAnnouncement(signer, myPub, null).also {
+            if (it is Result.Success) dmEncryptionManager.setAnnounced(false)
+        }
+    }
+
+    private suspend fun publishEncryptionAnnouncement(signer: NostrSigner, myPub: String, encPubkey: String?): Result<Unit> = try {
+        val signed = signer.signEvent(Nip4e.buildAnnouncement(myPub, encPubkey, epochSeconds()))
+        // Same relay set as the DM relay list: senders look for both on our outbox, and our
+        // own DM relays are where another device of ours will read it.
+        val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays + dmRelaysWithDefaults(myPub)).distinct()
+        publishEventToRelays(targets, signed)
+        Result.Success(Unit)
+    } catch (e: kotlinx.coroutines.CancellationException) {
+        throw e
+    } catch (e: Throwable) {
+        Result.Error(AppError.Unknown(e.message ?: "Failed to publish the encryption key announcement"))
+    }
+
+    /**
+     * Rumors still missing an archive copy. Messages newer than the announcement are already
+     * addressed to the encryption key by the sender (inbound) or by our own send path (outbound).
+     */
+    private suspend fun pendingArchiveRumors(myPub: String): List<Event> {
+        val cached =
+            try {
+                cacheStore.loadByKind(myPub, DM_CACHE_KIND)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (_: Exception) {
+                return emptyList()
+            }
+        val rumors =
+            cached.mapNotNull { row ->
+                Nip17.parseRumor(row.toDmMessage(myPub).eventJson())
+            }
+        return dmArchiveManager.pending(rumors, dmEncryptionManager.announcedAt())
+    }
+
+    override suspend fun countDmArchivableMessages(): Int {
+        val myPub = sessionManager.getPublicKey() ?: return 0
+        if (dmEncryptionManager.state.value !is DmEncryptionManager.State.Active) return 0
+        return pendingArchiveRumors(myPub).size
+    }
+
+    /**
+     * Republish decrypted history to ourselves, addressed to our encryption key, so a new device
+     * holding that key loads it without the signer. One signature per message, paced through the
+     * same gate as sends, and resumable: only relay-accepted copies advance the progress set.
+     */
+    override suspend fun archiveDmHistory(): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val encKey =
+            (dmEncryptionManager.state.value as? DmEncryptionManager.State.Active)
+                ?.let { dmEncryptionManager.heldKeys().firstOrNull() }
+                ?: return Result.Error(AppError.Unknown("Turn on the fast decryption key first."))
+
+        // Runs on the repository scope, not the caller's: archiving takes minutes and must survive
+        // the user leaving Settings. Progress and failures are reported through dmArchiveProgress.
+        scope.launch {
+            dmArchiveManager.run(
+                rumors = pendingArchiveRumors(myPub),
+                buildWrap = { rumor ->
+                    // One shape for both halves. Our own messages come out as ordinary NIP-17
+                    // self-wraps (seal.pubkey == rumor.pubkey); a peer's rumor makes the seal ours over
+                    // their rumor, which only our own unwrap accepts (see Nip17.unwrap) and which every
+                    // other client drops silently.
+                    bunkerPublishGate.withLock { delay(BUNKER_WRAP_ADMIT_INTERVAL_MS) }
+                    Nip17.wrap(
+                        rumor,
+                        myPub,
+                        signer,
+                        encryptTo = encKey.publicKeyHex,
+                        senderEncTag = encKey.publicKeyHex,
+                        encryptWith = encKey.privateKeyHex,
+                    )
+                },
+                // A new device's dm_inbox REQ looks exactly here.
+                publish = { wrap -> publishWrapJsonAwaitOk(dmRelaysWithDefaults(myPub), wrap.toJsonObject().toString(), wrap.id ?: "") },
+                persistProgress = { ids -> SecureStorage.saveDmArchivedRumorIdsFor(myPub, ids) },
+            )
+        }
+        return Result.Success(Unit)
+    }
+
+    override fun cancelDmArchive() {
+        dmArchiveManager.cancel()
+    }
+
+    /**
+     * Ask another device of this account for the encryption key (NIP-4e kind:4454). The reply is
+     * encrypted to a throwaway key only this device holds, so nothing usable is exposed by the
+     * request sitting on a relay.
+     */
+    override suspend fun requestDmEncryptionKey(): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        return try {
+            val throwaway = dmPairingManager.beginRequest()
+            val signed = signer.signEvent(Nip4e.buildClientKeyRequest(myPub, throwaway, epochSeconds()))
+            pendingPairingRequestId = signed.id
+            publishEventToRelays(pairingRelays(myPub), signed)
+            Result.Success(Unit)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            dmPairingManager.failed(e.message ?: "Could not publish the pairing request")
+            Result.Error(AppError.Unknown(e.message ?: "Could not publish the pairing request"))
+        }
+    }
+
+    /** Send our encryption key to the device that asked for it (NIP-4e kind:4455). */
+    override suspend fun approveDmPairing(): Result<Unit> {
+        val incoming =
+            dmPairingManager.state.value as? DmPairingManager.State.IncomingRequest
+                ?: return Result.Error(AppError.Unknown("There is no pairing request to approve."))
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val encKey =
+            dmEncryptionManager.heldKeys().firstOrNull()
+                ?: return Result.Error(AppError.Unknown("This device does not hold an encryption key."))
+        return try {
+            val throwaway = KeyPair.generate()
+            val encrypted = Nip44.encrypt(encKey.privateKeyHex, throwaway.privateKeyHex, incoming.throwawayPubkey)
+            val signed =
+                signer.signEvent(
+                    Nip4e.buildKeyShare(myPub, throwaway.publicKeyHex, incoming.throwawayPubkey, encrypted, epochSeconds()),
+                )
+            publishEventToRelays(pairingRelays(myPub), signed)
+            dmPairingManager.resolveIncoming(incoming.throwawayPubkey)
+            // The share is single-use: once the requester holds the key, leaving a copy of the
+            // ciphertext on relays only widens the window for offline attacks on the throwaway keys.
+            signed.id?.let { scope.launch { publishDeletion(myPub, signer, listOf(it)) } }
+            Result.Success(Unit)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            Result.Error(AppError.Unknown(e.message ?: "Could not send the encryption key"))
+        }
+    }
+
+    override fun declineDmPairing() {
+        (dmPairingManager.state.value as? DmPairingManager.State.IncomingRequest)?.let {
+            dmPairingManager.resolveIncoming(it.throwawayPubkey)
+        }
+    }
+
+    override fun dismissDmPairing() {
+        dmPairingManager.reset()
+    }
+
+    /** A kind:4455 answering our own outstanding request: decrypt, validate, hold. */
+    private fun handleKeyShare(event: Event, myPub: String) {
+        val ours = dmPairingManager.requestThrowawayKey() ?: return
+        if (Nip4e.keyShareRecipientFrom(event) != ours.publicKeyHex) return
+        val senderThrowaway = Nip4e.throwawayPubkeyFrom(event) ?: return
+        val keyHex =
+            runCatching { Nip44.decrypt(event.content, ours.privateKeyHex, senderThrowaway) }.getOrNull()
+                ?: return dmPairingManager.failed("The key from the other device could not be read.")
+        // importKey rejects anything that is not the key this account announced, so a forged or
+        // stale share cannot leave us holding something senders are not addressing.
+        if (!dmEncryptionManager.importKey(keyHex)) {
+            dmPairingManager.failed("The other device sent a key that does not match this account's announcement.")
+            return
+        }
+        dmPairingManager.succeeded()
+        val signer = ActiveAccountManager.session.value?.signer ?: return
+        val ids = listOfNotNull(event.id, pendingPairingRequestId)
+        pendingPairingRequestId = null
+        if (ids.isNotEmpty()) scope.launch { publishDeletion(myPub, signer, ids) }
+    }
+
+    /** NIP-09 delete for our own pairing events; best effort, relays may keep them anyway. */
+    private suspend fun publishDeletion(myPub: String, signer: NostrSigner, eventIds: List<String>) {
+        try {
+            val deletion =
+                Event(
+                    pubkey = myPub,
+                    createdAt = epochSeconds(),
+                    kind = 5,
+                    tags = eventIds.map { listOf("e", it) },
+                    content = "",
+                )
+            publishEventToRelays(pairingRelays(myPub), signer.signEvent(deletion))
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (_: Throwable) {
+        }
+    }
+
+    /**
+     * Watch our own pairing events. Both kinds are authored by our identity, are rare, and only
+     * matter live, so this is a small `since`-now subscription rather than a history read.
+     */
+    private suspend fun sendPairingReq(myPub: String) {
+        val filter =
+            buildJsonObject {
+                putJsonArray("kinds") {
+                    add(Nip4e.KIND_CLIENT_KEY)
+                    add(Nip4e.KIND_KEY_SHARE)
+                }
+                putJsonArray("authors") { add(myPub) }
+                put("since", epochSeconds())
+            }
+        val req =
+            buildJsonArray {
+                add("REQ")
+                add("nip4e_pair")
+                add(filter)
+            }.toString()
+        pairingRelays(myPub).forEach { url ->
+            val client =
+                connectionManager.getClientForRelay(url)
+                    ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+            try {
+                client?.send(req)
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    private fun pairingRelays(myPub: String): List<String> = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays + dmRelaysWithDefaults(myPub)).distinct()
+
+    /** Hold a key exported from another device. Rejected unless it matches the announced one. */
+    override fun importDmEncryptionKey(privateKeyHex: String): Boolean = dmEncryptionManager.importKey(privateKeyHex)
+
+    override fun exportDmEncryptionKey(): String? = dmEncryptionManager.exportKey()
 
     private suspend fun publishEventToRelays(relays: List<String>, event: Event) {
         val json =
@@ -2113,6 +2515,9 @@ class NostrRepository(
         if (dmInboxStarted) return
         val myPub = sessionManager.getPublicKey() ?: return
         dmInboxStarted = true
+
+        dmArchiveManager.hydrate(SecureStorage.loadDmArchivedRumorIdsFor(myPub))
+        sendPairingReq(myPub)
 
         // Seed the follow set from its persisted cache before the DM list partitions, so
         // conversations land in Follows/Others immediately instead of all falling in Others until
@@ -2240,6 +2645,7 @@ class NostrRepository(
             }
         }
         dmManager.clear()
+        dmArchiveManager.clear()
         _myDmRelays.value = emptyList()
         dmInboxEosedRelays = emptySet()
         // Drop the in-memory send queue; the persisted per-account copy stays on disk and is
@@ -2554,6 +2960,9 @@ class NostrRepository(
         dmPersistenceJobs.forEach { it.cancel() }
         dmPersistenceJobs.clear()
         dmManager.clear()
+        // Not dmEncryptionManager: the session collector owns it, and clearing here would race a
+        // warm account switch that has already installed the new signer.
+        dmArchiveManager.clear()
         _myDmRelays.value = emptyList()
         dmInboxStarted = false
         dmPersistenceWired = false
@@ -5072,6 +5481,38 @@ class NostrRepository(
                     // backlog; anything after is a live incoming DM.
                     val liveWrap = dmInboxSubscribedRelays.isNotEmpty() &&
                         dmInboxEosedRelays.containsAll(dmInboxSubscribedRelays)
+                    // NIP-4e fast path: a wrap addressed to a key we hold decrypts in-process, so
+                    // it skips the boot hold, the trickle and the bunker gate entirely. This is
+                    // the payoff of announcing a key: an adopted-sender backlog drains at local
+                    // speed while the signer stays idle. A miss here costs two failed HMACs and
+                    // falls through to the paced signer path below, without counting as a failure.
+                    if (dmEncryptionManager.heldKeys().isNotEmpty() &&
+                        sessionManager.getPublicKey() == myPub &&
+                        AppModule.dmSettings.dmEnabled.value
+                    ) {
+                        val localOnly =
+                            dmEncryptionManager.heldKeys().map { kp ->
+                                Nip17.Nip44Decryptor { peer, ciphertext -> Nip44.decrypt(ciphertext, kp.privateKeyHex, peer) }
+                            }
+                        val handledLocally =
+                            try {
+                                dmManager.ingestGiftWrap(giftWrap, myPub, localOnly, ::verifyLegacyDmSender)
+                            } catch (e: kotlinx.coroutines.CancellationException) {
+                                throw e
+                            } catch (_: Throwable) {
+                                false
+                            }
+                        if (handledLocally) {
+                            if (wrapId != null && wrapId !in dmProcessedWrapIds) {
+                                dmProcessedWrapIds = dmProcessedWrapIds + wrapId
+                                dmFailCounts = dmFailCounts - wrapId
+                                scheduleSaveProcessedWrapIds(myPub)
+                            }
+                            if (wrapId != null) dmInFlightWrapIds = dmInFlightWrapIds - wrapId
+                            maybeLatchDmFullSync(myPub)
+                            return@launch
+                        }
+                    }
                     try {
                         // A bunker signer pays a remote round-trip per NIP-44 decrypt, and a gift
                         // wrap needs two (wrap then seal). A cold start with a large DM backlog
@@ -5095,7 +5536,7 @@ class NostrRepository(
                                 false
                             } else {
                                 kotlinx.coroutines.withTimeoutOrNull(DM_DECRYPT_TIMEOUT_MS) {
-                                    dmManager.ingestGiftWrap(giftWrap, myPub, signer)
+                                    dmManager.ingestGiftWrap(giftWrap, myPub, dmDecryptors(signer), ::verifyLegacyDmSender)
                                 } ?: false
                             }
                         }
@@ -5154,15 +5595,6 @@ class NostrRepository(
                 }
                 return
             }
-            // A user's NIP-4e encryption key announcement (kind:10044). Sending only: we announce
-            // no key of our own here, so nothing changes about how our inbox is read.
-            if (kind == Nip4e.KIND_ENCRYPTION_KEY) {
-                if (!AppModule.dmSettings.dmEnabled.value) return
-                runCatching { parseSignedEventJson(event.toString()) }.getOrNull()?.let {
-                    dmManager.ingestEncryptionKey(it)
-                }
-                return
-            }
             // A user's NIP-17 DM relay list (kind:10050).
             if (kind == Nip17.KIND_DM_RELAYS) {
                 if (!AppModule.dmSettings.dmEnabled.value) return
@@ -5180,6 +5612,33 @@ class NostrRepository(
                             scope.launch { resendDmInboxReq(it.pubkey) }
                         }
                     }
+                }
+                return
+            }
+            // NIP-4e device pairing, our own account only: a device asking for the encryption key
+            // (4454) and a device answering with it (4455).
+            if (kind == Nip4e.KIND_CLIENT_KEY || kind == Nip4e.KIND_KEY_SHARE) {
+                if (!AppModule.dmSettings.dmEnabled.value) return
+                val myPub = sessionManager.getPublicKey() ?: return
+                runCatching { parseSignedEventJson(event.toString()) }.getOrNull()?.let {
+                    if (it.pubkey != myPub) return
+                    if (kind == Nip4e.KIND_CLIENT_KEY) {
+                        // Only a device that holds the key can answer.
+                        if (dmEncryptionManager.heldKeys().isNotEmpty()) dmPairingManager.onRequestSeen(it)
+                    } else {
+                        handleKeyShare(it, myPub)
+                    }
+                }
+                return
+            }
+            // A user's NIP-4e encryption key announcement (kind:10044).
+            if (kind == Nip4e.KIND_ENCRYPTION_KEY) {
+                if (!AppModule.dmSettings.dmEnabled.value) return
+                runCatching { parseSignedEventJson(event.toString()) }.getOrNull()?.let {
+                    dmManager.ingestEncryptionKey(it)
+                    // Our own announcement is the relay's truth about this account: another device
+                    // may have rotated to a key we do not hold, or withdrawn ours.
+                    if (it.pubkey == sessionManager.getPublicKey()) dmEncryptionManager.ingestOwnAnnouncement(it)
                 }
                 return
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2040,6 +2040,11 @@ class NostrRepository(
     private val defaultDmRelays =
         listOf("wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net", "wss://auth.nostr1.com")
 
+    // The kind:10002 an account gets when it has none. Read+write general-purpose relays, so the
+    // advertised list is one other clients can actually fetch from and publish to.
+    private val defaultOutboxRelays =
+        listOf("wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net")
+
     private var dmInboxStarted = false
     private var dmPersistenceWired = false
     private val dmPersistenceJobs = mutableListOf<kotlinx.coroutines.Job>()
@@ -3256,9 +3261,35 @@ class NostrRepository(
                 // Track bootstrap relays for reconnection so metadata fetches
                 // keep working if a bootstrap relay drops mid-session.
                 connectedPoolRelays.addAll(outboxManager.bootstrapRelays)
+                scope.launch { publishDefaultRelayListIfAbsent(pubKey) }
             },
         )
     }
+
+    /**
+     * Give an account with no kind:10002 a default one. Discovery has settled by the time this
+     * runs, so an empty list means the account really published none — and an account the outbox
+     * model cannot place is one whose events other clients look for in the wrong places, including
+     * the kind:10044 and kind:10050 that make DMs reachable.
+     *
+     * General-purpose relays only: the bootstrap set includes a NIP-65 index that does not accept
+     * ordinary events, and an AUTH-gated relay, neither of which belongs in someone's advertised
+     * write list.
+     */
+    private suspend fun publishDefaultRelayListIfAbsent(pubKey: String) {
+        if (pubKey in defaultRelayListPublishedFor) return
+        if (outboxManager.userRelayList.value.isNotEmpty()) return
+        // The account may have been switched away from while discovery ran; publishing then would
+        // sign for whoever is active now.
+        if (sessionManager.getPublicKey() != pubKey) return
+        defaultRelayListPublishedFor += pubKey
+        val defaults = defaultOutboxRelays.map { Nip65Relay(url = it, read = true, write = true) }
+        publishRelayList(defaults)
+    }
+
+    // Accounts already given a default kind:10002 this session, so a re-run of discovery does not
+    // republish (and does not overwrite a list the user edited in the meantime).
+    private val defaultRelayListPublishedFor = mutableSetOf<String>()
 
     override suspend fun connect() {
         connect(connectionManager.currentRelayUrl.value)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2492,33 +2492,51 @@ class NostrRepository(
         }
     }
 
+    /** What a wrap publish achieved, and why not when it achieved nothing. */
+    private data class WrapPublish(val accepted: Boolean, val reason: String?)
+
     // Publish a pre-serialized gift wrap event and wait for a relay OK, so a DM has a real delivered
     // signal (not fire-and-forget). Returns true once any relay accepts the event.
-    private suspend fun publishWrapJsonAwaitOk(relays: List<String>, wrapJson: String, wrapId: String): Boolean {
-        if (wrapId.isBlank()) return false
+    private suspend fun publishWrapJsonAwaitOk(relays: List<String>, wrapJson: String, wrapId: String): Boolean = publishWrapJsonAwaitOkDetailed(relays, wrapJson, wrapId).accepted
+
+    /**
+     * As [publishWrapJsonAwaitOk], but keeps a relay's stated reason for refusing. A DM that no
+     * relay took has to be able to say why: "rate-limited" and "auth-required" are the difference
+     * between waiting and fixing something.
+     */
+    private suspend fun publishWrapJsonAwaitOkDetailed(relays: List<String>, wrapJson: String, wrapId: String): WrapPublish {
+        if (wrapId.isBlank()) return WrapPublish(false, "the message could not be addressed")
         val frame = """["EVENT",$wrapJson]"""
         // Concurrent for the same reason as publishEventToRelays: a relay that never answers OK
         // costs the full timeout, and serially those stack into a send that looks hung.
-        return coroutineScope {
-            relays.distinct().map { url ->
-                async {
-                    try {
-                        val result =
-                            withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
-                                val client =
-                                    connectionManager.getClientForRelay(url)
-                                        ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
-                                client?.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
-                            }
-                        result is PublishResult.Success
-                    } catch (e: kotlinx.coroutines.CancellationException) {
-                        throw e
-                    } catch (_: Throwable) {
-                        false
+        val results =
+            coroutineScope {
+                relays.distinct().map { url ->
+                    async {
+                        try {
+                            val result =
+                                withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
+                                    val client =
+                                        connectionManager.getClientForRelay(url)
+                                            ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+                                    client?.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
+                                }
+                            url to result
+                        } catch (e: kotlinx.coroutines.CancellationException) {
+                            throw e
+                        } catch (_: Throwable) {
+                            url to null
+                        }
                     }
-                }
-            }.awaitAll().any { it }
-        }
+                }.awaitAll()
+            }
+        if (results.any { it.second is PublishResult.Success }) return WrapPublish(true, null)
+        // A stated rejection is worth more than a timeout, which only says nobody answered.
+        val rejection = results.firstNotNullOfOrNull { (url, r) -> (r as? PublishResult.Rejected)?.let { url to it.reason } }
+        val reason =
+            rejection?.let { (url, why) -> "${url.removePrefix("wss://").trimEnd('/')} refused it: $why" }
+                ?: "no DM relay accepted it"
+        return WrapPublish(false, reason)
     }
 
     // Persisted DM send queue: undelivered wraps by account, mirrored to SecureStorage.
@@ -2548,19 +2566,25 @@ class NostrRepository(
     // stay persisted and resume on the next startDmInbox.
     private suspend fun deliverPendingDmWrap(myPub: String, entry: PendingDmWrap) {
         var attempt = 0
+        var lastReason: String? = null
         while (attempt < DM_SEND_MAX_ATTEMPTS) {
             if (dmManager.messageStatus.value[entry.rumorId] is GroupManager.MessageStatus.Delivered) {
                 removeDmWrap(myPub, entry.wrapId)
                 return
             }
-            if (publishWrapJsonAwaitOk(entry.relays, entry.wrapJson, entry.wrapId)) {
+            val outcome = publishWrapJsonAwaitOkDetailed(entry.relays, entry.wrapJson, entry.wrapId)
+            if (outcome.accepted) {
                 dmManager.markDelivered(entry.rumorId)
                 removeDmWrap(myPub, entry.wrapId)
                 return
             }
+            lastReason = outcome.reason
             attempt++
             delay(minOf(DM_SEND_RETRY_MAX_MS, DM_SEND_RETRY_BASE_MS * attempt))
         }
+        // Out of attempts. The wrap stays queued for the next session, but the bubble stops
+        // pretending: a message that reached no relay was never sent, and only the sender can tell.
+        dmManager.markFailed(entry.rumorId, lastReason ?: "no DM relay accepted it")
     }
 
     // Resume undelivered wraps from disk on login so a send interrupted by an app close still lands.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2186,8 +2186,13 @@ class NostrRepository(
         // Same relay set as the DM relay list: senders look for both on our outbox, and our
         // own DM relays are where another device of ours will read it.
         val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays + dmRelaysWithDefaults(myPub)).distinct()
-        publishEventToRelays(targets, signed)
-        Result.Success(Unit)
+        // Wait for a real OK: the toggle flips on Success, so a fire-and-forget publish would let
+        // the UI claim a key is announced that no relay ever took.
+        if (publishWrapJsonAwaitOk(targets, signed.toJsonObject().toString(), signed.id.orEmpty())) {
+            Result.Success(Unit)
+        } else {
+            Result.Error(AppError.Unknown("No relay accepted the encryption key announcement."))
+        }
     } catch (e: kotlinx.coroutines.CancellationException) {
         throw e
     } catch (e: Throwable) {
@@ -2416,18 +2421,27 @@ class NostrRepository(
                 add("EVENT")
                 add(event.toJsonObject())
             }.toString()
-        relays.distinct().forEach { url ->
-            // Bound the connect + send per relay so a dead/half-open socket can't hang the caller
-            // (or leak the background publish job) indefinitely.
-            try {
-                withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
-                    val client =
-                        connectionManager.getClientForRelay(url)
-                            ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
-                    client?.send(json)
+        // Fan out concurrently: the target set is write + bootstrap + DM relays, and a cold pool
+        // pays a connect per relay. Serially that is one timeout after another, which the caller
+        // sees as a UI action stuck for a minute.
+        coroutineScope {
+            relays.distinct().map { url ->
+                async {
+                    // Bound the connect + send per relay so a dead/half-open socket can't hang the
+                    // caller (or leak the background publish job) indefinitely.
+                    try {
+                        withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
+                            val client =
+                                connectionManager.getClientForRelay(url)
+                                    ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+                            client?.send(json)
+                        }
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                    }
                 }
-            } catch (_: Throwable) {
-            }
+            }.awaitAll()
         }
     }
 
@@ -2436,21 +2450,28 @@ class NostrRepository(
     private suspend fun publishWrapJsonAwaitOk(relays: List<String>, wrapJson: String, wrapId: String): Boolean {
         if (wrapId.isBlank()) return false
         val frame = """["EVENT",$wrapJson]"""
-        var accepted = false
-        relays.distinct().forEach { url ->
-            try {
-                val result =
-                    withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
-                        val client =
-                            connectionManager.getClientForRelay(url)
-                                ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
-                        client?.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
+        // Concurrent for the same reason as publishEventToRelays: a relay that never answers OK
+        // costs the full timeout, and serially those stack into a send that looks hung.
+        return coroutineScope {
+            relays.distinct().map { url ->
+                async {
+                    try {
+                        val result =
+                            withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
+                                val client =
+                                    connectionManager.getClientForRelay(url)
+                                        ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+                                client?.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
+                            }
+                        result is PublishResult.Success
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                        false
                     }
-                if (result is PublishResult.Success) accepted = true
-            } catch (_: Throwable) {
-            }
+                }
+            }.awaitAll().any { it }
         }
-        return accepted
     }
 
     // Persisted DM send queue: undelivered wraps by account, mirrored to SecureStorage.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -271,6 +271,10 @@ class NostrRepository(
     // can't leak the publish job; delivery is best-effort and swallows failures anyway.
     private val PUBLISH_RELAY_TIMEOUT_MS = 8_000L
 
+    // Budget for a peer's kind:10050 before the first message of a conversation goes out. Paid once
+    // per peer, and only when we hold no list for them; the send proceeds to the defaults after it.
+    private val PEER_DM_RELAY_WAIT_MS = 3_000L
+
     // How far back the pairing subscription looks. Long enough to cover a request published while
     // this app was closed (its client is still sitting on the pairing screen), short enough that a
     // request the user walked away from days ago never re-prompts. Kept under
@@ -2018,6 +2022,20 @@ class NostrRepository(
         scope.launch { fetchDmRelays(pubkey) }
     }
 
+    /**
+     * Resolve [pubkey]'s DM relay list if we do not hold one yet, waiting a bounded moment for the
+     * answer. Nothing else fetches a peer's kind:10050 before a send: the list only arrived as a
+     * side effect of receiving from them, so the first message of a conversation was addressed to
+     * the defaults and never reached anyone who reads elsewhere.
+     */
+    private suspend fun awaitPeerDmRelays(pubkey: String) {
+        if (dmManager.dmRelaysFor(pubkey).isNotEmpty()) return
+        fetchDmRelays(pubkey)
+        withTimeoutOrNull(PEER_DM_RELAY_WAIT_MS) {
+            dmManager.dmRelaysByPubkey.first { it[pubkey]?.isNotEmpty() == true }
+        }
+    }
+
     // Fallback DM relays for users (and us) without a published kind:10050.
     private val defaultDmRelays =
         listOf("wss://relay.damus.io", "wss://nos.lol", "wss://relay.primal.net", "wss://auth.nostr1.com")
@@ -2049,6 +2067,10 @@ class NostrRepository(
             ActiveAccountManager.session.value?.signer
                 ?: return Result.Error(AppError.Auth.NotAuthenticated)
         val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        // Where the recipient actually reads. Without their kind:10050 the wrap goes to the app
+        // defaults only, which for a first contact means it is published where they never look and
+        // is lost silently. Their kind:10044 rides the same REQ, so addressing improves too.
+        awaitPeerDmRelays(recipientPubkey)
         return try {
             val rumor = Nip17.buildRumor(myPub, recipientPubkey, content)
             // NIP-4e: a recipient who announced an encryption key gets both NIP-44 layers addressed

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -83,6 +83,7 @@ import org.nostr.nostrord.storage.loadDmArchivedRumorIdsFor
 import org.nostr.nostrord.storage.loadDmEncKeys
 import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
+import org.nostr.nostrord.storage.loadDmPairingProcessedFor
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
 import org.nostr.nostrord.storage.loadDmSeenRelays
 import org.nostr.nostrord.storage.loadDmSendQueue
@@ -97,6 +98,7 @@ import org.nostr.nostrord.storage.saveCurrentRelayUrlFor
 import org.nostr.nostrord.storage.saveDmArchivedRumorIdsFor
 import org.nostr.nostrord.storage.saveDmEncKeys
 import org.nostr.nostrord.storage.saveDmLastRead
+import org.nostr.nostrord.storage.saveDmPairingProcessedFor
 import org.nostr.nostrord.storage.saveDmProcessedWrapIds
 import org.nostr.nostrord.storage.saveDmSeenRelays
 import org.nostr.nostrord.storage.saveDmSendQueue
@@ -268,6 +270,13 @@ class NostrRepository(
     // Per-relay budget for a background event publish (connect + send). Bounds a dead socket so it
     // can't leak the publish job; delivery is best-effort and swallows failures anyway.
     private val PUBLISH_RELAY_TIMEOUT_MS = 8_000L
+
+    // How far back the pairing subscription looks. Long enough to cover a request published while
+    // this app was closed (its client is still sitting on the pairing screen), short enough that a
+    // request the user walked away from days ago never re-prompts. Kept under
+    // DmPairingManager.PROCESSED_RETENTION_SECONDS so a decision always outlives what the relay
+    // will still serve.
+    private val PAIRING_LOOKBACK_SECONDS = 6L * 60 * 60
 
     // DM wrap publish retry: rides out a transiently offline DM relay so a message isn't stranded
     // local-only. Linear backoff, capped; ~a couple minutes of attempts before giving up this session.
@@ -1240,7 +1249,15 @@ class NostrRepository(
             ActiveAccountManager.session.collect { session ->
                 dmPairingManager.clear()
                 pendingPairingRequestId = null
-                if (session == null) dmEncryptionManager.clear() else dmEncryptionManager.loadFor(session.pubkey, session.signer.isRemote)
+                if (session == null) {
+                    dmEncryptionManager.clear()
+                    dmPairingManager.onProcessedChanged = null
+                } else {
+                    dmEncryptionManager.loadFor(session.pubkey, session.signer.isRemote)
+                    val pubkey = session.pubkey
+                    dmPairingManager.hydrateProcessed(SecureStorage.loadDmPairingProcessedFor(pubkey))
+                    dmPairingManager.onProcessedChanged = { SecureStorage.saveDmPairingProcessedFor(pubkey, it) }
+                }
             }
         }
 
@@ -2286,6 +2303,9 @@ class NostrRepository(
             val throwaway = dmPairingManager.beginRequest()
             val signed = signer.signEvent(Nip4e.buildClientKeyRequest(myPub, throwaway, epochSeconds()))
             pendingPairingRequestId = signed.id
+            // Our own request must never prompt us: the throwaway-key guard is in-memory only, so
+            // after a restart the relay replays this event back to us like any other.
+            signed.id?.let { dmPairingManager.markProcessed(it) }
             publishEventToRelays(pairingRelays(myPub), signed)
             Result.Success(Unit)
         } catch (e: kotlinx.coroutines.CancellationException) {
@@ -2378,8 +2398,13 @@ class NostrRepository(
     }
 
     /**
-     * Watch our own pairing events. Both kinds are authored by our identity, are rare, and only
-     * matter live, so this is a small `since`-now subscription rather than a history read.
+     * Watch our own pairing events. Both kinds are authored by our identity and are rare, so this
+     * stays a small windowed subscription rather than a history read.
+     *
+     * The window reaches back [PAIRING_LOOKBACK_SECONDS]: the other client publishes its request
+     * once and then just waits on its pairing screen, so a `since`-now filter would hide every
+     * request made before this app happened to subscribe — which is the normal order (the user
+     * opens the requesting client first, then comes here to approve).
      */
     private suspend fun sendPairingReq(myPub: String) {
         val filter =
@@ -2389,7 +2414,7 @@ class NostrRepository(
                     add(Nip4e.KIND_KEY_SHARE)
                 }
                 putJsonArray("authors") { add(myPub) }
-                put("since", epochSeconds())
+                put("since", epochSeconds() - PAIRING_LOOKBACK_SECONDS)
             }
         val req =
             buildJsonArray {
@@ -5631,6 +5656,10 @@ class NostrRepository(
                         val newRelays = dmRelaysWithDefaults(it.pubkey).distinct().toSet()
                         if (newRelays != dmInboxSubscribedRelays) {
                             scope.launch { resendDmInboxReq(it.pubkey) }
+                            // The pairing sub went out before this list resolved, so it is watching
+                            // the defaults only. Another device publishes its request to these
+                            // relays; without re-firing here the request is never even asked for.
+                            scope.launch { sendPairingReq(it.pubkey) }
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -271,6 +271,10 @@ class NostrRepository(
     // can't leak the publish job; delivery is best-effort and swallows failures anyway.
     private val PUBLISH_RELAY_TIMEOUT_MS = 8_000L
 
+    // Budget for the relays to answer with this account's own kind:10044 before enabling acts on
+    // local state. Short: it is paid on every Settings open and on a first enable.
+    private val OWN_ANNOUNCEMENT_WAIT_MS = 2_500L
+
     // Budget for a peer's kind:10050 before the first message of a conversation goes out. Paid once
     // per peer, and only when we hold no list for them; the send proceeds to the defaults after it.
     private val PEER_DM_RELAY_WAIT_MS = 3_000L
@@ -2180,16 +2184,33 @@ class NostrRepository(
             ActiveAccountManager.session.value?.signer
                 ?: return Result.Error(AppError.Auth.NotAuthenticated)
         val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
-        val state = dmEncryptionManager.state.value
-        if (state is DmEncryptionManager.State.AnnouncedElsewhere) {
+        // Ask the relays what this account announces BEFORE minting anything. Local state on a
+        // device that just logged in says Disabled until the fetch lands, and enabling on that
+        // stale read overwrites the other device's kind:10044 — leaving the two devices holding
+        // different keys, each believing it is the current one.
+        refreshDmEncryptionState()
+        if (dmEncryptionManager.state.value is DmEncryptionManager.State.AnnouncedElsewhere) {
             return Result.Error(
-                AppError.Unknown("This account already announced an encryption key from another device. Import that key here first."),
+                AppError.Unknown("This account announces a key that is not stored on this device. Import it, or replace it below."),
             )
         }
-        val encPubkey = dmEncryptionManager.currentEncPubkeyOrNull() ?: dmEncryptionManager.generateKey()
-        return publishEncryptionAnnouncement(signer, myPub, encPubkey).also {
-            if (it is Result.Success) dmEncryptionManager.setAnnounced(true)
-        }
+        // A key from an earlier session is re-announced as-is; otherwise this mints one.
+        val held = dmEncryptionManager.currentEncPubkeyOrNull()
+            ?: return announceFreshEncryptionKey(signer, myPub)
+        return publishEncryptionAnnouncement(signer, myPub, held)
+    }
+
+    /**
+     * Re-read this account's own kind:10044 from the relays and let the manager reconcile against
+     * it. Bounded: the fetch has no EOSE plumbing here, so a first-ever enable (nothing to find)
+     * costs this wait once rather than risking a decision made on a stale local read.
+     */
+    override suspend fun refreshDmEncryptionState() {
+        val myPub = sessionManager.getPublicKey() ?: return
+        fetchDmRelays(myPub)
+        // A fixed pause, not a wait for a particular state: waiting for AnnouncedElsewhere made a
+        // momentary wrong answer the thing that ended the wait.
+        delay(OWN_ANNOUNCEMENT_WAIT_MS)
     }
 
     /**
@@ -2205,10 +2226,44 @@ class NostrRepository(
         if (dmEncryptionManager.state.value !is DmEncryptionManager.State.Active) {
             return Result.Error(AppError.Unknown("Turn on the fast decryption key first."))
         }
-        val fresh = dmEncryptionManager.generateKey()
-        return publishEncryptionAnnouncement(signer, myPub, fresh).also {
-            if (it is Result.Success) dmEncryptionManager.setAnnounced(true)
+        return announceFreshEncryptionKey(signer, myPub)
+    }
+
+    /**
+     * Escape hatch for a key announced by a device we no longer have. Without it the account is
+     * stuck: senders address a key nobody here holds, so inbound DMs cannot be opened at all, and
+     * enable/rotate both refuse while another device owns the announcement.
+     */
+    override suspend fun resetDmEncryptionKey(): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        if (dmEncryptionManager.state.value !is DmEncryptionManager.State.AnnouncedElsewhere) {
+            return Result.Error(AppError.Unknown("This device already holds the announced key."))
         }
+        return announceFreshEncryptionKey(signer, myPub)
+    }
+
+    /**
+     * Publish a brand-new key, and hold it whatever the publish reports.
+     *
+     * An unconfirmed publish is not a failed one: a relay that stores the event and never answers
+     * OK leaves the account advertising a key this device would otherwise have thrown away, and
+     * the announcement coming back then reads as another device's — the account locks itself out
+     * of its own key. Holding it costs nothing if the publish really was lost.
+     *
+     * Which held key is current is then the relays' call, not ours: [refreshDmEncryptionState]
+     * re-reads the account's own kind:10044 and promotes whichever key it names.
+     */
+    private suspend fun announceFreshEncryptionKey(signer: NostrSigner, myPub: String): Result<Unit> {
+        val fresh = KeyPair.generate()
+        // Persist the key BEFORE any network call. It is the only thing here that cannot be
+        // recovered: an unannounced key on the device is inert, while an announcement whose key was
+        // lost (a cancelled publish, a closed screen, a killed process) costs the account every
+        // message sent to it, permanently.
+        dmEncryptionManager.adoptKey(fresh)
+        return publishEncryptionAnnouncement(signer, myPub, fresh.publicKeyHex)
     }
 
     /**
@@ -2220,22 +2275,29 @@ class NostrRepository(
             ActiveAccountManager.session.value?.signer
                 ?: return Result.Error(AppError.Auth.NotAuthenticated)
         val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
-        return publishEncryptionAnnouncement(signer, myPub, null).also {
-            if (it is Result.Success) dmEncryptionManager.setAnnounced(false)
-        }
+        return publishEncryptionAnnouncement(signer, myPub, null)
     }
 
+    /**
+     * Sign and publish the account's kind:10044. The signed event is recorded as our announcement
+     * immediately, before the network call: the relay echoes it back within a second on the
+     * standing REQ, and an announcement we have not recorded yet reads as a key someone else owns.
+     *
+     * The publish result decides only what the screen says about confirmation. Whether the key is
+     * announced is what the newest kind:10044 says, and by then we have already seen it.
+     */
     private suspend fun publishEncryptionAnnouncement(signer: NostrSigner, myPub: String, encPubkey: String?): Result<Unit> = try {
-        val signed = signer.signEvent(Nip4e.buildAnnouncement(myPub, encPubkey, epochSeconds()))
+        val createdAt = epochSeconds()
+        val signed = signer.signEvent(Nip4e.buildAnnouncement(myPub, encPubkey, createdAt))
+        dmEncryptionManager.ingestAnnouncement(encPubkey, createdAt, fromRelay = false)
         // Same relay set as the DM relay list: senders look for both on our outbox, and our
         // own DM relays are where another device of ours will read it.
         val targets = (outboxManager.getWriteRelays() + outboxManager.bootstrapRelays + dmRelaysWithDefaults(myPub)).distinct()
-        // Wait for a real OK: the toggle flips on Success, so a fire-and-forget publish would let
-        // the UI claim a key is announced that no relay ever took.
         if (publishWrapJsonAwaitOk(targets, signed.toJsonObject().toString(), signed.id.orEmpty())) {
+            dmEncryptionManager.ingestAnnouncement(encPubkey, createdAt, fromRelay = true)
             Result.Success(Unit)
         } else {
-            Result.Error(AppError.Unknown("No relay accepted the encryption key announcement."))
+            Result.Error(AppError.Unknown("No relay confirmed the announcement yet. The key is saved on this device."))
         }
     } catch (e: kotlinx.coroutines.CancellationException) {
         throw e
@@ -5765,7 +5827,9 @@ class NostrRepository(
                     dmManager.ingestEncryptionKey(it)
                     // Our own announcement is the relay's truth about this account: another device
                     // may have rotated to a key we do not hold, or withdrawn ours.
-                    if (it.pubkey == sessionManager.getPublicKey()) dmEncryptionManager.ingestOwnAnnouncement(it)
+                    if (it.pubkey == sessionManager.getPublicKey()) {
+                        dmEncryptionManager.ingestAnnouncement(Nip4e.encryptionKeyFrom(it), it.createdAt, fromRelay = true)
+                    }
                 }
                 return
             }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -5,8 +5,11 @@ import kotlinx.serialization.Serializable
 import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.network.livekit.LiveKitCredentials
 import org.nostr.nostrord.network.managers.ConnectionManager
+import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmConversation
+import org.nostr.nostrord.network.managers.DmEncryptionManager
 import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
@@ -199,6 +202,51 @@ interface NostrRepositoryApi {
 
     /** Fetch a peer's kind:10050 so [dmRelaysByPubkey] gains its entry (fire-and-forget). */
     fun requestPeerDmRelays(pubkey: String)
+
+    /** Whether this account holds and advertises a NIP-4e encryption key (see DmEncryptionManager). */
+    val dmEncryptionState: StateFlow<DmEncryptionManager.State>
+
+    /** Announce a NIP-4e encryption key so inbound DMs decrypt without the signer. */
+    suspend fun enableDmEncryption(): Result<Unit>
+
+    /** Stop advertising the encryption key. The key is kept, or its history becomes unreadable. */
+    suspend fun disableDmEncryption(): Result<Unit>
+
+    /** Advertise a fresh encryption key. The previous one stays held so its history keeps opening. */
+    suspend fun rotateDmEncryptionKey(): Result<Unit>
+
+    /** Hold the encryption key exported from another device. False when it is not the announced one. */
+    fun importDmEncryptionKey(privateKeyHex: String): Boolean
+
+    /** The current encryption private key, for moving it to another device. */
+    fun exportDmEncryptionKey(): String?
+
+    /** Progress of the self-archive republish (see DmArchiveManager). */
+    val dmArchiveProgress: StateFlow<DmArchiveManager.Progress>
+
+    /** How many stored messages still need an archive copy; drives the confirmation copy. */
+    suspend fun countDmArchivableMessages(): Int
+
+    /** Republish decrypted history to ourselves addressed to the encryption key. Resumable. */
+    suspend fun archiveDmHistory(): Result<Unit>
+
+    /** Stop an archive run in progress; already-published copies stay. */
+    fun cancelDmArchive()
+
+    /** NIP-4e device pairing: request the key, or answer another device asking for it. */
+    val dmPairingState: StateFlow<DmPairingManager.State>
+
+    /** Ask another device of this account for the encryption key (kind:4454). */
+    suspend fun requestDmEncryptionKey(): Result<Unit>
+
+    /** Send our encryption key to the device that asked (kind:4455). */
+    suspend fun approveDmPairing(): Result<Unit>
+
+    /** Refuse the pending request; the asking device keeps waiting. */
+    fun declineDmPairing()
+
+    /** Clear a finished or failed pairing back to idle. */
+    fun dismissDmPairing()
 
     /** Send a NIP-17 direct message to [recipientPubkey]. */
     suspend fun sendDm(recipientPubkey: String, content: String): Result<Unit>

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -206,6 +206,12 @@ interface NostrRepositoryApi {
     /** Whether this account holds and advertises a NIP-4e encryption key (see DmEncryptionManager). */
     val dmEncryptionState: StateFlow<DmEncryptionManager.State>
 
+    /**
+     * Re-read this account's own kind:10044 and reconcile [dmEncryptionState] against it, so the
+     * screen shows what the relays actually announce instead of what this device last did.
+     */
+    suspend fun refreshDmEncryptionState()
+
     /** Announce a NIP-4e encryption key so inbound DMs decrypt without the signer. */
     suspend fun enableDmEncryption(): Result<Unit>
 
@@ -214,6 +220,13 @@ interface NostrRepositoryApi {
 
     /** Advertise a fresh encryption key. The previous one stays held so its history keeps opening. */
     suspend fun rotateDmEncryptionKey(): Result<Unit>
+
+    /**
+     * Take over from a key announced by a device we no longer have: announce a fresh one we hold.
+     * Everything addressed to the lost key stops being readable, which is why this is separate
+     * from [rotateDmEncryptionKey] and only reachable from `AnnouncedElsewhere`.
+     */
+    suspend fun resetDmEncryptionKey(): Result<Unit>
 
     /** Hold the encryption key exported from another device. False when it is not the announced one. */
     fun importDmEncryptionKey(privateKeyHex: String): Boolean

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmArchiveManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmArchiveManager.kt
@@ -1,0 +1,122 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.nostr.nostrord.nostr.Event
+import kotlin.concurrent.Volatile
+
+/**
+ * Republishes already-decrypted DM history to ourselves, addressed to our NIP-4e encryption key,
+ * so a device that holds that key loads the whole history without ever calling the signer.
+ *
+ * Only the messages predating the announcement need it: everything after is already addressed to
+ * the encryption key by the sender (inbound) or by our own send path (outbound).
+ *
+ * Progress is gated on relay acceptance and persisted, so a re-run resumes instead of republishing.
+ * Losing the progress set only wastes relay storage: rumor ids are unchanged, so every client
+ * (ours and Jumble alike) collapses an archived copy onto the original.
+ */
+class DmArchiveManager {
+    data class Progress(
+        val done: Int = 0,
+        val total: Int = 0,
+        val failed: Int = 0,
+        val running: Boolean = false,
+        val error: String? = null,
+    )
+
+    private val _progress = MutableStateFlow(Progress())
+    val progress: StateFlow<Progress> = _progress.asStateFlow()
+
+    private var archivedIds: Set<String> = emptySet()
+
+    @Volatile
+    private var cancelRequested = false
+
+    fun hydrate(ids: Set<String>) {
+        archivedIds = ids
+    }
+
+    fun archivedIds(): Set<String> = archivedIds
+
+    fun clear() {
+        archivedIds = emptySet()
+        cancelRequested = false
+        _progress.value = Progress()
+    }
+
+    fun cancel() {
+        cancelRequested = true
+    }
+
+    /** Rumors still needing an archive copy: not already archived, and older than [announcedAt]. */
+    fun pending(rumors: List<Event>, announcedAt: Long): List<Event> = rumors.filter { rumor ->
+        val id = rumor.id
+        id != null && id !in archivedIds && (announcedAt <= 0L || rumor.createdAt < announcedAt)
+    }
+
+    /**
+     * Archive [rumors] one at a time. [buildWrap] turns a rumor into the gift wrap to publish
+     * (null skips it), [publish] returns whether a relay accepted it, and [persistProgress] is
+     * called with the updated id set only after acceptance.
+     *
+     * Stops with an error after [MAX_CONSECUTIVE_FAILURES] rejections in a row rather than
+     * hammering a relay that is refusing on size or rate caps.
+     */
+    suspend fun run(
+        rumors: List<Event>,
+        buildWrap: suspend (Event) -> Event?,
+        publish: suspend (Event) -> Boolean,
+        persistProgress: (Set<String>) -> Unit,
+    ) {
+        if (_progress.value.running) return
+        cancelRequested = false
+        _progress.value = Progress(total = rumors.size, running = true)
+
+        var done = 0
+        var failed = 0
+        var consecutiveFailures = 0
+        try {
+            for (rumor in rumors) {
+                if (cancelRequested) break
+                val id = rumor.id ?: continue
+                val accepted =
+                    try {
+                        val wrap = buildWrap(rumor)
+                        wrap != null && publish(wrap)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                        false
+                    }
+                if (accepted) {
+                    archivedIds = archivedIds + id
+                    persistProgress(archivedIds)
+                    done++
+                    consecutiveFailures = 0
+                } else {
+                    failed++
+                    consecutiveFailures++
+                }
+                _progress.value = _progress.value.copy(done = done, failed = failed)
+                if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+                    _progress.value =
+                        _progress.value.copy(
+                            running = false,
+                            error = "Your DM relays stopped accepting the archive. Try again later.",
+                        )
+                    return
+                }
+            }
+            _progress.value = _progress.value.copy(running = false)
+        } finally {
+            if (_progress.value.running) _progress.value = _progress.value.copy(running = false)
+        }
+    }
+
+    companion object {
+        const val MAX_CONSECUTIVE_FAILURES = 5
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManager.kt
@@ -1,0 +1,181 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.Nip4e
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.loadNip4eAnnouncedAtFor
+import org.nostr.nostrord.storage.loadNip4eAnnouncedFor
+import org.nostr.nostrord.storage.loadNip4eKeysFor
+import org.nostr.nostrord.storage.saveNip4eAnnouncedAtFor
+import org.nostr.nostrord.storage.saveNip4eAnnouncedFor
+import org.nostr.nostrord.storage.saveNip4eKeysFor
+import org.nostr.nostrord.utils.epochSeconds
+
+/**
+ * Owns this account's NIP-4e encryption keys: the keys we hold locally, and whether the current
+ * one is advertised in our kind:10044.
+ *
+ * The point of holding a key is that inbound DMs addressed to it decrypt in-process, so a remote
+ * signer leaves the read path entirely. Accounts with a local key already decrypt in-process and
+ * gain nothing, hence [State.Unavailable].
+ *
+ * Keys are a LIST, newest first. Rotation (ours, or done by another device on this account)
+ * retires a key without deleting it, because messages already addressed to it can only ever be
+ * opened with it. Disabling only stops advertising; it never drops a key.
+ */
+class DmEncryptionManager {
+    sealed interface State {
+        /** Signing is local, so there is nothing to offload. The UI hides the whole section. */
+        data object Unavailable : State
+
+        /** No key held and none announced. */
+        data object Disabled : State
+
+        /** We hold [encPubkey] and it is the announced one: senders address it, we decrypt locally. */
+        data class Active(val encPubkey: String) : State
+
+        /** Key kept from an earlier enable, currently un-advertised. History still opens. */
+        data class HeldNotAnnounced(val encPubkey: String) : State
+
+        /** Another device announced [encPubkey] for this account; we cannot read until we hold it. */
+        data class AnnouncedElsewhere(val encPubkey: String) : State
+    }
+
+    private val _state = MutableStateFlow<State>(State.Unavailable)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    private var accountPubkey: String = ""
+    private var remoteSigner: Boolean = false
+    private var keys: List<KeyPair> = emptyList()
+    private var announced: Boolean = false
+    private var announcedAt: Long = 0L
+
+    /** Key announced by another device that we do not hold; drives [State.AnnouncedElsewhere]. */
+    private var foreignAnnouncedKey: String? = null
+
+    /** Load the account's keys. [remoteSigner] gates the whole feature (see [State.Unavailable]). */
+    fun loadFor(pubkey: String, remoteSigner: Boolean) {
+        accountPubkey = pubkey
+        this.remoteSigner = remoteSigner
+        keys = SecureStorage.loadNip4eKeysFor(pubkey).mapNotNull { hex -> runCatching { KeyPair.fromPrivateKeyHex(hex) }.getOrNull() }
+        announced = SecureStorage.loadNip4eAnnouncedFor(pubkey)
+        announcedAt = SecureStorage.loadNip4eAnnouncedAtFor(pubkey)
+        foreignAnnouncedKey = null
+        recompute()
+    }
+
+    /** All held keys, current first. Receive tries each, so a retired key still opens its history. */
+    fun heldKeys(): List<KeyPair> = keys
+
+    fun currentEncPubkeyOrNull(): String? = keys.firstOrNull()?.publicKeyHex
+
+    /** Generate and hold a new key, making it current. Returns its pubkey. */
+    fun generateKey(): String {
+        val fresh = KeyPair.generate()
+        keys = listOf(fresh) + keys.filter { it.publicKeyHex != fresh.publicKeyHex }
+        persistKeys()
+        recompute()
+        return fresh.publicKeyHex
+    }
+
+    /**
+     * Hold the key exported from another device. Rejected unless it derives to the key this
+     * account actually announced, so a typo cannot silently leave us unable to read.
+     */
+    fun importKey(privateKeyHex: String): Boolean {
+        val kp = runCatching { KeyPair.fromPrivateKeyHex(privateKeyHex.trim()) }.getOrNull() ?: return false
+        val expected = foreignAnnouncedKey
+        if (expected != null && kp.publicKeyHex != expected) return false
+        keys = listOf(kp) + keys.filter { it.publicKeyHex != kp.publicKeyHex }
+        persistKeys()
+        if (expected != null) {
+            foreignAnnouncedKey = null
+            announced = true
+            SecureStorage.saveNip4eAnnouncedFor(accountPubkey, true)
+        }
+        recompute()
+        return true
+    }
+
+    /** The current private key, for moving it to another device. */
+    fun exportKey(): String? = keys.firstOrNull()?.privateKeyHex
+
+    /** Record whether our current key is advertised. Never touches the key list. */
+    fun setAnnounced(value: Boolean) {
+        announced = value
+        SecureStorage.saveNip4eAnnouncedFor(accountPubkey, value)
+        // First announcement only: it marks where NIP-4e addressing begins, which is the cutoff
+        // the self-archive works back from. Re-enabling later must not move it forward.
+        if (value && announcedAt <= 0L) {
+            announcedAt = epochSeconds()
+            SecureStorage.saveNip4eAnnouncedAtFor(accountPubkey, announcedAt)
+        }
+        if (value) foreignAnnouncedKey = null
+        recompute()
+    }
+
+    /** When NIP-4e addressing began for this account; 0 when it never has. */
+    fun announcedAt(): Long = announcedAt
+
+    /**
+     * Reconcile against our own kind:10044 as relays actually have it: another device may have
+     * rotated to a key we do not hold, or withdrawn ours entirely.
+     */
+    fun ingestOwnAnnouncement(event: Event) {
+        if (event.pubkey != accountPubkey) return
+        val announcedKey = Nip4e.encryptionKeyFrom(event)
+        when {
+            announcedKey == null -> {
+                // Withdrawn (possibly by another device). Keys stay; we just stop being addressed.
+                foreignAnnouncedKey = null
+                if (announced) setAnnounced(false) else recompute()
+            }
+            keys.any { it.publicKeyHex == announcedKey } -> {
+                foreignAnnouncedKey = null
+                // Make the announced key current so sends tag the key senders are addressing.
+                keys = keys.sortedByDescending { it.publicKeyHex == announcedKey }
+                persistKeys()
+                if (!announced) setAnnounced(true) else recompute()
+            }
+            else -> {
+                foreignAnnouncedKey = announcedKey
+                if (announced) {
+                    announced = false
+                    SecureStorage.saveNip4eAnnouncedFor(accountPubkey, false)
+                }
+                recompute()
+            }
+        }
+    }
+
+    /** Drop in-memory state on account switch. Storage is untouched. */
+    fun clear() {
+        accountPubkey = ""
+        remoteSigner = false
+        keys = emptyList()
+        announced = false
+        announcedAt = 0L
+        foreignAnnouncedKey = null
+        _state.value = State.Unavailable
+    }
+
+    private fun persistKeys() {
+        SecureStorage.saveNip4eKeysFor(accountPubkey, keys.map { it.privateKeyHex })
+    }
+
+    private fun recompute() {
+        val current = keys.firstOrNull()?.publicKeyHex
+        _state.value =
+            when {
+                !remoteSigner -> State.Unavailable
+                foreignAnnouncedKey != null -> State.AnnouncedElsewhere(foreignAnnouncedKey!!)
+                current == null -> State.Disabled
+                announced -> State.Active(current)
+                else -> State.HeldNotAnnounced(current)
+            }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManager.kt
@@ -1,24 +1,26 @@
 package org.nostr.nostrord.network.managers
 
+import kotlinx.atomicfu.locks.SynchronizedObject
+import kotlinx.atomicfu.locks.synchronized
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
-import org.nostr.nostrord.nostr.Nip4e
+import org.nostr.nostrord.storage.Nip4eAnnouncement
 import org.nostr.nostrord.storage.Nip4eStoredKey
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.loadNip4eAnnouncedAtFor
 import org.nostr.nostrord.storage.loadNip4eAnnouncedFor
+import org.nostr.nostrord.storage.loadNip4eAnnouncementFor
 import org.nostr.nostrord.storage.loadNip4eKeysFor
 import org.nostr.nostrord.storage.saveNip4eAnnouncedAtFor
-import org.nostr.nostrord.storage.saveNip4eAnnouncedFor
+import org.nostr.nostrord.storage.saveNip4eAnnouncementFor
 import org.nostr.nostrord.storage.saveNip4eKeysFor
 import org.nostr.nostrord.utils.epochSeconds
 
 /**
- * Owns this account's NIP-4e encryption keys: the keys we hold locally, and whether the current
- * one is advertised in our kind:10044.
+ * Owns this account's NIP-4e encryption keys: the keys held on this device, and the newest
+ * kind:10044 known for the account.
  *
  * The point of holding a key is that inbound DMs addressed to it decrypt in-process, so a remote
  * signer leaves the read path entirely. Accounts with a local key already decrypt in-process and
@@ -26,7 +28,14 @@ import org.nostr.nostrord.utils.epochSeconds
  *
  * Keys are a LIST, newest first. Rotation (ours, or done by another device on this account)
  * retires a key without deleting it, because messages already addressed to it can only ever be
- * opened with it. Disabling only stops advertising; it never drops a key.
+ * opened with it. Withdrawing the announcement never drops a key.
+ *
+ * State is DERIVED, never latched. It answers one question — does the key set contain the key the
+ * newest announcement names — and answers it again on every change to either side. An earlier
+ * version cached that answer in flags patched from six entry points, which let the account read as
+ * "announced by another device" while holding the very key in question, permanently: the relay
+ * echoes our own announcement back within a second, and the key was not adopted until the publish
+ * returned up to eight seconds later.
  */
 class DmEncryptionManager {
     sealed interface State {
@@ -36,143 +45,149 @@ class DmEncryptionManager {
         /** No key held and none announced. */
         data object Disabled : State
 
-        /** We hold [encPubkey] and it is the announced one: senders address it, we decrypt locally. */
-        data class Active(val encPubkey: String) : State
+        /**
+         * We hold [encPubkey] and it is the announced one: senders address it, we decrypt locally.
+         * [confirmed] is false while the announcement is only known locally, so the UI can say it
+         * is still being published rather than claiming senders already see it.
+         */
+        data class Active(val encPubkey: String, val confirmed: Boolean = true) : State
 
         /** Key kept from an earlier enable, currently un-advertised. History still opens. */
         data class HeldNotAnnounced(val encPubkey: String) : State
 
-        /** Another device announced [encPubkey] for this account; we cannot read until we hold it. */
+        /** The account announces [encPubkey], which is not on this device. */
         data class AnnouncedElsewhere(val encPubkey: String) : State
     }
 
     private val _state = MutableStateFlow<State>(State.Unavailable)
     val state: StateFlow<State> = _state.asStateFlow()
 
+    // Guards every field below. They are written from the relay pipeline (announcements arriving),
+    // from the UI scope (enable/rotate/reset/import), and from the session collector (load/clear).
+    private val lock = SynchronizedObject()
+
     private var accountPubkey: String = ""
     private var remoteSigner: Boolean = false
     private var keys: List<Nip4eStoredKey> = emptyList()
-    private var announced: Boolean = false
-    private var announcedAt: Long = 0L
 
-    /** Key announced by another device that we do not hold; drives [State.AnnouncedElsewhere]. */
-    private var foreignAnnouncedKey: String? = null
+    /** The newest kind:10044 known for this account. Null encPubkey means the key was withdrawn. */
+    private var announcement: Nip4eAnnouncement? = null
+    private var announcedAt: Long = 0L
 
     /** Load the account's keys. [remoteSigner] gates the whole feature (see [State.Unavailable]). */
     fun loadFor(pubkey: String, remoteSigner: Boolean) {
-        accountPubkey = pubkey
-        this.remoteSigner = remoteSigner
-        keys = prune(SecureStorage.loadNip4eKeysFor(pubkey))
-        announced = SecureStorage.loadNip4eAnnouncedFor(pubkey)
-        announcedAt = SecureStorage.loadNip4eAnnouncedAtFor(pubkey)
-        foreignAnnouncedKey = null
-        recompute()
+        synchronized(lock) {
+            accountPubkey = pubkey
+            this.remoteSigner = remoteSigner
+            keys = prune(SecureStorage.loadNip4eKeysFor(pubkey))
+            announcement = SecureStorage.loadNip4eAnnouncementFor(pubkey) ?: legacyAnnouncement(pubkey)
+            announcedAt = SecureStorage.loadNip4eAnnouncedAtFor(pubkey)
+            recompute()
+        }
+    }
+
+    /**
+     * Slots written before announcements were persisted only recorded a boolean. Treat "was
+     * announced, and we hold a key" as an announcement of that key at an unknown time, so any real
+     * copy from a relay supersedes it.
+     */
+    private fun legacyAnnouncement(pubkey: String): Nip4eAnnouncement? {
+        if (!SecureStorage.loadNip4eAnnouncedFor(pubkey)) return null
+        val current = keys.firstOrNull()?.keyPair()?.publicKeyHex ?: return null
+        return Nip4eAnnouncement(encPubkey = current, createdAt = 0L, confirmed = true)
     }
 
     /** All held keys, current first. Receive tries each, so a retired key still opens its history. */
-    fun heldKeys(): List<KeyPair> = keys.mapNotNull { it.keyPair() }
+    fun heldKeys(): List<KeyPair> = synchronized(lock) { keys.mapNotNull { it.keyPair() } }
 
-    fun currentEncPubkeyOrNull(): String? = keys.firstOrNull()?.keyPair()?.publicKeyHex
+    fun currentEncPubkeyOrNull(): String? = synchronized(lock) { keys.firstOrNull()?.keyPair()?.publicKeyHex }
 
     /**
-     * Generate and hold a new key, making it current and retiring the previous one. Returns its
-     * pubkey. Retired keys are pruned here, so rotating is also what bounds the number of live
-     * decryption capabilities sitting on this device.
+     * Hold [kp], making it current and retiring the previous one. Returns its pubkey.
+     *
+     * Call this BEFORE publishing an announcement for it: the key is what cannot be recovered. An
+     * unannounced key on the device is inert, while an announced key the device failed to keep
+     * costs the account every message sent to it.
      */
-    fun generateKey(): String {
-        val fresh = KeyPair.generate()
-        val now = epochSeconds()
-        val retired = keys.map { if (it.retiredAt == 0L) it.copy(retiredAt = now) else it }
-        keys = prune(listOf(Nip4eStoredKey(fresh.privateKeyHex)) + retired.filter { it.privateKeyHex != fresh.privateKeyHex })
-        persistKeys()
-        recompute()
-        return fresh.publicKeyHex
+    fun adoptKey(kp: KeyPair): String {
+        synchronized(lock) {
+            adopt(kp)
+            recompute()
+        }
+        return kp.publicKeyHex
     }
 
+    /** Generate, hold, and make current in one step. */
+    fun generateKey(): String = adoptKey(KeyPair.generate())
+
     /**
-     * Hold the key exported from another device. Rejected unless it derives to the key this
-     * account actually announced, so a typo cannot silently leave us unable to read.
+     * Hold a key exported from another device. Rejected unless it derives to the key this account
+     * announces, so a typo cannot silently leave us unable to read.
      */
     fun importKey(privateKeyHex: String): Boolean {
         val kp = runCatching { KeyPair.fromPrivateKeyHex(privateKeyHex.trim()) }.getOrNull() ?: return false
-        val expected = foreignAnnouncedKey
-        if (expected != null && kp.publicKeyHex != expected) return false
-        val now = epochSeconds()
-        val retired = keys.map { if (it.retiredAt == 0L) it.copy(retiredAt = now) else it }
-        keys = prune(listOf(Nip4eStoredKey(kp.privateKeyHex)) + retired.filter { it.privateKeyHex != kp.privateKeyHex })
-        persistKeys()
-        if (expected != null) {
-            foreignAnnouncedKey = null
-            announced = true
-            SecureStorage.saveNip4eAnnouncedFor(accountPubkey, true)
+        return synchronized(lock) {
+            val expected = announcement?.encPubkey
+            if (expected != null && kp.publicKeyHex != expected) {
+                false
+            } else {
+                adopt(kp)
+                recompute()
+                true
+            }
         }
-        recompute()
-        return true
     }
 
     /** The current private key, for moving it to another device. */
-    fun exportKey(): String? = keys.firstOrNull()?.privateKeyHex
+    fun exportKey(): String? = synchronized(lock) { keys.firstOrNull()?.privateKeyHex }
 
-    /** Record whether our current key is advertised. Never touches the key list. */
-    fun setAnnounced(value: Boolean) {
-        announced = value
-        SecureStorage.saveNip4eAnnouncedFor(accountPubkey, value)
-        // First announcement only: it marks where NIP-4e addressing begins, which is the cutoff
-        // the self-archive works back from. Re-enabling later must not move it forward.
-        if (value && announcedAt <= 0L) {
-            announcedAt = epochSeconds()
-            SecureStorage.saveNip4eAnnouncedAtFor(accountPubkey, announcedAt)
+    /**
+     * Record the newest kind:10044 for this account: ours the moment it is signed, or a relay's
+     * copy as it arrives. Only a strictly newer one counts, since relays that have not caught up
+     * keep serving the previous version.
+     *
+     * Recording our own at signing time is what makes the echo of that same event a no-op instead
+     * of a claim that someone else owns the key.
+     */
+    fun ingestAnnouncement(encPubkey: String?, createdAt: Long, fromRelay: Boolean) {
+        synchronized(lock) {
+            val known = announcement
+            when {
+                // Our own is authoritative the moment it is signed, including a second announcement
+                // inside the same second (epochSeconds granularity), which a relay copy cannot be.
+                known == null || createdAt > known.createdAt || (!fromRelay && createdAt >= known.createdAt) ->
+                    announcement = Nip4eAnnouncement(encPubkey, createdAt, confirmed = fromRelay)
+                // The relay serving back the announcement we just signed is the confirmation that
+                // it landed; same event, so only the confirmed flag moves.
+                fromRelay && !known.confirmed && createdAt == known.createdAt ->
+                    announcement = known.copy(confirmed = true)
+                else -> return@synchronized
+            }
+            SecureStorage.saveNip4eAnnouncementFor(accountPubkey, announcement)
+            recompute()
         }
-        if (value) foreignAnnouncedKey = null
-        recompute()
     }
 
     /** When NIP-4e addressing began for this account; 0 when it never has. */
     fun announcedAt(): Long = announcedAt
 
-    /**
-     * Reconcile against our own kind:10044 as relays actually have it: another device may have
-     * rotated to a key we do not hold, or withdrawn ours entirely.
-     */
-    fun ingestOwnAnnouncement(event: Event) {
-        if (event.pubkey != accountPubkey) return
-        val announcedKey = Nip4e.encryptionKeyFrom(event)
-        when {
-            announcedKey == null -> {
-                // Withdrawn (possibly by another device). Keys stay; we just stop being addressed.
-                foreignAnnouncedKey = null
-                if (announced) setAnnounced(false) else recompute()
-            }
-            keys.any { it.keyPair()?.publicKeyHex == announcedKey } -> {
-                foreignAnnouncedKey = null
-                // Make the announced key current so sends tag the key senders are addressing.
-                keys = keys.sortedByDescending { it.keyPair()?.publicKeyHex == announcedKey }
-                persistKeys()
-                if (!announced) setAnnounced(true) else recompute()
-            }
-            else -> {
-                foreignAnnouncedKey = announcedKey
-                if (announced) {
-                    announced = false
-                    SecureStorage.saveNip4eAnnouncedFor(accountPubkey, false)
-                }
-                recompute()
-            }
+    /** Drop in-memory state on account switch. Storage is untouched. */
+    fun clear() {
+        synchronized(lock) {
+            accountPubkey = ""
+            remoteSigner = false
+            keys = emptyList()
+            announcement = null
+            announcedAt = 0L
+            _state.value = State.Unavailable
         }
     }
 
-    /** Drop in-memory state on account switch. Storage is untouched. */
-    fun clear() {
-        accountPubkey = ""
-        remoteSigner = false
-        keys = emptyList()
-        announced = false
-        announcedAt = 0L
-        foreignAnnouncedKey = null
-        _state.value = State.Unavailable
-    }
-
-    private fun persistKeys() {
+    /** Make [kp] the current key, stamping the previous one as retired. Caller holds [lock]. */
+    private fun adopt(kp: KeyPair) {
+        val now = epochSeconds()
+        val retired = keys.map { if (it.retiredAt == 0L) it.copy(retiredAt = now) else it }
+        keys = prune(listOf(Nip4eStoredKey(kp.privateKeyHex)) + retired.filter { it.privateKeyHex != kp.privateKeyHex })
         SecureStorage.saveNip4eKeysFor(accountPubkey, keys)
     }
 
@@ -194,14 +209,30 @@ class DmEncryptionManager {
         return current + retired
     }
 
+    /**
+     * Derive the state from the two facts that decide it, and promote the announced key to current
+     * so sends tag the key senders are actually addressing. Caller holds [lock].
+     */
     private fun recompute() {
-        val current = currentEncPubkeyOrNull()
+        val announcedKey = announcement?.encPubkey
+        val holdsAnnounced = announcedKey != null && keys.any { it.keyPair()?.publicKeyHex == announcedKey }
+        if (holdsAnnounced && keys.firstOrNull()?.keyPair()?.publicKeyHex != announcedKey) {
+            keys = keys.sortedByDescending { it.keyPair()?.publicKeyHex == announcedKey }
+            SecureStorage.saveNip4eKeysFor(accountPubkey, keys)
+        }
+        // First announcement only: it marks where NIP-4e addressing begins, which is the cutoff the
+        // self-archive works back from. A later rotation must not move it forward.
+        if (holdsAnnounced && announcedAt <= 0L) {
+            announcedAt = epochSeconds()
+            SecureStorage.saveNip4eAnnouncedAtFor(accountPubkey, announcedAt)
+        }
+        val current = keys.firstOrNull()?.keyPair()?.publicKeyHex
         _state.value =
             when {
                 !remoteSigner -> State.Unavailable
-                foreignAnnouncedKey != null -> State.AnnouncedElsewhere(foreignAnnouncedKey!!)
+                holdsAnnounced -> State.Active(announcedKey!!, confirmed = announcement?.confirmed == true)
+                announcedKey != null -> State.AnnouncedElsewhere(announcedKey)
                 current == null -> State.Disabled
-                announced -> State.Active(current)
                 else -> State.HeldNotAnnounced(current)
             }
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip4e
+import org.nostr.nostrord.storage.Nip4eStoredKey
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.loadNip4eAnnouncedAtFor
 import org.nostr.nostrord.storage.loadNip4eAnnouncedFor
@@ -50,7 +51,7 @@ class DmEncryptionManager {
 
     private var accountPubkey: String = ""
     private var remoteSigner: Boolean = false
-    private var keys: List<KeyPair> = emptyList()
+    private var keys: List<Nip4eStoredKey> = emptyList()
     private var announced: Boolean = false
     private var announcedAt: Long = 0L
 
@@ -61,7 +62,7 @@ class DmEncryptionManager {
     fun loadFor(pubkey: String, remoteSigner: Boolean) {
         accountPubkey = pubkey
         this.remoteSigner = remoteSigner
-        keys = SecureStorage.loadNip4eKeysFor(pubkey).mapNotNull { hex -> runCatching { KeyPair.fromPrivateKeyHex(hex) }.getOrNull() }
+        keys = prune(SecureStorage.loadNip4eKeysFor(pubkey))
         announced = SecureStorage.loadNip4eAnnouncedFor(pubkey)
         announcedAt = SecureStorage.loadNip4eAnnouncedAtFor(pubkey)
         foreignAnnouncedKey = null
@@ -69,14 +70,20 @@ class DmEncryptionManager {
     }
 
     /** All held keys, current first. Receive tries each, so a retired key still opens its history. */
-    fun heldKeys(): List<KeyPair> = keys
+    fun heldKeys(): List<KeyPair> = keys.mapNotNull { it.keyPair() }
 
-    fun currentEncPubkeyOrNull(): String? = keys.firstOrNull()?.publicKeyHex
+    fun currentEncPubkeyOrNull(): String? = keys.firstOrNull()?.keyPair()?.publicKeyHex
 
-    /** Generate and hold a new key, making it current. Returns its pubkey. */
+    /**
+     * Generate and hold a new key, making it current and retiring the previous one. Returns its
+     * pubkey. Retired keys are pruned here, so rotating is also what bounds the number of live
+     * decryption capabilities sitting on this device.
+     */
     fun generateKey(): String {
         val fresh = KeyPair.generate()
-        keys = listOf(fresh) + keys.filter { it.publicKeyHex != fresh.publicKeyHex }
+        val now = epochSeconds()
+        val retired = keys.map { if (it.retiredAt == 0L) it.copy(retiredAt = now) else it }
+        keys = prune(listOf(Nip4eStoredKey(fresh.privateKeyHex)) + retired.filter { it.privateKeyHex != fresh.privateKeyHex })
         persistKeys()
         recompute()
         return fresh.publicKeyHex
@@ -90,7 +97,9 @@ class DmEncryptionManager {
         val kp = runCatching { KeyPair.fromPrivateKeyHex(privateKeyHex.trim()) }.getOrNull() ?: return false
         val expected = foreignAnnouncedKey
         if (expected != null && kp.publicKeyHex != expected) return false
-        keys = listOf(kp) + keys.filter { it.publicKeyHex != kp.publicKeyHex }
+        val now = epochSeconds()
+        val retired = keys.map { if (it.retiredAt == 0L) it.copy(retiredAt = now) else it }
+        keys = prune(listOf(Nip4eStoredKey(kp.privateKeyHex)) + retired.filter { it.privateKeyHex != kp.privateKeyHex })
         persistKeys()
         if (expected != null) {
             foreignAnnouncedKey = null
@@ -134,10 +143,10 @@ class DmEncryptionManager {
                 foreignAnnouncedKey = null
                 if (announced) setAnnounced(false) else recompute()
             }
-            keys.any { it.publicKeyHex == announcedKey } -> {
+            keys.any { it.keyPair()?.publicKeyHex == announcedKey } -> {
                 foreignAnnouncedKey = null
                 // Make the announced key current so sends tag the key senders are addressing.
-                keys = keys.sortedByDescending { it.publicKeyHex == announcedKey }
+                keys = keys.sortedByDescending { it.keyPair()?.publicKeyHex == announcedKey }
                 persistKeys()
                 if (!announced) setAnnounced(true) else recompute()
             }
@@ -164,11 +173,29 @@ class DmEncryptionManager {
     }
 
     private fun persistKeys() {
-        SecureStorage.saveNip4eKeysFor(accountPubkey, keys.map { it.privateKeyHex })
+        SecureStorage.saveNip4eKeysFor(accountPubkey, keys)
+    }
+
+    private fun Nip4eStoredKey.keyPair(): KeyPair? = runCatching { KeyPair.fromPrivateKeyHex(privateKeyHex) }.getOrNull()
+
+    /**
+     * Drop retired keys past the retention window or beyond the cap. The current key (retiredAt 0)
+     * is never dropped. A pruned key's messages stop opening on this device, which is the point:
+     * a rotated-away key is a decryption capability we no longer want lying around. Archive the
+     * history to the new key before rotating if it needs to outlive the window.
+     */
+    private fun prune(all: List<Nip4eStoredKey>): List<Nip4eStoredKey> {
+        val now = epochSeconds()
+        val current = all.filter { it.retiredAt == 0L }
+        val retired = all.filter { it.retiredAt != 0L }
+            .filter { now - it.retiredAt < RETENTION_SECONDS }
+            .sortedByDescending { it.retiredAt }
+            .take(MAX_RETIRED_KEYS)
+        return current + retired
     }
 
     private fun recompute() {
-        val current = keys.firstOrNull()?.publicKeyHex
+        val current = currentEncPubkeyOrNull()
         _state.value =
             when {
                 !remoteSigner -> State.Unavailable
@@ -177,5 +204,12 @@ class DmEncryptionManager {
                 announced -> State.Active(current)
                 else -> State.HeldNotAnnounced(current)
             }
+    }
+
+    companion object {
+        /** Matches Jumble so a key rotated on either client behaves the same. */
+        const val RETENTION_SECONDS = 90L * 24 * 60 * 60
+
+        const val MAX_RETIRED_KEYS = 10
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -144,6 +144,22 @@ class DmManager(
         _messageStatus.update { if (rumorId in it) it + (rumorId to GroupManager.MessageStatus.Delivered) else it }
     }
 
+    /**
+     * Report a send that no relay ever accepted, so the bubble says so instead of sitting there
+     * looking ordinary. Only overrides Sending: the recipient wrap and the self-copy are published
+     * separately, and the self-copy failing does not un-deliver a message the peer's relay took.
+     */
+    fun markFailed(rumorId: String, reason: String) {
+        val peer = peerByRumor.value[rumorId] ?: ""
+        _messageStatus.update { current ->
+            if (current[rumorId] !is GroupManager.MessageStatus.Sending) {
+                current
+            } else {
+                current + (rumorId to GroupManager.MessageStatus.Failed(reason, peer, eventJson = null))
+            }
+        }
+    }
+
     // Dedup: a gift wrap can arrive from several relays; the same rumor can arrive via the
     // recipient wrap and the self wrap. Held as an immutable set swapped atomically: wraps
     // are ingested by several coroutines at once, and a plain HashSet corrupts under that.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -165,11 +165,35 @@ class DmManager(
      * never want to retry), false on a TRANSIENT failure (e.g. a bunker decrypt timeout) so the
      * caller can leave it un-acked and retry it on a later backfill.
      */
-    suspend fun ingestGiftWrap(giftWrap: Event, myPubkey: String, signer: NostrSigner): Boolean {
-        val unwrapped = Nip17.unwrap(giftWrap, signer)
+    suspend fun ingestGiftWrap(giftWrap: Event, myPubkey: String, signer: NostrSigner): Boolean = ingestGiftWrap(
+        giftWrap,
+        myPubkey,
+        listOf(Nip17.Nip44Decryptor { peer, ciphertext -> signer.nip44Decrypt(peer, ciphertext) }),
+    )
+
+    /**
+     * Decrypt and file a received gift wrap. [decryptors] are tried in order on both layers, so a
+     * caller holding NIP-4e keys puts them ahead of the signer and pays no round-trip.
+     *
+     * [verifyLegacySender] authenticates the NIP-4e legacy shape, where the seal is signed by the
+     * sender's encryption key and therefore proves nothing on its own: it must confirm that seal
+     * pubkey is the encryption key the rumor's author announced. Returning false leaves the wrap
+     * unhandled, which our pipeline retries later, so an unreachable kind:10044 defers the message
+     * rather than deciding it wrongly.
+     */
+    suspend fun ingestGiftWrap(
+        giftWrap: Event,
+        myPubkey: String,
+        decryptors: List<Nip17.Nip44Decryptor>,
+        verifyLegacySender: suspend (authorPubkey: String, sealPubkey: String) -> Boolean = { _, _ -> false },
+    ): Boolean {
+        val unwrapped = Nip17.unwrap(giftWrap, myPubkey, decryptors)
         if (unwrapped == null) {
             // Decrypt/verify failed. On a bunker this is usually a transient timeout under load;
             // report not-handled so the wrap is retried instead of being permanently skipped.
+            return false
+        }
+        if (!unwrapped.sealSignedByIdentity && !verifyLegacySender(unwrapped.rumor.pubkey, unwrapped.sealPubkey)) {
             return false
         }
         val rumor = unwrapped.rumor

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmPairingManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmPairingManager.kt
@@ -1,0 +1,95 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.Nip4e
+
+/**
+ * NIP-4e device pairing (kinds 4454 / 4455): moves the encryption key to another device of the
+ * same account without the user copying it by hand.
+ *
+ * The device that wants the key publishes a throwaway pubkey; a device that holds the key answers
+ * with the key encrypted throwaway-to-throwaway. Identity keys sign both events but encrypt
+ * neither, so only the requesting device can open the answer. Both events are deleted afterwards.
+ *
+ * Both sides display a code derived from the requester's throwaway pubkey, so the user approves
+ * the request they actually made rather than whatever arrived first.
+ */
+class DmPairingManager {
+    sealed interface State {
+        data object Idle : State
+
+        /** This device asked for the key and is waiting for another device to answer. */
+        data class Requesting(val code: String) : State
+
+        /** Another device of this account is asking us for the key. */
+        data class IncomingRequest(val code: String, val throwawayPubkey: String) : State
+
+        data object Completed : State
+
+        data class Failed(val reason: String) : State
+    }
+
+    private val _state = MutableStateFlow<State>(State.Idle)
+    val state: StateFlow<State> = _state.asStateFlow()
+
+    /** Our throwaway keypair while requesting; the only thing that can open the answer. */
+    private var requestKey: KeyPair? = null
+
+    /** Requests already answered this session, so a re-delivered 4454 does not re-prompt. */
+    private var answered: Set<String> = emptySet()
+
+    /** Begin a request. Returns the throwaway pubkey to publish in the kind:4454. */
+    fun beginRequest(): String {
+        val throwaway = KeyPair.generate()
+        requestKey = throwaway
+        _state.value = State.Requesting(Nip4e.pairingCode(throwaway.publicKeyHex))
+        return throwaway.publicKeyHex
+    }
+
+    fun requestThrowawayKey(): KeyPair? = requestKey
+
+    /**
+     * A kind:4454 from our own account arrived. Ignored when it is our own outstanding request,
+     * or one we already answered; otherwise it becomes a prompt for the user.
+     */
+    fun onRequestSeen(event: Event) {
+        val throwaway = Nip4e.throwawayPubkeyFrom(event) ?: return
+        if (throwaway == requestKey?.publicKeyHex) return
+        if (throwaway in answered) return
+        if (_state.value is State.Requesting) return
+        _state.value = State.IncomingRequest(Nip4e.pairingCode(throwaway), throwaway)
+    }
+
+    /** Mark an incoming request handled (approved and answered, or declined). */
+    fun resolveIncoming(throwawayPubkey: String) {
+        answered = answered + throwawayPubkey
+        if ((_state.value as? State.IncomingRequest)?.throwawayPubkey == throwawayPubkey) {
+            _state.value = State.Idle
+        }
+    }
+
+    fun succeeded() {
+        requestKey = null
+        _state.value = State.Completed
+    }
+
+    fun failed(reason: String) {
+        requestKey = null
+        _state.value = State.Failed(reason)
+    }
+
+    fun reset() {
+        requestKey = null
+        _state.value = State.Idle
+    }
+
+    fun clear() {
+        requestKey = null
+        answered = emptySet()
+        _state.value = State.Idle
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmPairingManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmPairingManager.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip4e
+import org.nostr.nostrord.utils.epochSeconds
 
 /**
  * NIP-4e device pairing (kinds 4454 / 4455): moves the encryption key to another device of the
@@ -26,7 +27,7 @@ class DmPairingManager {
         data class Requesting(val code: String) : State
 
         /** Another device of this account is asking us for the key. */
-        data class IncomingRequest(val code: String, val throwawayPubkey: String) : State
+        data class IncomingRequest(val code: String, val throwawayPubkey: String, val eventId: String) : State
 
         data object Completed : State
 
@@ -39,8 +40,19 @@ class DmPairingManager {
     /** Our throwaway keypair while requesting; the only thing that can open the answer. */
     private var requestKey: KeyPair? = null
 
-    /** Requests already answered this session, so a re-delivered 4454 does not re-prompt. */
-    private var answered: Set<String> = emptySet()
+    /**
+     * Requests already decided, by kind:4454 event id, with when they were decided. Persisted by
+     * the owner through [onProcessedChanged]: the subscription looks back in time, so a decision
+     * kept only in memory means every restart re-prompts for the same declined request.
+     */
+    private var processed: Map<String, Long> = emptyMap()
+
+    /** Called whenever [processed] changes, so the owner can persist it. */
+    var onProcessedChanged: ((Map<String, Long>) -> Unit)? = null
+
+    fun hydrateProcessed(stored: Map<String, Long>) {
+        processed = prune(stored)
+    }
 
     /** Begin a request. Returns the throwaway pubkey to publish in the kind:4454. */
     fun beginRequest(): String {
@@ -54,22 +66,40 @@ class DmPairingManager {
 
     /**
      * A kind:4454 from our own account arrived. Ignored when it is our own outstanding request,
-     * or one we already answered; otherwise it becomes a prompt for the user.
+     * or one already decided; otherwise it becomes a prompt for the user.
      */
     fun onRequestSeen(event: Event) {
+        val eventId = event.id ?: return
         val throwaway = Nip4e.throwawayPubkeyFrom(event) ?: return
         if (throwaway == requestKey?.publicKeyHex) return
-        if (throwaway in answered) return
+        if (eventId in processed) return
         if (_state.value is State.Requesting) return
-        _state.value = State.IncomingRequest(Nip4e.pairingCode(throwaway), throwaway)
+        _state.value = State.IncomingRequest(Nip4e.pairingCode(throwaway), throwaway, eventId)
+    }
+
+    /**
+     * Record a request as decided (approved, declined, or made by us), so it never prompts again
+     * while the relay still serves it.
+     */
+    fun markProcessed(eventId: String) {
+        if (eventId.isBlank() || eventId in processed) return
+        processed = prune(processed + (eventId to epochSeconds()))
+        onProcessedChanged?.invoke(processed)
     }
 
     /** Mark an incoming request handled (approved and answered, or declined). */
     fun resolveIncoming(throwawayPubkey: String) {
-        answered = answered + throwawayPubkey
-        if ((_state.value as? State.IncomingRequest)?.throwawayPubkey == throwawayPubkey) {
+        val incoming = _state.value as? State.IncomingRequest
+        if (incoming?.throwawayPubkey == throwawayPubkey) {
+            markProcessed(incoming.eventId)
             _state.value = State.Idle
         }
+    }
+
+    /** Drop decisions older than the window the pairing subscription can still deliver. */
+    private fun prune(all: Map<String, Long>): Map<String, Long> {
+        val now = epochSeconds()
+        return all.filterValues { now - it < PROCESSED_RETENTION_SECONDS }
     }
 
     fun succeeded() {
@@ -89,7 +119,15 @@ class DmPairingManager {
 
     fun clear() {
         requestKey = null
-        answered = emptySet()
+        processed = emptyMap()
         _state.value = State.Idle
+    }
+
+    companion object {
+        /**
+         * Must cover the pairing subscription's lookback, or a decision expires while the relay is
+         * still serving the request it decided and the prompt comes back.
+         */
+        const val PROCESSED_RETENTION_SECONDS = 24L * 60 * 60
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/LegacySealVerifier.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/LegacySealVerifier.kt
@@ -1,0 +1,28 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.delay
+
+/**
+ * Authenticates a NIP-4e legacy seal, where the seal is signed by the sender's encryption key and
+ * so proves nothing on its own: the seal's author must be the encryption key that the rumor's
+ * author announced in their kind:10044.
+ *
+ * A cached announcement that disagrees is not a rejection: the author may have rotated since we
+ * last looked, so one fetch is forced before deciding. An unresolved announcement returns false,
+ * which leaves the wrap unhandled for the pipeline to retry rather than deciding on incomplete
+ * information. (Jumble instead persists a monotonic verified flag and renders unverified messages;
+ * deferring is stricter and needs no per-message UI.)
+ */
+class LegacySealVerifier(
+    private val fetchWaitMs: Long,
+    private val announcedKeyFor: (authorPubkey: String) -> String?,
+    private val requestAnnouncement: suspend (authorPubkey: String) -> Unit,
+) {
+    suspend fun verify(authorPubkey: String, sealPubkey: String): Boolean {
+        if (announcedKeyFor(authorPubkey) == sealPubkey) return true
+        // Unknown or stale: exactly one fetch, then decide on what we have.
+        requestAnnouncement(authorPubkey)
+        delay(fetchWaitMs)
+        return announcedKeyFor(authorPubkey) == sealPubkey
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
@@ -17,14 +17,13 @@ import kotlin.random.Random
  *   rumor (kind 14, unsigned) -> seal (kind 13, identity-signed, NIP-44 to the recipient)
  *   -> gift wrap (kind 1059, ephemeral-signed, NIP-44 to the recipient, randomized timestamp)
  *
- * The seal is encrypted/decrypted with the account's identity key through [NostrSigner.nip44Encrypt]
- * / [nip44Decrypt] so remote signers can plug in; the gift wrap is encrypted under a throwaway key
- * we generate and own.
+ * The gift wrap is encrypted under a throwaway key we generate and own. The seal goes through
+ * [NostrSigner.nip44Encrypt] / [nip44Decrypt] so remote signers plug in.
  *
  * Both layers address the recipient's identity key by default (standard, interoperable NIP-17,
- * single `p` tag). A recipient who announced a NIP-4e encryption key is addressed at that key
- * instead: see [Nip4e] and the `encryptTo` parameters. Only the ECDH peer changes; authorship,
- * signatures and `p` routing stay on identity keys.
+ * single `p` tag). NIP-4e recipients are addressed at their announced encryption key instead:
+ * see [Nip4e], `encryptTo`, and the shape taxonomy on [unwrap]. Only the ECDH peer changes;
+ * authorship, signatures and `p` routing stay on identity keys.
  */
 object Nip17 {
     const val KIND_CHAT = 14
@@ -75,8 +74,16 @@ object Nip17 {
         createdAt: Long = rumor.createdAt,
         encryptTo: String = recipientPubkey,
         senderEncTag: String? = null,
+        encryptWith: String? = null,
     ): Event {
-        val encrypted = signer.nip44Encrypt(encryptTo, rumor.toJsonString())
+        // Holding an encryption key turns the seal's NIP-44 into a local operation; only the
+        // signature still needs the signer.
+        val encrypted =
+            if (encryptWith != null) {
+                Nip44.encrypt(rumor.toJsonString(), encryptWith, encryptTo)
+            } else {
+                signer.nip44Encrypt(encryptTo, rumor.toJsonString())
+            }
         val unsigned =
             Event(
                 pubkey = signer.pubkey,
@@ -86,6 +93,29 @@ object Nip17 {
                 content = encrypted,
             )
         return signer.signEvent(unsigned)
+    }
+
+    /**
+     * NIP-4e legacy seal: signed by the encryption key itself, so `seal.pubkey` is that key and
+     * there is no `n` tag. Deployed readers that predate the identity-signed shape only accept
+     * this one, and it costs no signer call. A recipient must authenticate it by checking
+     * `seal.pubkey` against the author's announced kind:10044.
+     */
+    fun legacySeal(
+        rumor: Event,
+        encryptionPrivateKeyHex: String,
+        encryptTo: String,
+        createdAt: Long = rumor.createdAt,
+    ): Event {
+        val encryptionKey = KeyPair.fromPrivateKeyHex(encryptionPrivateKeyHex)
+        val unsigned =
+            Event(
+                pubkey = encryptionKey.publicKeyHex,
+                createdAt = createdAt,
+                kind = KIND_SEAL,
+                content = Nip44.encrypt(rumor.toJsonString(), encryptionPrivateKeyHex, encryptTo),
+            )
+        return unsigned.sign(encryptionKey)
     }
 
     /**
@@ -134,36 +164,93 @@ object Nip17 {
         wrapCreatedAt: Long = randomizedWrapTime(),
         encryptTo: String = recipientPubkey,
         senderEncTag: String? = null,
+        encryptWith: String? = null,
     ): Event = giftWrap(
-        seal(rumor, recipientPubkey, signer, sealCreatedAt, encryptTo, senderEncTag),
+        seal(rumor, recipientPubkey, signer, sealCreatedAt, encryptTo, senderEncTag, encryptWith),
         recipientPubkey,
         wrapCreatedAt,
         encryptTo,
     )
 
+    /** One way of running a NIP-44 decrypt: a locally held key, or a round-trip to the signer. */
+    fun interface Nip44Decryptor {
+        suspend fun decrypt(peerPubkeyHex: String, ciphertext: String): String
+    }
+
     data class Unwrapped(
         val rumor: Event,
         val senderPubkey: String,
         val giftWrapId: String?,
+        /** The `n` value on the seal, when the sender named their NIP-4e encryption key. */
+        val senderEncryptionPubkey: String? = null,
+        val sealPubkey: String = senderPubkey,
+        /**
+         * False for a seal signed by the sender's encryption key rather than their identity: the
+         * sender is unauthenticated here, and the caller MUST check [sealPubkey] against the
+         * author's announced kind:10044 before showing the message.
+         */
+        val sealSignedByIdentity: Boolean = true,
     )
 
     /**
-     * Unwrap a received kind:1059 with [signer] (the recipient): gift wrap -> seal -> rumor.
+     * Unwrap a received kind:1059 for [myPubkey]: gift wrap -> seal -> rumor, trying each of
+     * [decryptors] in turn on both layers. Order matters: locally held keys fail in microseconds
+     * on a bad HMAC, a remote signer costs a network round-trip, so put local keys first.
+     *
      * Returns null if anything is malformed, the seal signature is invalid, or the rumor author
-     * differs from the seal author (NIP-59 forgery guard).
+     * differs from the seal author on a shape where they must match (NIP-59 forgery guard).
+     *
+     * Four shapes are accepted, all of which are live on relays today:
+     * - classic NIP-17: no `n`, seal identity-signed, both layers addressed to the identity key;
+     * - NIP-4e modern: `n` names the sender's encryption key, seal still identity-signed;
+     * - NIP-4e legacy: seal signed by the sender's ENCRYPTION key, no `n`, so
+     *   `seal.pubkey != rumor.pubkey` and the caller authenticates via kind:10044;
+     * - our own seal over someone else's rumor: only our signer can produce our signature, so the
+     *   author guard is relaxed for it (self-archive).
      */
-    suspend fun unwrap(giftWrap: Event, signer: NostrSigner): Unwrapped? {
+    suspend fun unwrap(giftWrap: Event, myPubkey: String, decryptors: List<Nip44Decryptor>): Unwrapped? {
         if (giftWrap.kind != KIND_GIFT_WRAP) return null
-        val seal =
-            runCatching { parseEvent(signer.nip44Decrypt(giftWrap.pubkey, giftWrap.content)) }
-                .getOrNull() ?: return null
+        val sealJson = tryDecrypt(decryptors, giftWrap.pubkey, giftWrap.content) ?: return null
+        val seal = runCatching { parseEvent(sealJson) }.getOrNull() ?: return null
         if (seal.kind != KIND_SEAL || !seal.verify()) return null
-        val rumor =
-            runCatching { parseEvent(signer.nip44Decrypt(seal.pubkey, seal.content)) }
-                .getOrNull() ?: return null
-        if (rumor.pubkey != seal.pubkey) return null
-        return Unwrapped(rumor = rumor, senderPubkey = seal.pubkey, giftWrapId = giftWrap.id)
+        // The seal names the key its content is encrypted against; without it the peer is the
+        // seal's own author, which is both the classic and the legacy behavior.
+        val senderEncPubkey = Nip4e.encryptionKeyFromTags(seal.tags)
+        val rumorJson = tryDecrypt(decryptors, senderEncPubkey ?: seal.pubkey, seal.content) ?: return null
+        val rumor = runCatching { parseEvent(rumorJson) }.getOrNull() ?: return null
+
+        return when {
+            seal.pubkey == myPubkey ->
+                Unwrapped(rumor, rumor.pubkey, giftWrap.id, senderEncPubkey, seal.pubkey, sealSignedByIdentity = true)
+            senderEncPubkey != null || seal.pubkey == rumor.pubkey -> {
+                if (rumor.pubkey != seal.pubkey) return null
+                Unwrapped(rumor, seal.pubkey, giftWrap.id, senderEncPubkey, seal.pubkey, sealSignedByIdentity = true)
+            }
+            else ->
+                Unwrapped(rumor, rumor.pubkey, giftWrap.id, senderEncPubkey, seal.pubkey, sealSignedByIdentity = false)
+        }
     }
+
+    /** Unwrap with a single signer, the classic path. */
+    suspend fun unwrap(giftWrap: Event, signer: NostrSigner): Unwrapped? = unwrap(giftWrap, signer.pubkey, listOf(Nip44Decryptor { peer, ciphertext -> signer.nip44Decrypt(peer, ciphertext) }))
+
+    private suspend fun tryDecrypt(decryptors: List<Nip44Decryptor>, peerPubkeyHex: String, ciphertext: String): String? {
+        for (decryptor in decryptors) {
+            val plaintext =
+                try {
+                    decryptor.decrypt(peerPubkeyHex, ciphertext)
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    throw e
+                } catch (_: Throwable) {
+                    null
+                }
+            if (plaintext != null) return plaintext
+        }
+        return null
+    }
+
+    /** Parse a stored kind:14 rumor back into an [Event]; null when the JSON is unusable. */
+    fun parseRumor(json: String): Event? = runCatching { parseEvent(json) }.getOrNull()?.takeIf { it.kind == KIND_CHAT }
 
     private val lenientJson = Json { ignoreUnknownKeys = true }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip4e.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip4e.kt
@@ -20,6 +20,12 @@ object Nip4e {
     /** Replaceable announcement carrying the account's encryption pubkey. */
     const val KIND_ENCRYPTION_KEY = 10044
 
+    /** Device pairing: new client offers a throwaway pubkey (Phase 2b). */
+    const val KIND_CLIENT_KEY = 4454
+
+    /** Device pairing: holder sends the encryption privkey to that throwaway key (Phase 2b). */
+    const val KIND_KEY_SHARE = 4455
+
     /** Names an encryption pubkey. On kind:10044 it is the announcement; on a seal, the sender's. */
     const val TAG_ENCRYPTION_PUBKEY = "n"
 
@@ -54,6 +60,83 @@ object Nip4e {
         tags = encPubkeyHex?.takeIf { isPubkey(it) }?.let { listOf(listOf(TAG_ENCRYPTION_PUBKEY, it)) } ?: emptyList(),
         content = "",
     )
+
+    /** Throwaway pubkey a pairing event carries (uppercase `P`). */
+    const val TAG_THROWAWAY_PUBKEY = "P"
+
+    /** The same value under the name Coop reads; emitted alongside `P` for compatibility. */
+    const val TAG_THROWAWAY_PUBKEY_LEGACY = "pubkey"
+
+    /**
+     * Device pairing, step 1: a device without the encryption key publishes a throwaway pubkey
+     * [throwawayPubkey], identity-signed, so a device that holds the key can answer it.
+     *
+     * No device label: it would tell every relay which OS and browser the requesting device runs,
+     * and the pairing code already lets the user confirm which request they are approving.
+     */
+    fun buildClientKeyRequest(
+        identityPubkey: String,
+        throwawayPubkey: String,
+        createdAt: Long,
+    ): Event = Event(
+        pubkey = identityPubkey,
+        createdAt = createdAt,
+        kind = KIND_CLIENT_KEY,
+        // Both names for the same key: the NIP defines `P`, Coop only reads `pubkey`.
+        tags =
+        listOf(
+            listOf(TAG_THROWAWAY_PUBKEY_LEGACY, throwawayPubkey),
+            listOf(TAG_THROWAWAY_PUBKEY, throwawayPubkey),
+        ),
+        content = "",
+    )
+
+    /**
+     * Device pairing, step 2: the holding device answers with the encryption key, NIP-44 encrypted
+     * from its own throwaway [senderThrowawayPubkey] to the requester's [recipientThrowawayPubkey].
+     * Neither identity key is involved in the encryption, so the share is readable only by the
+     * device that generated the request.
+     */
+    fun buildKeyShare(
+        identityPubkey: String,
+        senderThrowawayPubkey: String,
+        recipientThrowawayPubkey: String,
+        encryptedKey: String,
+        createdAt: Long,
+    ): Event = Event(
+        pubkey = identityPubkey,
+        createdAt = createdAt,
+        kind = KIND_KEY_SHARE,
+        tags =
+        listOf(
+            listOf(TAG_THROWAWAY_PUBKEY, senderThrowawayPubkey),
+            listOf("p", recipientThrowawayPubkey),
+        ),
+        content = encryptedKey,
+    )
+
+    /** The throwaway pubkey [event] publishes: `P`, or Coop's `pubkey` when that is all it sent. */
+    fun throwawayPubkeyFrom(event: Event): String? = event.tags.firstOrNull { it.firstOrNull() == TAG_THROWAWAY_PUBKEY && isPubkey(it.getOrNull(1)) }?.get(1)
+        ?: event.tags.firstOrNull { it.firstOrNull() == TAG_THROWAWAY_PUBKEY_LEGACY && isPubkey(it.getOrNull(1)) }?.get(1)
+
+    /** Which throwaway pubkey a kind:4455 is addressed to (lowercase `p`). */
+    fun keyShareRecipientFrom(event: Event): String? = event.tags
+        .firstOrNull { it.firstOrNull() == "p" && isPubkey(it.getOrNull(1)) }
+        ?.get(1)
+
+    /**
+     * Short code both devices show so the user can confirm they are approving the request they
+     * actually made. Derived from the throwaway pubkey rather than carried in a tag: the
+     * requesting device generated it and the holding device reads it off the request, so nothing
+     * new goes on the wire and there is nothing extra to agree on.
+     *
+     * Eight characters in two groups, matching Jumble exactly: the whole point is that the user
+     * can compare the code across two devices, which fails if the clients format it differently.
+     */
+    fun pairingCode(throwawayPubkey: String): String {
+        val code = throwawayPubkey.take(8).uppercase()
+        return "${code.take(4)} ${code.drop(4)}"
+    }
 
     private fun isPubkey(value: String?): Boolean = value != null && value.length == 64 && value.all { it.isHexDigit() }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1253,6 +1253,31 @@ fun SecureStorage.saveNip4eAnnouncedAtFor(
     saveStringPref(nip4eAnnouncedAtKey(pubkey), epochSeconds.toString())
 }
 
+private fun dmPairingProcessedKey(pubkey: String): String = "dm_pairing_processed_${pubkeyDigest(pubkey)}"
+
+/**
+ * Pairing requests (kind:4454 event ids) already decided, with the epoch second of the decision.
+ * Persisted because the decision has to outlive the process: the subscription looks back in time,
+ * so a declined request is served again on every restart and would re-prompt forever.
+ */
+fun SecureStorage.loadDmPairingProcessedFor(pubkey: String): Map<String, Long> {
+    if (pubkey.isBlank()) return emptyMap()
+    val raw = getStringPref(dmPairingProcessedKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return emptyMap()
+    return runCatching { Json.decodeFromString<Map<String, Long>>(raw) }.getOrDefault(emptyMap())
+}
+
+fun SecureStorage.saveDmPairingProcessedFor(
+    pubkey: String,
+    processed: Map<String, Long>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(dmPairingProcessedKey(pubkey), Json.encodeToString<Map<String, Long>>(processed))
+    } catch (_: Exception) {
+    }
+}
+
 private fun dmArchivedRumorIdsKey(pubkey: String): String = "dm_archived_rumors_${pubkeyDigest(pubkey)}"
 
 /** Rumor ids whose archive copy a relay accepted, so a re-run resumes instead of republishing. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1192,6 +1192,38 @@ private fun nip4eKeysKey(pubkey: String): String = "nip4e_keys_${pubkeyDigest(pu
 
 private fun nip4eAnnouncedKey(pubkey: String): String = "nip4e_announced_${pubkeyDigest(pubkey)}"
 
+private fun nip4eAnnouncementKey(pubkey: String): String = "nip4e_announcement_${pubkeyDigest(pubkey)}"
+
+/**
+ * The newest kind:10044 known for an account: which encryption key it names (null when the key was
+ * withdrawn) and its created_at, so a lagging relay's older copy never wins. [confirmed] is true
+ * once a relay served it back, which is what tells "published" from "signed here a moment ago".
+ */
+@Serializable
+data class Nip4eAnnouncement(
+    val encPubkey: String?,
+    val createdAt: Long,
+    val confirmed: Boolean = false,
+)
+
+fun SecureStorage.loadNip4eAnnouncementFor(pubkey: String): Nip4eAnnouncement? {
+    if (pubkey.isBlank()) return null
+    val raw = getStringPref(nip4eAnnouncementKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return null
+    return runCatching { Json.decodeFromString<Nip4eAnnouncement>(raw) }.getOrNull()
+}
+
+fun SecureStorage.saveNip4eAnnouncementFor(
+    pubkey: String,
+    announcement: Nip4eAnnouncement?,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(nip4eAnnouncementKey(pubkey), announcement?.let { Json.encodeToString(it) } ?: "")
+    } catch (_: Exception) {
+    }
+}
+
 /**
  * One held encryption key. [retiredAt] is 0 for the current key and the epoch second it was
  * replaced for the others, which is what bounds how long a retired key stays on disk.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -10,6 +10,7 @@ import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.outbox.Kind10009Baseline
 import org.nostr.nostrord.nostr.Crypto
 import org.nostr.nostrord.nostr.toHexString
+import org.nostr.nostrord.utils.epochSeconds
 
 // 128-bit (32 hex) SHA-256 prefix of the pubkey. Used as the storage subkey
 // for all per-account slots: hashCode is 32-bit (collision-feasible) and the
@@ -1191,20 +1192,37 @@ private fun nip4eKeysKey(pubkey: String): String = "nip4e_keys_${pubkeyDigest(pu
 
 private fun nip4eAnnouncedKey(pubkey: String): String = "nip4e_announced_${pubkeyDigest(pubkey)}"
 
-fun SecureStorage.loadNip4eKeysFor(pubkey: String): List<String> {
+/**
+ * One held encryption key. [retiredAt] is 0 for the current key and the epoch second it was
+ * replaced for the others, which is what bounds how long a retired key stays on disk.
+ */
+@Serializable
+data class Nip4eStoredKey(
+    val privateKeyHex: String,
+    val retiredAt: Long = 0L,
+)
+
+fun SecureStorage.loadNip4eKeysFor(pubkey: String): List<Nip4eStoredKey> {
     if (pubkey.isBlank()) return emptyList()
     val raw = getSensitive(nip4eKeysKey(pubkey)) ?: return emptyList()
     if (raw.isBlank()) return emptyList()
-    return runCatching { Json.decodeFromString<List<String>>(raw) }.getOrDefault(emptyList())
+    runCatching { return Json.decodeFromString<List<Nip4eStoredKey>>(raw) }
+    // Slots written before keys carried a retirement stamp: the first is current, and the rest
+    // start their retention window now rather than being pruned on the spot.
+    return runCatching {
+        Json.decodeFromString<List<String>>(raw).mapIndexed { index, hex ->
+            Nip4eStoredKey(hex, retiredAt = if (index == 0) 0L else org.nostr.nostrord.utils.epochSeconds())
+        }
+    }.getOrDefault(emptyList())
 }
 
 fun SecureStorage.saveNip4eKeysFor(
     pubkey: String,
-    privateKeysHex: List<String>,
+    keys: List<Nip4eStoredKey>,
 ) {
     if (pubkey.isBlank()) return
     try {
-        saveSensitive(nip4eKeysKey(pubkey), Json.encodeToString(privateKeysHex))
+        saveSensitive(nip4eKeysKey(pubkey), Json.encodeToString(keys))
     } catch (_: Exception) {
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1184,6 +1184,91 @@ fun SecureStorage.saveDmEncKeys(
     }
 }
 
+// Our own NIP-4e encryption keys, newest first. A rotation retires a key but never deletes it:
+// messages already addressed to it only ever open with it. Held like the identity key (sensitive
+// slot), and cleared only when the account is removed from this device.
+private fun nip4eKeysKey(pubkey: String): String = "nip4e_keys_${pubkeyDigest(pubkey)}"
+
+private fun nip4eAnnouncedKey(pubkey: String): String = "nip4e_announced_${pubkeyDigest(pubkey)}"
+
+fun SecureStorage.loadNip4eKeysFor(pubkey: String): List<String> {
+    if (pubkey.isBlank()) return emptyList()
+    val raw = getSensitive(nip4eKeysKey(pubkey)) ?: return emptyList()
+    if (raw.isBlank()) return emptyList()
+    return runCatching { Json.decodeFromString<List<String>>(raw) }.getOrDefault(emptyList())
+}
+
+fun SecureStorage.saveNip4eKeysFor(
+    pubkey: String,
+    privateKeysHex: List<String>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveSensitive(nip4eKeysKey(pubkey), Json.encodeToString(privateKeysHex))
+    } catch (_: Exception) {
+    }
+}
+
+/** Whether the key we hold is the one currently advertised in our kind:10044. */
+fun SecureStorage.clearNip4eKeysFor(pubkey: String) {
+    if (pubkey.isBlank()) return
+    try {
+        saveSensitive(nip4eKeysKey(pubkey), "")
+        saveBooleanPref(nip4eAnnouncedKey(pubkey), false)
+    } catch (_: Exception) {
+    }
+}
+
+private fun nip4eAnnouncedAtKey(pubkey: String): String = "nip4e_announced_at_${pubkeyDigest(pubkey)}"
+
+/**
+ * When we started advertising the current key. Messages older than this predate NIP-4e addressing
+ * and are the only ones the self-archive needs to republish.
+ */
+fun SecureStorage.loadNip4eAnnouncedAtFor(pubkey: String): Long = if (pubkey.isBlank()) 0L else getStringPref(nip4eAnnouncedAtKey(pubkey), "")?.toLongOrNull() ?: 0L
+
+fun SecureStorage.saveNip4eAnnouncedAtFor(
+    pubkey: String,
+    epochSeconds: Long,
+) {
+    if (pubkey.isBlank()) return
+    saveStringPref(nip4eAnnouncedAtKey(pubkey), epochSeconds.toString())
+}
+
+private fun dmArchivedRumorIdsKey(pubkey: String): String = "dm_archived_rumors_${pubkeyDigest(pubkey)}"
+
+/** Rumor ids whose archive copy a relay accepted, so a re-run resumes instead of republishing. */
+fun SecureStorage.loadDmArchivedRumorIdsFor(pubkey: String): Set<String> {
+    if (pubkey.isBlank()) return emptySet()
+    val raw = getStringPref(dmArchivedRumorIdsKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return emptySet()
+    return runCatching { Json.decodeFromString<List<String>>(raw).toSet() }.getOrDefault(emptySet())
+}
+
+fun SecureStorage.saveDmArchivedRumorIdsFor(
+    pubkey: String,
+    ids: Set<String>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(dmArchivedRumorIdsKey(pubkey), Json.encodeToString<List<String>>(ids.toList()))
+    } catch (_: Exception) {
+    }
+}
+
+/** Whether this account holds a NIP-4e key on this device; drives the removal warning. */
+fun SecureStorage.hasNip4eKeyFor(pubkey: String): Boolean = loadNip4eKeysFor(pubkey).isNotEmpty()
+
+fun SecureStorage.loadNip4eAnnouncedFor(pubkey: String): Boolean = pubkey.isNotBlank() && getBooleanPref(nip4eAnnouncedKey(pubkey), default = false)
+
+fun SecureStorage.saveNip4eAnnouncedFor(
+    pubkey: String,
+    announced: Boolean,
+) {
+    if (pubkey.isBlank()) return
+    saveBooleanPref(nip4eAnnouncedKey(pubkey), announced)
+}
+
 // Notification history — persisted feed of cross-relay notifications shown in
 // the notification center. Scoped by pubkey so multi-account devices stay isolated.
 private fun notificationHistoryKey(pubkey: String): String = "notification_history_${pubkeyDigest(pubkey)}"
@@ -1492,6 +1577,9 @@ fun SecureStorage.clearAllCredentialsForAccount(pubkey: String) {
     clearPomegranateCentralFor(pubkey)
     clearPomegranateDisconnectedFor(pubkey)
     clearNip55SignerPackageFor(pubkey)
+    // The NIP-4e key decrypts this account's DMs, so it cannot outlive the account on the device.
+    // The removal dialog warns to export it first, since its message history goes with it.
+    clearNip4eKeysFor(pubkey)
 }
 
 private fun droppedGroupsForAccountKey(pubkey: String) = "dropped_groups_${pubkeyDigest(pubkey)}"

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -62,6 +62,13 @@ class DmViewModel(
     /** Fetch the peer's kind:10050 so [peerDmRelays] fills in (for the header "DM relays" view). */
     fun loadPeerDmRelays(peerPubkey: String) = repo.requestPeerDmRelays(peerPubkey)
 
+    /**
+     * Opening a conversation resolves where that peer reads, so the first message is addressed
+     * before it is written rather than after the reply teaches us. The send waits on this too;
+     * asking here means it is usually already answered by the time anyone types.
+     */
+    fun openConversation(peerPubkey: String) = repo.requestPeerDmRelays(peerPubkey)
+
     fun getPublicKey(): String? = repo.getPublicKey()
 
     fun send(

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
@@ -41,6 +41,12 @@ class DmEncryptionViewModel(
     /** False hides the whole block: nothing here would speed up a locally signing account. */
     val visible: Boolean get() = state.value !is DmEncryptionManager.State.Unavailable
 
+    init {
+        // What the relays announce is the truth about this account, and this device's stored state
+        // can be a session old. Asking on open is what surfaces a key another device announced.
+        viewModelScope.launch { repo.refreshDmEncryptionState() }
+    }
+
     fun clearError() {
         _error.value = null
     }
@@ -89,6 +95,40 @@ class DmEncryptionViewModel(
             when (val result = repo.rotateDmEncryptionKey()) {
                 is Result.Error -> _error.value = result.error.message
                 else -> _revealedKey.value = null
+            }
+            _busy.value = false
+        }
+    }
+
+    private val _resetConfirmOpen = MutableStateFlow(false)
+    val resetConfirmOpen: StateFlow<Boolean> = _resetConfirmOpen.asStateFlow()
+
+    /** Confirmed first: a reset abandons the announced key, and nothing sent to it opens again. */
+    fun askToReset() {
+        _resetConfirmOpen.value = true
+    }
+
+    fun dismissResetConfirm() {
+        _resetConfirmOpen.value = false
+    }
+
+    /**
+     * Take over the announcement when the device that made it is gone. Without this the account is
+     * stuck: senders keep addressing a key nobody here holds, so inbound messages never open.
+     */
+    fun confirmReset() {
+        _resetConfirmOpen.value = false
+        if (_busy.value) return
+        _busy.value = true
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.resetDmEncryptionKey()) {
+                is Result.Error -> _error.value = result.error.message
+                else -> {
+                    // The request aimed at the lost device can no longer be answered.
+                    repo.dismissDmPairing()
+                    _importInput.value = ""
+                }
             }
             _busy.value = false
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
@@ -1,0 +1,181 @@
+package org.nostr.nostrord.ui.screens.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.network.managers.DmArchiveManager
+import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmPairingManager
+import org.nostr.nostrord.utils.Result
+
+/**
+ * Shared logic for the Settings "Fast decryption key" block (NIP-4e). Both UIs consume this VM.
+ *
+ * The key is announced so senders address it instead of the account's identity key, which lets
+ * inbound messages decrypt on this device rather than through the remote signer. It is offered
+ * only where that helps: accounts whose signing is already local gain nothing and see nothing
+ * ([DmEncryptionManager.State.Unavailable] -> [visible] false).
+ */
+class DmEncryptionViewModel(
+    private val repo: NostrRepositoryApi,
+) : ViewModel() {
+    val state: StateFlow<DmEncryptionManager.State> = repo.dmEncryptionState
+
+    private val _busy = MutableStateFlow(false)
+    val busy: StateFlow<Boolean> = _busy.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    /** The private key, once the user asked to see it in order to move it to another device. */
+    private val _revealedKey = MutableStateFlow<String?>(null)
+    val revealedKey: StateFlow<String?> = _revealedKey.asStateFlow()
+
+    private val _importInput = MutableStateFlow("")
+    val importInput: StateFlow<String> = _importInput.asStateFlow()
+
+    /** False hides the whole block: nothing here would speed up a locally signing account. */
+    val visible: Boolean get() = state.value !is DmEncryptionManager.State.Unavailable
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    fun setImportInput(value: String) {
+        _importInput.value = value
+        _error.value = null
+    }
+
+    fun enable() {
+        if (_busy.value) return
+        _busy.value = true
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.enableDmEncryption()) {
+                is Result.Error -> _error.value = result.error.message
+                else -> {}
+            }
+            _busy.value = false
+        }
+    }
+
+    /** Stops advertising the key. The key itself stays, or its message history stops opening. */
+    fun disable() {
+        if (_busy.value) return
+        _busy.value = true
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.disableDmEncryption()) {
+                is Result.Error -> _error.value = result.error.message
+                else -> {}
+            }
+            _busy.value = false
+        }
+    }
+
+    /**
+     * Advertise a fresh key. Offered for the case where the current one may have leaked: the old
+     * key is kept, so nothing already received stops opening.
+     */
+    fun rotate() {
+        if (_busy.value) return
+        _busy.value = true
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.rotateDmEncryptionKey()) {
+                is Result.Error -> _error.value = result.error.message
+                else -> _revealedKey.value = null
+            }
+            _busy.value = false
+        }
+    }
+
+    fun revealKey() {
+        _revealedKey.value = repo.exportDmEncryptionKey()
+        if (_revealedKey.value == null) _error.value = "There is no key on this device yet."
+    }
+
+    fun hideKey() {
+        _revealedKey.value = null
+    }
+
+    val archiveProgress: StateFlow<DmArchiveManager.Progress> = repo.dmArchiveProgress
+
+    /** How many stored messages still need an archive copy; null until counted. */
+    private val _archivableCount = MutableStateFlow<Int?>(null)
+    val archivableCount: StateFlow<Int?> = _archivableCount.asStateFlow()
+
+    private val _archiveConfirmOpen = MutableStateFlow(false)
+    val archiveConfirmOpen: StateFlow<Boolean> = _archiveConfirmOpen.asStateFlow()
+
+    /** Count first: the confirmation has to state the volume being published before anything is. */
+    fun askToArchive() {
+        _archiveConfirmOpen.value = true
+        viewModelScope.launch { _archivableCount.value = repo.countDmArchivableMessages() }
+    }
+
+    fun dismissArchiveConfirm() {
+        _archiveConfirmOpen.value = false
+    }
+
+    fun confirmArchive() {
+        _archiveConfirmOpen.value = false
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.archiveDmHistory()) {
+                is Result.Error -> _error.value = result.error.message
+                else -> _archivableCount.value = repo.countDmArchivableMessages()
+            }
+        }
+    }
+
+    fun cancelArchive() {
+        repo.cancelDmArchive()
+    }
+
+    val pairingState: StateFlow<DmPairingManager.State> = repo.dmPairingState
+
+    /** Ask another device of this account for the key, instead of copying it by hand. */
+    fun requestKeyFromOtherDevice() {
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.requestDmEncryptionKey()) {
+                is Result.Error -> _error.value = result.error.message
+                else -> {}
+            }
+        }
+    }
+
+    fun approvePairing() {
+        _error.value = null
+        viewModelScope.launch {
+            when (val result = repo.approveDmPairing()) {
+                is Result.Error -> _error.value = result.error.message
+                else -> {}
+            }
+        }
+    }
+
+    fun declinePairing() {
+        repo.declineDmPairing()
+    }
+
+    fun dismissPairing() {
+        repo.dismissDmPairing()
+    }
+
+    fun importKey() {
+        val input = _importInput.value.trim()
+        if (input.isEmpty()) return
+        if (!repo.importDmEncryptionKey(input)) {
+            _error.value = "That key does not match the one this account announced."
+            return
+        }
+        _importInput.value = ""
+        _error.value = null
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -8,8 +8,11 @@ import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.network.RoleDefinition
 import org.nostr.nostrord.network.livekit.LiveKitCredentials
 import org.nostr.nostrord.network.managers.ConnectionManager
+import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmConversation
+import org.nostr.nostrord.network.managers.DmEncryptionManager
 import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
@@ -147,6 +150,66 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmRelaysByPubkeyFlow
     override val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = MutableStateFlow(emptyMap())
     override fun requestPeerDmRelays(pubkey: String) {}
+
+    val dmEncryptionStateFlow = MutableStateFlow<DmEncryptionManager.State>(DmEncryptionManager.State.Unavailable)
+    override val dmEncryptionState: StateFlow<DmEncryptionManager.State> = dmEncryptionStateFlow
+    var enableDmEncryptionResult: Result<Unit> = Result.Success(Unit)
+    var importDmEncryptionKeyResult: Boolean = true
+    var exportedDmEncryptionKey: String? = null
+
+    override suspend fun enableDmEncryption(): Result<Unit> = enableDmEncryptionResult
+
+    override suspend fun disableDmEncryption(): Result<Unit> = Result.Success(Unit)
+
+    var rotateDmEncryptionKeyResult: Result<Unit> = Result.Success(Unit)
+
+    override suspend fun rotateDmEncryptionKey(): Result<Unit> {
+        calls += "rotateDmEncryptionKey"
+        return rotateDmEncryptionKeyResult
+    }
+
+    override fun importDmEncryptionKey(privateKeyHex: String): Boolean = importDmEncryptionKeyResult
+
+    override fun exportDmEncryptionKey(): String? = exportedDmEncryptionKey
+
+    val dmArchiveProgressFlow = MutableStateFlow(DmArchiveManager.Progress())
+    override val dmArchiveProgress: StateFlow<DmArchiveManager.Progress> = dmArchiveProgressFlow
+    var archivableCount: Int = 0
+    var archiveDmHistoryResult: Result<Unit> = Result.Success(Unit)
+
+    override suspend fun countDmArchivableMessages(): Int = archivableCount
+
+    override suspend fun archiveDmHistory(): Result<Unit> {
+        calls += "archiveDmHistory"
+        return archiveDmHistoryResult
+    }
+
+    override fun cancelDmArchive() {
+        calls += "cancelDmArchive"
+    }
+
+    val dmPairingStateFlow = MutableStateFlow<DmPairingManager.State>(DmPairingManager.State.Idle)
+    override val dmPairingState: StateFlow<DmPairingManager.State> = dmPairingStateFlow
+    var requestDmEncryptionKeyResult: Result<Unit> = Result.Success(Unit)
+    var approveDmPairingResult: Result<Unit> = Result.Success(Unit)
+
+    override suspend fun requestDmEncryptionKey(): Result<Unit> {
+        calls += "requestDmEncryptionKey"
+        return requestDmEncryptionKeyResult
+    }
+
+    override suspend fun approveDmPairing(): Result<Unit> {
+        calls += "approveDmPairing"
+        return approveDmPairingResult
+    }
+
+    override fun declineDmPairing() {
+        calls += "declineDmPairing"
+    }
+
+    override fun dismissDmPairing() {
+        calls += "dismissDmPairing"
+    }
     override val latestMessageTimestamps: StateFlow<Map<String, Long>> = MutableStateFlow(emptyMap())
     override val totalUnread: StateFlow<Int> = MutableStateFlow(0)
     override val unreadByRelay: StateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -157,6 +157,10 @@ class FakeNostrRepository : NostrRepositoryApi {
     var importDmEncryptionKeyResult: Boolean = true
     var exportedDmEncryptionKey: String? = null
 
+    override suspend fun refreshDmEncryptionState() {
+        calls += "refreshDmEncryptionState"
+    }
+
     override suspend fun enableDmEncryption(): Result<Unit> = enableDmEncryptionResult
 
     override suspend fun disableDmEncryption(): Result<Unit> = Result.Success(Unit)
@@ -166,6 +170,13 @@ class FakeNostrRepository : NostrRepositoryApi {
     override suspend fun rotateDmEncryptionKey(): Result<Unit> {
         calls += "rotateDmEncryptionKey"
         return rotateDmEncryptionKeyResult
+    }
+
+    var resetDmEncryptionKeyResult: Result<Unit> = Result.Success(Unit)
+
+    override suspend fun resetDmEncryptionKey(): Result<Unit> {
+        calls += "resetDmEncryptionKey"
+        return resetDmEncryptionKeyResult
     }
 
     override fun importDmEncryptionKey(privateKeyHex: String): Boolean = importDmEncryptionKeyResult

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmArchiveManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmArchiveManagerTest.kt
@@ -1,0 +1,185 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.auth.NostrSigner
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.Nip17
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DmArchiveManagerTest {
+    private fun rumor(author: String, recipient: String, content: String, createdAt: Long) = Nip17.buildRumor(author, recipient, content, createdAt)
+
+    private fun wrapOf(rumor: Event) = rumor.copy(kind = Nip17.KIND_GIFT_WRAP)
+
+    @Test
+    fun `only messages predating the announcement are archived`() {
+        val manager = DmArchiveManager()
+        val me = "a".repeat(64)
+        val peer = "b".repeat(64)
+        val old = rumor(peer, me, "before", createdAt = 100L)
+        val new = rumor(peer, me, "after", createdAt = 300L)
+
+        val pending = manager.pending(listOf(old, new), announcedAt = 200L)
+        // Anything sent after the announcement is already addressed to the encryption key.
+        assertEquals(listOf(old.id), pending.map { it.id })
+    }
+
+    @Test
+    fun `already archived ids are skipped on a re-run`() {
+        val manager = DmArchiveManager()
+        val me = "a".repeat(64)
+        val peer = "b".repeat(64)
+        val first = rumor(peer, me, "one", createdAt = 10L)
+        val second = rumor(peer, me, "two", createdAt = 20L)
+        manager.hydrate(setOf(first.id!!))
+
+        assertEquals(listOf(second.id), manager.pending(listOf(first, second), announcedAt = 0L).map { it.id })
+    }
+
+    @Test
+    fun `progress only advances on relay acceptance`() = runTest {
+        val manager = DmArchiveManager()
+        val me = "a".repeat(64)
+        val peer = "b".repeat(64)
+        val accepted = rumor(peer, me, "accepted", createdAt = 10L)
+        val rejected = rumor(peer, me, "rejected", createdAt = 20L)
+        var persisted: Set<String> = emptySet()
+
+        manager.run(
+            rumors = listOf(accepted, rejected),
+            buildWrap = { wrapOf(it) },
+            publish = { wrap -> wrap.content == "accepted" },
+            persistProgress = { persisted = it },
+        )
+
+        assertEquals(1, manager.progress.value.done)
+        assertEquals(1, manager.progress.value.failed)
+        assertTrue(!manager.progress.value.running)
+        // A rejected copy must stay pending, or it would be silently lost on the next device.
+        assertEquals(setOf(accepted.id), persisted)
+    }
+
+    @Test
+    fun `a relay refusing everything aborts instead of hammering`() = runTest {
+        val manager = DmArchiveManager()
+        val me = "a".repeat(64)
+        val peer = "b".repeat(64)
+        val rumors = (1..20).map { rumor(peer, me, "m$it", createdAt = it.toLong()) }
+        var attempts = 0
+
+        manager.run(
+            rumors = rumors,
+            buildWrap = { wrapOf(it) },
+            publish = {
+                attempts++
+                false
+            },
+            persistProgress = {},
+        )
+
+        assertEquals(DmArchiveManager.MAX_CONSECUTIVE_FAILURES, attempts)
+        assertNotNull(manager.progress.value.error)
+        assertTrue(!manager.progress.value.running)
+    }
+
+    @Test
+    fun `cancelling stops the run and keeps what was published`() = runTest {
+        val manager = DmArchiveManager()
+        val me = "a".repeat(64)
+        val peer = "b".repeat(64)
+        val rumors = (1..5).map { rumor(peer, me, "m$it", createdAt = it.toLong()) }
+
+        manager.run(
+            rumors = rumors,
+            buildWrap = { wrapOf(it) },
+            publish = {
+                manager.cancel()
+                true
+            },
+            persistProgress = {},
+        )
+
+        assertEquals(1, manager.progress.value.done)
+        assertTrue(!manager.progress.value.running)
+        assertEquals(1, manager.archivedIds().size)
+    }
+
+    @Test
+    fun `an archived foreign rumor comes back with its original author`() = runTest {
+        // End to end over the real envelope: this is the shape the repository publishes.
+        val me = NostrSigner.Local(KeyPair.generate())
+        val alice = NostrSigner.Local(KeyPair.generate())
+        val myEnc = KeyPair.generate()
+        val original = Nip17.buildRumor(alice.pubkey, me.pubkey, "said long ago", createdAt = 50L)
+
+        val archived =
+            Nip17.wrap(
+                original,
+                me.pubkey,
+                me,
+                encryptTo = myEnc.publicKeyHex,
+                senderEncTag = myEnc.publicKeyHex,
+                encryptWith = myEnc.privateKeyHex,
+            )
+
+        val decryptor = Nip17.Nip44Decryptor { peer, ciphertext -> org.nostr.nostrord.nostr.Nip44.decrypt(ciphertext, myEnc.privateKeyHex, peer) }
+        val out = Nip17.unwrap(archived, me.pubkey, listOf(decryptor))
+
+        assertNotNull(out)
+        assertEquals("said long ago", out.rumor.content)
+        assertEquals(alice.pubkey, out.senderPubkey, "the archive must not reattribute the message to us")
+        assertEquals(original.id, out.rumor.id, "same rumor id, so every client dedupes it against the original")
+    }
+
+    @Test
+    fun `nobody else accepts our archive of a foreign rumor`() = runTest {
+        val me = NostrSigner.Local(KeyPair.generate())
+        val alice = NostrSigner.Local(KeyPair.generate())
+        val myEnc = KeyPair.generate()
+        val archived =
+            Nip17.wrap(
+                Nip17.buildRumor(alice.pubkey, me.pubkey, "private", createdAt = 50L),
+                me.pubkey,
+                me,
+                encryptTo = myEnc.publicKeyHex,
+                senderEncTag = myEnc.publicKeyHex,
+                encryptWith = myEnc.privateKeyHex,
+            )
+
+        val decryptor = Nip17.Nip44Decryptor { peer, ciphertext -> org.nostr.nostrord.nostr.Nip44.decrypt(ciphertext, myEnc.privateKeyHex, peer) }
+        // Same key material, but the reader is not the seal's author: the carve-out does not apply
+        // and the NIP-59 author guard rejects it. This is why other clients drop it silently.
+        assertNull(Nip17.unwrap(archived, alice.pubkey, listOf(decryptor)))
+    }
+
+    @Test
+    fun `our own archived message stays a plain interoperable self-wrap`() = runTest {
+        val me = NostrSigner.Local(KeyPair.generate())
+        val peer = KeyPair.generate()
+        val myEnc = KeyPair.generate()
+        val mine = Nip17.buildRumor(me.pubkey, peer.publicKeyHex, "I said this", createdAt = 50L)
+
+        val archived =
+            Nip17.wrap(
+                mine,
+                me.pubkey,
+                me,
+                encryptTo = myEnc.publicKeyHex,
+                senderEncTag = myEnc.publicKeyHex,
+                encryptWith = myEnc.privateKeyHex,
+            )
+
+        val decryptor = Nip17.Nip44Decryptor { p, ciphertext -> org.nostr.nostrord.nostr.Nip44.decrypt(ciphertext, myEnc.privateKeyHex, p) }
+        // seal.pubkey == rumor.pubkey here, so it passes the ordinary guard: no carve-out needed
+        // and any conforming client on this account reads it.
+        val out = Nip17.unwrap(archived, "00".repeat(32), listOf(decryptor))
+        assertNotNull(out)
+        assertEquals(me.pubkey, out.senderPubkey)
+        assertEquals(listOf(listOf("p", myEnc.publicKeyHex), listOf("p", me.pubkey)), archived.tags)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManagerTest.kt
@@ -1,11 +1,11 @@
 package org.nostr.nostrord.network.managers
 
 import org.nostr.nostrord.nostr.KeyPair
-import org.nostr.nostrord.nostr.Nip4e
 import org.nostr.nostrord.storage.Nip4eStoredKey
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.loadNip4eKeysFor
 import org.nostr.nostrord.storage.saveNip4eAnnouncedFor
+import org.nostr.nostrord.storage.saveNip4eAnnouncementFor
 import org.nostr.nostrord.storage.saveNip4eKeysFor
 import org.nostr.nostrord.utils.epochSeconds
 import kotlin.test.Test
@@ -18,10 +18,14 @@ class DmEncryptionManagerTest {
     // Distinct per test: the manager persists to SecureStorage, which is shared across the run.
     private fun account(tag: String) = tag.padEnd(64, '0')
 
+    /** Announce [key] for this account, as signing our own kind:10044 does. */
+    private fun DmEncryptionManager.announce(key: String?, at: Long = epochSeconds()) = ingestAnnouncement(key, at, fromRelay = false)
+
     /** A manager on a known-empty account: the slots outlive the process, so reset them first. */
     private fun freshManager(pubkey: String, remoteSigner: Boolean = true): DmEncryptionManager {
         SecureStorage.saveNip4eKeysFor(pubkey, emptyList())
         SecureStorage.saveNip4eAnnouncedFor(pubkey, false)
+        SecureStorage.saveNip4eAnnouncementFor(pubkey, null)
         return DmEncryptionManager().also { it.loadFor(pubkey, remoteSigner) }
     }
 
@@ -39,7 +43,7 @@ class DmEncryptionManagerTest {
         val encPubkey = manager.generateKey()
         assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.HeldNotAnnounced).encPubkey)
 
-        manager.setAnnounced(true)
+        manager.announce(manager.currentEncPubkeyOrNull())
         assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
     }
 
@@ -47,9 +51,9 @@ class DmEncryptionManagerTest {
     fun `disabling stops advertising but never drops the key`() {
         val manager = freshManager(account("a3"))
         val encPubkey = manager.generateKey()
-        manager.setAnnounced(true)
+        manager.announce(manager.currentEncPubkeyOrNull())
 
-        manager.setAnnounced(false)
+        manager.announce(null)
         // Messages already addressed to this key only open with it, so it has to survive.
         assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.HeldNotAnnounced).encPubkey)
         assertEquals(encPubkey, manager.currentEncPubkeyOrNull())
@@ -61,7 +65,7 @@ class DmEncryptionManagerTest {
         val manager = freshManager(pubkey)
         val elsewhere = KeyPair.generate()
 
-        manager.ingestOwnAnnouncement(Nip4e.buildAnnouncement(pubkey, elsewhere.publicKeyHex, createdAt = 10L))
+        manager.ingestAnnouncement(elsewhere.publicKeyHex, 10L, fromRelay = true)
         assertEquals(elsewhere.publicKeyHex, (manager.state.value as DmEncryptionManager.State.AnnouncedElsewhere).encPubkey)
 
         // A different key would leave us unable to read, so it is refused outright.
@@ -87,9 +91,9 @@ class DmEncryptionManagerTest {
         val pubkey = account("a6")
         val manager = freshManager(pubkey)
         val encPubkey = manager.generateKey()
-        manager.setAnnounced(true)
+        manager.announce(encPubkey, at = 10L)
 
-        manager.ingestOwnAnnouncement(Nip4e.buildAnnouncement(pubkey, null, createdAt = 20L))
+        manager.ingestAnnouncement(null, 20L, fromRelay = true)
         assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.HeldNotAnnounced).encPubkey)
     }
 
@@ -99,7 +103,7 @@ class DmEncryptionManagerTest {
         val manager = freshManager(pubkey)
         val encPubkey = manager.generateKey()
 
-        manager.ingestOwnAnnouncement(Nip4e.buildAnnouncement(pubkey, encPubkey, createdAt = 30L))
+        manager.ingestAnnouncement(encPubkey, 30L, fromRelay = true)
         assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
     }
 
@@ -107,10 +111,13 @@ class DmEncryptionManagerTest {
     fun `rotating advertises a new key and keeps the old one readable`() {
         val manager = freshManager(account("a9"))
         val first = manager.generateKey()
-        manager.setAnnounced(true)
+        manager.announce(first, at = 10L)
 
+        // Rotation is adopt-then-announce, as the repository does it: until the new announcement
+        // is recorded, the announced key is still the old one and stays current.
         val second = manager.generateKey()
-        manager.setAnnounced(true)
+        assertEquals(first, manager.currentEncPubkeyOrNull())
+        manager.announce(second, at = 20L)
 
         assertEquals(second, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
         // Contacts who have not re-read the announcement still address the old key, and its
@@ -122,11 +129,11 @@ class DmEncryptionManagerTest {
     fun `rotating does not move the archive cutoff`() {
         val manager = freshManager(account("aa"))
         manager.generateKey()
-        manager.setAnnounced(true)
+        manager.announce(manager.currentEncPubkeyOrNull())
         val firstAnnouncedAt = manager.announcedAt()
 
         manager.generateKey()
-        manager.setAnnounced(true)
+        manager.announce(manager.currentEncPubkeyOrNull())
 
         // Messages between the first announcement and the rotation are already addressed to a key
         // we still hold, so moving the cutoff would re-archive them for nothing.
@@ -196,8 +203,9 @@ class DmEncryptionManagerTest {
     fun `rotating stamps the replaced key so its window starts now`() {
         val manager = freshManager(account("ae"))
         val first = manager.generateKey()
-        manager.setAnnounced(true)
+        manager.announce(first)
         val second = manager.generateKey()
+        manager.announce(second)
 
         assertEquals(listOf(second, first), manager.heldKeys().map { it.publicKeyHex })
         val stored = SecureStorage.loadNip4eKeysFor(account("ae"))
@@ -212,5 +220,94 @@ class DmEncryptionManagerTest {
         manager.clear()
         assertIs<DmEncryptionManager.State.Unavailable>(manager.state.value)
         assertTrue(manager.heldKeys().isEmpty())
+    }
+
+    @Test
+    fun `a stale announcement from a lagging relay does not flip the state`() {
+        val pubkey = account("af")
+        val manager = freshManager(pubkey)
+        val mine = KeyPair.generate()
+        val theirs = KeyPair.generate()
+        manager.adoptKey(mine)
+        manager.announce(mine.publicKeyHex, at = 100L)
+
+        // The other device announced later, so it is the current one.
+        manager.ingestAnnouncement(theirs.publicKeyHex, 200L, fromRelay = true)
+        assertEquals(theirs.publicKeyHex, (manager.state.value as DmEncryptionManager.State.AnnouncedElsewhere).encPubkey)
+
+        // A relay that has not caught up still serves the previous version. kind:10044 is
+        // replaceable, so the older copy must not win just by arriving last.
+        manager.ingestAnnouncement(mine.publicKeyHex, 100L, fromRelay = true)
+        assertEquals(theirs.publicKeyHex, (manager.state.value as DmEncryptionManager.State.AnnouncedElsewhere).encPubkey)
+
+        // A genuinely newer one does win.
+        manager.ingestAnnouncement(mine.publicKeyHex, 300L, fromRelay = true)
+        assertEquals(mine.publicKeyHex, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
+    }
+
+    @Test
+    fun `a key held from an unconfirmed publish is claimed when its announcement lands`() {
+        val pubkey = account("b0")
+        val manager = freshManager(pubkey)
+        val fresh = KeyPair.generate()
+        // The publish reported no relay OK, so nothing was announced locally, but the event may
+        // still have been stored. Holding the key is what lets the account claim it back.
+        manager.adoptKey(fresh)
+
+        manager.ingestAnnouncement(fresh.publicKeyHex, 50L, fromRelay = true)
+
+        assertEquals(fresh.publicKeyHex, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
+    }
+
+    @Test
+    fun `adopting the announced key claims the announcement, even after it was read as foreign`() {
+        val pubkey = account("b1")
+        val manager = freshManager(pubkey)
+        val fresh = KeyPair.generate()
+
+        // The relay echoes our own announcement back while the publish is still awaiting its OK,
+        // so it is reconciled before the key is held: it reads as another device's.
+        manager.ingestAnnouncement(fresh.publicKeyHex, 70L, fromRelay = true)
+        assertIs<DmEncryptionManager.State.AnnouncedElsewhere>(manager.state.value)
+
+        // Holding it must settle the state here: re-reading the same event cannot, since the
+        // created_at guard drops it as already seen.
+        manager.adoptKey(fresh)
+
+        assertEquals(fresh.publicKeyHex, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
+    }
+
+    @Test
+    fun `the relay echo of our own announcement never reads as another device's`() {
+        val pubkey = account("b2")
+        val manager = freshManager(pubkey)
+        val fresh = KeyPair.generate()
+
+        // The order the repository publishes in: hold the key, record what we signed, publish.
+        manager.adoptKey(fresh)
+        manager.announce(fresh.publicKeyHex, at = 500L)
+        val announcing = manager.state.value as DmEncryptionManager.State.Active
+        assertFalse(announcing.confirmed, "nothing has confirmed the announcement yet")
+
+        // The relay serves the same event back a second later, while the publish still awaits OK.
+        manager.ingestAnnouncement(fresh.publicKeyHex, 500L, fromRelay = true)
+
+        val state = manager.state.value as DmEncryptionManager.State.Active
+        assertEquals(fresh.publicKeyHex, state.encPubkey)
+        assertTrue(state.confirmed, "the echo is what confirms it landed")
+    }
+
+    @Test
+    fun `a key lost before its announcement was recorded is still claimed on the next load`() {
+        val pubkey = account("b3")
+        val manager = freshManager(pubkey)
+        val fresh = KeyPair.generate()
+        manager.adoptKey(fresh)
+        manager.announce(fresh.publicKeyHex, at = 600L)
+
+        // A restart: both facts come back from storage, and the state is derived from them again.
+        val restarted = DmEncryptionManager().also { it.loadFor(pubkey, remoteSigner = true) }
+
+        assertEquals(fresh.publicKeyHex, (restarted.state.value as DmEncryptionManager.State.Active).encPubkey)
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManagerTest.kt
@@ -1,0 +1,141 @@
+package org.nostr.nostrord.network.managers
+
+import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.Nip4e
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.saveNip4eAnnouncedFor
+import org.nostr.nostrord.storage.saveNip4eKeysFor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DmEncryptionManagerTest {
+    // Distinct per test: the manager persists to SecureStorage, which is shared across the run.
+    private fun account(tag: String) = tag.padEnd(64, '0')
+
+    /** A manager on a known-empty account: the slots outlive the process, so reset them first. */
+    private fun freshManager(pubkey: String, remoteSigner: Boolean = true): DmEncryptionManager {
+        SecureStorage.saveNip4eKeysFor(pubkey, emptyList())
+        SecureStorage.saveNip4eAnnouncedFor(pubkey, false)
+        return DmEncryptionManager().also { it.loadFor(pubkey, remoteSigner) }
+    }
+
+    @Test
+    fun `a locally signing account is offered nothing`() {
+        val manager = freshManager(account("a1"), remoteSigner = false)
+        assertIs<DmEncryptionManager.State.Unavailable>(manager.state.value)
+    }
+
+    @Test
+    fun `generating holds the key and announcing activates it`() {
+        val manager = freshManager(account("a2"))
+        assertIs<DmEncryptionManager.State.Disabled>(manager.state.value)
+
+        val encPubkey = manager.generateKey()
+        assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.HeldNotAnnounced).encPubkey)
+
+        manager.setAnnounced(true)
+        assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
+    }
+
+    @Test
+    fun `disabling stops advertising but never drops the key`() {
+        val manager = freshManager(account("a3"))
+        val encPubkey = manager.generateKey()
+        manager.setAnnounced(true)
+
+        manager.setAnnounced(false)
+        // Messages already addressed to this key only open with it, so it has to survive.
+        assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.HeldNotAnnounced).encPubkey)
+        assertEquals(encPubkey, manager.currentEncPubkeyOrNull())
+    }
+
+    @Test
+    fun `a key announced by another device must be imported`() {
+        val pubkey = account("a4")
+        val manager = freshManager(pubkey)
+        val elsewhere = KeyPair.generate()
+
+        manager.ingestOwnAnnouncement(Nip4e.buildAnnouncement(pubkey, elsewhere.publicKeyHex, createdAt = 10L))
+        assertEquals(elsewhere.publicKeyHex, (manager.state.value as DmEncryptionManager.State.AnnouncedElsewhere).encPubkey)
+
+        // A different key would leave us unable to read, so it is refused outright.
+        assertFalse(manager.importKey(KeyPair.generate().privateKeyHex))
+        assertIs<DmEncryptionManager.State.AnnouncedElsewhere>(manager.state.value)
+
+        assertTrue(manager.importKey(elsewhere.privateKeyHex))
+        assertEquals(elsewhere.publicKeyHex, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
+    }
+
+    @Test
+    fun `retired keys stay held so their history keeps opening`() {
+        val manager = freshManager(account("a5"))
+        val first = manager.generateKey()
+        val second = manager.generateKey()
+
+        val held = manager.heldKeys().map { it.publicKeyHex }
+        assertEquals(listOf(second, first), held, "current key first, retired keys still tried on receive")
+    }
+
+    @Test
+    fun `a withdrawal from another device stops us advertising`() {
+        val pubkey = account("a6")
+        val manager = freshManager(pubkey)
+        val encPubkey = manager.generateKey()
+        manager.setAnnounced(true)
+
+        manager.ingestOwnAnnouncement(Nip4e.buildAnnouncement(pubkey, null, createdAt = 20L))
+        assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.HeldNotAnnounced).encPubkey)
+    }
+
+    @Test
+    fun `our own announcement of a key we hold reactivates it`() {
+        val pubkey = account("a7")
+        val manager = freshManager(pubkey)
+        val encPubkey = manager.generateKey()
+
+        manager.ingestOwnAnnouncement(Nip4e.buildAnnouncement(pubkey, encPubkey, createdAt = 30L))
+        assertEquals(encPubkey, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
+    }
+
+    @Test
+    fun `rotating advertises a new key and keeps the old one readable`() {
+        val manager = freshManager(account("a9"))
+        val first = manager.generateKey()
+        manager.setAnnounced(true)
+
+        val second = manager.generateKey()
+        manager.setAnnounced(true)
+
+        assertEquals(second, (manager.state.value as DmEncryptionManager.State.Active).encPubkey)
+        // Contacts who have not re-read the announcement still address the old key, and its
+        // history only ever opens with it.
+        assertEquals(listOf(second, first), manager.heldKeys().map { it.publicKeyHex })
+    }
+
+    @Test
+    fun `rotating does not move the archive cutoff`() {
+        val manager = freshManager(account("aa"))
+        manager.generateKey()
+        manager.setAnnounced(true)
+        val firstAnnouncedAt = manager.announcedAt()
+
+        manager.generateKey()
+        manager.setAnnounced(true)
+
+        // Messages between the first announcement and the rotation are already addressed to a key
+        // we still hold, so moving the cutoff would re-archive them for nothing.
+        assertEquals(firstAnnouncedAt, manager.announcedAt())
+    }
+
+    @Test
+    fun `account switch drops in-memory state`() {
+        val manager = freshManager(account("a8"))
+        manager.generateKey()
+        manager.clear()
+        assertIs<DmEncryptionManager.State.Unavailable>(manager.state.value)
+        assertTrue(manager.heldKeys().isEmpty())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmEncryptionManagerTest.kt
@@ -2,9 +2,12 @@ package org.nostr.nostrord.network.managers
 
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip4e
+import org.nostr.nostrord.storage.Nip4eStoredKey
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.loadNip4eKeysFor
 import org.nostr.nostrord.storage.saveNip4eAnnouncedFor
 import org.nostr.nostrord.storage.saveNip4eKeysFor
+import org.nostr.nostrord.utils.epochSeconds
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -128,6 +131,78 @@ class DmEncryptionManagerTest {
         // Messages between the first announcement and the rotation are already addressed to a key
         // we still hold, so moving the cutoff would re-archive them for nothing.
         assertEquals(firstAnnouncedAt, manager.announcedAt())
+    }
+
+    @Test
+    fun `a retired key past the retention window is dropped`() {
+        val pubkey = account("ab")
+        val stale = KeyPair.generate()
+        val current = KeyPair.generate()
+        SecureStorage.saveNip4eAnnouncedFor(pubkey, true)
+        SecureStorage.saveNip4eKeysFor(
+            pubkey,
+            listOf(
+                Nip4eStoredKey(current.privateKeyHex),
+                Nip4eStoredKey(stale.privateKeyHex, retiredAt = epochSeconds() - DmEncryptionManager.RETENTION_SECONDS - 1),
+            ),
+        )
+
+        val manager = DmEncryptionManager()
+        manager.loadFor(pubkey, remoteSigner = true)
+
+        // A rotated-away key is a decryption capability we deliberately stop keeping around.
+        assertEquals(listOf(current.publicKeyHex), manager.heldKeys().map { it.publicKeyHex })
+    }
+
+    @Test
+    fun `a retired key inside the window is kept`() {
+        val pubkey = account("ac")
+        val recent = KeyPair.generate()
+        val current = KeyPair.generate()
+        SecureStorage.saveNip4eAnnouncedFor(pubkey, true)
+        SecureStorage.saveNip4eKeysFor(
+            pubkey,
+            listOf(
+                Nip4eStoredKey(current.privateKeyHex),
+                Nip4eStoredKey(recent.privateKeyHex, retiredAt = epochSeconds() - 60),
+            ),
+        )
+
+        val manager = DmEncryptionManager()
+        manager.loadFor(pubkey, remoteSigner = true)
+
+        assertEquals(listOf(current.publicKeyHex, recent.publicKeyHex), manager.heldKeys().map { it.publicKeyHex })
+    }
+
+    @Test
+    fun `no more than the cap of retired keys is kept`() {
+        val pubkey = account("ad")
+        val current = KeyPair.generate()
+        val now = epochSeconds()
+        val retired = (1..DmEncryptionManager.MAX_RETIRED_KEYS + 5).map {
+            Nip4eStoredKey(KeyPair.generate().privateKeyHex, retiredAt = now - it)
+        }
+        SecureStorage.saveNip4eAnnouncedFor(pubkey, true)
+        SecureStorage.saveNip4eKeysFor(pubkey, listOf(Nip4eStoredKey(current.privateKeyHex)) + retired)
+
+        val manager = DmEncryptionManager()
+        manager.loadFor(pubkey, remoteSigner = true)
+
+        assertEquals(DmEncryptionManager.MAX_RETIRED_KEYS + 1, manager.heldKeys().size)
+        assertEquals(current.publicKeyHex, manager.heldKeys().first().publicKeyHex, "the current key is never pruned")
+    }
+
+    @Test
+    fun `rotating stamps the replaced key so its window starts now`() {
+        val manager = freshManager(account("ae"))
+        val first = manager.generateKey()
+        manager.setAnnounced(true)
+        val second = manager.generateKey()
+
+        assertEquals(listOf(second, first), manager.heldKeys().map { it.publicKeyHex })
+        val stored = SecureStorage.loadNip4eKeysFor(account("ae"))
+        assertEquals(0L, stored.first().retiredAt, "the current key carries no retirement stamp")
+        assertTrue(stored[1].retiredAt > 0L, "the replaced key starts its retention window")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
@@ -257,4 +257,33 @@ class DmManagerTest {
         dm.recordWrapRelay(wrapId, "wss://new.example") // duplicate: no extra fire
         assertEquals(1, fired)
     }
+
+    @Test
+    fun `a send that no relay took is reported, and never un-delivers a sent one`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val me = "a".repeat(64)
+        val peer = "b".repeat(64)
+        val rumor = org.nostr.nostrord.nostr.Event(
+            id = "d".repeat(64),
+            pubkey = me,
+            createdAt = 1L,
+            kind = 14,
+            tags = listOf(listOf("p", peer)),
+            content = "hi",
+        )
+        dm.addOptimistic(rumor, peer, me)
+
+        dm.markFailed(rumor.id!!, "no DM relay accepted it")
+        val failed = dm.messageStatus.value[rumor.id] as GroupManager.MessageStatus.Failed
+        assertEquals("no DM relay accepted it", failed.reason)
+        assertEquals(peer, failed.groupId)
+
+        // The recipient wrap and the self-copy are published separately: the self-copy failing
+        // must not walk back a message the peer's relay already took.
+        val other = rumor.copy(id = "e".repeat(64))
+        dm.addOptimistic(other, peer, me)
+        dm.markDelivered(other.id!!)
+        dm.markFailed(other.id!!, "no DM relay accepted it")
+        assertEquals(GroupManager.MessageStatus.Delivered, dm.messageStatus.value[other.id])
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
@@ -1,0 +1,101 @@
+package org.nostr.nostrord.network.managers
+
+import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.Nip44
+import org.nostr.nostrord.nostr.Nip4e
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+
+class DmPairingManagerTest {
+    private val identity = "a".repeat(64)
+
+    private fun request(throwawayPubkey: String) = Nip4e.buildClientKeyRequest(identity, throwawayPubkey, createdAt = 1L)
+
+    @Test
+    fun `requesting shows a code derived from the throwaway key`() {
+        val manager = DmPairingManager()
+        val throwaway = manager.beginRequest()
+
+        val state = manager.state.value
+        assertIs<DmPairingManager.State.Requesting>(state)
+        assertEquals(Nip4e.pairingCode(throwaway), state.code)
+        assertNotNull(manager.requestThrowawayKey())
+    }
+
+    @Test
+    fun `our own request never prompts us`() {
+        val manager = DmPairingManager()
+        val throwaway = manager.beginRequest()
+
+        manager.onRequestSeen(request(throwaway))
+
+        // The requesting device receives its own event back from the relay; answering itself
+        // would be a no-op at best and a confusing prompt at worst.
+        assertIs<DmPairingManager.State.Requesting>(manager.state.value)
+    }
+
+    @Test
+    fun `another device's request becomes a prompt with the same code`() {
+        val manager = DmPairingManager()
+        val other = KeyPair.generate()
+
+        manager.onRequestSeen(request(other.publicKeyHex))
+
+        val state = manager.state.value
+        assertIs<DmPairingManager.State.IncomingRequest>(state)
+        assertEquals(other.publicKeyHex, state.throwawayPubkey)
+        // Both devices derive the code from the same value, so comparing them is meaningful.
+        assertEquals(Nip4e.pairingCode(other.publicKeyHex), state.code)
+    }
+
+    @Test
+    fun `a resolved request does not prompt again when the event is re-delivered`() {
+        val manager = DmPairingManager()
+        val other = KeyPair.generate()
+
+        manager.onRequestSeen(request(other.publicKeyHex))
+        manager.resolveIncoming(other.publicKeyHex)
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
+
+        // Same event arriving from a second relay must stay silent.
+        manager.onRequestSeen(request(other.publicKeyHex))
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
+    }
+
+    @Test
+    fun `a request with no throwaway key is ignored`() {
+        val manager = DmPairingManager()
+        manager.onRequestSeen(Nip4e.buildClientKeyRequest(identity, "not-a-key", createdAt = 1L))
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
+    }
+
+    @Test
+    fun `account switch drops any pending pairing`() {
+        val manager = DmPairingManager()
+        manager.beginRequest()
+        manager.clear()
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
+        assertEquals(null, manager.requestThrowawayKey())
+    }
+
+    @Test
+    fun `the shared key round-trips between the two throwaway keys`() {
+        // The share is encrypted throwaway-to-throwaway, so neither identity key can open it and
+        // only the device that published the request can read the answer.
+        val encryptionKey = KeyPair.generate()
+        val requester = KeyPair.generate()
+        val holder = KeyPair.generate()
+
+        val ciphertext = Nip44.encrypt(encryptionKey.privateKeyHex, holder.privateKeyHex, requester.publicKeyHex)
+        val share = Nip4e.buildKeyShare(identity, holder.publicKeyHex, requester.publicKeyHex, ciphertext, createdAt = 2L)
+
+        assertEquals(requester.publicKeyHex, Nip4e.keyShareRecipientFrom(share))
+        assertEquals(holder.publicKeyHex, Nip4e.throwawayPubkeyFrom(share))
+        assertEquals(
+            encryptionKey.privateKeyHex,
+            Nip44.decrypt(share.content, requester.privateKeyHex, holder.publicKeyHex),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
@@ -11,7 +11,8 @@ import kotlin.test.assertNotNull
 class DmPairingManagerTest {
     private val identity = "a".repeat(64)
 
-    private fun request(throwawayPubkey: String) = Nip4e.buildClientKeyRequest(identity, throwawayPubkey, createdAt = 1L)
+    // Carries an id like the relay-delivered event does: dedup is keyed on it.
+    private fun request(throwawayPubkey: String) = Nip4e.buildClientKeyRequest(identity, throwawayPubkey, createdAt = 1L).let { it.copy(id = it.calculateId()) }
 
     @Test
     fun `requesting shows a code derived from the throwaway key`() {
@@ -62,6 +63,41 @@ class DmPairingManagerTest {
         // Same event arriving from a second relay must stay silent.
         manager.onRequestSeen(request(other.publicKeyHex))
         assertIs<DmPairingManager.State.Idle>(manager.state.value)
+    }
+
+    @Test
+    fun `a declined request stays declined across a restart`() {
+        val other = KeyPair.generate()
+        val event = request(other.publicKeyHex)
+        var persisted: Map<String, Long> = emptyMap()
+
+        val manager = DmPairingManager()
+        manager.onProcessedChanged = { persisted = it }
+        manager.onRequestSeen(event)
+        manager.resolveIncoming(other.publicKeyHex)
+        assertEquals(setOf(event.id), persisted.keys)
+
+        // The subscription looks back in time, so the relay serves the same request again on the
+        // next launch. A fresh manager hydrated from storage must stay quiet.
+        val restarted = DmPairingManager()
+        restarted.hydrateProcessed(persisted)
+        restarted.onRequestSeen(event)
+        assertIs<DmPairingManager.State.Idle>(restarted.state.value)
+    }
+
+    @Test
+    fun `a decision older than the retention window is forgotten`() {
+        val other = KeyPair.generate()
+        val event = request(other.publicKeyHex)
+        val expired = mapOf(event.id!! to 1L)
+
+        val manager = DmPairingManager()
+        manager.hydrateProcessed(expired)
+        manager.onRequestSeen(event)
+
+        // Past the window the relay no longer serves it either; a request this old arriving now is
+        // a new one worth showing.
+        assertIs<DmPairingManager.State.IncomingRequest>(manager.state.value)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/LegacySealVerifierTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/LegacySealVerifierTest.kt
@@ -1,0 +1,86 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class LegacySealVerifierTest {
+    private val author = "a".repeat(64)
+    private val announced = "b".repeat(64)
+    private val other = "c".repeat(64)
+
+    private fun verifier(
+        keys: MutableMap<String, String?>,
+        onFetch: () -> Unit = {},
+    ) = LegacySealVerifier(
+        fetchWaitMs = 3_000L,
+        announcedKeyFor = { keys[it] },
+        requestAnnouncement = { onFetch() },
+    )
+
+    @Test
+    fun `a seal matching the cached announcement is accepted without a fetch`() = runTest {
+        var fetches = 0
+        val verifier = verifier(mutableMapOf(author to announced)) { fetches++ }
+
+        assertTrue(verifier.verify(author, announced))
+        assertEquals(0, fetches, "the cached announcement already answers it")
+    }
+
+    @Test
+    fun `an unknown author is fetched once and then accepted`() = runTest {
+        val keys = mutableMapOf<String, String?>()
+        var fetches = 0
+        val verifier = verifier(keys) {
+            fetches++
+            keys[author] = announced
+        }
+
+        assertTrue(verifier.verify(author, announced))
+        assertEquals(1, fetches)
+    }
+
+    @Test
+    fun `an unresolvable announcement defers instead of deciding`() = runTest {
+        var fetches = 0
+        val verifier = verifier(mutableMapOf()) { fetches++ }
+
+        // False leaves the wrap unhandled, so the pipeline retries it later. Accepting here would
+        // let anyone attribute a message to this author; rejecting would drop it for good.
+        assertFalse(verifier.verify(author, announced))
+        assertEquals(1, fetches)
+    }
+
+    @Test
+    fun `a stale cached key forces exactly one re-fetch before deciding`() = runTest {
+        // The author rotated: our cache still holds the retired key, and the seal is signed with
+        // the new one. One fetch resolves it.
+        val keys = mutableMapOf<String, String?>(author to other)
+        var fetches = 0
+        val verifier = verifier(keys) {
+            fetches++
+            keys[author] = announced
+        }
+
+        assertTrue(verifier.verify(author, announced))
+        assertEquals(1, fetches)
+    }
+
+    @Test
+    fun `a seal that still disagrees after the re-fetch is not accepted`() = runTest {
+        var fetches = 0
+        val verifier = verifier(mutableMapOf(author to announced)) { fetches++ }
+
+        assertFalse(verifier.verify(author, other))
+        assertEquals(1, fetches, "one re-fetch, then a decision: never a fetch loop")
+    }
+
+    @Test
+    fun `an author who withdrew their key cannot be legacy-verified`() = runTest {
+        // A null entry means the latest announcement carries no key at all.
+        val verifier = verifier(mutableMapOf(author to null))
+        assertFalse(verifier.verify(author, announced))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip17Test.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip17Test.kt
@@ -161,6 +161,98 @@ class Nip17Test {
         assertNull(Nip17.unwrap(wrap, bob))
     }
 
+    private fun keyDecryptor(kp: KeyPair) = Nip17.Nip44Decryptor { peer, ciphertext -> Nip44.decrypt(ciphertext, kp.privateKeyHex, peer) }
+
+    @Test
+    fun `a legacy seal is reported unauthenticated for the caller to check`() = runTest {
+        val alice = signer()
+        val aliceEnc = KeyPair.generate()
+        val bob = signer()
+        val bobEnc = KeyPair.generate()
+        val rumor = Nip17.buildRumor(alice.pubkey, bob.pubkey, "legacy shape")
+        // Seal signed by the sender's ENCRYPTION key: proves nothing about who sent it.
+        val seal = Nip17.legacySeal(rumor, aliceEnc.privateKeyHex, bobEnc.publicKeyHex)
+        val wrap = Nip17.giftWrap(seal, bob.pubkey, encryptTo = bobEnc.publicKeyHex)
+
+        val out = Nip17.unwrap(wrap, bob.pubkey, listOf(keyDecryptor(bobEnc)))
+        assertNotNull(out)
+        assertEquals("legacy shape", out.rumor.content)
+        assertEquals(alice.pubkey, out.senderPubkey, "the claimed sender is the rumor author")
+        assertEquals(aliceEnc.publicKeyHex, out.sealPubkey)
+        assertTrue(!out.sealSignedByIdentity, "caller must verify this against the author's kind:10044")
+    }
+
+    @Test
+    fun `a modern seal cannot claim someone else's rumor`() = runTest {
+        val alice = signer()
+        val mallory = signer()
+        val bobEnc = KeyPair.generate()
+        // Mallory seals a rumor attributed to Alice and tags it as NIP-4e.
+        val rumor = Nip17.buildRumor(alice.pubkey, mallory.pubkey, "forged")
+        val seal = Nip17.seal(rumor, mallory.pubkey, mallory, encryptTo = bobEnc.publicKeyHex, senderEncTag = mallory.pubkey)
+        val wrap = Nip17.giftWrap(seal, mallory.pubkey, encryptTo = bobEnc.publicKeyHex)
+
+        assertNull(Nip17.unwrap(wrap, "00".repeat(32), listOf(keyDecryptor(bobEnc))))
+    }
+
+    @Test
+    fun `our own seal may carry someone else's rumor`() = runTest {
+        // The self-archive shape: only our signer can produce our signature, so the author guard
+        // is relaxed for it.
+        val me = signer()
+        val alice = signer()
+        val myEnc = KeyPair.generate()
+        val rumor = Nip17.buildRumor(alice.pubkey, me.pubkey, "archived")
+        // Seal content encrypted locally with our encryption key to our own identity, so the seal
+        // needs no `n`: the reader's peer is seal.pubkey, and we hold the other half.
+        val seal = Nip17.seal(rumor, me.pubkey, me, encryptTo = me.pubkey, encryptWith = myEnc.privateKeyHex)
+        val wrap = Nip17.giftWrap(seal, me.pubkey, encryptTo = myEnc.publicKeyHex)
+
+        val out = Nip17.unwrap(wrap, me.pubkey, listOf(keyDecryptor(myEnc)))
+        assertNotNull(out)
+        assertEquals("archived", out.rumor.content)
+        assertEquals(alice.pubkey, out.senderPubkey, "the original author survives archiving")
+    }
+
+    @Test
+    fun `a retired key still opens its own history`() = runTest {
+        val alice = signer()
+        val bob = signer()
+        val retired = KeyPair.generate()
+        val current = KeyPair.generate()
+        val wrap =
+            Nip17.wrap(
+                Nip17.buildRumor(alice.pubkey, bob.pubkey, "old message"),
+                bob.pubkey,
+                alice,
+                encryptTo = retired.publicKeyHex,
+                senderEncTag = alice.pubkey,
+            )
+
+        // Current key first, exactly as the receive path orders them.
+        val out = Nip17.unwrap(wrap, bob.pubkey, listOf(keyDecryptor(current), keyDecryptor(retired)))
+        assertNotNull(out)
+        assertEquals("old message", out.rumor.content)
+    }
+
+    @Test
+    fun `the signer is only reached after the local keys miss`() = runTest {
+        val alice = signer()
+        val bob = signer()
+        var signerCalls = 0
+        val wrap = Nip17.wrap(Nip17.buildRumor(alice.pubkey, bob.pubkey, "classic"), bob.pubkey, alice)
+        val counting =
+            Nip17.Nip44Decryptor { peer, ciphertext ->
+                signerCalls++
+                bob.nip44Decrypt(peer, ciphertext)
+            }
+
+        val out = Nip17.unwrap(wrap, bob.pubkey, listOf(keyDecryptor(KeyPair.generate()), counting))
+        assertNotNull(out)
+        assertEquals("classic", out.rumor.content)
+        assertEquals(2, signerCalls, "one round-trip per layer, and only after the local key failed")
+    }
+
     @Test
     fun `a signer without NIP-44 support rejects encryption`() = runTest {
         val stub =

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip4eTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip4eTest.kt
@@ -59,6 +59,60 @@ class Nip4eTest {
     }
 
     @Test
+    fun `a pairing request carries the throwaway key under both tag names`() {
+        val throwaway = "c".repeat(64)
+        val request = Nip4e.buildClientKeyRequest(identity, throwaway, createdAt = 5L)
+
+        assertEquals(Nip4e.KIND_CLIENT_KEY, request.kind)
+        assertEquals(throwaway, Nip4e.throwawayPubkeyFrom(request))
+        // `P` is what the NIP defines; `pubkey` is the only one Coop reads.
+        assertTrue(request.tags.any { it.firstOrNull() == Nip4e.TAG_THROWAWAY_PUBKEY && it[1] == throwaway })
+        assertTrue(request.tags.any { it.firstOrNull() == Nip4e.TAG_THROWAWAY_PUBKEY_LEGACY && it[1] == throwaway })
+    }
+
+    @Test
+    fun `a request carrying only Coop's tag is still understood`() {
+        val throwaway = "c".repeat(64)
+        val coopStyle =
+            Event(
+                pubkey = identity,
+                createdAt = 5L,
+                kind = Nip4e.KIND_CLIENT_KEY,
+                tags = listOf(listOf(Nip4e.TAG_THROWAWAY_PUBKEY_LEGACY, throwaway)),
+                content = "",
+            )
+        assertEquals(throwaway, Nip4e.throwawayPubkeyFrom(coopStyle))
+    }
+
+    @Test
+    fun `no device label goes on the wire`() {
+        // It would tell relays the OS and browser of the device asking to be paired.
+        val request = Nip4e.buildClientKeyRequest(identity, "c".repeat(64), createdAt = 5L)
+        assertTrue(request.tags.none { it.firstOrNull() == "client" })
+    }
+
+    @Test
+    fun `a key share names both throwaway keys`() {
+        val sender = "c".repeat(64)
+        val recipient = "d".repeat(64)
+        val share = Nip4e.buildKeyShare(identity, sender, recipient, "ciphertext", createdAt = 6L)
+
+        assertEquals(Nip4e.KIND_KEY_SHARE, share.kind)
+        assertEquals(sender, Nip4e.throwawayPubkeyFrom(share))
+        assertEquals(recipient, Nip4e.keyShareRecipientFrom(share))
+        assertEquals("ciphertext", share.content)
+    }
+
+    @Test
+    fun `the pairing code matches the format the other clients show`() {
+        // The user compares this across two devices, so the format has to be identical to
+        // Jumble's: first 8 characters, uppercase, split into two groups.
+        val throwaway = "abcdef12" + "0".repeat(56)
+        assertEquals("ABCD EF12", Nip4e.pairingCode(throwaway))
+        assertEquals(Nip4e.pairingCode(throwaway), Nip4e.pairingCode(throwaway))
+    }
+
+    @Test
     fun `seal n tags are read from tags directly`() {
         assertEquals(encKey, Nip4e.encryptionKeyFromTags(listOf(listOf("n", encKey))))
         assertNull(Nip4e.encryptionKeyFromTags(listOf(listOf("p", identity))))

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmEncryptionViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmEncryptionViewModelTest.kt
@@ -178,6 +178,47 @@ class DmEncryptionViewModelTest {
     }
 
     @Test
+    fun `a reset is confirmed before anything is published`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.AnnouncedElsewhere("c".repeat(64))
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.askToReset()
+        advanceUntilIdle()
+        assertTrue(vm.resetConfirmOpen.value)
+        assertFalse("resetDmEncryptionKey" in repo.calls)
+
+        vm.dismissResetConfirm()
+        advanceUntilIdle()
+        assertFalse(vm.resetConfirmOpen.value)
+        assertFalse("resetDmEncryptionKey" in repo.calls)
+
+        vm.askToReset()
+        vm.confirmReset()
+        advanceUntilIdle()
+
+        assertTrue("resetDmEncryptionKey" in repo.calls)
+        assertFalse(vm.resetConfirmOpen.value)
+        assertNull(vm.error.value)
+        assertFalse(vm.busy.value)
+    }
+
+    @Test
+    fun `a failed reset surfaces the error and keeps the account resettable`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.AnnouncedElsewhere("c".repeat(64))
+        repo.resetDmEncryptionKeyResult = Result.Error(AppError.Unknown("relays refused it"))
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.askToReset()
+        vm.confirmReset()
+        advanceUntilIdle()
+
+        assertEquals("relays refused it", vm.error.value)
+        assertFalse(vm.busy.value)
+    }
+
+    @Test
     fun `revealing the key exposes it only on request`() {
         val repo = FakeNostrRepository()
         repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Active("b".repeat(64))

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmEncryptionViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmEncryptionViewModelTest.kt
@@ -1,0 +1,193 @@
+package org.nostr.nostrord.ui
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.nostr.nostrord.network.FakeNostrRepository
+import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.ui.screens.settings.DmEncryptionViewModel
+import org.nostr.nostrord.utils.AppError
+import org.nostr.nostrord.utils.Result
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DmEncryptionViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `hidden for an account that signs locally`() {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Unavailable
+        assertFalse(DmEncryptionViewModel(repo).visible)
+    }
+
+    @Test
+    fun `shown once the account could benefit`() {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Disabled
+        assertTrue(DmEncryptionViewModel(repo).visible)
+    }
+
+    @Test
+    fun `a failed enable surfaces the error and clears busy`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Disabled
+        repo.enableDmEncryptionResult = Result.Error(AppError.Unknown("relays refused it"))
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.enable()
+        advanceUntilIdle()
+
+        assertEquals("relays refused it", vm.error.value)
+        assertFalse(vm.busy.value)
+    }
+
+    @Test
+    fun `a successful enable leaves no error`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Disabled
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.enable()
+        advanceUntilIdle()
+
+        assertNull(vm.error.value)
+        assertFalse(vm.busy.value)
+    }
+
+    @Test
+    fun `a rejected import explains why instead of silently failing`() {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.AnnouncedElsewhere("b".repeat(64))
+        repo.importDmEncryptionKeyResult = false
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.setImportInput("c".repeat(64))
+        vm.importKey()
+
+        assertNotNull(vm.error.value)
+        assertEquals("c".repeat(64), vm.importInput.value, "the input is kept so it can be corrected")
+    }
+
+    @Test
+    fun `an accepted import clears the field`() {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.AnnouncedElsewhere("b".repeat(64))
+        repo.importDmEncryptionKeyResult = true
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.setImportInput("b".repeat(64))
+        vm.importKey()
+
+        assertNull(vm.error.value)
+        assertEquals("", vm.importInput.value)
+    }
+
+    @Test
+    fun `the archive confirmation states the volume before publishing anything`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Active("b".repeat(64))
+        repo.archivableCount = 42
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.askToArchive()
+        advanceUntilIdle()
+
+        assertTrue(vm.archiveConfirmOpen.value)
+        assertEquals(42, vm.archivableCount.value)
+        assertFalse(repo.calls.contains("archiveDmHistory"), "nothing is published before confirmation")
+    }
+
+    @Test
+    fun `dismissing the confirmation publishes nothing`() {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Active("b".repeat(64))
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.askToArchive()
+        vm.dismissArchiveConfirm()
+
+        assertFalse(vm.archiveConfirmOpen.value)
+        assertFalse(repo.calls.contains("archiveDmHistory"))
+    }
+
+    @Test
+    fun `confirming runs the archive and surfaces a failure`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Active("b".repeat(64))
+        repo.archiveDmHistoryResult = Result.Error(AppError.Unknown("relays stopped accepting"))
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.confirmArchive()
+        advanceUntilIdle()
+
+        assertTrue(repo.calls.contains("archiveDmHistory"))
+        assertEquals("relays stopped accepting", vm.error.value)
+    }
+
+    @Test
+    fun `rotating hides a revealed key so the stale one is not copied`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Active("b".repeat(64))
+        repo.exportedDmEncryptionKey = "d".repeat(64)
+        val vm = DmEncryptionViewModel(repo)
+        vm.revealKey()
+
+        vm.rotate()
+        advanceUntilIdle()
+
+        assertTrue(repo.calls.contains("rotateDmEncryptionKey"))
+        assertNull(vm.revealedKey.value, "the shown key is no longer the current one")
+        assertFalse(vm.busy.value)
+    }
+
+    @Test
+    fun `a failed rotation surfaces the error`() = runTest(testDispatcher) {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Active("b".repeat(64))
+        repo.rotateDmEncryptionKeyResult = Result.Error(AppError.Unknown("relays refused it"))
+        val vm = DmEncryptionViewModel(repo)
+
+        vm.rotate()
+        advanceUntilIdle()
+
+        assertEquals("relays refused it", vm.error.value)
+        assertFalse(vm.busy.value)
+    }
+
+    @Test
+    fun `revealing the key exposes it only on request`() {
+        val repo = FakeNostrRepository()
+        repo.dmEncryptionStateFlow.value = DmEncryptionManager.State.Active("b".repeat(64))
+        repo.exportedDmEncryptionKey = "d".repeat(64)
+        val vm = DmEncryptionViewModel(repo)
+
+        assertNull(vm.revealedKey.value)
+        vm.revealKey()
+        assertEquals("d".repeat(64), vm.revealedKey.value)
+        vm.hideKey()
+        assertNull(vm.revealedKey.value)
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/accounts/MeMenu.kt
@@ -56,6 +56,8 @@ import org.nostr.nostrord.auth.AuthMethod
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.hasNip4eKeyFor
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.badges.UnreadBadge
@@ -247,6 +249,7 @@ fun MeMenu(
             isActive = isActiveTarget,
             fallbackLabel = fallbackLabel,
             isBusy = isBusy,
+            holdsDmEncryptionKey = SecureStorage.hasNip4eKeyFor(target.pubkey),
             onDismiss = { if (!isBusy) removeTarget = null },
             onConfirm = {
                 if (isBusy) return@RemoveAccountDialog
@@ -487,6 +490,7 @@ private fun RemoveAccountDialog(
     isActive: Boolean,
     fallbackLabel: String?,
     isBusy: Boolean,
+    holdsDmEncryptionKey: Boolean,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
@@ -494,7 +498,14 @@ private fun RemoveAccountDialog(
     // body branches on `method` so Bunker / NIP-07 users see accurate wording —
     // the LOCAL "Credentials and local data" line was misleading for them.
     val title = org.nostr.nostrord.auth.removeAccountDialogTitle(isActive, accountLabel)
-    val body = org.nostr.nostrord.auth.removeAccountDialogBody(isActive, accountLabel, fallbackLabel, method)
+    val body =
+        org.nostr.nostrord.auth.removeAccountDialogBody(
+            isActive,
+            accountLabel,
+            fallbackLabel,
+            method,
+            holdsDmEncryptionKey = holdsDmEncryptionKey,
+        )
     val confirmLabel = org.nostr.nostrord.auth.removeAccountConfirmLabel(isActive)
     val busyLabel = org.nostr.nostrord.auth.removeAccountBusyLabel(isActive)
     ConfirmDialog(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -118,6 +118,7 @@ import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.startup.ExternalLaunchContext
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.hasNip4eKeyFor
 import org.nostr.nostrord.ui.components.BunkerStatusBanner
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.accounts.AddAccountSheet
@@ -1374,6 +1375,7 @@ private fun AccountBar(onOpenSettings: () -> Unit, onViewProfile: (String) -> Un
                 accountLabel = signOutLabel,
                 fallbackLabel = fallbackLabel,
                 method = active.authMethod,
+                holdsDmEncryptionKey = SecureStorage.hasNip4eKeyFor(active.pubkey),
             ),
             confirmLabel =
             if (isBusy) removeAccountBusyLabel(isActive = true) else removeAccountConfirmLabel(isActive = true),

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -153,6 +153,8 @@ fun DmPageScreen(
         val messagesByPeer by dmVm.messagesByPeer.collectAsState()
         val messages = messagesByPeer[pubkey].orEmpty()
         val dmStatus by dmVm.messageStatus.collectAsState()
+        // Resolve where this peer reads before the first message is written, not after their reply.
+        LaunchedEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
         LaunchedEffect(pubkey, messages.size) {
             if (messages.isNotEmpty()) dmVm.markRead(pubkey)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -54,6 +54,8 @@ import kotlinx.coroutines.delay
 import org.nostr.nostrord.auth.AuthMethod
 import org.nostr.nostrord.auth.logoutConfirmBody
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
 import org.nostr.nostrord.settings.AppTheme
@@ -1330,7 +1332,238 @@ private fun DmSettingsPanelContent(
         }
         // Relay editor only matters while DMs are on; hidden with the rest of the feature when off.
         if (dmEnabled) {
+            DmEncryptionPanelContent()
             DmRelayPanelContent()
+        }
+    }
+}
+
+@Composable
+private fun DmArchiveContent(vm: DmEncryptionViewModel) {
+    val progress by vm.archiveProgress.collectAsState()
+    val confirmOpen by vm.archiveConfirmOpen.collectAsState()
+    val count by vm.archivableCount.collectAsState()
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(Spacing.md),
+    ) {
+        when {
+            progress.running -> {
+                Text(
+                    text = "Archiving ${progress.done} of ${progress.total}…",
+                    style = NostrordTypography.Caption,
+                    color = NostrordColors.TextSecondary,
+                )
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { vm.cancelArchive() }) {
+                        Text("Stop", color = NostrordColors.Error, style = NostrordTypography.Button)
+                    }
+                }
+            }
+            confirmOpen -> {
+                Text(
+                    text = "This publishes ${count ?: 0} wrapped copies of your message history to your DM " +
+                        "relays, encrypted to your fast decryption key. New devices holding this key can " +
+                        "then load your history without contacting your signer. Publishing takes a few " +
+                        "minutes and reveals to your DM relays roughly how many messages you have.",
+                    style = NostrordTypography.Caption,
+                    color = NostrordColors.TextSecondary,
+                )
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { vm.dismissArchiveConfirm() }) {
+                        Text("Cancel", color = NostrordColors.TextSecondary, style = NostrordTypography.Button)
+                    }
+                    TextButton(onClick = { vm.confirmArchive() }, enabled = (count ?: 0) > 0) {
+                        Text("Publish archive", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                    }
+                }
+            }
+            else -> {
+                // Reported here rather than through the VM error: the run outlives this screen.
+                progress.error?.let {
+                    Text(text = it, style = NostrordTypography.Caption, color = NostrordColors.Error)
+                }
+                if (progress.done > 0 && progress.error == null) {
+                    Text(
+                        text = "Archived ${progress.done} of ${progress.total}.",
+                        style = NostrordTypography.Caption,
+                        color = NostrordColors.Success,
+                    )
+                }
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = { vm.askToArchive() }) {
+                        Text("Archive history to this key", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DmEncryptionPanelContent() {
+    val activeAccountId by AppModule.accountStore.activeId.collectAsState()
+    val vm = viewModel(key = activeAccountId) { DmEncryptionViewModel(AppModule.nostrRepository) }
+    val state by vm.state.collectAsState()
+    val busy by vm.busy.collectAsState()
+    val error by vm.error.collectAsState()
+    val revealedKey by vm.revealedKey.collectAsState()
+    val importInput by vm.importInput.collectAsState()
+    val pairingState by vm.pairingState.collectAsState()
+
+    // Nothing to offload when signing is already local.
+    if (state is DmEncryptionManager.State.Unavailable) return
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = NostrordShapes.cardShape,
+        colors = CardDefaults.cardColors(containerColor = NostrordColors.Surface),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(Spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(Spacing.lg),
+        ) {
+            Text(
+                text = "Fast decryption key",
+                style = NostrordTypography.Button,
+                color = NostrordColors.TextPrimary,
+            )
+            Text(
+                text = "Creates a separate encryption key stored on this device. New messages decrypt " +
+                    "instantly without contacting your signer.",
+                style = NostrordTypography.Caption,
+                color = NostrordColors.TextSecondary,
+            )
+
+            when (val s = state) {
+                is DmEncryptionManager.State.AnnouncedElsewhere -> {
+                    InfoCard(
+                        title = "Key held on another device",
+                        titleColor = NostrordColors.Warning,
+                        icon = Icons.Default.Key,
+                        content = "This account already announced an encryption key from another device. " +
+                            "Ask that device to send it, or paste it here from its Show key screen.",
+                        isCompact = false,
+                    )
+                    when (val pairing = pairingState) {
+                        is DmPairingManager.State.Requesting ->
+                            Text(
+                                text = "Waiting for your other device. Approve the request showing code " +
+                                    "${pairing.code} there.",
+                                style = NostrordTypography.Caption,
+                                color = NostrordColors.TextSecondary,
+                            )
+                        is DmPairingManager.State.Failed ->
+                            Text(text = pairing.reason, style = NostrordTypography.Caption, color = NostrordColors.Error)
+                        else ->
+                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                                TextButton(onClick = { vm.requestKeyFromOtherDevice() }) {
+                                    Text("Ask my other device", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                                }
+                            }
+                    }
+                    OutlinedTextField(
+                        value = importInput,
+                        onValueChange = { vm.setImportInput(it) },
+                        label = { Text("Encryption key") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        colors = OutlinedTextFieldDefaults.colors(),
+                    )
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                        TextButton(onClick = { vm.importKey() }, enabled = importInput.isNotBlank()) {
+                            Text("Import key", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                        }
+                    }
+                }
+                is DmEncryptionManager.State.Active -> {
+                    Text(
+                        text = "Active. Senders are addressing ${s.encPubkey.take(12)}…",
+                        style = NostrordTypography.Caption,
+                        color = NostrordColors.Success,
+                    )
+                    // Another device of this account is asking for the key. The code comes from the
+                    // request itself, so matching it against the other screen proves which one asked.
+                    (pairingState as? DmPairingManager.State.IncomingRequest)?.let { request ->
+                        InfoCard(
+                            title = "Another device wants this key",
+                            titleColor = NostrordColors.Warning,
+                            icon = Icons.Default.Key,
+                            content = "Approve only if that device is showing code ${request.code}.",
+                            isCompact = false,
+                        )
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                            TextButton(onClick = { vm.declinePairing() }) {
+                                Text("Decline", color = NostrordColors.TextSecondary, style = NostrordTypography.Button)
+                            }
+                            TextButton(onClick = { vm.approvePairing() }) {
+                                Text("Send key", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                            }
+                        }
+                    }
+                    revealedKey?.let {
+                        Text(text = it, style = NostrordTypography.Caption, color = NostrordColors.TextPrimary)
+                    }
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                        TextButton(onClick = { if (revealedKey == null) vm.revealKey() else vm.hideKey() }) {
+                            Text(
+                                if (revealedKey == null) "Show key" else "Hide key",
+                                color = NostrordColors.Primary,
+                                style = NostrordTypography.Button,
+                            )
+                        }
+                        TextButton(onClick = { vm.rotate() }, enabled = !busy) {
+                            Text("Replace key", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                        }
+                        TextButton(onClick = { vm.disable() }, enabled = !busy) {
+                            Text(
+                                if (busy) "Working…" else "Turn off",
+                                color = NostrordColors.Error,
+                                style = NostrordTypography.Button,
+                            )
+                        }
+                    }
+                    Text(
+                        text = "Replace the key if this device may have been compromised. Contacts start " +
+                            "using the new one as they see it; the old key stays here so everything sent " +
+                            "to it keeps opening.",
+                        style = NostrordTypography.Caption,
+                        color = NostrordColors.TextSecondary,
+                    )
+                    Text(
+                        text = "Turning this off sends new messages back to your signer key. The key stays " +
+                            "saved on this device because messages already sent to it can only ever be " +
+                            "opened with it. It is never deleted, only no longer advertised.",
+                        style = NostrordTypography.Caption,
+                        color = NostrordColors.TextSecondary,
+                    )
+                    DmArchiveContent(vm)
+                }
+                else -> {
+                    if (state is DmEncryptionManager.State.HeldNotAnnounced) {
+                        Text(
+                            text = "A key from an earlier session is still saved here. Turning this on " +
+                                "advertises it again.",
+                            style = NostrordTypography.Caption,
+                            color = NostrordColors.TextSecondary,
+                        )
+                    }
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                        TextButton(onClick = { vm.enable() }, enabled = !busy) {
+                            Text(
+                                if (busy) "Publishing…" else "Turn on",
+                                color = NostrordColors.Primary,
+                                style = NostrordTypography.Button,
+                            )
+                        }
+                    }
+                }
+            }
+
+            error?.let {
+                Text(text = it, style = NostrordTypography.MessageBody, color = NostrordColors.Error)
+            }
         }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -1413,6 +1413,7 @@ private fun DmEncryptionPanelContent() {
     val revealedKey by vm.revealedKey.collectAsState()
     val importInput by vm.importInput.collectAsState()
     val pairingState by vm.pairingState.collectAsState()
+    val resetConfirmOpen by vm.resetConfirmOpen.collectAsState()
 
     // Nothing to offload when signing is already local.
     if (state is DmEncryptionManager.State.Unavailable) return
@@ -1441,11 +1442,12 @@ private fun DmEncryptionPanelContent() {
             when (val s = state) {
                 is DmEncryptionManager.State.AnnouncedElsewhere -> {
                     InfoCard(
-                        title = "Key held on another device",
+                        title = "The announced key is not on this device",
                         titleColor = NostrordColors.Warning,
                         icon = Icons.Default.Key,
-                        content = "This account already announced an encryption key from another device. " +
-                            "Ask that device to send it, or paste it here from its Show key screen.",
+                        content = "This account announces an encryption key that is not stored here. If " +
+                            "another device or app holds it, bring it over. Otherwise replace it, and " +
+                            "messages sent to the old key will not be readable.",
                         isCompact = false,
                     )
                     when (val pairing = pairingState) {
@@ -1478,12 +1480,48 @@ private fun DmEncryptionPanelContent() {
                             Text("Import key", color = NostrordColors.Primary, style = NostrordTypography.Button)
                         }
                     }
+                    // Last resort when that device is gone for good: without it the account stays
+                    // unable to read, since senders address a key nobody here holds.
+                    if (resetConfirmOpen) {
+                        InfoCard(
+                            title = "Reset the encryption key?",
+                            titleColor = NostrordColors.Error,
+                            icon = Icons.Default.Warning,
+                            content = "Messages already sent to the old key will never open on any device " +
+                                "again. Chat history already saved here is not lost.",
+                            isCompact = false,
+                        )
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                            TextButton(onClick = { vm.dismissResetConfirm() }) {
+                                Text("Cancel", color = NostrordColors.TextSecondary, style = NostrordTypography.Button)
+                            }
+                            TextButton(onClick = { vm.confirmReset() }, enabled = !busy) {
+                                Text(
+                                    if (busy) "Publishing…" else "Reset key",
+                                    color = NostrordColors.Error,
+                                    style = NostrordTypography.Button,
+                                )
+                            }
+                        }
+                    } else {
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                            TextButton(onClick = { vm.askToReset() }, enabled = !busy) {
+                                Text("No access to that device?", color = NostrordColors.Error, style = NostrordTypography.Button)
+                            }
+                        }
+                    }
                 }
                 is DmEncryptionManager.State.Active -> {
                     Text(
-                        text = "Active. Senders are addressing ${s.encPubkey.take(12)}…",
+                        text =
+                        if (s.confirmed) {
+                            "Active. Senders are addressing ${s.encPubkey.take(12)}…"
+                        } else {
+                            "Announcing ${s.encPubkey.take(12)}…. The key is saved on this device; " +
+                                "waiting for a relay to confirm."
+                        },
                         style = NostrordTypography.Caption,
-                        color = NostrordColors.Success,
+                        color = if (s.confirmed) NostrordColors.Success else NostrordColors.TextSecondary,
                     )
                     // Another device of this account is asking for the key. The code comes from the
                     // request itself, so matching it against the other screen proves which one asked.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -61,8 +61,10 @@ import org.nostr.nostrord.network.outbox.RelayListManager
 import org.nostr.nostrord.settings.AppTheme
 import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.storage.PassphraseSettings
+import org.nostr.nostrord.ui.Identifier
 import org.nostr.nostrord.ui.Screen
 import org.nostr.nostrord.ui.components.ConfirmDialog
+import org.nostr.nostrord.ui.components.IdentifierRow
 import org.nostr.nostrord.ui.components.RadioCircle
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.cards.InfoCard
@@ -1502,8 +1504,10 @@ private fun DmEncryptionPanelContent() {
                             }
                         }
                     }
+                    // Same field as the private key on Backup: monospace, copy button, no wrapping
+                    // of a value the user has to move to another device by hand.
                     revealedKey?.let {
-                        Text(text = it, style = NostrordTypography.Caption, color = NostrordColors.TextPrimary)
+                        IdentifierRow(ids = listOf(Identifier("hex", it)))
                     }
                     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                         TextButton(onClick = { if (revealedKey == null) vm.revealKey() else vm.hideKey() }) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -1372,6 +1372,13 @@ private fun DmArchiveContent(vm: DmEncryptionViewModel) {
                     style = NostrordTypography.Caption,
                     color = NostrordColors.TextSecondary,
                 )
+                // The one consequence the volume/relay copy above does not cover.
+                Text(
+                    text = "It also widens what a leak of this key costs: afterwards that one key opens your " +
+                        "whole history from the relays, not only the messages sent while it was current.",
+                    style = NostrordTypography.Caption,
+                    color = NostrordColors.Warning,
+                )
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                     TextButton(onClick = { vm.dismissArchiveConfirm() }) {
                         Text("Cancel", color = NostrordColors.TextSecondary, style = NostrordTypography.Button)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -11,6 +11,8 @@ import org.nostr.nostrord.auth.signerLabel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.storage.SecureStorage
+import org.nostr.nostrord.storage.hasNip4eKeyFor
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.GroupView
@@ -997,6 +999,7 @@ val AppFrame =
                         accountLabel = signOutLabel,
                         fallbackLabel = fallbackLabel,
                         method = active.authMethod,
+                        holdsDmEncryptionKey = SecureStorage.hasNip4eKeyFor(active.pubkey),
                     ),
                     confirmLabel =
                     if (logoutBusy) removeAccountBusyLabel(isActive = true) else removeAccountConfirmLabel(isActive = true),

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -116,6 +116,8 @@ val DmPage =
         // Metadata map for resolving @-mention names inside rich message bodies.
         val userMetadata = useStateFlow(dmVm.userMetadata)
         val dmStatus = useStateFlow(dmVm.messageStatus)
+        // Resolve where this peer reads before the first message is written, not after their reply.
+        useEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
         useEffect(pubkey, messages.size) {
             if (messages.isNotEmpty()) dmVm.markRead(pubkey)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -3,6 +3,9 @@ package org.nostr.nostrord.web.screens
 import org.nostr.nostrord.auth.AuthMethod
 import org.nostr.nostrord.auth.logoutConfirmBody
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.managers.DmArchiveManager
+import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.outbox.RelayListManager
 import org.nostr.nostrord.network.upload.MediaUploadService
@@ -20,6 +23,7 @@ import org.nostr.nostrord.ui.screens.backup.BackupViewModel
 import org.nostr.nostrord.ui.screens.backup.MIN_BACKUP_PASSWORD
 import org.nostr.nostrord.ui.screens.backup.backupSecurityTips
 import org.nostr.nostrord.ui.screens.profile.EditProfileViewModel
+import org.nostr.nostrord.ui.screens.settings.DmEncryptionViewModel
 import org.nostr.nostrord.ui.screens.settings.DmRelaySettingsViewModel
 import org.nostr.nostrord.ui.screens.settings.MutedGroupsViewModel
 import org.nostr.nostrord.ui.screens.settings.MutedUsersViewModel
@@ -54,6 +58,7 @@ import web.cssom.ClassName
 import web.html.InputType
 import web.html.checkbox
 import web.html.password
+import web.html.text
 
 external interface SettingsScreenProps : Props {
     var onClose: () -> Unit
@@ -684,6 +689,10 @@ private val DmRelaysPanel =
             ) { dm.setDmEnabled(!dmEnabled) }
         }
 
+        if (dmEnabled) {
+            DmEncryptionPanel()
+        }
+
         // Relay editor only matters while DMs are on; hidden with the rest of the feature when off.
         if (dmEnabled) {
             div {
@@ -1266,6 +1275,235 @@ private val BlossomServerList =
             }
         }
     }
+
+// ── NIP-4e fast decryption key ───────────────────────────────────────────────
+
+private val DmEncryptionPanel =
+    FC<Props> {
+        val vm = useViewModel { DmEncryptionViewModel(AppModule.nostrRepository) }
+        val state = useStateFlow(vm.state)
+        val busy = useStateFlow(vm.busy)
+        val error = useStateFlow(vm.error)
+        val revealedKey = useStateFlow(vm.revealedKey)
+        val importInput = useStateFlow(vm.importInput)
+        val archiveProgress = useStateFlow(vm.archiveProgress)
+        val archiveConfirmOpen = useStateFlow(vm.archiveConfirmOpen)
+        val archivableCount = useStateFlow(vm.archivableCount)
+        val pairingState = useStateFlow(vm.pairingState)
+
+        // Nothing to offload when signing is already local.
+        if (state !is DmEncryptionManager.State.Unavailable) {
+            div {
+                className = ClassName("settings-card")
+                div {
+                    className = ClassName("settings-section-head")
+                    +"FAST DECRYPTION KEY"
+                }
+                div {
+                    className = ClassName("settings-tip")
+                    +(
+                        "Creates a separate encryption key stored on this device. New messages decrypt " +
+                            "instantly without contacting your signer."
+                        )
+                }
+
+                when (state) {
+                    is DmEncryptionManager.State.AnnouncedElsewhere -> {
+                        div {
+                            className = ClassName("settings-status-line")
+                            +(
+                                "This account already announced an encryption key from another device. " +
+                                    "Ask that device to send it, or paste it here from its Show key screen."
+                                )
+                        }
+                        when (pairingState) {
+                            is DmPairingManager.State.Requesting ->
+                                div {
+                                    className = ClassName("settings-status-line")
+                                    +"Waiting for your other device. Approve the request showing code ${pairingState.code} there."
+                                }
+                            is DmPairingManager.State.Failed ->
+                                div {
+                                    className = ClassName("settings-error")
+                                    +pairingState.reason
+                                }
+                            else ->
+                                button {
+                                    className = ClassName("settings-outline-btn")
+                                    onClick = { vm.requestKeyFromOtherDevice() }
+                                    +"Ask my other device"
+                                }
+                        }
+                        input {
+                            className = ClassName("modal-input")
+                            type = InputType.text
+                            value = importInput
+                            placeholder = "Encryption key"
+                            onChange = { vm.setImportInput(it.target.value) }
+                        }
+                        button {
+                            className = ClassName("settings-outline-btn")
+                            disabled = importInput.isBlank()
+                            onClick = { vm.importKey() }
+                            +"Import key"
+                        }
+                    }
+                    is DmEncryptionManager.State.Active -> {
+                        div {
+                            className = ClassName("settings-status-line")
+                            +"Active. Senders are addressing ${state.encPubkey.take(12)}…"
+                        }
+                        // Another device of this account is asking for the key. The code comes from
+                        // the request itself, so matching it proves which device asked.
+                        (pairingState as? DmPairingManager.State.IncomingRequest)?.let { request ->
+                            div {
+                                className = ClassName("settings-tip")
+                                +"Another device wants this key. Approve only if it is showing code ${request.code}."
+                            }
+                            button {
+                                className = ClassName("settings-outline-btn")
+                                onClick = { vm.declinePairing() }
+                                +"Decline"
+                            }
+                            button {
+                                className = ClassName("settings-outline-btn")
+                                onClick = { vm.approvePairing() }
+                                +"Send key"
+                            }
+                        }
+                        revealedKey?.let {
+                            div {
+                                className = ClassName("settings-status-line")
+                                +it
+                            }
+                        }
+                        button {
+                            className = ClassName("settings-outline-btn")
+                            onClick = { if (revealedKey == null) vm.revealKey() else vm.hideKey() }
+                            +(if (revealedKey == null) "Show key" else "Hide key")
+                        }
+                        button {
+                            className = ClassName("settings-outline-btn")
+                            disabled = busy
+                            onClick = { vm.rotate() }
+                            +"Replace key"
+                        }
+                        button {
+                            className = ClassName("settings-outline-btn")
+                            disabled = busy
+                            onClick = { vm.disable() }
+                            +(if (busy) "Working…" else "Turn off")
+                        }
+                        div {
+                            className = ClassName("settings-tip")
+                            +(
+                                "Replace the key if this device may have been compromised. Contacts start " +
+                                    "using the new one as they see it; the old key stays here so everything " +
+                                    "sent to it keeps opening."
+                                )
+                        }
+                        div {
+                            className = ClassName("settings-tip")
+                            +(
+                                "Turning this off sends new messages back to your signer key. The key stays " +
+                                    "saved on this device because messages already sent to it can only ever " +
+                                    "be opened with it. It is never deleted, only no longer advertised."
+                                )
+                        }
+                        dmArchiveSection(vm, archiveProgress, archiveConfirmOpen, archivableCount)
+                    }
+                    else -> {
+                        if (state is DmEncryptionManager.State.HeldNotAnnounced) {
+                            div {
+                                className = ClassName("settings-status-line")
+                                +"A key from an earlier session is still saved here. Turning this on advertises it again."
+                            }
+                        }
+                        button {
+                            className = ClassName("settings-outline-btn")
+                            disabled = busy
+                            onClick = { vm.enable() }
+                            +(if (busy) "Publishing…" else "Turn on")
+                        }
+                    }
+                }
+
+                error?.let {
+                    div {
+                        className = ClassName("settings-error")
+                        +it
+                    }
+                }
+            }
+        }
+    }
+
+/**
+ * Self-archive controls. Values are passed in rather than read here: this renders inside a
+ * conditional branch, so it must not call hooks.
+ */
+private fun react.ChildrenBuilder.dmArchiveSection(
+    vm: DmEncryptionViewModel,
+    progress: DmArchiveManager.Progress,
+    confirmOpen: Boolean,
+    count: Int?,
+) {
+    when {
+        progress.running -> {
+            div {
+                className = ClassName("settings-status-line")
+                +"Archiving ${progress.done} of ${progress.total}…"
+            }
+            button {
+                className = ClassName("settings-outline-btn")
+                onClick = { vm.cancelArchive() }
+                +"Stop"
+            }
+        }
+        confirmOpen -> {
+            div {
+                className = ClassName("settings-tip")
+                +(
+                    "This publishes ${count ?: 0} wrapped copies of your message history to your DM " +
+                        "relays, encrypted to your fast decryption key. New devices holding this key can " +
+                        "then load your history without contacting your signer. Publishing takes a few " +
+                        "minutes and reveals to your DM relays roughly how many messages you have."
+                    )
+            }
+            button {
+                className = ClassName("settings-outline-btn")
+                onClick = { vm.dismissArchiveConfirm() }
+                +"Cancel"
+            }
+            button {
+                className = ClassName("settings-outline-btn")
+                disabled = (count ?: 0) <= 0
+                onClick = { vm.confirmArchive() }
+                +"Publish archive"
+            }
+        }
+        else -> {
+            // Reported here rather than through the VM error: the run outlives this screen.
+            progress.error?.let {
+                div {
+                    className = ClassName("settings-error")
+                    +it
+                }
+            }
+            if (progress.done > 0 && progress.error == null) {
+                div {
+                    className = ClassName("settings-status-line")
+                    +"Archived ${progress.done} of ${progress.total}."
+                }
+            }
+            button {
+                className = ClassName("settings-outline-btn")
+                onClick = { vm.askToArchive() }
+                +"Archive history to this key"
+            }
+        }
+    }
+}
 
 // ── Security ─────────────────────────────────────────────────────────────────
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -1291,6 +1291,7 @@ private val DmEncryptionPanel =
         val archiveConfirmOpen = useStateFlow(vm.archiveConfirmOpen)
         val archivableCount = useStateFlow(vm.archivableCount)
         val pairingState = useStateFlow(vm.pairingState)
+        val resetConfirmOpen = useStateFlow(vm.resetConfirmOpen)
 
         // Nothing to offload when signing is already local.
         if (state !is DmEncryptionManager.State.Unavailable) {
@@ -1311,9 +1312,10 @@ private val DmEncryptionPanel =
                 when (state) {
                     is DmEncryptionManager.State.AnnouncedElsewhere -> {
                         noticeCard(
-                            title = "Key held on another device",
-                            body = "This account already announced an encryption key from another device. " +
-                                "Ask that device to send it, or paste it here from its Show key screen.",
+                            title = "The announced key is not on this device",
+                            body = "This account announces an encryption key that is not stored here. If another " +
+                                "device or app holds it, bring it over. Otherwise replace it, and messages sent " +
+                                "to the old key will not be readable.",
                             alert = true,
                             ic = Ic.Key,
                         )
@@ -1354,12 +1356,53 @@ private val DmEncryptionPanel =
                                 +"Import key"
                             }
                         }
+                        // Last resort when that device is gone for good: without it the account
+                        // stays unable to read, since senders address a key nobody here holds.
+                        if (resetConfirmOpen) {
+                            noticeCard(
+                                title = "Reset the encryption key?",
+                                body = "Messages already sent to the old key will never open on any device again. " +
+                                    "Chat history already saved here is not lost.",
+                                alert = true,
+                                ic = Ic.Warning,
+                            )
+                            div {
+                                className = ClassName("settings-form-actions")
+                                button {
+                                    className = ClassName("btn-text btn-sm")
+                                    onClick = { vm.dismissResetConfirm() }
+                                    +"Cancel"
+                                }
+                                button {
+                                    className = ClassName("btn-text btn-sm danger")
+                                    disabled = busy
+                                    onClick = { vm.confirmReset() }
+                                    +(if (busy) "Publishing…" else "Reset key")
+                                }
+                            }
+                        } else {
+                            div {
+                                className = ClassName("settings-form-actions")
+                                button {
+                                    className = ClassName("btn-text btn-sm danger")
+                                    disabled = busy
+                                    onClick = { vm.askToReset() }
+                                    +"No access to that device?"
+                                }
+                            }
                         }
                     }
                     is DmEncryptionManager.State.Active -> {
                         div {
-                            className = ClassName("settings-status-line success")
-                            +"Active. Senders are addressing ${state.encPubkey.take(12)}…"
+                            className = ClassName(if (state.confirmed) "settings-status-line success" else "settings-status-line")
+                            +(
+                                if (state.confirmed) {
+                                    "Active. Senders are addressing ${state.encPubkey.take(12)}…"
+                                } else {
+                                    "Announcing ${state.encPubkey.take(12)}…. The key is saved on this device; " +
+                                        "waiting for a relay to confirm."
+                                }
+                                )
                         }
                         // Another device of this account is asking for the key. The code comes from
                         // the request itself, so matching it proves which device asked.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -1534,16 +1534,27 @@ private fun react.ChildrenBuilder.dmArchiveSection(
                         "minutes and reveals to your DM relays roughly how many messages you have."
                     )
             }
-            button {
-                className = ClassName("settings-outline-btn")
-                onClick = { vm.dismissArchiveConfirm() }
-                +"Cancel"
+            // The one consequence the volume/relay copy above does not cover.
+            div {
+                className = ClassName("settings-tip warning")
+                +(
+                    "It also widens what a leak of this key costs: afterwards that one key opens your whole " +
+                        "history from the relays, not only the messages sent while it was current."
+                    )
             }
-            button {
-                className = ClassName("settings-outline-btn")
-                disabled = (count ?: 0) <= 0
-                onClick = { vm.confirmArchive() }
-                +"Publish archive"
+            div {
+                className = ClassName("settings-form-actions")
+                button {
+                    className = ClassName("btn-text btn-sm")
+                    onClick = { vm.dismissArchiveConfirm() }
+                    +"Cancel"
+                }
+                button {
+                    className = ClassName("btn-primary btn-sm")
+                    disabled = (count ?: 0) <= 0
+                    onClick = { vm.confirmArchive() }
+                    +"Publish archive"
+                }
             }
         }
         else -> {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -40,6 +40,7 @@ import org.nostr.nostrord.web.components.IdentifierRow
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.noticeCard
 import org.nostr.nostrord.web.components.useEscClose
 import org.nostr.nostrord.web.navigation.pushRoute
 import react.FC
@@ -1309,13 +1310,13 @@ private val DmEncryptionPanel =
 
                 when (state) {
                     is DmEncryptionManager.State.AnnouncedElsewhere -> {
-                        div {
-                            className = ClassName("settings-status-line")
-                            +(
-                                "This account already announced an encryption key from another device. " +
-                                    "Ask that device to send it, or paste it here from its Show key screen."
-                                )
-                        }
+                        noticeCard(
+                            title = "Key held on another device",
+                            body = "This account already announced an encryption key from another device. " +
+                                "Ask that device to send it, or paste it here from its Show key screen.",
+                            alert = true,
+                            ic = Ic.Key,
+                        )
                         when (pairingState) {
                             is DmPairingManager.State.Requesting ->
                                 div {
@@ -1328,10 +1329,13 @@ private val DmEncryptionPanel =
                                     +pairingState.reason
                                 }
                             else ->
-                                button {
-                                    className = ClassName("settings-outline-btn")
-                                    onClick = { vm.requestKeyFromOtherDevice() }
-                                    +"Ask my other device"
+                                div {
+                                    className = ClassName("settings-form-actions")
+                                    button {
+                                        className = ClassName("btn-text btn-sm accent")
+                                        onClick = { vm.requestKeyFromOtherDevice() }
+                                        +"Ask my other device"
+                                    }
                                 }
                         }
                         input {
@@ -1341,58 +1345,69 @@ private val DmEncryptionPanel =
                             placeholder = "Encryption key"
                             onChange = { vm.setImportInput(it.target.value) }
                         }
-                        button {
-                            className = ClassName("settings-outline-btn")
-                            disabled = importInput.isBlank()
-                            onClick = { vm.importKey() }
-                            +"Import key"
+                        div {
+                            className = ClassName("settings-form-actions")
+                            button {
+                                className = ClassName("btn-primary btn-sm")
+                                disabled = importInput.isBlank()
+                                onClick = { vm.importKey() }
+                                +"Import key"
+                            }
+                        }
                         }
                     }
                     is DmEncryptionManager.State.Active -> {
                         div {
-                            className = ClassName("settings-status-line")
+                            className = ClassName("settings-status-line success")
                             +"Active. Senders are addressing ${state.encPubkey.take(12)}…"
                         }
                         // Another device of this account is asking for the key. The code comes from
                         // the request itself, so matching it proves which device asked.
                         (pairingState as? DmPairingManager.State.IncomingRequest)?.let { request ->
+                            noticeCard(
+                                title = "Another device wants this key",
+                                body = "Approve only if that device is showing code ${request.code}.",
+                                alert = true,
+                                ic = Ic.Key,
+                            )
                             div {
-                                className = ClassName("settings-tip")
-                                +"Another device wants this key. Approve only if it is showing code ${request.code}."
-                            }
-                            button {
-                                className = ClassName("settings-outline-btn")
-                                onClick = { vm.declinePairing() }
-                                +"Decline"
-                            }
-                            button {
-                                className = ClassName("settings-outline-btn")
-                                onClick = { vm.approvePairing() }
-                                +"Send key"
+                                className = ClassName("settings-form-actions")
+                                button {
+                                    className = ClassName("btn-text btn-sm")
+                                    onClick = { vm.declinePairing() }
+                                    +"Decline"
+                                }
+                                button {
+                                    className = ClassName("btn-primary btn-sm")
+                                    onClick = { vm.approvePairing() }
+                                    +"Send key"
+                                }
                             }
                         }
+                        // Same field as the private key on Backup: monospace, copy button, no
+                        // wrapping of a value the user has to move to another device by hand.
                         revealedKey?.let {
-                            div {
-                                className = ClassName("settings-status-line")
-                                +it
+                            IdentifierRow { ids = listOf(Identifier("hex", it)) }
+                        }
+                        div {
+                            className = ClassName("settings-form-actions")
+                            button {
+                                className = ClassName("btn-text btn-sm accent")
+                                onClick = { if (revealedKey == null) vm.revealKey() else vm.hideKey() }
+                                +(if (revealedKey == null) "Show key" else "Hide key")
                             }
-                        }
-                        button {
-                            className = ClassName("settings-outline-btn")
-                            onClick = { if (revealedKey == null) vm.revealKey() else vm.hideKey() }
-                            +(if (revealedKey == null) "Show key" else "Hide key")
-                        }
-                        button {
-                            className = ClassName("settings-outline-btn")
-                            disabled = busy
-                            onClick = { vm.rotate() }
-                            +"Replace key"
-                        }
-                        button {
-                            className = ClassName("settings-outline-btn")
-                            disabled = busy
-                            onClick = { vm.disable() }
-                            +(if (busy) "Working…" else "Turn off")
+                            button {
+                                className = ClassName("btn-text btn-sm accent")
+                                disabled = busy
+                                onClick = { vm.rotate() }
+                                +"Replace key"
+                            }
+                            button {
+                                className = ClassName("btn-text btn-sm danger")
+                                disabled = busy
+                                onClick = { vm.disable() }
+                                +(if (busy) "Working…" else "Turn off")
+                            }
                         }
                         div {
                             className = ClassName("settings-tip")
@@ -1419,11 +1434,14 @@ private val DmEncryptionPanel =
                                 +"A key from an earlier session is still saved here. Turning this on advertises it again."
                             }
                         }
-                        button {
-                            className = ClassName("settings-outline-btn")
-                            disabled = busy
-                            onClick = { vm.enable() }
-                            +(if (busy) "Publishing…" else "Turn on")
+                        div {
+                            className = ClassName("settings-form-actions")
+                            button {
+                                className = ClassName("btn-primary btn-sm")
+                                disabled = busy
+                                onClick = { vm.enable() }
+                                +(if (busy) "Publishing…" else "Turn on")
+                            }
                         }
                     }
                 }
@@ -1454,10 +1472,13 @@ private fun react.ChildrenBuilder.dmArchiveSection(
                 className = ClassName("settings-status-line")
                 +"Archiving ${progress.done} of ${progress.total}…"
             }
-            button {
-                className = ClassName("settings-outline-btn")
-                onClick = { vm.cancelArchive() }
-                +"Stop"
+            div {
+                className = ClassName("settings-form-actions")
+                button {
+                    className = ClassName("btn-text btn-sm danger")
+                    onClick = { vm.cancelArchive() }
+                    +"Stop"
+                }
             }
         }
         confirmOpen -> {
@@ -1496,10 +1517,13 @@ private fun react.ChildrenBuilder.dmArchiveSection(
                     +"Archived ${progress.done} of ${progress.total}."
                 }
             }
-            button {
-                className = ClassName("settings-outline-btn")
-                onClick = { vm.askToArchive() }
-                +"Archive history to this key"
+            div {
+                className = ClassName("settings-form-actions")
+                button {
+                    className = ClassName("btn-text btn-sm accent")
+                    onClick = { vm.askToArchive() }
+                    +"Archive history to this key"
+                }
             }
         }
     }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -5382,6 +5382,28 @@ body {
     background: var(--color-hover);
 }
 
+/* Ghost variants that carry meaning through color, for rows of quiet actions where one is
+   affirmative and one destructive (mirrors the native TextButton palette). */
+.btn-text.accent,
+.btn-ghost.accent {
+    color: var(--color-primary);
+}
+
+.btn-text.danger,
+.btn-ghost.danger {
+    color: var(--color-error);
+}
+
+.btn-text.accent:hover:not(:disabled),
+.btn-ghost.accent:hover:not(:disabled) {
+    color: var(--color-primary);
+}
+
+.btn-text.danger:hover:not(:disabled),
+.btn-ghost.danger:hover:not(:disabled) {
+    color: var(--color-error);
+}
+
 .btn-primary {
     color: #ffffff;
     background: var(--color-primary);
@@ -8267,7 +8289,9 @@ body {
 
 .settings-form-actions {
     display: flex;
+    flex-wrap: wrap;
     justify-content: flex-end;
+    gap: 8px;
     margin-top: 8px;
 }
 
@@ -8466,6 +8490,11 @@ body {
     margin-bottom: 14px;
     font-size: 13px;
     color: var(--color-text-secondary);
+}
+
+/* A state line that reports something working (a key being advertised, a job finished). */
+.settings-status-line.success {
+    color: var(--color-success);
 }
 
 /* Mobile-only back row (settings panel → section list). */

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -8357,6 +8357,11 @@ body {
     color: var(--color-text-secondary);
 }
 
+/* A tip that states a consequence the user should weigh, not just context. */
+.settings-tip.warning {
+    color: var(--color-warning-orange);
+}
+
 .settings-error {
     margin-top: 6px;
     font-size: 13px;


### PR DESCRIPTION
Supersedes #259, which GitHub closed when its base branch (#247) was merged and deleted. Same commits, rebased onto main.

Phases 2, 2b and 3 of the NIP-4e plan, plus the correctness work that came out of testing them against Jumble on real relays.

The account announces its own kind:10044, holds the private key locally, and decrypts inbound DMs in process, so a bunker or extension leaves the read path entirely. Device pairing (4454/4455) moves the key to a second device, and the self-archive republishes history addressed to that key. Wire format follows the deployed Jumble implementation where it diverges from nostr-protocol/nips#1647.

Six of these commits are not features, they are what device testing produced. The state machine one matters most: the state was cached in mutable flags written from six entry points, so the relay echoing our own announcement back before the key was adopted made the account read as "announced by another device" while holding that very key, and a screen closed during the publish lost the key for good. It is derived from the newest announcement plus the held keys now, and the key is persisted before any network call.

| Area | What changed |
|---|---|
| Key state | derived from (newest kind:10044, keys held), one lock, key adopted before publishing |
| Pairing | requests were filtered `since`-now and never re-sent, so they never arrived; decisions lived in memory, so a decline came back on every restart |
| Sending | publish fan-out was serial behind an 8s per-relay timeout; a peer's kind:10050 was never fetched before the first message, so first contact went to the defaults and was lost |
| Reporting | a send that reached no relay looked identical to one in flight |
| Discovery | an account with no kind:10002 gets a default one, as kind:10050 already did |
| UI | the block never asserts another device exists; Active tells "senders are addressing this" from "waiting for a relay to confirm" |

Not done: the manual validation matrices in the plan, and iOS (no macOS box here).

- 25147ba4 feat(dm): NIP-4e encryption keys for direct messages
- 1976f7b2 feat(dm): prune retired NIP-4e keys after 90 days
- 97adc6c7 fix(dm): publish to relays concurrently and confirm the announcement
- e71e628a fix(dm): deliver pairing requests and remember the answer
- e1dfcde7 fix(dm): resolve where a peer reads before sending to them
- 260109e0 fix(dm): say when a message reached no relay
- 0109a052 feat(outbox): publish a default kind:10002 for an account that has none
- a5295364 refactor(settings): rework the DM encryption block on the web
- 85c5b622 fix(dm): derive the encryption-key state, and give a stuck account a way out
- 95d66e90 feat(dm): warn that archiving widens a key leak