### PR TITLE
Stop the connection churn and repeated kind:22242 signing prompts

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.android.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.SIGNER_DIAG_ROLE
 import org.nostr.nostrord.network.sendAndAwaitOkOrError
 import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
@@ -113,7 +114,7 @@ actual class Nip46Client actual constructor(
      * adding the result to [relayClients].
      */
     private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
-        val client = NostrGroupClient(relayUrl)
+        val client = NostrGroupClient(relayUrl, diagRole = SIGNER_DIAG_ROLE)
         client.connect { msg -> handleMessage(msg, client) }
         if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
             client.disconnect()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/NostrSigner.kt
@@ -37,6 +37,13 @@ interface NostrSigner {
     val isRemote: Boolean get() = false
 
     /**
+     * True when every operation opens a dialog the user must answer (NIP-07 extension,
+     * NIP-55 signer app). Callers must not time out and retry against these: a retry cannot
+     * reach the user any faster, it only queues a second dialog behind the one on screen.
+     */
+    val promptsUser: Boolean get() = false
+
+    /**
      * Sign [event] with this account's key material.
      *
      * Throws [SigningException] on permission denial, signer disconnection,
@@ -141,6 +148,7 @@ interface NostrSigner {
             return try {
                 nip46Client.nip44Decrypt(peerPubkeyHex, ciphertext)
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 throw SigningException("Bunker NIP-44 decryption failed: ${e.message}", e)
             }
         }
@@ -165,19 +173,30 @@ interface NostrSigner {
     ) : NostrSigner {
         override val isRemote: Boolean = true
 
+        // Every call renders an extension dialog, and a PIN-locked extension follows each
+        // one with an unlock prompt. [SignerPrompts] keeps them to one at a time.
+        override val promptsUser: Boolean = true
+
         @Volatile private var disposed = false
 
         override suspend fun signEvent(event: Event): Event {
             if (disposed) throw SigningException("NIP-07 signer has been disposed")
-            val signedJson = Nip07.signEvent(event.toJsonString())
+            val signedJson =
+                try {
+                    SignerPrompts.queued(promptsUser) { Nip07.signEvent(event.toJsonString()) }
+                } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) throw e
+                    throw SigningException("NIP-07 signing failed: ${e.message}", e)
+                }
             return parseSignedEventJson(signedJson)
         }
 
         override suspend fun nip44Encrypt(peerPubkeyHex: String, plaintext: String): String {
             if (disposed) throw SigningException("NIP-07 signer has been disposed")
             return try {
-                Nip07.nip44Encrypt(peerPubkeyHex, plaintext)
+                SignerPrompts.queued(promptsUser) { Nip07.nip44Encrypt(peerPubkeyHex, plaintext) }
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 throw SigningException("NIP-07 NIP-44 encryption failed: ${e.message}", e)
             }
         }
@@ -185,8 +204,9 @@ interface NostrSigner {
         override suspend fun nip44Decrypt(peerPubkeyHex: String, ciphertext: String): String {
             if (disposed) throw SigningException("NIP-07 signer has been disposed")
             return try {
-                Nip07.nip44Decrypt(peerPubkeyHex, ciphertext)
+                SignerPrompts.queued(promptsUser) { Nip07.nip44Decrypt(peerPubkeyHex, ciphertext) }
             } catch (e: Exception) {
+                if (e is kotlinx.coroutines.CancellationException) throw e
                 throw SigningException("NIP-07 NIP-44 decryption failed: ${e.message}", e)
             }
         }
@@ -207,12 +227,19 @@ interface NostrSigner {
     ) : NostrSigner {
         override val isRemote: Boolean = true
 
+        // A request the user has not pre-authorized opens the signer's approval screen.
+        // Pre-authorized ones return over IPC in milliseconds, so taking a turn costs
+        // them nothing and keeps an unauthorized burst from stacking approval screens.
+        override val promptsUser: Boolean = true
+
         @Volatile private var disposed = false
 
         override suspend fun signEvent(event: Event): Event {
             if (disposed) throw SigningException("Amber signer has been disposed")
             return try {
-                parseSignedEventJson(Nip55.signEvent(event.toJsonString(), pubkey, signerPackage))
+                parseSignedEventJson(
+                    SignerPrompts.queued(promptsUser) { Nip55.signEvent(event.toJsonString(), pubkey, signerPackage) },
+                )
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 if (e is SigningException) throw e
@@ -223,7 +250,7 @@ interface NostrSigner {
         override suspend fun nip44Encrypt(peerPubkeyHex: String, plaintext: String): String {
             if (disposed) throw SigningException("Amber signer has been disposed")
             return try {
-                Nip55.nip44Encrypt(peerPubkeyHex, plaintext, pubkey, signerPackage)
+                SignerPrompts.queued(promptsUser) { Nip55.nip44Encrypt(peerPubkeyHex, plaintext, pubkey, signerPackage) }
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 throw SigningException("Amber NIP-44 encryption failed: ${e.message}", e)
@@ -233,7 +260,7 @@ interface NostrSigner {
         override suspend fun nip44Decrypt(peerPubkeyHex: String, ciphertext: String): String {
             if (disposed) throw SigningException("Amber signer has been disposed")
             return try {
-                Nip55.nip44Decrypt(peerPubkeyHex, ciphertext, pubkey, signerPackage)
+                SignerPrompts.queued(promptsUser) { Nip55.nip44Decrypt(peerPubkeyHex, ciphertext, pubkey, signerPackage) }
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
                 throw SigningException("Amber NIP-44 decryption failed: ${e.message}", e)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/SignerPrompts.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/auth/SignerPrompts.kt
@@ -1,0 +1,106 @@
+package org.nostr.nostrord.auth
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.nostr.nostrord.utils.epochMillis
+import kotlin.concurrent.Volatile
+
+/**
+ * Serializes the signer operations that put a dialog in front of the user.
+ *
+ * A NIP-07 extension or a NIP-55 signer app renders one dialog per request. Fired
+ * concurrently - every reconnecting relay challenging for NIP-42 at once, or the account's
+ * encrypted lists loading together - they reach the user as a wall of dialogs, each one
+ * followed by a PIN prompt when the signer is PIN-locked. Prompting signers take their turn
+ * one at a time so at most one dialog is ever on screen.
+ *
+ * Local and bunker signers show nothing and are NOT serialized: a DM backlog queued behind
+ * one slow bunker round-trip would starve group AUTH.
+ */
+object SignerPrompts {
+    private val gate = Mutex()
+
+    suspend fun <T> queued(
+        promptsUser: Boolean,
+        block: suspend () -> T,
+    ): T = if (promptsUser) gate.withLock { block() } else block()
+}
+
+/**
+ * Remembers self-decrypts so one ciphertext is sent to the signer once per session.
+ *
+ * The account's encrypted lists (kind:10000 mutes, kind:10009 private groups, kind:30078
+ * per-group notification levels) are replaceable: every connected relay delivers its own
+ * copy of the same event, and each copy carries the identical ciphertext. Without this,
+ * each copy reaches the signer and a prompting signer opens one dialog per relay.
+ *
+ * A refusal is remembered too, and for much longer than it takes the same list to be
+ * redelivered - re-asking on every redelivery turns a single "no" into a dialog every
+ * minute for the rest of the session.
+ */
+class SelfDecryptCache {
+    private val mutex = Mutex()
+
+    @Volatile private var plaintexts: Map<String, String> = emptyMap()
+
+    @Volatile private var refusedAt: Map<String, Long> = emptyMap()
+
+    /**
+     * The plaintext of [ciphertext], decrypting through [decrypt] only if this exact
+     * ciphertext has not already been read or refused. Null when it cannot be read; the
+     * caller leaves the section opaque.
+     */
+    suspend fun decrypt(
+        peerPubkey: String,
+        ciphertext: String,
+        decrypt: suspend () -> String?,
+    ): String? {
+        val key = "$peerPubkey|$ciphertext"
+        plaintexts[key]?.let { return it }
+        return mutex.withLock {
+            // Re-checked under the lock: copies of the same list race here, and the first
+            // arrival resolves the ciphertext the others are queued to ask about.
+            plaintexts[key]?.let { return@withLock it }
+            val refused = refusedAt[key]
+            if (refused != null && epochMillis() - refused < REFUSAL_RETRY_MS) return@withLock null
+            val plaintext =
+                try {
+                    decrypt()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (_: Throwable) {
+                    null
+                }
+            if (plaintext == null) {
+                refusedAt = refusedAt + (key to epochMillis())
+            } else {
+                plaintexts = bounded(plaintexts + (key to plaintext))
+                refusedAt = refusedAt - key
+            }
+            plaintext
+        }
+    }
+
+    /** Session-scoped: an account switch must not carry another account's plaintext. */
+    fun clear() {
+        plaintexts = emptyMap()
+        refusedAt = emptyMap()
+    }
+
+    private fun bounded(entries: Map<String, String>): Map<String, String> = if (entries.size <= MAX_ENTRIES) {
+        entries
+    } else {
+        entries.entries.drop(entries.size - MAX_ENTRIES).associate { it.key to it.value }
+    }
+
+    private companion object {
+        // Long enough that a rejected list is not re-asked on every redelivery, short
+        // enough that a signer that was briefly unreachable heals without a relaunch.
+        const val REFUSAL_RETRY_MS = 10 * 60_000L
+
+        // One entry per list version read this session; the bound only catches a client
+        // that rewrites its lists in a loop.
+        const val MAX_ENTRIES = 32
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -203,9 +203,17 @@ suspend fun NostrGroupClient.sendAndAwaitOkOrError(eventJson: String, eventId: S
     PublishResult.Error(eventId, e)
 }
 
+/** [NostrGroupClient.diagRole] for the sockets the NIP-46 client owns. */
+const val SIGNER_DIAG_ROLE = "signer"
+
 class NostrGroupClient(
     private val relayUrl: String = "wss://groups.fiatjaf.com",
+    diagRole: String? = null,
 ) {
+    // A NIP-46 socket: it carries the signer's response subscription, so it is worth far more
+    // alive than a group socket and is never torn down on a slow publish.
+    private val isSignerSocket = diagRole == SIGNER_DIAG_ROLE
+
     // Managed coroutine scope for this client - cancelled on disconnect
     // networkClientDispatcher, NOT Default: concurrent ws handshakes park their thread
     // in Ktor's generateNonce runBlocking and can deadlock the whole Default pool
@@ -311,8 +319,8 @@ class NostrGroupClient(
      * pongs never reach the frame loop, so inbound silence alone cannot
      * distinguish a quiet-but-alive relay from a dead socket.
      */
-    suspend fun probeLiveness(timeoutMs: Long = 5_000) {
-        if (!isConnected() || probeInFlight) return
+    suspend fun probeLiveness(timeoutMs: Long = 5_000): Boolean {
+        if (!isConnected() || probeInFlight) return true
         probeInFlight = true
         try {
             val sentAtMs = epochMillis()
@@ -320,8 +328,9 @@ class NostrGroupClient(
                 session?.send(Frame.Text("""["REQ","_probe",{"ids":["${"0".repeat(64)}"],"limit":1}]"""))
             } catch (e: Exception) {
                 if (e is kotlinx.coroutines.CancellationException) throw e
+                // The write itself threw: the pipe is broken, no second opinion needed.
                 markDead()
-                return
+                return false
             }
             while (epochMillis() - sentAtMs < timeoutMs) {
                 delay(250)
@@ -329,10 +338,12 @@ class NostrGroupClient(
                     try {
                         session?.send(Frame.Text("""["CLOSE","_probe"]"""))
                     } catch (_: Exception) {}
-                    return
+                    return true
                 }
             }
-            markDead()
+            // Unanswered. Whether that convicts the socket is RelayProbeGuard's call: silence can
+            // be the relay ignoring the REQ, and one socket's worth of evidence never shows that.
+            return false
         } finally {
             probeInFlight = false
         }
@@ -563,14 +574,23 @@ class NostrGroupClient(
             // Wait for OK with timeout
             withTimeout(timeoutMs) {
                 deferred.await()
-            }
+            }.also { org.nostr.nostrord.network.managers.RelayProbeGuard.onPublishAnswered(relayUrl) }
         } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
             pendingOkMutex.withLock { pendingOkResponses.remove(eventId) }
-            // No OK and not a single frame of any kind while we waited: the socket
-            // is a zombie, not a slow relay. Tear it down so the reconnect path
-            // (resubscribe + pending-event flush) takes over; otherwise the write
-            // keeps buffering into a dead pipe and the message stays Sending forever.
-            if (lastInboundAtMs < sentAtMs) {
+            // No OK and not a single frame of any kind while we waited. That can be a zombie
+            // socket - tearing it down hands over to reconnect + resubscribe + pending-event
+            // flush, instead of buffering writes into a dead pipe forever - but it can equally be
+            // a relay rate-limiting the publish, which answers late rather than never. One late OK
+            // is not a corpse, so the kill waits for the count (RelayProbeGuard).
+            //
+            // A signer socket is never killed here at all. It carries the NIP-46 response
+            // subscription, so dropping it guarantees the reply we are waiting for lands on a
+            // relay we just left: a slow publish would become a signer that went silent for 90s,
+            // per request, which is exactly the failure this diagnostic was chasing.
+            if (lastInboundAtMs < sentAtMs &&
+                !isSignerSocket &&
+                org.nostr.nostrord.network.managers.RelayProbeGuard.onPublishTimeout(relayUrl)
+            ) {
                 markDead()
             }
             PublishResult.Timeout(eventId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -36,6 +36,7 @@ import kotlinx.serialization.json.*
 import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.auth.ActiveAccountManager
 import org.nostr.nostrord.auth.NostrSigner
+import org.nostr.nostrord.auth.SelfDecryptCache
 import org.nostr.nostrord.auth.parseSignedEventJson
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.livekit.LiveKitCredentials
@@ -57,6 +58,7 @@ import org.nostr.nostrord.network.managers.OutboxManager
 import org.nostr.nostrord.network.managers.PendingDmWrap
 import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.RelayMetadataManager
+import org.nostr.nostrord.network.managers.RelayProbeGuard
 import org.nostr.nostrord.network.managers.RelayReconnectScheduler
 import org.nostr.nostrord.network.managers.SessionManager
 import org.nostr.nostrord.network.managers.UnreadManager
@@ -135,12 +137,28 @@ private const val GIFT_WRAP_BACKDATE_SECONDS = 2L * 24 * 60 * 60
 // last minute proves the socket is alive; below this, probing is pure overhead.
 private const val FOREGROUND_PROBE_MIN_SILENCE_MS = 60_000L
 
+// Min gap between two foreground socket sweeps. Visibility changes come in bursts (tab
+// switching, app switching); each sweep can kill and rebuild sockets, and every rebuilt
+// socket costs a NIP-42 signature.
+private const val FOREGROUND_SWEEP_MIN_INTERVAL_MS = 60_000L
+
 /**
  * Coalescing window for kind:30078 notification-prefs publishes: a burst of toggles is
  * one event. Short on purpose — with a NIP-07 or bunker signer this is the delay before
  * the signing prompt appears, and anything longer reads as a popup out of nowhere.
  */
 private const val NOTIF_PREFS_PUBLISH_DEBOUNCE_MS = 600L
+
+/**
+ * How long a replaceable list waits after its first copy before its private section is
+ * decrypted. Relays hold different versions, and only the newest is worth reading: with a
+ * signer that asks the user, every other version in the burst is a dialog answered for
+ * nothing. Matches the settle window kind:10009 discovery already uses.
+ */
+private const val REPLACEABLE_SETTLE_MS = 1_500L
+
+/** Cap on one self-decrypt, for signers that answer on their own (local key, bunker). */
+private const val PRIVATE_DECRYPT_TIMEOUT_MS = 20_000L
 
 /** Floor between focus-driven kind:30078 re-fetches, so window flipping can't spam relays. */
 private const val NOTIF_PREFS_FETCH_MIN_INTERVAL_S = 3L
@@ -727,6 +745,11 @@ class NostrRepository(
     private var privateMuted: Set<String> = emptySet()
     private var muteListCreatedAt = 0L
     private var muteListContent = ""
+
+    // Shared by every self-encrypted list (kind:10000, kind:10009, kind:30078): one decrypt
+    // per distinct ciphertext, however many relays deliver a copy of the same event.
+    private val selfDecryptCache = SelfDecryptCache()
+
     private var muteListPublicTags: List<List<String>> = emptyList()
 
     // Decrypted private-section tags, valid only for the ciphertext they came from:
@@ -734,6 +757,12 @@ class NostrRepository(
     private var muteListPrivateTags: List<List<String>> = emptyList()
     private var muteListPrivateDecryptedFrom = ""
     private var muteListRequested = false
+
+    // Newest private section seen, and the job reading it. Same reason as the kind:30078
+    // pair: the decrypted-from marker only moves after a decrypt, so it cannot be the
+    // freshness floor while a burst of relay copies is arriving.
+    private var muteListPendingPrivate: String? = null
+    private var muteListPrivateApplyJob: Job? = null
     private var pendingMuteListPublish: Job? = null
     private var hasUnpublishedMuteChanges = false
     private val muteListMutex = Mutex()
@@ -805,28 +834,41 @@ class NostrRepository(
         }
         applyMutedSetsAndPersist(pubKey)
         if (!contentChanged && content == muteListPrivateDecryptedFrom) return
-        // Decrypt the private section off the ingest path (a bunker signer is a remote
-        // round-trip). One decrypt per new list, not per event.
-        scope.launch {
-            val signer = ActiveAccountManager.session.value?.signer ?: return@launch
-            val plaintext =
-                try {
-                    signer.nip44Decrypt(pubKey, content)
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (_: Throwable) {
-                    // NIP-04-era or foreign encryption: leave the section opaque; the
-                    // writable() guard keeps it verbatim on publish.
-                    return@launch
+        muteListPendingPrivate = content
+        scheduleMuteListPrivateApply(pubKey)
+    }
+
+    /**
+     * Decrypts and applies the private mute section off the ingest path (a bunker signer is a
+     * remote round-trip), once the burst of relay copies has settled.
+     *
+     * Single-flight on purpose: a newer version landing mid-decrypt is picked up by the loop
+     * rather than starting a second one, so a prompting signer never shows two dialogs for
+     * one list. A ciphertext that is NIP-04-era, foreign, or already refused reads as null:
+     * the section stays opaque and the writable() guard keeps it verbatim on publish.
+     */
+    private fun scheduleMuteListPrivateApply(pubKey: String) {
+        if (muteListPrivateApplyJob?.isActive == true) return
+        muteListPrivateApplyJob = scope.launch {
+            // Slower relays get to land their newer version before anything is decrypted.
+            delay(REPLACEABLE_SETTLE_MS)
+            while (true) {
+                val content = muteListPendingPrivate ?: return@launch
+                if (content == muteListPrivateDecryptedFrom) return@launch
+                val plaintext = decryptOwnSection(pubKey, content) ?: return@launch
+                val privateTags = org.nostr.nostrord.nostr.Nip51.decodeTags(plaintext) ?: return@launch
+                if (sessionManager.getPublicKey() != pubKey) return@launch
+                // Superseded while decrypting (newer event, local tap): only the version the
+                // list currently carries may be applied.
+                if (hasUnpublishedMuteChanges) return@launch
+                if (muteListContent == content) {
+                    muteListPrivateTags = privateTags
+                    muteListPrivateDecryptedFrom = content
+                    privateMuted = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(privateTags)
+                    applyMutedSetsAndPersist(pubKey)
                 }
-            val privateTags = org.nostr.nostrord.nostr.Nip51.decodeTags(plaintext) ?: return@launch
-            // Superseded while decrypting (newer event, local tap, account switch): drop it.
-            if (muteListContent != content || hasUnpublishedMuteChanges) return@launch
-            if (sessionManager.getPublicKey() != pubKey) return@launch
-            muteListPrivateTags = privateTags
-            muteListPrivateDecryptedFrom = content
-            privateMuted = org.nostr.nostrord.nostr.Nip51.mutedPubkeysFrom(privateTags)
-            applyMutedSetsAndPersist(pubKey)
+                if (muteListPendingPrivate == content) return@launch
+            }
         }
     }
 
@@ -836,6 +878,13 @@ class NostrRepository(
     // hand any relay the account's group membership.
 
     private var notifPrefsCreatedAt = 0L
+
+    // Newest version seen, whether or not it has been decrypted yet, and its ciphertext.
+    // The applied timestamp above cannot serve as the freshness floor during a burst: it
+    // only rises after a decrypt, which with a prompting signer is the user's response time.
+    private var notifPrefsNewestSeenAt = 0L
+    private var notifPrefsPendingContent: String? = null
+    private var notifPrefsApplyJob: Job? = null
 
     /**
      * The override map as last agreed with the network: what this device published, or
@@ -870,8 +919,11 @@ class NostrRepository(
         val settings = notificationSettings ?: return
         notifPrefsWatchJob?.cancel()
         notifPrefsPublishJob?.cancel()
+        notifPrefsApplyJob?.cancel()
+        notifPrefsPendingContent = null
         notifPrefsPublishing = false
         notifPrefsCreatedAt = SecureStorage.loadKind30078TimestampFor(pubkey, Nip78.D_NOTIFICATIONS)
+        notifPrefsNewestSeenAt = notifPrefsCreatedAt
         // A change only survives once it is published, so whatever is on disk is by
         // definition the last state that reached the network.
         notifPrefsSynced = settings.muteState.value.overrides
@@ -1055,28 +1107,61 @@ class NostrRepository(
         if (createdAt <= notifPrefsCreatedAt) return
         val content = event["content"]?.jsonPrimitive?.contentOrNull ?: return
         if (content.isBlank()) return
-        // Decrypt off the ingest path: a bunker signer is a remote round-trip.
-        scope.launch {
-            val signer = ActiveAccountManager.session.value?.signer ?: return@launch
-            val plaintext =
-                try {
-                    signer.nip44Decrypt(pubKey, content)
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (_: Throwable) {
-                    return@launch
+        // Recorded synchronously, before any decrypt: relays hold different versions of a
+        // replaceable event, and the applied-timestamp below only rises once a decrypt has
+        // finished. Without this floor every version in the burst reaches the signer, and
+        // all but the newest are discarded after the user answered for them.
+        if (createdAt <= notifPrefsNewestSeenAt) return
+        notifPrefsNewestSeenAt = createdAt
+        notifPrefsPendingContent = content
+        scheduleNotifPrefsApply(pubKey, settings)
+    }
+
+    /**
+     * Decrypts and applies the newest kind:30078 seen, once the burst has settled.
+     *
+     * Single-flight on purpose: a version landing while a decrypt is in flight is picked up
+     * by the loop below rather than starting a second one. Cancelling the in-flight decrypt
+     * instead would abandon a signer dialog the user is looking at and raise another.
+     */
+    private fun scheduleNotifPrefsApply(
+        pubKey: String,
+        settings: org.nostr.nostrord.settings.NotificationSettings,
+    ) {
+        if (notifPrefsApplyJob?.isActive == true) return
+        notifPrefsApplyJob = scope.launch {
+            // Slower relays get to land their newer version before anything is decrypted.
+            delay(REPLACEABLE_SETTLE_MS)
+            while (true) {
+                val createdAt = notifPrefsNewestSeenAt
+                val content = notifPrefsPendingContent ?: return@launch
+                if (createdAt <= notifPrefsCreatedAt) return@launch
+                if (notifPrefsPublishing) return@launch
+                val plaintext = decryptOwnSection(pubKey, content)
+                if (plaintext == null) {
+                    // Unread (signer refused, or was not reachable yet). Drop the floor so a
+                    // later delivery may try again; the decrypt cache is what keeps that retry
+                    // from reaching the signer while the refusal is still fresh.
+                    if (notifPrefsNewestSeenAt == createdAt) {
+                        notifPrefsNewestSeenAt = notifPrefsCreatedAt
+                        return@launch
+                    }
+                    continue // a newer version landed meanwhile: read that one instead
                 }
-            val decoded = Nip78.decodeNotifications(plaintext) ?: return@launch
-            // Superseded while decrypting (newer event, local change, account switch).
-            if (createdAt <= notifPrefsCreatedAt) return@launch
-            if (notifPrefsPublishing) return@launch
-            if (sessionManager.getPublicKey() != pubKey) return@launch
-            notifPrefsCreatedAt = createdAt
-            SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, createdAt)
-            // Recorded BEFORE the write: applying it makes muteState emit, and the watcher
-            // must already see this payload as the agreed state or it republishes it.
-            notifPrefsSynced = decoded.groupLevels
-            settings.applyRemoteGroupLevels(decoded.groupLevels)
+                val decoded = Nip78.decodeNotifications(plaintext) ?: return@launch
+                // Superseded while decrypting (newer event, local change, account switch).
+                if (createdAt <= notifPrefsCreatedAt) return@launch
+                if (notifPrefsPublishing) return@launch
+                if (sessionManager.getPublicKey() != pubKey) return@launch
+                notifPrefsCreatedAt = createdAt
+                SecureStorage.saveKind30078TimestampFor(pubKey, Nip78.D_NOTIFICATIONS, createdAt)
+                // Recorded BEFORE the write: applying it makes muteState emit, and the watcher
+                // must already see this payload as the agreed state or it republishes it.
+                notifPrefsSynced = decoded.groupLevels
+                settings.applyRemoteGroupLevels(decoded.groupLevels)
+                // A newer version landed while this one was being read: take it now.
+                if (notifPrefsNewestSeenAt <= createdAt) return@launch
+            }
         }
     }
 
@@ -1946,6 +2031,9 @@ class NostrRepository(
         AppModule.avSpaceHost.release()
         lastRequestGroupsAt.clear()
         relaysNeedingResubscribe.clear()
+        // Probe evidence is about the relay, but the sockets it judged belong to the account being
+        // torn down; the next one gets a fresh read.
+        RelayProbeGuard.reset()
         muxRestrictedRetryJobs.values.forEach { it.cancel() }
         muxRestrictedRetryJobs.clear()
         muxRestrictedRetryAttempts.clear()
@@ -3146,6 +3234,14 @@ class NostrRepository(
         muteListPrivateTags = emptyList()
         muteListPrivateDecryptedFrom = ""
         muteListRequested = false
+        muteListPrivateApplyJob?.cancel()
+        muteListPrivateApplyJob = null
+        muteListPendingPrivate = null
+        notifPrefsApplyJob?.cancel()
+        notifPrefsApplyJob = null
+        notifPrefsPendingContent = null
+        notifPrefsNewestSeenAt = 0L
+        selfDecryptCache.clear()
         publicMuted = emptySet()
         privateMuted = emptySet()
         _mutedPubkeys.value = emptySet()
@@ -3443,7 +3539,7 @@ class NostrRepository(
                 // here left their recovery to the periodic staleness net.
                 is ConnectionManager.ConnectionState.Reconnecting,
                 is ConnectionManager.ConnectionState.Connecting,
-                -> {
+                -> if (claimForegroundSweep()) {
                     probeIdleSockets()
                     groupManager.refreshLiveSubscriptions()
                     reconnectDroppedNip29PoolRelays()
@@ -3452,7 +3548,7 @@ class NostrRepository(
                 // Already connected — verify the sockets actually survived the
                 // background period (Doze/radio sleep kills TCP without a close
                 // frame; "Connected" can be a zombie), then refresh subs.
-                is ConnectionManager.ConnectionState.Connected -> {
+                is ConnectionManager.ConnectionState.Connected -> if (claimForegroundSweep()) {
                     probeIdleSockets()
                     groupManager.refreshLiveSubscriptions()
                     reconnectDroppedNip29PoolRelays()
@@ -3460,6 +3556,26 @@ class NostrRepository(
             }
             refreshUserListsOnForeground()
         }
+    }
+
+    private var lastForegroundSweepAtMs = 0L
+
+    /**
+     * True at most once per [FOREGROUND_SWEEP_MIN_INTERVAL_MS], for the socket sweep that
+     * follows a return to the foreground.
+     *
+     * "Foreground" fires on every visibility change: a browser tab switch, an app switch, a
+     * screen unlock. Sweeping on each one probes sockets that have simply been quiet, and a
+     * probe that misses its answer tears the socket down - so a user alt-tabbing produces a
+     * stream of reconnects, each of which costs the signer a fresh NIP-42 signature. A socket
+     * that really died during a 30 s absence is caught by the next sweep or by the 5-minute
+     * staleness net.
+     */
+    private fun claimForegroundSweep(): Boolean {
+        val now = org.nostr.nostrord.utils.epochMillis()
+        if (now - lastForegroundSweepAtMs < FOREGROUND_SWEEP_MIN_INTERVAL_MS) return false
+        lastForegroundSweepAtMs = now
+        return true
     }
 
     // Throttle for the foreground kind:3/kind:10000 re-fetch (seconds).
@@ -3487,9 +3603,9 @@ class NostrRepository(
 
     /**
      * Probe every connected relay socket that has been frame-silent for a while.
-     * Zombies are marked dead inside probeLiveness, and the resulting
-     * onConnectionLost drives reconnect + resubscribe + pending-event flush.
-     * Probes run concurrently so one dead socket doesn't delay the others.
+     * A zombie is marked dead by RelayProbeGuard once the misses add up, and the
+     * resulting onConnectionLost drives reconnect + resubscribe + pending-event
+     * flush. Probes run concurrently so one dead socket doesn't delay the others.
      */
     private suspend fun probeIdleSockets() {
         val clients = (
@@ -3499,7 +3615,7 @@ class NostrRepository(
         for (client in clients) {
             val silence = client.inboundSilenceMs() ?: continue
             if (silence < FOREGROUND_PROBE_MIN_SILENCE_MS) continue
-            scope.launch { client.probeLiveness() }
+            scope.launch { RelayProbeGuard.probe(client) }
         }
     }
 
@@ -5472,13 +5588,23 @@ class NostrRepository(
      */
     private suspend fun decryptOwnListSection(ciphertext: String): String? {
         val pubKey = sessionManager.getPublicKey() ?: return null
-        val signer = ActiveAccountManager.session.value?.signer ?: return null
-        return try {
+        return decryptOwnSection(pubKey, ciphertext)
+    }
+
+    /**
+     * One decrypt per distinct ciphertext of our own, shared by every self-encrypted list
+     * (kind:10000, kind:10009, kind:30078). Null when the signer cannot or will not read it.
+     */
+    private suspend fun decryptOwnSection(pubKey: String, ciphertext: String): String? = selfDecryptCache.decrypt(pubKey, ciphertext) {
+        val signer = ActiveAccountManager.session.value?.signer ?: return@decrypt null
+        // A signer that asks the user gets no deadline: only the user can answer, and a
+        // deadline here would abandon the open dialog and later raise a second one.
+        if (signer.promptsUser) {
             signer.nip44Decrypt(pubKey, ciphertext)
-        } catch (e: kotlinx.coroutines.CancellationException) {
-            throw e
-        } catch (_: Throwable) {
-            null
+        } else {
+            kotlinx.coroutines.withTimeoutOrNull(PRIVATE_DECRYPT_TIMEOUT_MS) {
+                signer.nip44Decrypt(pubKey, ciphertext)
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/AuthSignThrottle.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/AuthSignThrottle.kt
@@ -1,0 +1,72 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlin.concurrent.Volatile
+
+/**
+ * Paces kind:22242 signing per relay and identity, for every login method.
+ *
+ * A NIP-42 challenge is bound to one socket, so a signature can never be reused: every
+ * reconnect costs one signature. That is fine once, but a relay that drops sockets in a loop
+ * (or re-challenges an already authenticated one) turns into a steady stream of sign requests
+ * at whatever signs for the account - a remote NIP-46 bunker sees them all, and one server
+ * signing for many accounts feels the total.
+ *
+ * The first AUTH for a relay is never delayed, so a cold start and a genuine reconnect are as
+ * fast as before. Repeats inside [WINDOW_MS] wait out an interval that grows with how often
+ * this relay has already been signed for, which turns an unbounded churn loop into a slow
+ * trickle while still authenticating eventually.
+ *
+ * Keyed per identity: switching accounts deliberately re-AUTHs every socket under the new
+ * pubkey, and that burst must not be paced by the outgoing account's history.
+ */
+class AuthSignThrottle {
+    private val mutex = Mutex()
+
+    @Volatile private var signedAt: Map<String, List<Long>> = emptyMap()
+
+    /** How long to wait before signing another AUTH for [relayUrl] as [pubkey]. */
+    suspend fun delayBeforeSignMs(relayUrl: String, pubkey: String, nowMs: Long): Long = mutex.withLock {
+        val recent = recentLocked(relayUrl, pubkey, nowMs)
+        val last = recent.lastOrNull() ?: return@withLock 0L
+        val required = requiredIntervalMs(recent.size)
+        (last + required - nowMs).coerceAtLeast(0L)
+    }
+
+    /** Record that an AUTH for [relayUrl] as [pubkey] is being sent to the signer. */
+    suspend fun recordSign(relayUrl: String, pubkey: String, nowMs: Long) = mutex.withLock {
+        val key = key(relayUrl, pubkey)
+        val recent = recentLocked(relayUrl, pubkey, nowMs)
+        signedAt = (signedAt + (key to (recent + nowMs).takeLast(MAX_HISTORY))).let { entries ->
+            // Prune identities/relays that fell out of the window entirely, so a long session
+            // across many relays doesn't grow this map without bound.
+            entries.filterValues { times -> times.any { nowMs - it < WINDOW_MS } }
+        }
+    }
+
+    /** Logout: the next login starts from a clean history. Callable off a coroutine. */
+    fun clear() {
+        signedAt = emptyMap()
+    }
+
+    private fun recentLocked(relayUrl: String, pubkey: String, nowMs: Long): List<Long> = signedAt[key(relayUrl, pubkey)].orEmpty().filter { nowMs - it < WINDOW_MS }
+
+    private fun key(relayUrl: String, pubkey: String) = "$relayUrl|$pubkey"
+
+    companion object {
+        // Signatures older than this stop counting: a relay that needed re-AUTH half an hour
+        // ago is not churning.
+        const val WINDOW_MS = 10 * 60_000L
+
+        private val INTERVALS_MS = longArrayOf(15_000L, 30_000L, 60_000L, 120_000L)
+
+        private const val MAX_HISTORY = 8
+
+        /** Interval owed after [signsInWindow] signatures for the same relay+identity. */
+        fun requiredIntervalMs(signsInWindow: Int): Long = when {
+            signsInWindow <= 0 -> 0L
+            else -> INTERVALS_MS[(signsInWindow - 1).coerceAtMost(INTERVALS_MS.lastIndex)]
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -1092,7 +1092,7 @@ class GroupManager(
                 muxTracker.clearRelay(url)
                 val probeClient = client
                 if (probeClient != null && (probeClient.inboundSilenceMs(nowMs) ?: 0L) > MUX_OPEN_REARM_MS) {
-                    scope.launch { probeClient.probeLiveness() }
+                    scope.launch { RelayProbeGuard.probe(probeClient) }
                 }
             }
 
@@ -1331,11 +1331,12 @@ class GroupManager(
                     // A zombie socket eats the re-sent REQ silently and update()
                     // re-arms the staleness clock, deferring detection forever. When
                     // the socket itself has been frame-silent for the whole window,
-                    // verify it: probeLiveness marks it dead if nothing answers, and
-                    // onConnectionLost drives reconnect + resubscribe + pending flush.
+                    // verify it: the guard marks it dead once the probes go
+                    // unanswered, and onConnectionLost drives reconnect +
+                    // resubscribe + pending flush.
                     val client = connectionManager.getClientForRelay(relayUrl)
                     if (client != null && (client.inboundSilenceMs(now) ?: 0L) > MUX_STALE_REARM_MS) {
-                        scope.launch { client.probeLiveness() }
+                        scope.launch { RelayProbeGuard.probe(client) }
                     }
                 }
                 refreshMuxSubscriptionsForRelay(relayUrl)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/OutboxManager.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.outbox.Kind10009Baseline
@@ -54,9 +53,6 @@ class OutboxManager(
          * with an empty one, and a replaceable event leaves nothing to recover from.
          */
         const val BASELINE_WAIT_MS = 7_000L
-
-        /** Cap on one private-section decrypt: a bunker signer may be slow, offline, or refuse. */
-        const val PRIVATE_DECRYPT_TIMEOUT_MS = 20_000L
 
         /** How long a failed decrypt is remembered before the next event may try again. */
         const val PRIVATE_DECRYPT_RETRY_MS = 60_000L
@@ -256,6 +252,12 @@ class OutboxManager(
             } catch (_: Exception) {
                 Kind10009Baseline.EMPTY
             }
+        // The section this account already read, when the relays still hold that version: the
+        // signer is not asked again for a ciphertext whose plaintext is on disk.
+        val alreadyRead = kind10009Baseline.readablePrivateTags
+        privateTags = alreadyRead.orEmpty()
+        privateDecryptedFrom = if (alreadyRead != null) kind10009Baseline.content else ""
+        if (alreadyRead != null) _privateSectionOpaque.value = false
         // Which groups are private has to be known before the first publish of the session, not
         // only after a successful decrypt.
         _privateGroupEntries.value =
@@ -486,15 +488,15 @@ class OutboxManager(
             _privateSectionOpaque.value = true
             return emptyList()
         }
+        // No deadline here: [decryptPrivate] owns it, because only the caller knows whether
+        // the signer answers on its own or is waiting on the user at a dialog.
         val plaintext =
-            withTimeoutOrNull(PRIVATE_DECRYPT_TIMEOUT_MS) {
-                try {
-                    decryptPrivate(content)
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (_: Throwable) {
-                    null
-                }
+            try {
+                decryptPrivate(content)
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
+            } catch (_: Throwable) {
+                null
             }
         val decoded = plaintext?.let { Nip51.decodeTags(it) }
         if (decoded == null) {
@@ -545,8 +547,14 @@ class OutboxManager(
         privateTags = newPrivateTags
         privateDecryptedFrom = ciphertext
         // Carry the new section, not the replaced one: a second publish before our own event
-        // comes back from the relays would otherwise undo the change.
-        val updated = baseline.copy(content = ciphertext)
+        // comes back from the relays would otherwise undo the change. The plaintext rides
+        // along: this client wrote the ciphertext, so its own event never needs a decrypt.
+        val updated =
+            baseline.copy(
+                content = ciphertext,
+                privateTags = newPrivateTags,
+                privateDecryptedFrom = ciphertext,
+            )
         groupsMutex.withLock { kind10009Baseline = updated }
         try {
             SecureStorage.saveKind10009BaselineFor(pubKey, updated)
@@ -865,12 +873,19 @@ class OutboxManager(
         if (!supersededByNewerSeen && !_privateSectionOpaque.value) {
             _privateGroupEntries.value = privateEntries - publicEntries
             _privateOnlyRelays.value = privateRelays - publicRelays
+            val readTags = privateTags
+            val readFrom = privateDecryptedFrom
             val withPrivate =
                 groupsMutex.withLock {
                     kind10009Baseline =
                         kind10009Baseline.copy(
                             privateEntries = _privateGroupEntries.value.map { (relay, id) -> listOf(relay, id) },
                             privateOnlyRelays = _privateOnlyRelays.value.toList(),
+                            // Stamped with the ciphertext it came from, so a session that
+                            // finds a newer version on the relays asks the signer instead of
+                            // trusting the plaintext of the one it replaced.
+                            privateTags = readTags,
+                            privateDecryptedFrom = readFrom,
                         )
                     kind10009Baseline
                 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayProbeGuard.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayProbeGuard.kt
@@ -1,0 +1,78 @@
+package org.nostr.nostrord.network.managers
+
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.utils.epochMillis
+
+/**
+ * Runs liveness probes under [RelayProbePolicy], keeping the evidence per RELAY rather than per
+ * socket.
+ *
+ * Per-socket state is what made the probe loop: every counter died with the socket it was about to
+ * convict, so each replacement started innocent and was killed on its first silence, forever. The
+ * tallies here outlive the socket, so a relay that never answers a probe is recognized as such.
+ */
+object RelayProbeGuard {
+    private val consecutiveMisses = mutableMapOf<String, Int>()
+    private val killStreak = mutableMapOf<String, Int>()
+    private val mutedUntilMs = mutableMapOf<String, Long>()
+
+    /** Probe [client] and tear it down only once the misses add up. Safe to call concurrently. */
+    suspend fun probe(client: NostrGroupClient) {
+        val url = client.getRelayUrl()
+        val now = epochMillis()
+        if ((mutedUntilMs[url] ?: 0L) > now) return
+        if (client.probeLiveness()) {
+            consecutiveMisses.remove(url)
+            killStreak.remove(url)
+            return
+        }
+        val misses = (consecutiveMisses[url] ?: 0) + 1
+        if (!RelayProbePolicy.killsSocket(misses)) {
+            consecutiveMisses[url] = misses
+            return
+        }
+        consecutiveMisses.remove(url)
+        val kills = (killStreak[url] ?: 0) + 1
+        killStreak[url] = kills
+        // Mute BEFORE the kill: the reconnect it triggers goes silent the same way, and probing
+        // the replacement is the loop this exists to stop.
+        if (RelayProbePolicy.mutesProbe(kills)) {
+            mutedUntilMs[url] = now + RelayProbePolicy.MUTE_MS
+            killStreak.remove(url)
+            return
+        }
+        client.markDead()
+    }
+
+    /**
+     * A publish got no OK and no frame of any kind while it waited. Returns true once that has
+     * happened enough times in a row on [relayUrl] to call the socket dead.
+     *
+     * Same reasoning as the probe: a relay that rate-limits a publish answers late, not never, and
+     * one late OK is not a zombie. The count is per relay so it survives the socket it judges.
+     */
+    fun onPublishTimeout(relayUrl: String): Boolean {
+        val misses = (publishMisses[relayUrl] ?: 0) + 1
+        if (!RelayProbePolicy.killsSocket(misses)) {
+            publishMisses[relayUrl] = misses
+            return false
+        }
+        publishMisses.remove(relayUrl)
+        return true
+    }
+
+    /** A publish came back: whatever the relay was doing, the socket carries traffic. */
+    fun onPublishAnswered(relayUrl: String) {
+        publishMisses.remove(relayUrl)
+    }
+
+    /** Drop all evidence (logout, account switch): a new session gets a clean read of the relays. */
+    fun reset() {
+        consecutiveMisses.clear()
+        killStreak.clear()
+        mutedUntilMs.clear()
+        publishMisses.clear()
+    }
+
+    private val publishMisses = mutableMapOf<String, Int>()
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayProbePolicy.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/RelayProbePolicy.kt
@@ -1,0 +1,38 @@
+package org.nostr.nostrord.network.managers
+
+/**
+ * When an unanswered liveness probe means the socket is dead.
+ *
+ * The probe sends a REQ no relay can match and waits for any frame back. Silence is evidence, not
+ * proof: a relay under its own rate limit drops the REQ, and a busy client can leave the answer
+ * unread past the deadline. Tearing the socket down on the first silence turns either into a loop
+ * (kill, reconnect, probe, kill) that costs a handshake a minute per relay and proves nothing,
+ * because the replacement socket behaves exactly like the one before it.
+ */
+object RelayProbePolicy {
+    /**
+     * Unanswered probes in a row before the socket is torn down.
+     *
+     * Two probes are ~10s apart at worst, so a real zombie is still caught in the same window the
+     * reconnect scheduler works in, while a single dropped REQ costs nothing.
+     */
+    const val MISSES_BEFORE_KILL = 2
+
+    /**
+     * Probe kills in a row on one relay, with no probe ever answered in between, before probing it
+     * is muted.
+     *
+     * A kill is a hypothesis: this socket is dead, a new one will work. When the new socket goes
+     * just as silent, the hypothesis is wrong - the relay does not answer our probe at all - and
+     * killing it again only churns connections. Stop asking and let the relay's own traffic (or a
+     * real close) speak instead.
+     */
+    const val KILLS_BEFORE_MUTE = 2
+
+    /** How long a relay that proved probe-blind is left alone. */
+    const val MUTE_MS = 30 * 60 * 1000L
+
+    fun killsSocket(consecutiveMisses: Int): Boolean = consecutiveMisses >= MISSES_BEFORE_KILL
+
+    fun mutesProbe(killStreak: Int): Boolean = killStreak >= KILLS_BEFORE_MUTE
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/SessionManager.kt
@@ -1,6 +1,8 @@
 package org.nostr.nostrord.network.managers
 
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.auth.Account
 import org.nostr.nostrord.network.AuthManager
@@ -31,12 +33,30 @@ class SessionManager(
     // so the in-flight retry loop always signs the relay's current challenge.
     private val latestChallenge = mutableMapOf<NostrGroupClient, String>()
 
+    // Sockets whose AUTH the user declined at a signer dialog. A decline is an answer, so
+    // this socket stops asking: a chatty relay re-challenging in a loop would otherwise
+    // reopen the dialog for as long as the connection lives. Pruned by liveness rather than
+    // by an explicit close hook, which this class does not get.
+    private val authDeclined = mutableSetOf<NostrGroupClient>()
+
+    // One 22242 signature in flight per relay. The focused client and a pool client can hold
+    // the same relay, and a reconnect opens the next socket before the previous one is reaped:
+    // their challenges take turns at the signer instead of arriving together. Only the sign
+    // call is gated (not the retry loop, which lives as long as its socket), so a socket
+    // sharing a relay is delayed, never starved.
+    private val relayAuthGates = mutableMapOf<String, Mutex>()
+    private val relayAuthGatesLock = Mutex()
+
+    private suspend fun gateFor(relayUrl: String): Mutex = relayAuthGatesLock.withLock {
+        relayAuthGates.getOrPut(relayUrl) { Mutex() }
+    }
+
+    // Per relay+identity pacing of the signatures themselves. Applies to every login method:
+    // the signer is a shared, rate-limited resource whether it is an extension, a signer app
+    // or a remote bunker.
+    private val authThrottle = AuthSignThrottle()
+
     private companion object {
-        // Bounds ONE sign attempt (a healthy bunker answers in 1-4s; local keys are
-        // instant). Well under Nip46Client's own 120s request timeout so a stalled
-        // signer transport frees this socket's attempt quickly and the retry loop —
-        // not the relay's goodwill in re-challenging — owns recovery.
-        const val AUTH_SIGN_TIMEOUT_MS = 20_000L
         const val AUTH_RETRY_BASE_MS = 5_000L
         const val AUTH_RETRY_MAX_MS = 30_000L
     }
@@ -102,6 +122,7 @@ class SessionManager(
         // re-requests group messages.
         authInProgress.clear()
         latestChallenge.clear()
+        authThrottle.clear()
         authManager.logout()
     }
 
@@ -186,6 +207,8 @@ class SessionManager(
     suspend fun handleAuthChallenge(client: NostrGroupClient, challenge: String): Boolean {
         val relayUrl = client.getRelayUrl()
         if (!client.isConnected()) return false // race-condition loser: already disconnected
+        authDeclined.removeAll { !it.isConnected() }
+        if (client in authDeclined) return false
         // Always record the newest challenge, even when this call loses the dedup below:
         // the in-flight loop reads it fresh on every attempt, so a relay that rotates
         // challenges never gets a stale one signed.
@@ -197,37 +220,59 @@ class SessionManager(
             return false
         }
 
+        val relayGate = gateFor(relayUrl)
+
         return try {
-            // Retry until the socket dies. One unbounded 120s bunker sign used to own the
-            // socket's ONLY attempt while the dedup above swallowed every re-challenge the
-            // relay sent (observed: 8 challenges ignored, zero AUTH frames, total deafness
-            // on a private relay when the signer transport was down). Each attempt now gets
-            // a bounded budget, and failures back off and retry — a deaf-but-connected
-            // socket has nothing better to do than keep trying to authenticate.
+            // Retry until the socket dies: the dedup above swallows every re-challenge the
+            // relay sends, so this loop - not the relay's goodwill - owns recovery (observed
+            // without it: 8 challenges ignored, zero AUTH frames, total deafness on a private
+            // relay while the signer transport was down). Attempts are sequential and paced,
+            // so a deaf-but-connected socket keeps trying without multiplying signer traffic.
             var attempt = 0
             while (client.isConnected()) {
                 attempt++
-                val authEvent = Event(
-                    pubkey = pubKey,
-                    createdAt = epochMillis() / 1000,
-                    kind = 22242,
-                    tags = listOf(
-                        listOf("relay", relayUrl),
-                        listOf("challenge", latestChallenge[client] ?: challenge),
-                    ),
-                    content = "",
-                )
 
-                // interactive=false: a failed background AUTH sign must not flip the
-                // bunker banner to "can't reach your signer". (banner-flicker fix)
-                val signedEvent = try {
-                    kotlinx.coroutines.withTimeoutOrNull(AUTH_SIGN_TIMEOUT_MS) {
+                val promptsUser =
+                    org.nostr.nostrord.auth.ActiveAccountManager.session.value?.signer?.promptsUser == true
+
+                val signedEvent = relayGate.withLock {
+                    // Pace repeats for this relay+identity, under the gate so a socket that
+                    // just waited its turn is measured against the signature that ran ahead
+                    // of it. The first signature is immediate; a relay that keeps dropping and
+                    // re-challenging waits progressively longer, so socket churn no longer
+                    // translates one-to-one into signer traffic.
+                    val wait = authThrottle.delayBeforeSignMs(relayUrl, pubKey, epochMillis())
+                    if (wait > 0) kotlinx.coroutines.delay(wait)
+                    if (!client.isConnected()) return false
+
+                    val authEvent = Event(
+                        pubkey = pubKey,
+                        createdAt = epochMillis() / 1000,
+                        kind = 22242,
+                        tags = listOf(
+                            listOf("relay", relayUrl),
+                            listOf("challenge", latestChallenge[client] ?: challenge),
+                        ),
+                        content = "",
+                    )
+
+                    // No deadline of our own, for any login method. Abandoning a request does
+                    // not recall it: a bunker still signs what it already received, and asking
+                    // again only adds a second request to the same queue. A prompting signer is
+                    // worse still - the dialog is on screen and a deadline just stacks another
+                    // behind it. Every signer path ends on its own (the NIP-46 client times a
+                    // request out at 120s) and the retry loop owns recovery from there.
+                    //
+                    // interactive=false: a failed background AUTH sign must not flip the
+                    // bunker banner to "can't reach your signer". (banner-flicker fix)
+                    authThrottle.recordSign(relayUrl, pubKey, epochMillis())
+                    try {
                         signEvent(authEvent, interactive = false)
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                        null // fail-fast throws (signer not connected yet) retry like failures
                     }
-                } catch (e: kotlinx.coroutines.CancellationException) {
-                    throw e
-                } catch (_: Throwable) {
-                    null // fail-fast throws (signer not connected yet) retry like timeouts
                 }
 
                 if (signedEvent != null) {
@@ -249,6 +294,13 @@ class SessionManager(
                     // fires when this client is the focused relay.
                     kotlinx.coroutines.delay(500)
                     return true
+                }
+
+                // The only way a prompting signer fails is that the user said no (or closed
+                // the dialog). Retrying reopens it, so the answer stands for this socket.
+                if (promptsUser) {
+                    authDeclined.add(client)
+                    return false
                 }
 
                 kotlinx.coroutines.delay(minOf(AUTH_RETRY_BASE_MS * (1L shl (attempt - 1)), AUTH_RETRY_MAX_MS))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/outbox/Kind10009Baseline.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/outbox/Kind10009Baseline.kt
@@ -22,6 +22,12 @@ import kotlinx.serialization.json.longOrNull
  * decrypt found inside [content]. They persist so a session that cannot read the section — a
  * bunker that is offline or refuses — still knows to keep those groups out of the public tags
  * instead of publishing them in the clear.
+ *
+ * [privateTags] is that decrypt's full output, including the tags this client does not model,
+ * and [privateDecryptedFrom] is the ciphertext it came from. Together they let a new session
+ * skip the decrypt when the relays still hold the same version: with a signer that asks the
+ * user, that decrypt is a dialog on every launch to re-read what is already on disk. They are
+ * trusted only while [privateDecryptedFrom] still equals [content].
  */
 @Serializable
 data class Kind10009Baseline(
@@ -30,7 +36,16 @@ data class Kind10009Baseline(
     val foreignTags: List<List<String>> = emptyList(),
     val privateEntries: List<List<String>> = emptyList(),
     val privateOnlyRelays: List<String> = emptyList(),
+    val privateTags: List<List<String>> = emptyList(),
+    val privateDecryptedFrom: String = "",
 ) {
+    /**
+     * The private tags this snapshot may be read for, or null when the signer has to be asked.
+     * A ciphertext that no longer matches [content] belongs to a version the relays replaced.
+     */
+    val readablePrivateTags: List<List<String>>?
+        get() = privateTags.takeIf { privateDecryptedFrom.isNotBlank() && privateDecryptedFrom == content }
+
     companion object {
         val EMPTY = Kind10009Baseline()
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/auth/SignerPromptsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/auth/SignerPromptsTest.kt
@@ -1,0 +1,145 @@
+package org.nostr.nostrord.auth
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class SelfDecryptCacheTest {
+    private val pubkey = "a".repeat(64)
+
+    @Test
+    fun `every relay copy of one list decrypts once`() = runTest {
+        val cache = SelfDecryptCache()
+        var prompts = 0
+        val gate = CompletableDeferred<Unit>()
+
+        // Five relays deliver the same replaceable event; all five reach the cache before
+        // the first decrypt resolves.
+        val copies = List(5) {
+            async {
+                cache.decrypt(pubkey, "cipher") {
+                    prompts++
+                    gate.await()
+                    "plain"
+                }
+            }
+        }
+        yield()
+        gate.complete(Unit)
+
+        assertEquals(List(5) { "plain" }, copies.awaitAll())
+        assertEquals(1, prompts)
+    }
+
+    @Test
+    fun `a later redelivery is answered from the cache`() = runTest {
+        val cache = SelfDecryptCache()
+        var prompts = 0
+        val read = suspend {
+            cache.decrypt(pubkey, "cipher") {
+                prompts++
+                "plain"
+            }
+        }
+
+        assertEquals("plain", read())
+        assertEquals("plain", read())
+        assertEquals(1, prompts)
+    }
+
+    @Test
+    fun `a refusal is not re-asked on the next redelivery`() = runTest {
+        val cache = SelfDecryptCache()
+        var prompts = 0
+        val read = suspend {
+            cache.decrypt(pubkey, "cipher") {
+                prompts++
+                throw NostrSigner.SigningException("user rejected")
+            }
+        }
+
+        assertNull(read())
+        assertNull(read())
+        assertNull(read())
+        assertEquals(1, prompts)
+    }
+
+    @Test
+    fun `a different ciphertext is a new decrypt`() = runTest {
+        val cache = SelfDecryptCache()
+        var prompts = 0
+        val read: suspend (String) -> String? = { ciphertext ->
+            cache.decrypt(pubkey, ciphertext) {
+                prompts++
+                "plain-$ciphertext"
+            }
+        }
+
+        assertEquals("plain-v1", read("v1"))
+        assertEquals("plain-v2", read("v2"))
+        assertEquals(2, prompts)
+    }
+
+    @Test
+    fun `clear drops another account's plaintext`() = runTest {
+        val cache = SelfDecryptCache()
+        var prompts = 0
+        val read = suspend {
+            cache.decrypt(pubkey, "cipher") {
+                prompts++
+                "plain"
+            }
+        }
+
+        read()
+        cache.clear()
+        read()
+        assertEquals(2, prompts)
+    }
+}
+
+class SignerPromptsTest {
+    @Test
+    fun `prompting signers never have two dialogs open at once`() = runTest {
+        var open = 0
+        var maxOpen = 0
+
+        List(8) {
+            async {
+                SignerPrompts.queued(promptsUser = true) {
+                    open++
+                    maxOpen = maxOf(maxOpen, open)
+                    yield()
+                    open--
+                }
+            }
+        }.awaitAll()
+
+        assertEquals(1, maxOpen)
+    }
+
+    @Test
+    fun `silent signers stay concurrent`() = runTest {
+        var open = 0
+        var maxOpen = 0
+
+        List(8) {
+            async {
+                SignerPrompts.queued(promptsUser = false) {
+                    open++
+                    maxOpen = maxOf(maxOpen, open)
+                    yield()
+                    open--
+                }
+            }
+        }.awaitAll()
+
+        assertTrue(maxOpen > 1, "a bunker backlog must not be serialized behind one request")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/AuthSignThrottleTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/AuthSignThrottleTest.kt
@@ -1,0 +1,77 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AuthSignThrottleTest {
+    private val relay = "wss://groups.example"
+    private val pubkey = "a".repeat(64)
+    private val other = "b".repeat(64)
+
+    @Test
+    fun firstAuthForRelayIsImmediate() = runTest {
+        val throttle = AuthSignThrottle()
+        assertEquals(0L, throttle.delayBeforeSignMs(relay, pubkey, nowMs = 1_000))
+    }
+
+    @Test
+    fun repeatWithinIntervalWaitsOutTheRemainder() = runTest {
+        val throttle = AuthSignThrottle()
+        throttle.recordSign(relay, pubkey, nowMs = 1_000)
+
+        assertEquals(15_000L, throttle.delayBeforeSignMs(relay, pubkey, nowMs = 1_000))
+        assertEquals(5_000L, throttle.delayBeforeSignMs(relay, pubkey, nowMs = 11_000))
+        assertEquals(0L, throttle.delayBeforeSignMs(relay, pubkey, nowMs = 16_000))
+    }
+
+    @Test
+    fun churningRelayBacksOffFurtherEachTime() = runTest {
+        val throttle = AuthSignThrottle()
+        var now = 0L
+        val waits = mutableListOf<Long>()
+        repeat(5) {
+            now += throttle.delayBeforeSignMs(relay, pubkey, now).also { waits += it }
+            throttle.recordSign(relay, pubkey, now)
+        }
+
+        assertEquals(listOf(0L, 15_000L, 30_000L, 60_000L, 120_000L), waits)
+    }
+
+    @Test
+    fun signaturesOlderThanTheWindowStopCounting() = runTest {
+        val throttle = AuthSignThrottle()
+        repeat(4) { throttle.recordSign(relay, pubkey, nowMs = it * 1_000L) }
+
+        val afterWindow = AuthSignThrottle.WINDOW_MS + 1_000
+        assertEquals(0L, throttle.delayBeforeSignMs(relay, pubkey, afterWindow))
+    }
+
+    @Test
+    fun pacingIsPerRelayAndPerIdentity() = runTest {
+        val throttle = AuthSignThrottle()
+        throttle.recordSign(relay, pubkey, nowMs = 1_000)
+
+        assertEquals(0L, throttle.delayBeforeSignMs("wss://other.example", pubkey, nowMs = 1_000))
+        // An account switch re-AUTHs every socket under the new pubkey; that burst is not
+        // the outgoing account's churn.
+        assertEquals(0L, throttle.delayBeforeSignMs(relay, other, nowMs = 1_000))
+    }
+
+    @Test
+    fun logoutClearsHistory() = runTest {
+        val throttle = AuthSignThrottle()
+        throttle.recordSign(relay, pubkey, nowMs = 1_000)
+        throttle.clear()
+
+        assertEquals(0L, throttle.delayBeforeSignMs(relay, pubkey, nowMs = 1_000))
+    }
+
+    @Test
+    fun intervalIsCappedForAPersistentlyChurningRelay() {
+        val cap = AuthSignThrottle.requiredIntervalMs(4)
+        assertEquals(cap, AuthSignThrottle.requiredIntervalMs(50))
+        assertTrue(cap > AuthSignThrottle.requiredIntervalMs(3))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/RelayProbePolicyTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/RelayProbePolicyTest.kt
@@ -1,0 +1,33 @@
+package org.nostr.nostrord.network.managers
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RelayProbePolicyTest {
+    @Test
+    fun `one unanswered probe is not enough to kill the socket`() {
+        assertFalse(RelayProbePolicy.killsSocket(1))
+    }
+
+    @Test
+    fun `repeated silence convicts the socket`() {
+        assertTrue(RelayProbePolicy.killsSocket(RelayProbePolicy.MISSES_BEFORE_KILL))
+        assertTrue(RelayProbePolicy.killsSocket(RelayProbePolicy.MISSES_BEFORE_KILL + 5))
+    }
+
+    @Test
+    fun `a relay is left alone once killing it stopped helping`() {
+        // One kill is a hypothesis worth testing, so probing continues.
+        assertFalse(RelayProbePolicy.mutesProbe(1))
+        // The replacement socket went silent the same way: the probe, not the socket, is wrong.
+        assertTrue(RelayProbePolicy.mutesProbe(RelayProbePolicy.KILLS_BEFORE_MUTE))
+    }
+
+    @Test
+    fun `the mute outlasts the reconnect cycle it exists to break`() {
+        // A killed socket reconnects in seconds and goes silent again within the probe window;
+        // a mute measured in minutes is what turns that loop back into a quiet connection.
+        assertTrue(RelayProbePolicy.MUTE_MS >= 10 * 60 * 1000L)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/outbox/Kind10009BaselineTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/outbox/Kind10009BaselineTest.kt
@@ -385,4 +385,59 @@ class Kind10009BaselineTest {
         assertTrue(outbox.currentKind10009Baseline().content.isEmpty(), "another account's content must never be republished as ours")
         scope.cancel()
     }
+
+    @Test
+    fun `a read private section is stamped with the ciphertext it came from`() = runTest {
+        val scope = TestScope(testScheduler)
+        val outbox = manager(scope)
+        val private = Nip51.encodeTags(listOf(listOf("group", "secret", "wss://relay.two")))
+
+        outbox.handleKind10009Event(
+            event(100, CIPHERTEXT, """[["group","abc","wss://relay.one"]]"""),
+            "wss://relay.one",
+            OWNER,
+            {},
+            decryptPrivate = { private },
+        )
+
+        // The next session reads this instead of opening a signer dialog for a ciphertext
+        // whose plaintext is already on disk.
+        val baseline = outbox.currentKind10009Baseline()
+        assertEquals(CIPHERTEXT, baseline.privateDecryptedFrom)
+        assertEquals(listOf(listOf("group", "secret", "wss://relay.two")), baseline.readablePrivateTags)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a section the signer refused is not stamped`() = runTest {
+        val scope = TestScope(testScheduler)
+        val outbox = manager(scope)
+
+        outbox.handleKind10009Event(
+            event(100, CIPHERTEXT, """[["group","abc","wss://relay.one"]]"""),
+            "wss://relay.one",
+            OWNER,
+            {},
+            decryptPrivate = { null },
+        )
+
+        assertEquals(null, outbox.currentKind10009Baseline().readablePrivateTags)
+        scope.cancel()
+    }
+
+    @Test
+    fun `a stamp from a replaced version is not trusted`() {
+        val read =
+            Kind10009Baseline(
+                content = CIPHERTEXT,
+                privateTags = listOf(listOf("group", "secret", "wss://relay.two")),
+                privateDecryptedFrom = CIPHERTEXT,
+            )
+        assertEquals(read.privateTags, read.readablePrivateTags)
+
+        // Another client republished the list: the plaintext on disk describes the section
+        // that version replaced, so the signer has to read the new one.
+        assertEquals(null, read.copy(content = "AhDifferentPayload==").readablePrivateTags)
+        assertEquals(null, read.copy(privateDecryptedFrom = "").readablePrivateTags)
+    }
 }

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.ios.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.SIGNER_DIAG_ROLE
 import org.nostr.nostrord.network.sendAndAwaitOkOrError
 import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
@@ -137,7 +138,7 @@ actual class Nip46Client actual constructor(
      * adding the result to [relayClients].
      */
     private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
-        val client = NostrGroupClient(relayUrl)
+        val client = NostrGroupClient(relayUrl, diagRole = SIGNER_DIAG_ROLE)
         client.connect { msg -> handleMessage(msg, client) }
         if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
             client.disconnect()

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.js.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.SIGNER_DIAG_ROLE
 import org.nostr.nostrord.network.sendAndAwaitOkOrError
 import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
@@ -109,7 +110,7 @@ actual class Nip46Client actual constructor(
      * adding the result to [relayClients].
      */
     private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
-        val client = NostrGroupClient(relayUrl)
+        val client = NostrGroupClient(relayUrl, diagRole = SIGNER_DIAG_ROLE)
         client.connect { msg -> handleMessage(msg, client) }
         if (!client.waitForConnection(NOSTRCONNECT_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
             client.disconnect()

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/nostr/Nip46Client.jvm.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.PublishResult
+import org.nostr.nostrord.network.SIGNER_DIAG_ROLE
 import org.nostr.nostrord.network.sendAndAwaitOkOrError
 import org.nostr.nostrord.network.summarizeFailures
 import org.nostr.nostrord.utils.epochMillis
@@ -113,7 +114,7 @@ actual class Nip46Client actual constructor(
      * adding the result to [relayClients].
      */
     private suspend fun openRelay(relayUrl: String): NostrGroupClient? = try {
-        val client = NostrGroupClient(relayUrl)
+        val client = NostrGroupClient(relayUrl, diagRole = SIGNER_DIAG_ROLE)
         client.connect { msg -> handleMessage(msg, client) }
         if (!client.waitForConnection(SIGNER_RELAY_CONNECT_TIMEOUT_MS) || !openResponseSubscription(client)) {
             client.disconnect()


### PR DESCRIPTION
Fixes #263.

Nostrord was killing and rebuilding healthy sockets in a loop, and every rebuilt socket costs a NIP-42 AUTH signature - which is what made long-lived sessions pester the signer (extension dialogs, bunker round-trips) all day. On an instrumented run one relay was killed 46 times in 44 minutes by our own probe. On top of that, the self-encrypted lists decrypted every relay's copy of every version on cold start, each one a signer prompt.

| Cause | Fix |
|---|---|
| Idle probe killed a socket on its first 5s silence, and the evidence died with the socket, so each replacement died on its first probe forever | `RelayProbeGuard`/`RelayProbePolicy`: conviction kept per relay - 2 misses to kill, 2 kills to mute the probe for 30min; `probeLiveness` no longer self-kills |
| One slow publish tore the socket down | Publish-timeout kill also needs 2 strikes per relay; NIP-46 signer sockets are never killed by a slow publish (they carry the response subscription) |
| AUTH re-signs unbounded, dialogs stacking | `AuthSignThrottle` per relay+account, sticky decline per socket, and no sign deadline for prompting signers - a timeout+retry against a human only queues a second dialog behind the open one |
| kind:10000/10009/30078 decrypted once per version per relay on cold start | `SelfDecryptCache` (one decrypt per distinct ciphertext) + 1.5s settle window with a synchronous newest-seen floor; kind:10009 persists decrypted private tags across relaunches |

Validated on device runs: kind:22242 signs flat at one per relay over 38 minutes (previously dozens), probe kill loop gone.

- c5786a33 fix(auth): stop the connection churn and repeated kind:22242 signing prompts