### PR TITLE
fix(quotes): resolve a quoted external event by id alone

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -2204,8 +2204,10 @@ class NostrGroupClient(
     }
 
     // #h filter included because some NIP-29 relays require it even for ID lookups.
+    // Distinct subId prefix: this runs alongside requestEventById for the same event, and a
+    // shared prefix collides within the same millisecond, replacing that subscription.
     suspend fun requestGroupMessageById(groupId: String, messageId: String) {
-        val subId = "e_${epochMillis()}"
+        val subId = "eh_${epochMillis()}"
         val req = buildJsonArray {
             add("REQ")
             add(subId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -411,7 +411,14 @@ class MetadataManager(
         messageHandler: (String, NostrGroupClient) -> Unit,
     ) {
         suspend fun NostrGroupClient.reqEvent() {
-            if (groupId != null) requestGroupMessageById(groupId, eventId) else requestEventById(eventId)
+            // Always ask by id alone. An external event (a kind:1 nevent quoted inside a group)
+            // carries no `h` tag, so an #h-scoped filter matches nothing on any relay, including
+            // the hint relay dialed below specifically to serve it.
+            requestEventById(eventId)
+            // The #h lookup is additive, and a separate subscription rather than a second filter
+            // on the same REQ: a strict NIP-29 relay CLOSEs a REQ whose filter omits `#h`, which
+            // would take the group lookup down with it.
+            if (groupId != null) requestGroupMessageById(groupId, eventId)
         }
         // Skip if already cached or already in-flight
         if (_cachedEvents.value.containsKey(eventId)) return


### PR DESCRIPTION
A quoted `nevent` was looked up with the `#h` of the group it was rendered in, so a kind:1 note or a NIP-84 highlight matched nothing anywhere: those carry no `h` tag. Captured live against the failing note, the hint relay connected and answered in 400ms, empty, and the card settled on "Event removed or unavailable":

```
["REQ","e_1786576115763",{"ids":["0348a801…"],"#h":["kwo1rv4arl8t"]}]   20:08:35.763
["EOSE","e_1786576115763"]                                              20:08:36.161
```

The nevent's own `kind` cannot gate this: it is optional in the TLV and absent from `note1` entirely. Nor can the group id, which is the screen's, not the quoted event's, so quoting across groups was already sending the wrong one. So the id-only REQ goes out unconditionally and the `#h` lookup becomes an addition, keeping the reason it exists (some NIP-29 relays ignore an ids-only filter).

For reference, jumble resolves the same two notes purely from the nevent relay hints with a bare `{ids:[…]}` filter, and has no `#h` anywhere; neither note is on its four default relays. The relay strategy was never the gap.

| | Before | After |
|---|---|---|
| kind:1 / 9802 quote in a group | `{ids, #h}` only, matches nothing | `{ids}` resolves it |
| Group message quote | `{ids, #h}` | unchanged, plus an `{ids}` attempt |
| Subscription id | both helpers used `e_<millis>` | `#h` lookup uses `eh_<millis>` |

The subscription id mattered: run back to back in the same millisecond, the shared prefix collides and the relay replaces the id-only subscription, silently dropping the REQ that carries the fix.

Verified on the web target against `nevent1qvzqq…qh0f7s6`, whose only reachable relay is `nostr.bitcoiner.social`, reached from the hint. `compileKotlinJvm`, `compileKotlinJs`, `:composeApp:jvmTest` green. Shared commonMain, so both UIs get it.

Left out, as separate concerns: `author` is still unread in `MetadataManager.requestEventById`, so the author's NIP-65 outbox is never consulted; and `getOrConnectRelay` returns a pooled client even when dead, so a hint pointing at a pooled-but-down relay still goes nowhere.

- 7131a818 fix(quotes): resolve a quoted external event by id alone