### PR TITLE
Treat a group id as unique only within its relay

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -308,7 +308,7 @@ object AppModule {
         // Settled while we waited (create/join bookkeeping claimed its own echo, or the
         // user already decided): a notification for it would be noise.
         if (add.groupId !in groupManager.pendingGroupInvites.value) return
-        val groupName = groupDisplayName(add.groupId)
+        val groupName = groupDisplayName(add.relayUrl, add.groupId)
         notificationHistoryStore.add(
             NotificationEntry(
                 id = add.eventId ?: "gadd_${add.groupId}",
@@ -385,10 +385,10 @@ object AppModule {
             // groupManager.isGroupJoined() is scoped to the active primary relay —
             // wrong for our purpose: we need cross-relay membership so notifications
             // fire for joined groups on background relays too. Scan all relay buckets.
-            isJoined = { groupId ->
-                groupManager.joinedGroupsByRelay.value.values.any { groupId in it }
+            isJoined = { relayUrl, groupId ->
+                groupManager.joinedGroupsByRelay.value[relayUrl].orEmpty().contains(groupId)
             },
-            isRestricted = { groupId -> groupManager.restrictedGroups.value.containsKey(groupId) },
+            isRestricted = { _, groupId -> groupManager.restrictedGroups.value.containsKey(groupId) },
             isAppFocused = { focusTracker.isAppFocused.value },
             findMessageAuthor = { messageId ->
                 groupManager.findMessageByIdAcrossGroups(messageId)?.second?.pubkey
@@ -396,19 +396,17 @@ object AppModule {
             // Deferred to call time: by the first message flush the repository exists,
             // so this lazy access never cycles with unreadManager's own construction.
             isMutedAuthor = { pubkey -> pubkey in nostrRepository.mutedPubkeys.value },
-            shouldNotify = { groupId, isDirect ->
+            shouldNotify = { _, groupId, isDirect ->
                 notificationSettings.shouldNotify(
                     notificationSettings.effectiveLevelFor(groupId),
                     isDirect,
                 )
             },
-            onUnreadIncrement = { groupId, message, _ ->
+            onUnreadIncrement = { relayUrl, groupId, message, _ ->
                 val selfPubkey = sessionManager.getPublicKey()
                 if (selfPubkey == null || message.pubkey != selfPubkey) {
-                    val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
-                        ?: groupManager.getRelayForGroup(groupId) ?: ""
                     val preview = notificationPreview(message.content)
-                    val groupName = groupDisplayName(groupId)
+                    val groupName = groupDisplayName(relayUrl, groupId)
                     val relayName = relayDisplayName(relayUrl)
                     notificationHistoryStore.add(
                         NotificationEntry(
@@ -453,11 +451,9 @@ object AppModule {
                     }
                 }
             },
-            onReplyNotify = { groupId, message ->
-                val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
-                    ?: groupManager.getRelayForGroup(groupId) ?: ""
+            onReplyNotify = { relayUrl, groupId, message ->
                 val preview = notificationPreview(message.content)
-                val groupName = groupDisplayName(groupId)
+                val groupName = groupDisplayName(relayUrl, groupId)
                 val relayName = relayDisplayName(relayUrl)
                 notificationHistoryStore.add(
                     NotificationEntry(
@@ -495,11 +491,9 @@ object AppModule {
                     )
                 }
             },
-            onThreadReplyNotify = { groupId, reply ->
-                val relayUrl = reply.relayUrl
-                    ?: groupManager.getRelayForGroup(groupId) ?: ""
+            onThreadReplyNotify = { relayUrl, groupId, reply ->
                 val preview = notificationPreview(reply.content)
-                val groupName = groupDisplayName(groupId)
+                val groupName = groupDisplayName(relayUrl, groupId)
                 val relayName = relayDisplayName(relayUrl)
                 // The E tag is the thread root; without it the entry would open the chat, where a
                 // kind:1111 does not exist. Falls back to the reply itself so the pane still opens.
@@ -541,11 +535,9 @@ object AppModule {
                     )
                 }
             },
-            onMentionNotify = { groupId, message ->
-                val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
-                    ?: groupManager.getRelayForGroup(groupId) ?: ""
+            onMentionNotify = { relayUrl, groupId, message ->
                 val preview = notificationPreview(message.content)
-                val groupName = groupDisplayName(groupId)
+                val groupName = groupDisplayName(relayUrl, groupId)
                 val relayName = relayDisplayName(relayUrl)
                 notificationHistoryStore.add(
                     NotificationEntry(
@@ -583,13 +575,11 @@ object AppModule {
                     )
                 }
             },
-            onReactionNotify = { groupId, reaction ->
+            onReactionNotify = { relayUrl, groupId, reaction ->
                 val selfPubkey = sessionManager.getPublicKey()
                 if (selfPubkey == null || reaction.pubkey != selfPubkey) {
-                    val relayUrl = groupManager.getLatestMessageRelayForGroup(groupId)
-                        ?: groupManager.getRelayForGroup(groupId) ?: ""
                     val emoji = reaction.emoji.ifBlank { "+" }
-                    val groupName = groupDisplayName(groupId)
+                    val groupName = groupDisplayName(relayUrl, groupId)
                     val relayName = relayDisplayName(relayUrl)
                     notificationHistoryStore.add(
                         NotificationEntry(
@@ -637,7 +627,7 @@ object AppModule {
             },
             // Drop a group's notifications from the feed the moment its unread
             // badge is cleared, so opening/reading a chat clears both (issue #67).
-            onGroupRead = { groupId -> notificationHistoryStore.markReadForGroup(groupId) },
+            onGroupRead = { relayUrl, groupId -> notificationHistoryStore.markReadForGroup(relayUrl, groupId) },
             scope = appScope,
         )
     }
@@ -785,12 +775,15 @@ object AppModule {
      * the truncated id. Joined-group metadata is also restored from
      * [SecureStorage] at startup, so cached entries survive cold launches.
      */
-    private fun groupDisplayName(groupId: String): String {
-        val name = groupManager.groupsByRelay.value.values
-            .firstNotNullOfOrNull { list ->
-                list.firstOrNull { it.id == groupId }?.name?.takeIf { it.isNotBlank() }
-            }
-        return name ?: groupId.take(8)
+    private fun groupDisplayName(
+        relayUrl: String,
+        groupId: String,
+    ): String {
+        val byRelay = groupManager.groupsByRelay.value
+        val host = relayUrl.normalizeRelayUrl()
+        val onHost = (byRelay[host] ?: byRelay.entries.firstOrNull { it.key.normalizeRelayUrl() == host }?.value)
+            ?.firstOrNull { it.id == groupId }?.name?.takeIf { it.isNotBlank() }
+        return onHost ?: groupId.take(8)
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -51,6 +51,7 @@ import org.nostr.nostrord.storage.cache.CacheStore
 import org.nostr.nostrord.storage.cache.createCacheStore
 import org.nostr.nostrord.ui.text.flattenMarkdownForPreview
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
@@ -388,7 +389,7 @@ object AppModule {
             isJoined = { relayUrl, groupId ->
                 groupManager.joinedGroupsByRelay.value[relayUrl].orEmpty().contains(groupId)
             },
-            isRestricted = { _, groupId -> groupManager.restrictedGroups.value.containsKey(groupId) },
+            isRestricted = { relayUrl, groupId -> groupKey(relayUrl, groupId) in groupManager.restrictedGroups.value },
             isAppFocused = { focusTracker.isAppFocused.value },
             findMessageAuthor = { messageId ->
                 groupManager.findMessageByIdAcrossGroups(messageId)?.second?.pubkey

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -118,6 +118,7 @@ import org.nostr.nostrord.ui.screens.dm.eventJson
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.urlDecode
 import kotlin.concurrent.Volatile
@@ -571,7 +572,7 @@ class NostrRepository(
     override val userRelayList: StateFlow<List<Nip65Relay>> = outboxManager.userRelayList
 
     // Expose unread state
-    override val unreadCounts: StateFlow<Map<String, Int>> = unreadManager.unreadCounts
+    override val unreadByGroupKey: StateFlow<Map<String, Int>> = unreadManager.unreadByGroupKey
     override val latestMessageTimestamps: StateFlow<Map<String, Long>> = unreadManager.latestMessageTimestamps
 
     // Filtered to relays the UI can actually show (rail's source list:
@@ -580,7 +581,7 @@ class NostrRepository(
     // counter ("(2) Nostrord" with no visible badge anywhere).
     override val unreadByRelay: StateFlow<Map<String, Int>> = combine(
         groupManager.joinedGroupsByRelay,
-        unreadManager.unreadCounts,
+        unreadManager.unreadByGroupKey,
         outboxManager.kind10009Relays,
         outboxManager.groupTagRelays,
         connectionManager.currentRelayUrl,
@@ -591,7 +592,7 @@ class NostrRepository(
             .toSet()
         joined
             .filterKeys { it in visible }
-            .mapValues { (_, ids) -> ids.sumOf { counts[it] ?: 0 } }
+            .mapValues { (relay, ids) -> ids.sumOf { counts[groupKey(relay, it)] ?: 0 } }
             .filterValues { it > 0 }
     }.stateIn(scope, SharingStarted.Eagerly, emptyMap())
     override val totalUnread: StateFlow<Int> = unreadByRelay
@@ -3647,12 +3648,16 @@ class NostrRepository(
      * so reconnect attempts for it use faster (500 ms base) backoff.
      * Pass null when the user leaves the group screen to revert to BACKGROUND priority.
      */
-    override fun setActiveGroup(groupId: String?) {
-        activeRelayUrl = if (groupId != null) groupManager.getRelayForGroup(groupId) else null
+    override fun setActiveGroup(
+        relayUrl: String?,
+        groupId: String?,
+    ) {
+        activeRelayUrl = relayUrl?.normalizeRelayUrl()
+            ?: groupId?.let { groupManager.getRelayForGroup(it) }
         // Update mux subscriptions to scope chat/reactions to the active group only.
         groupManager.setActiveGroupId(groupId)
         // Suppress unread-counter bumps for the group currently on screen.
-        unreadManager.setActiveGroup(groupId)
+        unreadManager.setActiveGroup(activeRelayUrl, groupId)
     }
 
     /**
@@ -4398,8 +4403,12 @@ class NostrRepository(
     }
 
     override suspend fun fetchGroupPreview(groupId: String, relayUrl: String) {
-        // Already have metadata for this group — skip
-        val existing = groupManager.groupsByRelay.value.values.flatten().find { it.id == groupId }
+        // Skip only when THIS relay's copy is already named. A same-id group on another relay is a
+        // different group, and treating it as a hit left the requested one permanently nameless.
+        val host = relayUrl.normalizeRelayUrl()
+        val existing = groupManager.groupsByRelay.value
+            .entries.firstOrNull { it.key.normalizeRelayUrl() == host }?.value
+            ?.find { it.id == groupId }
         if (existing?.name != null) return
 
         try {
@@ -4825,17 +4834,17 @@ class NostrRepository(
     ) = groupManager.setGroupRelayHint(groupId, relayUrl)
 
     // Unread message operations
-    override fun markGroupAsRead(groupId: String) {
-        unreadManager.markAsRead(groupId)
+    override fun markGroupAsRead(relayUrl: String, groupId: String) {
+        unreadManager.markAsRead(relayUrl, groupId)
     }
 
-    override fun markGroupAsReadUpTo(groupId: String, timestamp: Long) {
-        unreadManager.markAsReadUpTo(groupId, timestamp)
+    override fun markGroupAsReadUpTo(relayUrl: String, groupId: String, timestamp: Long) {
+        unreadManager.markAsReadUpTo(relayUrl, groupId, timestamp)
     }
 
-    override fun getUnreadCount(groupId: String): Int = unreadManager.getUnreadCount(groupId)
+    override fun getUnreadCount(relayUrl: String, groupId: String): Int = unreadManager.getUnreadCount(relayUrl, groupId)
 
-    override fun getLastReadTimestamp(groupId: String): Long? = unreadManager.getLastReadTimestamp(groupId)
+    override fun getLastReadTimestamp(relayUrl: String, groupId: String): Long? = unreadManager.getLastReadTimestamp(relayUrl, groupId)
 
     // Metadata operations
     private val metadataMessageHandler: (String, NostrGroupClient) -> Unit = { msg, client ->
@@ -6400,7 +6409,7 @@ class NostrRepository(
                                         ?.second?.pubkey == currentPubkey
                             }
                             if (isForSelf && groupId != null) {
-                                unreadManager.onReactionReceived(groupId, reaction)
+                                unreadManager.onReactionReceived(client.getRelayUrl(), groupId, reaction)
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -3708,7 +3708,7 @@ class NostrRepository(
      */
     private fun knownGroupIdsForRelay(relayUrl: String): List<String> {
         val normalized = relayUrl.normalizeRelayUrl()
-        val restricted = groupManager.restrictedGroups.value.keys
+        val restricted = groupManager.restrictedGroups.value
         val ids = LinkedHashSet<String>()
         groupManager.joinedGroupsByRelay.value[normalized].orEmpty().forEach { ids.add(it) }
         val lists = _userGroupLists.value
@@ -3724,7 +3724,7 @@ class NostrRepository(
         // converge one level per round.
         val metaById = groupManager.groupsByRelay.value[normalized].orEmpty().associateBy { it.id }
         ids.toList().forEach { id -> metaById[id]?.children?.forEach { ids.add(it) } }
-        return ids.filter { it !in restricted }
+        return ids.filter { groupKey(normalized, it) !in restricted }
     }
 
     // Group ids already requested (targeted #d) per normalized relay this session, so the
@@ -4652,8 +4652,11 @@ class NostrRepository(
             signEvent = { sessionManager.signEvent(it) },
         )
         if (notifyViaDm && result is Result.Success && targetPubkey != pubKey) {
+            // Resolve the relay on the ADD path, where the group is unambiguous: the invite naddr
+            // must address the relay the user was actually added on, not a same-id group elsewhere.
+            val inviteRelay = groupManager.getRelayForGroup(groupId) ?: connectionManager.currentRelayUrl.value
             // Fire-and-forget: the DM is a courtesy reach-out; its failure must not fail the add.
-            scope.launch { sendGroupAddedDm(groupId, targetPubkey) }
+            scope.launch { sendGroupAddedDm(inviteRelay, groupId, targetPubkey) }
         }
         return result
     }
@@ -4664,10 +4667,8 @@ class NostrRepository(
      * connect to the group's NIP-29 relay (the put-user #p watch can't). The naddr sits on
      * its own line so clients that card-preview group links render the invite card.
      */
-    private suspend fun sendGroupAddedDm(groupId: String, targetPubkey: String) {
+    private suspend fun sendGroupAddedDm(relayUrl: String, groupId: String, targetPubkey: String) {
         try {
-            val relayUrl = groupManager.getRelayForGroup(groupId)
-                ?: connectionManager.currentRelayUrl.value
             val relayPubkey = (relayMetadata.value[relayUrl] ?: relayMetadata.value[relayUrl.normalizeRelayUrl()])
                 ?.groupNaddrAuthor
             val naddr = Nip19.encodeNaddr(identifier = groupId, relay = relayUrl, kind = 39000, pubkeyHex = relayPubkey)
@@ -6218,7 +6219,7 @@ class NostrRepository(
                         val groupId = groupManager.getGroupIdByPrefix(prefix)
                             ?: groupManager.activeGroupId?.takeIf { it.startsWith(prefix) }
                         if (groupId != null) {
-                            groupManager.markGroupRestricted(groupId, reason)
+                            groupManager.markGroupRestricted(client.getRelayUrl(), groupId, reason)
                         }
                     }
                 }
@@ -6798,7 +6799,7 @@ class NostrRepository(
         // "Private group" placeholder. If the relay still denies a group post-AUTH, the fresh
         // CLOSED re-marks it.
         for (groupId in groupIds) {
-            groupManager.clearGroupRestricted(groupId)
+            groupManager.clearGroupRestricted(relayUrl, groupId)
         }
         // Re-request history ONLY for the empty groups (see needHistory above). An already
         // -loaded group keeps its messages + pagination state; requesting it here would reset

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -176,7 +176,9 @@ interface NostrRepositoryApi {
     // --- Metadata state ---
     val userMetadata: StateFlow<Map<String, UserMetadata>>
     val cachedEvents: StateFlow<Map<String, CachedEvent>>
-    val unreadCounts: StateFlow<Map<String, Int>>
+
+    /** Unread chat counts keyed by [org.nostr.nostrord.utils.groupKey], never by bare group id. */
+    val unreadByGroupKey: StateFlow<Map<String, Int>>
 
     // --- Direct messages (NIP-17) ---
     /** Conversations (most-recent first), derived from decrypted NIP-17 messages. */
@@ -454,7 +456,10 @@ interface NostrRepositoryApi {
      * The relay that hosts [groupId] is promoted to [RelayReconnectScheduler.Priority.ACTIVE]
      * so reconnect attempts for it use faster backoff. Pass null when leaving the group screen.
      */
-    fun setActiveGroup(groupId: String?)
+    fun setActiveGroup(
+        relayUrl: String?,
+        groupId: String?,
+    )
 
     // --- Group operations ---
     suspend fun createGroup(
@@ -796,14 +801,27 @@ interface NostrRepositoryApi {
         relayUrl: String,
     )
 
-    fun markGroupAsRead(groupId: String)
+    fun markGroupAsRead(
+        relayUrl: String,
+        groupId: String,
+    )
 
     /** Advance the last-read timestamp for partial-read tracking. See UnreadManager.markAsReadUpTo. */
-    fun markGroupAsReadUpTo(groupId: String, timestamp: Long)
+    fun markGroupAsReadUpTo(
+        relayUrl: String,
+        groupId: String,
+        timestamp: Long,
+    )
 
-    fun getUnreadCount(groupId: String): Int
+    fun getUnreadCount(
+        relayUrl: String,
+        groupId: String,
+    ): Int
 
-    fun getLastReadTimestamp(groupId: String): Long?
+    fun getLastReadTimestamp(
+        relayUrl: String,
+        groupId: String,
+    ): Long?
 
     // --- Metadata operations ---
     // [forceStale] re-fetches entries already cached but older than the staleness window

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -69,6 +69,9 @@ import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochMillis
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.groupKey
+import org.nostr.nostrord.utils.groupKeyId
+import org.nostr.nostrord.utils.groupKeyRelay
 import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import kotlin.coroutines.cancellation.CancellationException
@@ -618,9 +621,10 @@ class GroupManager(
         }
     }
 
-    // Groups whose subscriptions were closed with "restricted" by the relay.
-    // For private groups, the relay denies access to non-members (including metadata).
-    // The UI uses this to show a "Private Group" placeholder with invite code input.
+    // Groups whose subscriptions were closed with "restricted" by the relay, keyed by
+    // [groupKey] -> reason. For private groups the relay denies access to non-members
+    // (including metadata); the UI shows a "Private Group" placeholder with invite input.
+    // Access is granted per relay, so a denial here never gates the same id elsewhere.
     private val _restrictedGroups = MutableStateFlow<Map<String, String>>(emptyMap())
     val restrictedGroups: StateFlow<Map<String, String>> = _restrictedGroups.asStateFlow()
 
@@ -804,33 +808,41 @@ class GroupManager(
      * relay would keep CLOSE-ing the whole mux whenever this group is in it,
      * starving the other joined groups of metadata/delete updates.
      */
-    fun markGroupRestricted(groupId: String, reason: String) {
-        val wasAlreadyRestricted = groupId in _restrictedGroups.value
-        _restrictedGroups.update { it + (groupId to reason) }
+    fun markGroupRestricted(relayUrl: String, groupId: String, reason: String) {
+        val host = relayUrl.normalizeRelayUrl()
+        val key = groupKey(host, groupId)
+        val wasAlreadyRestricted = key in _restrictedGroups.value
+        _restrictedGroups.update { it + (key to reason) }
         if (!wasAlreadyRestricted) {
-            val relayUrl = getRelayForGroup(groupId)
-            if (relayUrl != null) {
-                currentPubkey?.let { pk ->
-                    try {
-                        SecureStorage.addRestrictedGroupForRelay(pk, relayUrl, groupId, reason, epochSeconds())
-                    } catch (_: Exception) {}
-                }
-                refreshMuxDebounced(relayUrl)
+            currentPubkey?.let { pk ->
+                try {
+                    SecureStorage.addRestrictedGroupForRelay(pk, host, groupId, reason, epochSeconds())
+                } catch (_: Exception) {}
             }
+            refreshMuxDebounced(host)
         }
     }
 
     /**
      * Clear restricted status for a group (e.g. after successful join).
+     *
+     * A null [relayUrl] clears the marker on every relay serving [groupId]; use it only where
+     * the origin is genuinely unknown, since access is per relay.
      */
-    fun clearGroupRestricted(groupId: String) {
-        if (groupId !in _restrictedGroups.value) return
-        _restrictedGroups.update { it - groupId }
-        val relayUrl = getRelayForGroup(groupId)
-        if (relayUrl != null) {
-            currentPubkey?.let { pk ->
+    fun clearGroupRestricted(relayUrl: String?, groupId: String) {
+        val relays =
+            if (relayUrl != null) {
+                listOf(relayUrl.normalizeRelayUrl())
+            } else {
+                _restrictedGroups.value.keys.filter { groupKeyId(it) == groupId }.map { groupKeyRelay(it) }
+            }
+        val keys = relays.map { groupKey(it, groupId) }.filter { it in _restrictedGroups.value }
+        if (keys.isEmpty()) return
+        _restrictedGroups.update { it - keys.toSet() }
+        currentPubkey?.let { pk ->
+            keys.forEach { key ->
                 try {
-                    SecureStorage.removeRestrictedGroupForRelay(pk, relayUrl, groupId)
+                    SecureStorage.removeRestrictedGroupForRelay(pk, groupKeyRelay(key), groupId)
                 } catch (_: Exception) {}
             }
         }
@@ -848,7 +860,8 @@ class GroupManager(
         val loaded = mutableMapOf<String, String>()
         for (url in relayUrls) {
             try {
-                loaded.putAll(SecureStorage.getRestrictedGroupsForRelay(pubKey, url, now))
+                SecureStorage.getRestrictedGroupsForRelay(pubKey, url, now)
+                    .forEach { (gid, reason) -> loaded[groupKey(url, gid)] = reason }
             } catch (_: Exception) {}
         }
         if (loaded.isNotEmpty()) {
@@ -955,15 +968,29 @@ class GroupManager(
     private val observedGroupsMutex = Mutex()
 
     /**
-     * Returns the relay URL that hosts the given group, by scanning the per-relay cache.
-     * Uses an immutable snapshot of _groupsByRelay so no lock is needed.
+     * Relay hosting [groupId], from the open-group hint or the per-relay caches.
+     *
+     * Returns null when the id is AMBIGUOUS - served by more than one relay with no hint to
+     * break the tie. A group id is only unique within a relay, so guessing here is what routed
+     * sends, invites and previews to a stranger's same-id group; callers that fall back to the
+     * connected relay are at least on a relay the user chose. Anything that knows its relay
+     * should pass it instead of asking.
+     *
+     * Uses immutable snapshots, so no lock is needed.
      */
-    fun getRelayForGroup(groupId: String): String? = groupRelayHints.value[groupId]
-        ?: _groupsByRelay.value.entries.firstOrNull { (_, groups) -> groups.any { it.id == groupId } }?.key
-        // Fallback: private groups may not appear in kind 39000 listing but are
-        // tracked in _joinedGroupsByRelay (from kind 10009). Without this,
-        // clientForGroup() falls back to the focused client which may be wrong.
-        ?: _joinedGroupsByRelay.value.entries.firstOrNull { (_, groupIds) -> groupId in groupIds }?.key
+    fun getRelayForGroup(groupId: String): String? {
+        groupRelayHints.value[groupId]?.let { return it }
+        val serving = LinkedHashSet<String>()
+        _groupsByRelay.value.forEach { (relay, groups) ->
+            if (groups.any { it.id == groupId }) serving.add(relay.normalizeRelayUrl())
+        }
+        // Private groups may not appear in the kind:39000 listing but are tracked in
+        // _joinedGroupsByRelay (from kind:10009).
+        _joinedGroupsByRelay.value.forEach { (relay, groupIds) ->
+            if (groupId in groupIds) serving.add(relay.normalizeRelayUrl())
+        }
+        return serving.singleOrNull()
+    }
 
     /**
      * Returns the WebSocket client for the relay that hosts [groupId].
@@ -1138,7 +1165,7 @@ class GroupManager(
                     hydrateJob?.join()
                     val newest = _messages.value[groupId]?.lastOrNull()?.createdAt
                     if (newest != null &&
-                        groupId !in _restrictedGroups.value.keys &&
+                        groupKey(url, groupId) !in _restrictedGroups.value &&
                         shouldRequest(groupId, "entry_gapfill", cooldownMs = 20_000L)
                     ) {
                         try {
@@ -1194,12 +1221,12 @@ class GroupManager(
         // Drop restricted groups from every batched filter — including a single
         // restricted #d/#h value makes the relay CLOSE the entire subscription,
         // silencing metadata/delete updates for the groups we DO belong to.
-        val restricted = _restrictedGroups.value.keys
-        val allGroupIds = getGroupIdsForMux(relayUrl).filter { it !in restricted }
+        val restricted = _restrictedGroups.value
+        val allGroupIds = getGroupIdsForMux(relayUrl).filter { groupKey(relayUrl, it) !in restricted }
         // The metadata + delete watches also cover every descendant channel of the mux
         // groups: the sidebar renders the whole subgroup subtree, so channel renames and
         // deletions must sync even for channels the user never joined or opened.
-        val metadataIds = expandWithDescendants(allGroupIds).filter { it !in restricted }
+        val metadataIds = expandWithDescendants(allGroupIds).filter { groupKey(relayUrl, it) !in restricted }
         // The put-user watch must be armed even with zero groups on this relay —
         // that is exactly the state in which an external add can only arrive via #p.
         val selfPubkey = currentPubkey
@@ -1677,7 +1704,7 @@ class GroupManager(
 
             publishJoinedGroups()
 
-            clearGroupRestricted(groupId)
+            clearGroupRestricted(normalizedGroupRelay, groupId)
             // Seconds, to match GroupMembershipState.requestedAtSeconds (the "Requested ..." label).
             _pendingApprovalSince.update { it + (groupId to epochSeconds()) }
             refreshMuxSubscriptionsForRelay(groupRelayUrl)
@@ -2545,7 +2572,7 @@ class GroupManager(
             // non-member and the relay WILL re-CLOSE our reads "restricted" a round-trip later.
             // Leaving is an explicit reset of intent — a future rejoin should
             // get a fresh access attempt instead of being silently excluded.
-            clearGroupRestricted(groupId)
+            clearGroupRestricted(null, groupId)
 
             // Overwrite the persisted membership cache (now that the in-memory maps no longer carry
             // this group) so a restart does not re-hydrate self into the left group's member list —
@@ -3004,9 +3031,9 @@ class GroupManager(
     suspend fun backfillRecentGapsForRelay(relayUrl: String) {
         val client = connectionManager.getClientForRelay(relayUrl) ?: return
         if (!client.isConnected()) return
-        val restricted = _restrictedGroups.value.keys
+        val restricted = _restrictedGroups.value
         val loaded = getGroupIdsForMux(relayUrl)
-            .filter { it !in restricted }
+            .filter { groupKey(relayUrl, it) !in restricted }
             .mapNotNull { gid -> _messages.value[gid]?.lastOrNull()?.createdAt?.let { gid to it } }
         if (loaded.isEmpty()) return
         val since = loaded.minOf { it.second } - LiveCursorStore.RECONNECT_OVERLAP_S
@@ -4155,14 +4182,17 @@ class GroupManager(
         // messages never reach us until an app restart.
         if (selfNowMember &&
             selfWasAbsent &&
-            (members.groupId in _pendingApprovalSince.value || members.groupId in _restrictedGroups.value)
+            (
+                members.groupId in _pendingApprovalSince.value ||
+                    (relayUrl != null && groupKey(relayUrl, members.groupId) in _restrictedGroups.value)
+                )
         ) {
-            onApprovalDetected(members.groupId)
-        } else if (selfNowMember && members.groupId in _restrictedGroups.value) {
+            onApprovalDetected(relayUrl, members.groupId)
+        } else if (selfNowMember && relayUrl != null && groupKey(relayUrl, members.groupId) in _restrictedGroups.value) {
             // Confirmed membership with no live transition (e.g. a stale 7-day restricted marker
             // restored from SecureStorage on cold start): just drop the "Private group / invite
             // code" placeholder. The mux is built fresh this session, so no re-arm is needed.
-            clearGroupRestricted(members.groupId)
+            clearGroupRestricted(relayUrl, members.groupId)
         }
 
         // Self-heal a stale durable left marker: the relay lists us as a member AND we are joined
@@ -4372,7 +4402,7 @@ class GroupManager(
         // Pre-add the relay may have CLOSED our reads "restricted"; we are a member now, so
         // the preview (opening the group from the notification / DM card) must get a fresh
         // read attempt while the decision is pending.
-        clearGroupRestricted(groupId)
+        clearGroupRestricted(relay, groupId)
         _externalAddPending.tryEmit(
             ExternalGroupAdd(groupId, relay, actorPubkey, eventId, invite.createdAtSeconds),
         )
@@ -4480,7 +4510,7 @@ class GroupManager(
             discardPendingInvite(groupId)
             // Grace against the orphan auto-forget while this group's kind:39000 is in flight.
             markRecentlyJoined(groupId)
-            clearGroupRestricted(groupId)
+            clearGroupRestricted(relay, groupId)
             _externalMembershipAdopted.tryEmit(
                 ExternalGroupAdd(
                     groupId = groupId,
@@ -4502,9 +4532,9 @@ class GroupManager(
     // tail, so without this the group stays on "No messages yet" until someone posts. We go
     // through requestGroupMessages (the state-machine path), NOT a raw _messages fetch /
     // dedup eviction, which is what broke pagination before.
-    private fun onApprovalDetected(groupId: String) {
+    private fun onApprovalDetected(relayUrl: String?, groupId: String) {
         _pendingApprovalSince.update { it - groupId }
-        clearGroupRestricted(groupId)
+        clearGroupRestricted(relayUrl, groupId)
         scope.launch {
             try {
                 loadingRegistry.getController(groupId).reset()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -10,12 +10,26 @@ import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.UnreadEntry
 import org.nostr.nostrord.storage.getUnreadEntries
+import org.nostr.nostrord.storage.lastReadFor
+import org.nostr.nostrord.storage.saveLastReadFor
 import org.nostr.nostrord.storage.saveUnreadEntries
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.groupKey
+import org.nostr.nostrord.utils.groupKeyId
+import org.nostr.nostrord.utils.groupKeyRelay
+import org.nostr.nostrord.utils.isGroupKey
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
+/**
+ * Unread badges and notification triggers, keyed by (relay, group id).
+ *
+ * The same group id on two relays is two distinct groups: reading one must not clear
+ * the other's badge, and a message on one must not raise a badge on the other. Every
+ * map here is keyed by [groupKey]; the bare id alone is never a key.
+ */
 class UnreadManager(
-    private val isJoined: (String) -> Boolean = { true },
-    private val isRestricted: (String) -> Boolean = { false },
+    private val isJoined: (relayUrl: String, groupId: String) -> Boolean = { _, _ -> true },
+    private val isRestricted: (relayUrl: String, groupId: String) -> Boolean = { _, _ -> false },
     private val isAppFocused: () -> Boolean = { true },
     private val findMessageAuthor: (messageId: String) -> String? = { null },
     // NIP-51 muted authors: their messages/reactions never bump badges or notify.
@@ -25,34 +39,35 @@ class UnreadManager(
     // mentions and reactions to the user's own message. Returning false suppresses
     // the notification callbacks below WITHOUT touching the unread badge — a muted
     // or "mentions only" group still accumulates its unread count.
-    private val shouldNotify: (groupId: String, isDirect: Boolean) -> Boolean = { _, _ -> true },
-    private val onUnreadIncrement: ((groupId: String, latestMessage: NostrGroupClient.NostrMessage, delta: Int) -> Unit)? = null,
-    private val onReplyNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
-    private val onMentionNotify: ((groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
-    private val onReactionNotify: ((groupId: String, reaction: NostrGroupClient.NostrReaction) -> Unit)? = null,
+    private val shouldNotify: (relayUrl: String, groupId: String, isDirect: Boolean) -> Boolean = { _, _, _ -> true },
+    private val onUnreadIncrement: ((relayUrl: String, groupId: String, latestMessage: NostrGroupClient.NostrMessage, delta: Int) -> Unit)? = null,
+    private val onReplyNotify: ((relayUrl: String, groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
+    private val onMentionNotify: ((relayUrl: String, groupId: String, message: NostrGroupClient.NostrMessage) -> Unit)? = null,
+    private val onReactionNotify: ((relayUrl: String, groupId: String, reaction: NostrGroupClient.NostrReaction) -> Unit)? = null,
     // A kind:1111 reply under a thread event of ours. Fired instead of [onReplyNotify] so the
     // entry can deep-link into the threads pane rather than the chat.
-    private val onThreadReplyNotify: ((groupId: String, reply: NostrGroupClient.NostrMessage) -> Unit)? = null,
+    private val onThreadReplyNotify: ((relayUrl: String, groupId: String, reply: NostrGroupClient.NostrMessage) -> Unit)? = null,
     // Called when a group is marked read so the notification feed can drop the
     // group's entries in lockstep with the unread badge (issue #67).
-    private val onGroupRead: ((groupId: String) -> Unit)? = null,
+    private val onGroupRead: ((relayUrl: String, groupId: String) -> Unit)? = null,
     // Background scope (Dispatchers.Default) for the SecureStorage writes. The badge update is an
     // in-memory StateFlow write that stays on the caller; only the EncryptedSharedPreferences
     // encryption + I/O is offloaded so marking-read can't block the Main thread (ANR on Android).
     private val scope: CoroutineScope,
 ) {
 
-    private val _unreadCounts = MutableStateFlow<Map<String, Int>>(emptyMap())
-    val unreadCounts: StateFlow<Map<String, Int>> = _unreadCounts.asStateFlow()
+    /** Counts keyed by [groupKey], not by group id. */
+    private val _unreadByGroupKey = MutableStateFlow<Map<String, Int>>(emptyMap())
+    val unreadByGroupKey: StateFlow<Map<String, Int>> = _unreadByGroupKey.asStateFlow()
 
-    // High-water mark per group: createdAt of the newest message we've already
-    // processed. Used as an extra anchor floor so re-delivered history (across
-    // reconnects or restarts) doesn't double-count.
+    // High-water mark per (relay, group): createdAt of the newest message we've
+    // already processed. Used as an extra anchor floor so re-delivered history
+    // (across reconnects or restarts) doesn't double-count.
     private val _latestMessageTimestamps = MutableStateFlow<Map<String, Long>>(emptyMap())
     val latestMessageTimestamps: StateFlow<Map<String, Long>> = _latestMessageTimestamps.asStateFlow()
 
     private var currentPubkey: String? = null
-    private var activeGroupId: String? = null
+    private var activeGroupKey: String? = null
 
     // First-time-seen anchor for groups with no persisted lastRead. Prevents the
     // initial history sync from inflating the badge for groups never opened.
@@ -90,36 +105,49 @@ class UnreadManager(
         }
     }
 
-    fun setActiveGroup(groupId: String?) {
-        val previous = activeGroupId
-        activeGroupId = groupId
+    fun setActiveGroup(
+        relayUrl: String?,
+        groupId: String?,
+    ) {
+        val previous = activeGroupKey
+        val next = if (relayUrl != null && groupId != null) groupKey(relayUrl, groupId) else null
+        activeGroupKey = next
         // markAsRead the outgoing group so messages buffered inside GroupManager's
         // 300ms ordering window — flushed after the screen unmounts — don't
         // retroactively count as unread.
-        if (previous != null && previous != groupId) markAsRead(previous)
+        if (previous != null && previous != next) {
+            markAsRead(groupKeyRelay(previous), groupKeyId(previous))
+        }
     }
 
     fun initialize(pubkey: String?) {
         currentPubkey = pubkey
         firstSeenAtByGroup.clear()
         if (pubkey == null) {
-            _unreadCounts.value = emptyMap()
+            _unreadByGroupKey.value = emptyMap()
             _latestMessageTimestamps.value = emptyMap()
             return
         }
-        val persisted = SecureStorage.getUnreadEntries(pubkey)
-        _unreadCounts.value = persisted.mapValues { it.value.count }
+        // Legacy bare-id entries are dropped: their relay is unknowable, and attributing
+        // them to a guess is what put a count on the wrong same-id group. The badge
+        // reseeds from live traffic; the read anchor survives via [lastReadFor]'s fallback.
+        val persisted = SecureStorage.getUnreadEntries(pubkey).filterKeys { isGroupKey(it) }
+        _unreadByGroupKey.value = persisted.mapValues { it.value.count }
         _latestMessageTimestamps.value = persisted.mapValues { it.value.highWater }
     }
 
-    fun markAsRead(groupId: String) {
+    fun markAsRead(
+        relayUrl: String,
+        groupId: String,
+    ) {
         val pubkey = currentPubkey ?: return
+        val key = groupKey(relayUrl, groupId)
         val now = epochSeconds()
         // In-memory badge clear + feed drop happen immediately; the storage writes go off-Main.
-        _unreadCounts.update { it + (groupId to 0) }
-        onGroupRead?.invoke(groupId)
+        _unreadByGroupKey.update { it + (key to 0) }
+        onGroupRead?.invoke(relayUrl.normalizeRelayUrl(), groupId)
         scope.launch {
-            SecureStorage.saveLastReadTimestamp(pubkey, groupId, now)
+            SecureStorage.saveLastReadFor(pubkey, relayUrl, groupId, now)
             persistEntries()
         }
     }
@@ -132,42 +160,76 @@ class UnreadManager(
      * [timestamp] catches up to the high-water mark (everything seen); otherwise
      * the counter is left alone and the next markAsRead clears it.
      */
-    fun markAsReadUpTo(groupId: String, timestamp: Long) {
+    fun markAsReadUpTo(
+        relayUrl: String,
+        groupId: String,
+        timestamp: Long,
+    ) {
         val pubkey = currentPubkey ?: return
+        val key = groupKey(relayUrl, groupId)
         // Off-Main: this runs per scroll-past, and the read + writes are EncryptedSharedPreferences
         // I/O that must not block the scroll on the Main thread.
         scope.launch {
-            val stored = SecureStorage.getLastReadTimestamp(pubkey, groupId) ?: 0L
+            val stored = SecureStorage.lastReadFor(pubkey, relayUrl, groupId) ?: 0L
             if (timestamp <= stored) return@launch
-            SecureStorage.saveLastReadTimestamp(pubkey, groupId, timestamp)
-            val highWater = _latestMessageTimestamps.value[groupId] ?: 0L
+            SecureStorage.saveLastReadFor(pubkey, relayUrl, groupId, timestamp)
+            val highWater = _latestMessageTimestamps.value[key] ?: 0L
             if (timestamp >= highWater) {
-                _unreadCounts.update { it + (groupId to 0) }
-                onGroupRead?.invoke(groupId)
+                _unreadByGroupKey.update { it + (key to 0) }
+                onGroupRead?.invoke(relayUrl.normalizeRelayUrl(), groupId)
             }
             persistEntries()
         }
     }
 
-    fun getLastReadTimestamp(groupId: String): Long? = currentPubkey?.let { SecureStorage.getLastReadTimestamp(it, groupId) }
+    fun getLastReadTimestamp(
+        relayUrl: String,
+        groupId: String,
+    ): Long? = currentPubkey?.let { SecureStorage.lastReadFor(it, relayUrl, groupId) }
 
-    fun getUnreadCount(groupId: String): Int = _unreadCounts.value[groupId] ?: 0
+    fun getUnreadCount(
+        relayUrl: String,
+        groupId: String,
+    ): Int = _unreadByGroupKey.value[groupKey(relayUrl, groupId)] ?: 0
 
-    fun onMessagesFlushed(groupId: String, newMessages: List<NostrGroupClient.NostrMessage>) {
-        val pubkey = currentPubkey ?: return
+    /**
+     * Chat messages left GroupManager's ordering buffer. The bucket is shared by every
+     * relay serving [groupId], so split by origin relay first: each same-id group owns
+     * its badge, its read anchor and its notifications.
+     *
+     * Messages without an origin relay are optimistic local sends, which never qualify.
+     */
+    fun onMessagesFlushed(
+        groupId: String,
+        newMessages: List<NostrGroupClient.NostrMessage>,
+    ) {
         if (newMessages.isEmpty()) return
-        if (!isJoined(groupId) || isRestricted(groupId)) return
+        newMessages
+            .groupBy { it.relayUrl?.normalizeRelayUrl() }
+            .forEach { (relayUrl, batch) ->
+                if (relayUrl != null) onMessagesFlushed(relayUrl, groupId, batch)
+            }
+    }
+
+    private fun onMessagesFlushed(
+        relayUrl: String,
+        groupId: String,
+        newMessages: List<NostrGroupClient.NostrMessage>,
+    ) {
+        val pubkey = currentPubkey ?: return
+        if (!isJoined(relayUrl, groupId) || isRestricted(relayUrl, groupId)) return
+        val key = groupKey(relayUrl, groupId)
 
         // Capture the previous high-water *before* advancing it, so the anchor
         // can use it to filter re-delivered history that was already counted.
-        val previousHighWater = _latestMessageTimestamps.value[groupId] ?: 0L
+        val previousHighWater = _latestMessageTimestamps.value[key] ?: 0L
         val latestInBatch = newMessages.maxOfOrNull { it.createdAt } ?: 0L
         val highWaterAdvanced = latestInBatch > previousHighWater
         if (highWaterAdvanced) {
-            _latestMessageTimestamps.update { it + (groupId to latestInBatch) }
+            _latestMessageTimestamps.update { it + (key to latestInBatch) }
         }
 
-        val isActive = groupId == activeGroupId
+        val isActive = key == activeGroupKey
         // Active group + app focused: user is reading live — silent. Persist
         // any high-water advance so a future session doesn't re-process.
         if (isActive && isAppFocused()) {
@@ -175,9 +237,9 @@ class UnreadManager(
             return
         }
 
-        val lastRead = SecureStorage.getLastReadTimestamp(pubkey, groupId)
+        val lastRead = SecureStorage.lastReadFor(pubkey, relayUrl, groupId)
         val anchor = maxOf(
-            lastRead ?: firstSeenAtByGroup.getOrPut(groupId) { firstSeenFallback() },
+            lastRead ?: firstSeenAtByGroup.getOrPut(key) { firstSeenFallback() },
             previousHighWater,
         )
         val qualifying = newMessages.filter {
@@ -191,8 +253,8 @@ class UnreadManager(
         // Active-but-unfocused: still notify (sound + popup) but don't bump the
         // badge — refocus shows the messages immediately, marking them as read.
         if (!isActive) {
-            _unreadCounts.update { current ->
-                current + (groupId to ((current[groupId] ?: 0) + qualifying.size))
+            _unreadByGroupKey.update { current ->
+                current + (key to ((current[key] ?: 0) + qualifying.size))
             }
         }
         persistEntries()
@@ -224,12 +286,12 @@ class UnreadManager(
 
         when {
             latestReply != null ->
-                if (shouldNotify(groupId, true)) onReplyNotify?.invoke(groupId, latestReply)
+                if (shouldNotify(relayUrl, groupId, true)) onReplyNotify?.invoke(relayUrl, groupId, latestReply)
             latestMention != null ->
-                if (shouldNotify(groupId, true)) onMentionNotify?.invoke(groupId, latestMention)
+                if (shouldNotify(relayUrl, groupId, true)) onMentionNotify?.invoke(relayUrl, groupId, latestMention)
             else ->
-                if (shouldNotify(groupId, false)) {
-                    onUnreadIncrement?.invoke(groupId, qualifying.maxBy { it.createdAt }, qualifying.size)
+                if (shouldNotify(relayUrl, groupId, false)) {
+                    onUnreadIncrement?.invoke(relayUrl, groupId, qualifying.maxBy { it.createdAt }, qualifying.size)
                 }
         }
     }
@@ -250,31 +312,41 @@ class UnreadManager(
      * the same second. Re-announcing is handled where it belongs - the feed dedupes by event id,
      * and AppModule gates sound and popup on the event being realtime.
      */
-    fun onThreadEventReceived(groupId: String, event: NostrGroupClient.NostrMessage) {
+    fun onThreadEventReceived(
+        groupId: String,
+        event: NostrGroupClient.NostrMessage,
+    ) {
         val pubkey = currentPubkey
+        val relayUrl = event.relayUrl?.normalizeRelayUrl()
         val verdict = when {
             pubkey == null -> "no-session"
+            relayUrl == null -> "no-origin-relay"
             event.kind != 1111 -> "not-a-reply(${event.kind})"
             event.pubkey == pubkey -> "own-reply"
             isMutedAuthor(event.pubkey) -> "muted-author"
-            !isJoined(groupId) -> "not-joined"
+            !isJoined(relayUrl, groupId) -> "not-joined"
             !threadReplyTargetsMe(event.tags, pubkey, findMessageAuthor) -> "not-for-me"
-            !shouldNotify(groupId, true) -> "group-muted"
+            !shouldNotify(relayUrl, groupId, true) -> "group-muted"
             else -> null
         }
-        if (verdict != null) return
-        onThreadReplyNotify?.invoke(groupId, event)
+        if (verdict != null || relayUrl == null) return
+        onThreadReplyNotify?.invoke(relayUrl, groupId, event)
     }
 
-    fun onReactionReceived(groupId: String, reaction: NostrGroupClient.NostrReaction) {
+    fun onReactionReceived(
+        relayUrl: String,
+        groupId: String,
+        reaction: NostrGroupClient.NostrReaction,
+    ) {
         val pubkey = currentPubkey ?: return
         if (reaction.pubkey == pubkey) return
         if (isMutedAuthor(reaction.pubkey)) return
-        if (!isJoined(groupId) || isRestricted(groupId)) return
-        val lastRead = SecureStorage.getLastReadTimestamp(pubkey, groupId)
-        val previousHighWater = _latestMessageTimestamps.value[groupId] ?: 0L
+        if (!isJoined(relayUrl, groupId) || isRestricted(relayUrl, groupId)) return
+        val key = groupKey(relayUrl, groupId)
+        val lastRead = SecureStorage.lastReadFor(pubkey, relayUrl, groupId)
+        val previousHighWater = _latestMessageTimestamps.value[key] ?: 0L
         val anchor = maxOf(
-            lastRead ?: firstSeenAtByGroup.getOrPut(groupId) { firstSeenFallback() },
+            lastRead ?: firstSeenAtByGroup.getOrPut(key) { firstSeenFallback() },
             previousHighWater,
         )
         if (reaction.createdAt <= anchor) return
@@ -284,12 +356,12 @@ class UnreadManager(
         // Caller already verified the target message author == self.
         val highWaterAdvanced = reaction.createdAt > previousHighWater
         if (highWaterAdvanced) {
-            _latestMessageTimestamps.update { it + (groupId to reaction.createdAt) }
+            _latestMessageTimestamps.update { it + (key to reaction.createdAt) }
         }
 
         // Mirror onMessagesFlushed's active/focus handling so reactions don't behave
         // differently from messages for the group the user is looking at.
-        val isActive = groupId == activeGroupId
+        val isActive = key == activeGroupKey
         // Active group + app focused: user is reading live — silent.
         if (isActive && isAppFocused()) {
             persistEntries()
@@ -300,28 +372,28 @@ class UnreadManager(
         // reaction is seen on refocus (matches messages; fixes the relay count
         // appearing for the group you're currently viewing).
         if (!isActive) {
-            _unreadCounts.update { current ->
-                current + (groupId to ((current[groupId] ?: 0) + 1))
+            _unreadByGroupKey.update { current ->
+                current + (key to ((current[key] ?: 0) + 1))
             }
         }
         persistEntries()
 
         // A reaction is always to the user's own message, so it counts as a
         // direct interaction for the notification gate.
-        if (shouldNotify(groupId, true)) onReactionNotify?.invoke(groupId, reaction)
+        if (shouldNotify(relayUrl, groupId, true)) onReactionNotify?.invoke(relayUrl, groupId, reaction)
     }
 
     fun clear() {
         currentPubkey = null
-        activeGroupId = null
-        _unreadCounts.value = emptyMap()
+        activeGroupKey = null
+        _unreadByGroupKey.value = emptyMap()
         _latestMessageTimestamps.value = emptyMap()
         firstSeenAtByGroup.clear()
     }
 
     private fun persistEntries() {
         val pubkey = currentPubkey ?: return
-        val counts = _unreadCounts.value
+        val counts = _unreadByGroupKey.value
         val highWaters = _latestMessageTimestamps.value
         val entries = (counts.keys + highWaters.keys).associateWith { id ->
             UnreadEntry(counts[id] ?: 0, highWaters[id] ?: 0L)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
@@ -10,6 +10,7 @@ import org.nostr.nostrord.storage.getAnnouncedNotificationIds
 import org.nostr.nostrord.storage.getPersistedNotifications
 import org.nostr.nostrord.storage.saveAnnouncedNotificationIds
 import org.nostr.nostrord.storage.savePersistedNotifications
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
 @Serializable
 enum class NotificationType { REPLY, MENTION, REACTION, MESSAGE, GROUP_ADD }
@@ -101,18 +102,24 @@ class NotificationHistoryStore {
         if (changed) persist()
     }
 
-    /** Mark every unread notification for [groupId] as read. No-op if none match. */
     /**
      * Mark a group's CHAT notifications read, as reading its chat does.
+     *
+     * Scoped to [relayUrl]: the same group id on another relay is a different group, and its
+     * entries must survive reading this one.
      *
      * Thread entries are left alone: their event is not in the chat, so opening the chat is no
      * evidence the user saw it. They clear via [markReadForThread] when that thread is opened.
      */
-    fun markReadForGroup(groupId: String) {
+    fun markReadForGroup(
+        relayUrl: String,
+        groupId: String,
+    ) {
+        val host = relayUrl.normalizeRelayUrl()
         var changed = false
         _entries.update { current ->
             current.map {
-                if (it.groupId == groupId && it.threadRootId == null && !it.read) {
+                if (it.groupId == groupId && it.relayUrl.normalizeRelayUrl() == host && it.threadRootId == null && !it.read) {
                     changed = true
                     it.copy(read = true)
                 } else {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -11,6 +11,7 @@ import org.nostr.nostrord.network.outbox.Kind10009Baseline
 import org.nostr.nostrord.nostr.Crypto
 import org.nostr.nostrord.nostr.toHexString
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.groupKey
 
 // 128-bit (32 hex) SHA-256 prefix of the pubkey. Used as the storage subkey
 // for all per-account slots: hashCode is 32-bit (collision-feasible) and the
@@ -951,6 +952,29 @@ fun SecureStorage.removeLeftGroupForRelay(
         }
     }
 }
+
+// ── Last-read anchor, per (relay, group) ────────────────────────────────────
+// The bare-id slot underneath is reused with a composite key so the same group
+// id on two relays keeps two independent read positions.
+
+fun SecureStorage.saveLastReadFor(
+    pubkey: String,
+    relayUrl: String,
+    groupId: String,
+    timestamp: Long,
+) = saveLastReadTimestamp(pubkey, groupKey(relayUrl, groupId), timestamp)
+
+/**
+ * Read anchor for [groupId] on [relayUrl], falling back to the legacy bare-id slot
+ * written before group state was relay-scoped. The fallback seeds both same-id groups
+ * from the old value once; each then diverges on its own composite slot.
+ */
+fun SecureStorage.lastReadFor(
+    pubkey: String,
+    relayUrl: String,
+    groupId: String,
+): Long? = getLastReadTimestamp(pubkey, groupKey(relayUrl, groupId))
+    ?: getLastReadTimestamp(pubkey, groupId)
 
 // ── Unread state persistence ────────────────────────────────────────────────
 // Persists per-account unread counters + high-water timestamps so badges,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/MessageDraftStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/MessageDraftStore.kt
@@ -17,8 +17,11 @@ data class MessageDraft(
 }
 
 /**
- * Per-group composer drafts kept in memory for the session, so switching groups and
+ * Per-chat composer drafts kept in memory for the session, so switching groups and
  * coming back preserves what you were typing.
+ *
+ * Keyed by [org.nostr.nostrord.utils.groupKey]: the same group id on two relays is two
+ * chats, and one draft must not surface in the other's composer.
  *
  * Writes are plain map mutations (no StateFlow, no recomposition / re-render), so callers
  * can persist on every keystroke for free — this never triggers a chat re-render and so
@@ -27,20 +30,20 @@ data class MessageDraft(
 class MessageDraftStore {
     private val drafts = mutableMapOf<String, MessageDraft>()
 
-    fun get(groupId: String): MessageDraft = drafts[groupId] ?: MessageDraft()
+    fun get(chatKey: String): MessageDraft = drafts[chatKey] ?: MessageDraft()
 
-    fun setText(groupId: String, text: String) = update(groupId) { it.copy(text = text) }
+    fun setText(chatKey: String, text: String) = update(chatKey) { it.copy(text = text) }
 
-    fun setMentions(groupId: String, mentions: Map<String, String>) = update(groupId) { it.copy(mentions = mentions) }
+    fun setMentions(chatKey: String, mentions: Map<String, String>) = update(chatKey) { it.copy(mentions = mentions) }
 
-    fun setGroupMentions(groupId: String, groupMentions: Map<String, String>) = update(groupId) { it.copy(groupMentions = groupMentions) }
+    fun setGroupMentions(chatKey: String, groupMentions: Map<String, String>) = update(chatKey) { it.copy(groupMentions = groupMentions) }
 
-    fun clear(groupId: String) {
-        drafts.remove(groupId)
+    fun clear(chatKey: String) {
+        drafts.remove(chatKey)
     }
 
-    private inline fun update(groupId: String, transform: (MessageDraft) -> MessageDraft) {
-        val updated = transform(get(groupId))
-        if (updated.isEmpty) drafts.remove(groupId) else drafts[groupId] = updated
+    private inline fun update(chatKey: String, transform: (MessageDraft) -> MessageDraft) {
+        val updated = transform(get(chatKey))
+        if (updated.isEmpty) drafts.remove(chatKey) else drafts[chatKey] = updated
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTree.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTree.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.ui.screens.group
 
 import org.nostr.nostrord.network.GroupMetadata
+import org.nostr.nostrord.utils.groupKey
 
 /**
  * Discord-style channel model over the NIP-29 subgroup topology: the rail shows only
@@ -57,12 +58,17 @@ fun channelTree(
     return out
 }
 
-/** Unread total for a rail root: its own count plus every descendant channel's. */
+/**
+ * Unread total for a rail root: its own count plus every descendant channel's.
+ * [unreadByGroupKey] is keyed by [groupKey], so the tree is resolved against [relayUrl]
+ * and a same-id group on another relay never contributes.
+ */
 fun aggregateUnread(
+    relayUrl: String,
     rootId: String,
     childrenByParent: Map<String, Set<String>>,
-    unreadCounts: Map<String, Int>,
-): Int = channelTree(rootId, childrenByParent, emptyMap()).sumOf { unreadCounts[it.id] ?: 0 }
+    unreadByGroupKey: Map<String, Int>,
+): Int = channelTree(rootId, childrenByParent, emptyMap()).sumOf { unreadByGroupKey[groupKey(relayUrl, it.id)] ?: 0 }
 
 /**
  * [aggregateUnread] with muted subtrees removed, for badge rollups. Muting a root
@@ -71,16 +77,17 @@ fun aggregateUnread(
  * tracked either way, so opening a muted group still lands on its unread divider.
  */
 fun aggregateUnreadUnmuted(
+    relayUrl: String,
     rootId: String,
     childrenByParent: Map<String, Set<String>>,
-    unreadCounts: Map<String, Int>,
+    unreadByGroupKey: Map<String, Int>,
     isMuted: (String) -> Boolean,
 ): Int = if (isMuted(rootId)) {
     0
 } else {
     channelTree(rootId, childrenByParent, emptyMap())
         .filterNot { isMuted(it.id) }
-        .sumOf { unreadCounts[it.id] ?: 0 }
+        .sumOf { unreadByGroupKey[groupKey(relayUrl, it.id)] ?: 0 }
 }
 
 /** A channel the user can see but not read/post without joining (private or closed, not a member). */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
@@ -9,6 +9,8 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.GroupMetadata
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.NostrRepositoryApi
+import org.nostr.nostrord.utils.groupKey
+import org.nostr.nostrord.utils.groupKeyId
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
@@ -144,7 +146,14 @@ class GroupMembershipModel(
             if (meta != null) {
                 GroupAccess(isPrivate = !meta.isPublic, isOpen = meta.isOpen)
             } else {
-                val restrictedHere = groupId in restricted
+                // Denied on THIS relay only: the twin group's denial elsewhere says nothing
+                // about access here.
+                val restrictedHere =
+                    if (hostRelay != null) {
+                        groupKey(hostRelay, groupId) in restricted
+                    } else {
+                        restricted.keys.any { groupKeyId(it) == groupId }
+                    }
                 GroupAccess(isPrivate = restrictedHere, isOpen = !restrictedHere)
             }
         }.stateIn(scope, SharingStarted.Eagerly, GroupAccess())

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -31,6 +31,8 @@ import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.groupKey
+import org.nostr.nostrord.utils.groupKeyId
 import org.nostr.nostrord.utils.isJoinedOn
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.shortNpub
@@ -314,7 +316,24 @@ class GroupViewModel(
             }.stateIn(viewModelScope, SharingStarted.Eagerly, repo.groupRoles.value)
         }
     val loadingMembers = repo.loadingMembers
-    val restrictedGroups = repo.restrictedGroups
+
+    /**
+     * The route's relay withholds this group's events until you are a member. Scoped to
+     * (relay, group): access is granted per relay, so the twin group's denial elsewhere must
+     * not lock this screen. Both UIs read this instead of the raw map, which is keyed by
+     * [groupKey] and would silently match the wrong group by bare id.
+     */
+    val isRestrictedHere: StateFlow<Boolean> =
+        repo.restrictedGroups
+            .map { restrictedHere(it) }
+            .distinctUntilChanged()
+            .stateIn(viewModelScope, SharingStarted.Eagerly, false)
+
+    private fun restrictedHere(restricted: Map<String, String>): Boolean = if (hostRelay != null) {
+        groupKey(hostRelay, groupId) in restricted
+    } else {
+        restricted.keys.any { groupKeyId(it) == groupId }
+    }
     val isLoadingMore = repo.isLoadingMore
     val hasMoreMessages = repo.hasMoreMessages
     val currentRelayUrl = repo.currentRelayUrl
@@ -370,7 +389,7 @@ class GroupViewModel(
             val relayDone = (hostRelay ?: currentRelay.normalizeRelayUrl()) in doneRelays
             relayDone &&
                 !hasMetadata &&
-                groupId !in restricted &&
+                !restrictedHere(restricted) &&
                 connState is ConnectionManager.ConnectionState.Connected
         }.flatMapLatest { gone ->
             // The relay's group-list EOSE can land before this group's kind:39000, so hold the verdict

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -829,15 +829,22 @@ class GroupViewModel(
         viewModelScope.launch { repo.switchRelay(relayUrl) }
     }
 
+    /**
+     * Relay whose copy of [groupId] this screen is reading. Unread state is per (relay, group),
+     * so a route without a relay falls back to where the group is actually listed before the
+     * connected relay - never to a bare-id lookup.
+     */
+    private fun readRelay(): String = hostRelay ?: listedRelay.value ?: repo.currentRelayUrl.value.normalizeRelayUrl()
+
     fun markAsRead() {
-        repo.markGroupAsRead(groupId)
+        repo.markGroupAsRead(readRelay(), groupId)
     }
 
     fun markAsReadUpTo(timestamp: Long) {
-        repo.markGroupAsReadUpTo(groupId, timestamp)
+        repo.markGroupAsReadUpTo(readRelay(), groupId, timestamp)
     }
 
-    fun getLastReadTimestamp(): Long? = repo.getLastReadTimestamp(groupId)
+    fun getLastReadTimestamp(): Long? = repo.getLastReadTimestamp(readRelay(), groupId)
 
     fun resetGroupLoadingState() {
         viewModelScope.launch { repo.resetGroupLoadingState(groupId) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -21,6 +21,8 @@ import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.groupKey
+import org.nostr.nostrord.utils.groupKeyId
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /** One row in the threads list: a kind:11 root plus stats derived from its kind:1111 replies. */
@@ -433,11 +435,21 @@ class ThreadsViewModel(
         }
     }
 
+    /**
+     * Denied on THIS relay. Access is granted per relay, so the twin group's denial elsewhere
+     * must not lock this pane. With no host relay on the route, any denial for the id counts.
+     */
+    private fun restrictedHere(restricted: Map<String, String>): Boolean = if (hostRelay != null) {
+        groupKey(hostRelay, groupId) in restricted
+    } else {
+        restricted.keys.any { groupKeyId(it) == groupId }
+    }
+
     /** The relay withholds this group's events until you are a member (NIP-29 private group). */
     val isRestricted: StateFlow<Boolean> =
         repo.restrictedGroups
-            .map { groupId in it }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), groupId in repo.restrictedGroups.value)
+            .map { restrictedHere(it) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), restrictedHere(repo.restrictedGroups.value))
 
     /** A join request is in flight and no admin has answered yet. */
     val isPendingApproval: StateFlow<Boolean> =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/home/HomePageViewModel.kt
@@ -33,6 +33,7 @@ import org.nostr.nostrord.storage.loadFollowingCacheFor
 import org.nostr.nostrord.storage.saveFollowingCacheFor
 import org.nostr.nostrord.ui.screens.group.aggregateUnread
 import org.nostr.nostrord.ui.screens.group.aggregateUnreadUnmuted
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
@@ -180,8 +181,8 @@ class HomePageViewModel(
             .toList()
     }
 
-    /** Unread message counts per group id (drives the rail badges). */
-    val unreadCounts: StateFlow<Map<String, Int>> = repo.unreadCounts
+    /** Unread message counts keyed by [groupKey] (drives the rail badges). */
+    val unreadByGroupKey: StateFlow<Map<String, Int>> = repo.unreadByGroupKey
 
     /** Unread notifications (drives the bell badge on the groups rail). */
     val notificationUnread: StateFlow<Int> =
@@ -342,8 +343,11 @@ class HomePageViewModel(
      * zero here and surface through [railMutedActivity] as a dot instead.
      */
     val railUnreadCounts: StateFlow<Map<String, Int>> =
-        combine(railRootGroups, repo.childrenByParent, repo.unreadCounts, muteState) { roots, children, unread, mute ->
-            roots.associate { it.meta.id to aggregateUnreadUnmuted(it.meta.id, children, unread, mute::isMuted) }
+        combine(railRootGroups, repo.childrenByParent, repo.unreadByGroupKey, muteState) { roots, children, unread, mute ->
+            roots.associate { root ->
+                groupKey(root.relayUrl, root.meta.id) to
+                    aggregateUnreadUnmuted(root.relayUrl, root.meta.id, children, unread, mute::isMuted)
+            }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
 
     /**
@@ -352,10 +356,14 @@ class HomePageViewModel(
      * group moved.
      */
     val railMutedActivity: StateFlow<Set<String>> =
-        combine(railRootGroups, repo.childrenByParent, repo.unreadCounts, muteState) { roots, children, unread, mute ->
+        combine(railRootGroups, repo.childrenByParent, repo.unreadByGroupKey, muteState) { roots, children, unread, mute ->
             roots.mapNotNullTo(HashSet()) { root ->
+                val relay = root.relayUrl
                 val id = root.meta.id
-                id.takeIf { aggregateUnreadUnmuted(id, children, unread, mute::isMuted) == 0 && aggregateUnread(id, children, unread) > 0 }
+                groupKey(relay, id).takeIf {
+                    aggregateUnreadUnmuted(relay, id, children, unread, mute::isMuted) == 0 &&
+                        aggregateUnread(relay, id, children, unread) > 0
+                }
             }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptySet())
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsViewModel.kt
@@ -16,6 +16,7 @@ import org.nostr.nostrord.notifications.NotificationEntry
 import org.nostr.nostrord.notifications.NotificationType
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.ui.text.flattenMarkdownForPreview
+import org.nostr.nostrord.utils.groupKey
 
 /** Notifications type filter (prototype tabs). Reactions have no tab; they show under [ALL]. */
 enum class NotifFilter { ALL, MENTIONS, REPLIES, MESSAGES }
@@ -28,8 +29,13 @@ data class NotifTypeCounts(
     val messages: Int = 0,
 )
 
-/** A group that appears in the notifications, for the sidebar group filter. */
+/**
+ * A group that appears in the notifications, for the sidebar group filter.
+ * Identified by [key] ([groupKey]) because the same id on two relays is two groups.
+ */
 data class NotifGroupBucket(
+    val key: String,
+    val relayUrl: String,
     val groupId: String,
     val name: String,
     val unread: Int,
@@ -73,8 +79,9 @@ class NotificationsViewModel(
         SecureStorage.saveBooleanPref(KEY_UNREAD_ONLY, value)
     }
 
-    fun setGroupFilter(groupId: String?) {
-        _groupFilter.value = groupId
+    /** [key] is a [groupKey], or null for "all groups". */
+    fun setGroupFilter(key: String?) {
+        _groupFilter.value = key
     }
 
     private fun matchesType(
@@ -97,7 +104,7 @@ class NotificationsViewModel(
         combine(entries, _typeFilter, _unreadOnly, _groupFilter) { list, type, unread, group ->
             list.filter { e ->
                 matchesType(e, type) &&
-                    (group == null || e.groupId == group) &&
+                    (group == null || groupKey(e.relayUrl, e.groupId) == group) &&
                     (!unread || !e.read)
             }.map { e -> e.copy(preview = flattenMarkdownForPreview(e.preview)) }
         }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
@@ -125,10 +132,13 @@ class NotificationsViewModel(
             val base = if (unread) list.filter { !it.read } else list
             val order = LinkedHashMap<String, NotifGroupBucket>()
             base.forEach { e ->
-                val prev = order[e.groupId]
+                val key = groupKey(e.relayUrl, e.groupId)
+                val prev = order[key]
                 val unreadInc = if (e.read) 0 else 1
-                order[e.groupId] =
+                order[key] =
                     NotifGroupBucket(
+                        key = key,
+                        relayUrl = e.relayUrl,
                         groupId = e.groupId,
                         name = prev?.name?.takeIf { it.isNotBlank() }
                             ?: e.groupName?.takeIf { it.isNotBlank() }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupKey.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupKey.kt
@@ -1,0 +1,26 @@
+package org.nostr.nostrord.utils
+
+/**
+ * Identity of a NIP-29 group: the hosting relay plus the group id.
+ *
+ * A group id is only unique within one relay. `nostrord` on chat.wisp.talk and
+ * `nostrord` on groups.0xchat.com are two unrelated groups with separate members,
+ * messages and unread state, so every per-group store keys on this pair and never
+ * on the bare id.
+ *
+ * Relay first, separator `|`: relay URLs cannot contain `|`, group ids may, so
+ * [groupKeyRelay] / [groupKeyId] round-trip. The relay is normalized so a route
+ * built from a raw nevent hint (`wss://Relay.example/`) keys the same slot as one
+ * built from the relay list.
+ */
+fun groupKey(
+    relayUrl: String,
+    groupId: String,
+): String = "${relayUrl.normalizeRelayUrl()}|$groupId"
+
+fun groupKeyRelay(key: String): String = key.substringBefore('|')
+
+fun groupKeyId(key: String): String = key.substringAfter('|')
+
+/** False for legacy bare-id keys persisted before group state was relay-scoped. */
+fun isGroupKey(key: String): Boolean = key.contains('|')

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -21,6 +21,7 @@ import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip46Client
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.groupKey
 
 /**
  * In-memory fake of [NostrRepositoryApi] for ViewModel unit tests.
@@ -50,7 +51,7 @@ class FakeNostrRepository : NostrRepositoryApi {
     val _groupAdmins = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     val _userMetadata = MutableStateFlow<Map<String, UserMetadata>>(emptyMap())
     val _cachedEvents = MutableStateFlow<Map<String, CachedEvent>>(emptyMap())
-    val _unreadCounts = MutableStateFlow<Map<String, Int>>(emptyMap())
+    val _unreadByGroupKey = MutableStateFlow<Map<String, Int>>(emptyMap())
     val _userRelayList = MutableStateFlow<List<Nip65Relay>>(emptyList())
     val _relayMetadata = MutableStateFlow<Map<String, Nip11RelayInfo>>(emptyMap())
     val _unreachableRelays = MutableStateFlow<Set<String>>(emptySet())
@@ -139,7 +140,7 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val groupAdmins: StateFlow<Map<String, List<String>>> = _groupAdmins
     override val userMetadata: StateFlow<Map<String, UserMetadata>> = _userMetadata
     override val cachedEvents: StateFlow<Map<String, CachedEvent>> = _cachedEvents
-    override val unreadCounts: StateFlow<Map<String, Int>> = _unreadCounts
+    override val unreadByGroupKey: StateFlow<Map<String, Int>> = _unreadByGroupKey
     override val dmConversations: StateFlow<List<DmConversation>> = MutableStateFlow(emptyList())
     override val dmMessagesByPeer: StateFlow<Map<String, List<DmMessage>>> = MutableStateFlow(emptyMap())
     override val dmUnreadByPeer: StateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
@@ -590,13 +591,13 @@ class FakeNostrRepository : NostrRepositoryApi {
         relayHints[groupId] = relayUrl
     }
 
-    override fun markGroupAsRead(groupId: String) {}
+    override fun markGroupAsRead(relayUrl: String, groupId: String) {}
 
-    override fun markGroupAsReadUpTo(groupId: String, timestamp: Long) {}
+    override fun markGroupAsReadUpTo(relayUrl: String, groupId: String, timestamp: Long) {}
 
-    override fun getUnreadCount(groupId: String): Int = unreadCounts.value[groupId] ?: 0
+    override fun getUnreadCount(relayUrl: String, groupId: String): Int = unreadByGroupKey.value[groupKey(relayUrl, groupId)] ?: 0
 
-    override fun getLastReadTimestamp(groupId: String): Long? = null
+    override fun getLastReadTimestamp(relayUrl: String, groupId: String): Long? = null
 
     override suspend fun requestUserMetadata(pubkeys: Set<String>, forceStale: Boolean) {}
 
@@ -719,7 +720,7 @@ class FakeNostrRepository : NostrRepositoryApi {
 
     override fun onDestroy() {}
 
-    override fun setActiveGroup(groupId: String?) {}
+    override fun setActiveGroup(relayUrl: String?, groupId: String?) {}
 
     var addUserResult: Result<Unit> = Result.Success(Unit)
     var addUserCalls = mutableListOf<Triple<String, String, List<String>>>()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupRelayResolutionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/GroupRelayResolutionTest.kt
@@ -1,0 +1,67 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.network.GroupMetadata
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * A group id is only unique within one relay, so resolving a relay from a bare id must not
+ * guess when two relays serve the same id.
+ */
+class GroupRelayResolutionTest {
+
+    private val wisp = "wss://chat.wisp.talk"
+    private val oxchat = "wss://groups.0xchat.com"
+    private val gid = "nostrord"
+
+    private fun manager(scope: TestScope) = GroupManager(connectionManager = ConnectionManager(scope), scope = scope)
+
+    private fun meta(id: String) = GroupMetadata(
+        id = id,
+        name = id,
+        about = null,
+        picture = null,
+        isPublic = true,
+        isOpen = true,
+    )
+
+    @Test
+    fun `one relay serving the id resolves to it`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = manager(scope)
+
+        manager.handleGroupMetadata(meta(gid), oxchat)
+
+        assertEquals(oxchat, manager.getRelayForGroup(gid))
+        scope.cancel()
+    }
+
+    @Test
+    fun `two relays serving the id resolve to nothing rather than a coin flip`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = manager(scope)
+
+        manager.handleGroupMetadata(meta(gid), wisp)
+        manager.handleGroupMetadata(meta(gid), oxchat)
+
+        assertNull(manager.getRelayForGroup(gid))
+        scope.cancel()
+    }
+
+    @Test
+    fun `the open-group hint breaks the tie`() = runTest {
+        val scope = TestScope(testScheduler)
+        val manager = manager(scope)
+        manager.handleGroupMetadata(meta(gid), wisp)
+        manager.handleGroupMetadata(meta(gid), oxchat)
+
+        manager.setGroupRelayHint(gid, oxchat)
+
+        assertEquals(oxchat, manager.getRelayForGroup(gid))
+        scope.cancel()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/UnreadRelayScopeTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/UnreadRelayScopeTest.kt
@@ -1,0 +1,87 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.groupKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The same group id served by two relays is two groups. Their unread state must not bleed:
+ * this is what put a badge on chat.wisp.talk's "nostrord" for traffic in groups.0xchat.com's.
+ */
+class UnreadRelayScopeTest {
+
+    private val wisp = "wss://chat.wisp.talk"
+    private val oxchat = "wss://groups.0xchat.com"
+    private val gid = "nostrord"
+
+    private fun manager(scope: TestScope) = UnreadManager(
+        isJoined = { _, _ -> true },
+        isAppFocused = { true },
+        scope = scope,
+    )
+
+    private fun message(
+        id: String,
+        relayUrl: String,
+        createdAt: Long = epochSeconds() + 60,
+    ) = NostrGroupClient.NostrMessage(
+        id = id,
+        pubkey = "someone-else",
+        content = "hi",
+        createdAt = createdAt,
+        kind = 9,
+        relayUrl = relayUrl,
+    )
+
+    @Test
+    fun `a message on one relay does not raise the badge of the same-id group on another`() = runTest {
+        val unread = manager(TestScope(StandardTestDispatcher(testScheduler)))
+        unread.initialize("me")
+
+        unread.onMessagesFlushed(gid, listOf(message("m1", oxchat)))
+
+        assertEquals(1, unread.getUnreadCount(oxchat, gid))
+        assertEquals(0, unread.getUnreadCount(wisp, gid))
+        assertEquals(mapOf(groupKey(oxchat, gid) to 1), unread.unreadByGroupKey.value)
+    }
+
+    @Test
+    fun `opening one relay's copy leaves the other relay's badge standing`() = runTest {
+        val unread = manager(TestScope(StandardTestDispatcher(testScheduler)))
+        unread.initialize("me")
+        unread.onMessagesFlushed(gid, listOf(message("m1", oxchat), message("m2", wisp)))
+
+        unread.setActiveGroup(wisp, gid)
+        unread.markAsRead(wisp, gid)
+
+        assertEquals(0, unread.getUnreadCount(wisp, gid))
+        assertEquals(1, unread.getUnreadCount(oxchat, gid))
+    }
+
+    @Test
+    fun `the open group stays silent while its twin on another relay still counts`() = runTest {
+        val unread = manager(TestScope(StandardTestDispatcher(testScheduler)))
+        unread.initialize("me")
+        unread.setActiveGroup(wisp, gid)
+
+        unread.onMessagesFlushed(gid, listOf(message("m1", wisp), message("m2", oxchat)))
+
+        assertEquals(0, unread.getUnreadCount(wisp, gid))
+        assertEquals(1, unread.getUnreadCount(oxchat, gid))
+    }
+
+    @Test
+    fun `a relay url that differs only in case or trailing slash is the same group`() = runTest {
+        val unread = manager(TestScope(StandardTestDispatcher(testScheduler)))
+        unread.initialize("me")
+
+        unread.onMessagesFlushed(gid, listOf(message("m1", "wss://Groups.0xchat.com/")))
+
+        assertEquals(1, unread.getUnreadCount(oxchat, gid))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/HomePageViewModelTest.kt
@@ -17,6 +17,7 @@ import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.ui.screens.home.Friend
 import org.nostr.nostrord.ui.screens.home.HomePageViewModel
 import org.nostr.nostrord.ui.screens.home.railKey
+import org.nostr.nostrord.utils.groupKey
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -97,18 +98,18 @@ class HomePageViewModelTest {
         val fake = FakeNostrRepository()
         fake._groupsByRelay.value = mapOf("wss://a" to listOf(meta("loud", "Loud"), meta("quiet", "Quiet")))
         fake._joinedGroupsByRelay.value = mapOf("wss://a" to setOf("loud", "quiet"))
-        fake._unreadCounts.value = mapOf("loud" to 4, "quiet" to 7)
+        fake._unreadByGroupKey.value = mapOf(groupKey("wss://a", "loud") to 4, groupKey("wss://a", "quiet") to 7)
         val mute = MutableStateFlow(MuteState(overrides = mapOf("quiet" to NotificationLevel.MUTED)))
         val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher, muteState = mute)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(mapOf("loud" to 4, "quiet" to 0), vm.railUnreadCounts.value)
-        assertEquals(setOf("quiet"), vm.railMutedActivity.value)
+        assertEquals(mapOf(groupKey("wss://a", "loud") to 4, groupKey("wss://a", "quiet") to 0), vm.railUnreadCounts.value)
+        assertEquals(setOf(groupKey("wss://a", "quiet")), vm.railMutedActivity.value)
 
         // Unmuting restores the number without any new traffic.
         mute.value = MuteState()
         testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals(mapOf("loud" to 4, "quiet" to 7), vm.railUnreadCounts.value)
+        assertEquals(mapOf(groupKey("wss://a", "loud") to 4, groupKey("wss://a", "quiet") to 7), vm.railUnreadCounts.value)
         assertEquals(emptySet(), vm.railMutedActivity.value)
     }
 
@@ -121,7 +122,7 @@ class HomePageViewModelTest {
         val vm = HomePageViewModel(fake, computeDispatcher = testDispatcher, muteState = mute)
         testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(mapOf("quiet" to 0), vm.railUnreadCounts.value)
+        assertEquals(mapOf(groupKey("wss://a", "quiet") to 0), vm.railUnreadCounts.value)
         assertEquals(emptySet(), vm.railMutedActivity.value)
     }
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/MessageDraftStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/MessageDraftStoreTest.kt
@@ -1,0 +1,42 @@
+package org.nostr.nostrord.ui
+
+import org.nostr.nostrord.utils.groupKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/** Drafts are per (relay, group): the same group id on two relays composes independently. */
+class MessageDraftStoreTest {
+
+    private val wisp = groupKey("wss://chat.wisp.talk", "nostrord")
+    private val oxchat = groupKey("wss://groups.0xchat.com", "nostrord")
+
+    @Test
+    fun `a draft typed in one relay's group does not surface in its twin`() {
+        val store = MessageDraftStore()
+
+        store.setText(wisp, "half-typed on wisp")
+
+        assertEquals("half-typed on wisp", store.get(wisp).text)
+        assertEquals("", store.get(oxchat).text)
+    }
+
+    @Test
+    fun `clearing one leaves the other standing`() {
+        val store = MessageDraftStore()
+        store.setText(wisp, "on wisp")
+        store.setText(oxchat, "on 0xchat")
+
+        store.clear(wisp)
+
+        assertEquals("", store.get(wisp).text)
+        assertEquals("on 0xchat", store.get(oxchat).text)
+    }
+
+    @Test
+    fun `a relay url differing only in case or trailing slash is the same draft`() {
+        val store = MessageDraftStore()
+        store.setText(groupKey("wss://Chat.Wisp.Talk/", "nostrord"), "same slot")
+
+        assertEquals("same slot", store.get(wisp).text)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/NotificationRouteTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/NotificationRouteTest.kt
@@ -60,7 +60,7 @@ class NotificationReadScopeTest {
         store.add(entry("chat1", "g1", threadRootId = null))
         store.add(entry("thread1", "g1", threadRootId = "root1"))
 
-        store.markReadForGroup("g1")
+        store.markReadForGroup("wss://relay.example", "g1")
 
         assertEquals(true, store.entries.value.first { it.id == "chat1" }.read)
         assertEquals(false, store.entries.value.first { it.id == "thread1" }.read)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTreeTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/ChannelTreeTest.kt
@@ -1,12 +1,15 @@
 package org.nostr.nostrord.ui.screens.group
 
 import org.nostr.nostrord.network.GroupMetadata
+import org.nostr.nostrord.utils.groupKey
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ChannelTreeTest {
+
+    private val RELAY = "wss://relay.example"
     private fun meta(
         id: String,
         name: String? = null,
@@ -98,17 +101,25 @@ class ChannelTreeTest {
 
     // ── aggregateUnread ─────────────────────────────────────────────────────
 
+    /** Counts are keyed by (relay, group), so build the keys the aggregates read. */
+    private fun unreadOn(
+        relayUrl: String,
+        vararg counts: Pair<String, Int>,
+    ): Map<String, Int> = counts.associate { (id, n) -> groupKey(relayUrl, id) to n }
+
     @Test
     fun unreadAggregatesRootAndDescendants() {
         val children = mapOf("root" to setOf("a", "b"), "a" to setOf("a1"))
-        val unread = mapOf("root" to 1, "a" to 2, "a1" to 4, "b" to 8, "other" to 100)
-        assertEquals(15, aggregateUnread("root", children, unread))
+        val unread = unreadOn(RELAY, "root" to 1, "a" to 2, "a1" to 4, "b" to 8, "other" to 100)
+        assertEquals(15, aggregateUnread(RELAY, "root", children, unread))
     }
 
     @Test
     fun unreadOfLeafIsItsOwnCount() {
-        assertEquals(3, aggregateUnread("g", emptyMap(), mapOf("g" to 3)))
-        assertEquals(0, aggregateUnread("g", emptyMap(), emptyMap()))
+        assertEquals(3, aggregateUnread(RELAY, "g", emptyMap(), unreadOn(RELAY, "g" to 3)))
+        assertEquals(0, aggregateUnread(RELAY, "g", emptyMap(), emptyMap()))
+        // A count from another relay's same-id group never lands in this root's total.
+        assertEquals(0, aggregateUnread(RELAY, "g", emptyMap(), unreadOn("wss://other.example", "g" to 3)))
     }
 
     // ── moveChannelBefore ───────────────────────────────────────────────────
@@ -141,25 +152,25 @@ class ChannelTreeTest {
     @Test
     fun mutedRootZeroesItsWholeTree() {
         val children = mapOf("root" to setOf("c1", "c2"))
-        val unread = mapOf("root" to 3, "c1" to 5, "c2" to 1)
-        assertEquals(9, aggregateUnread("root", children, unread))
-        assertEquals(0, aggregateUnreadUnmuted("root", children, unread) { it == "root" })
+        val unread = unreadOn(RELAY, "root" to 3, "c1" to 5, "c2" to 1)
+        assertEquals(9, aggregateUnread(RELAY, "root", children, unread))
+        assertEquals(0, aggregateUnreadUnmuted(RELAY, "root", children, unread) { it == "root" })
     }
 
     @Test
     fun mutedChannelDropsOutOfALiveRoot() {
         val children = mapOf("root" to setOf("c1", "c2"))
-        val unread = mapOf("root" to 3, "c1" to 5, "c2" to 1)
-        assertEquals(4, aggregateUnreadUnmuted("root", children, unread) { it == "c1" })
+        val unread = unreadOn(RELAY, "root" to 3, "c1" to 5, "c2" to 1)
+        assertEquals(4, aggregateUnreadUnmuted(RELAY, "root", children, unread) { it == "c1" })
     }
 
     @Test
     fun nothingMutedMatchesThePlainAggregate() {
         val children = mapOf("root" to setOf("c1"))
-        val unread = mapOf("root" to 2, "c1" to 4)
+        val unread = unreadOn(RELAY, "root" to 2, "c1" to 4)
         assertEquals(
-            aggregateUnread("root", children, unread),
-            aggregateUnreadUnmuted("root", children, unread) { false },
+            aggregateUnread(RELAY, "root", children, unread),
+            aggregateUnreadUnmuted(RELAY, "root", children, unread) { false },
         )
     }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -89,6 +89,7 @@ import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.utils.getImageUrl
 import org.nostr.nostrord.utils.isAnimatedImageUrl
 import org.nostr.nostrord.utils.isBlockedImageHost
+import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.proxyViaWeserv
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.utils.shortNpub
@@ -1367,11 +1368,16 @@ private fun ThreadQuoteCard(
     val groupId = extractGroupFromEvent(event)?.first ?: currentGroupId
     val navigate = LocalFrameNavigator.current
     val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
-    // Flattening every relay's group list is an allocation plus a linear scan, and this card sits
-    // in a scrolling list: keyed so it runs when the lists change, not on every recomposition.
-    val groupName = remember(groupsByRelay, groupId) {
-        groupId?.let { gid -> groupsByRelay.values.flatten().firstOrNull { it.id == gid }?.name }
-            ?.takeIf { it.isNotBlank() }
+    // The hinted relay's own kind:39000 names the card; a same-id group elsewhere is a different
+    // group. Keyed so the scan runs when the lists change, not on every recomposition (this card
+    // sits in a scrolling list).
+    val groupName = remember(groupsByRelay, groupId, relayHint) {
+        groupId?.let { gid ->
+            val onHint = relayHint?.let { r ->
+                groupsByRelay.entries.firstOrNull { e -> e.key.normalizeRelayUrl() == r.normalizeRelayUrl() }?.value
+            }
+            (onHint?.firstOrNull { it.id == gid } ?: groupsByRelay.values.flatten().firstOrNull { it.id == gid })?.name
+        }?.takeIf { it.isNotBlank() }
     }
 
     val title = event.tags.firstOrNull { it.size >= 2 && (it[0] == "subject" || it[0] == "title") }
@@ -1840,7 +1846,7 @@ private fun QuotedEvent(
         ThreadQuoteCard(
             event = event,
             eventId = eventId,
-            relayHint = extractGroupFromEvent(event)?.second ?: relayHints.firstOrNull() ?: currentRelayUrl,
+            relayHint = (extractGroupFromEvent(event)?.second ?: relayHints.firstOrNull() ?: currentRelayUrl)?.normalizeRelayUrl(),
             currentGroupId = currentGroupId,
             modifier = modifier,
         )
@@ -1851,34 +1857,40 @@ private fun QuotedEvent(
     if (event != null) {
         val sourceGroupInfo = extractGroupFromEvent(event)
         if (sourceGroupInfo != null) {
-            val (sourceGroupId, sourceRelayUrl) = sourceGroupInfo
+            val (sourceGroupId, sourceRelayUrlRaw) = sourceGroupInfo
+            // The `h` tag rarely carries a relay; the nevent's hint is what says which relay's
+            // copy of the group the event lives in. Normalized so a hint like "wss://Relay/"
+            // compares and routes as the same relay as the connected one.
+            val sourceRelayUrl = (sourceRelayUrlRaw ?: relayHints.firstOrNull())?.normalizeRelayUrl()
+            val hostRelay = currentRelayUrl?.normalizeRelayUrl()
 
-            // Determine if this is a forwarded event
-            // It's forwarded if: we have a current group context AND the source group is different
-            // OR if the source relay is different from current relay
+            // Forwarded when the source is a different group. A different relay makes it a
+            // different group even at the same id: quoting 0xchat's "nostrord" inside wisp's
+            // "nostrord" must open 0xchat's, not silently stay here.
             val isFromDifferentGroup =
                 when {
                     currentGroupId != null && sourceGroupId != currentGroupId -> true
-                    currentRelayUrl != null &&
-                        sourceRelayUrl != null &&
-                        sourceRelayUrl != currentRelayUrl -> true
+                    hostRelay != null && sourceRelayUrl != null && sourceRelayUrl != hostRelay -> true
                     // If no current context provided, assume it's a quote from same group (not forwarded)
                     else -> false
                 }
 
             if (isFromDifferentGroup) {
-                // Look up the source group across ALL relays (not just the current one) so a
-                // cross-relay forwarded group still shows its name + avatar; fetch a preview from
-                // the relay hint when we don't know it yet (parity with web / GroupLinkCard).
+                // Prefer the source relay's own kind:39000 for the card's name + avatar; a same-id
+                // group on another relay is a different group and must not paint this card. Fetch a
+                // preview from the hint when that relay's copy isn't cached yet.
                 val sourceGroup =
-                    remember(groupsByRelay, groups, sourceGroupId) {
-                        groupsByRelay.values.flatten().find { it.id == sourceGroupId }
+                    remember(groupsByRelay, groups, sourceGroupId, sourceRelayUrl) {
+                        val onSource = sourceRelayUrl
+                            ?.let { r -> groupsByRelay.entries.firstOrNull { e -> e.key.normalizeRelayUrl() == r } }
+                            ?.value
+                        onSource?.find { it.id == sourceGroupId }
+                            ?: groupsByRelay.values.flatten().find { it.id == sourceGroupId }
                             ?: groups.find { it.id == sourceGroupId }
                     }
-                val previewRelay = sourceRelayUrl ?: relayHints.firstOrNull()
-                LaunchedEffect(sourceGroupId, previewRelay, sourceGroup?.name) {
-                    if (sourceGroup?.name == null && previewRelay != null) {
-                        AppModule.nostrRepository.fetchGroupPreview(sourceGroupId, previewRelay)
+                LaunchedEffect(sourceGroupId, sourceRelayUrl, sourceGroup?.name) {
+                    if (sourceGroup?.name == null && sourceRelayUrl != null) {
+                        AppModule.nostrRepository.fetchGroupPreview(sourceGroupId, sourceRelayUrl)
                     }
                 }
 
@@ -1887,10 +1899,7 @@ private fun QuotedEvent(
                     sourceGroupId = sourceGroupId,
                     sourceGroupName = sourceGroup?.name,
                     sourceGroupPicture = sourceGroup?.picture,
-                    // The `h` tag rarely carries a relay; fall back to the nevent's relay hint so
-                    // the click opens the group on the relay the event actually lives on (the nav
-                    // effect connects it on demand), matching web.
-                    sourceRelayUrl = sourceRelayUrl ?: relayHints.firstOrNull(),
+                    sourceRelayUrl = sourceRelayUrl,
                     onClick = onClick,
                     onNavigateToGroup = onNavigateToGroup,
                     modifier = modifier,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -174,6 +174,7 @@ import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.window.LocalDesktopWindowControls
 import org.nostr.nostrord.ui.window.onBackForwardMouseButtons
 import org.nostr.nostrord.utils.accountDisplayLabel
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import kotlin.math.roundToInt
@@ -358,8 +359,8 @@ fun AppFrame() {
             if (r != null && r.relayUrl != AppModule.nostrRepository.currentRelayUrl.value) {
                 AppModule.nostrRepository.switchRelay(r.relayUrl)
             }
-            AppModule.nostrRepository.setActiveGroup(r?.groupId)
-            if (r != null) AppModule.nostrRepository.markGroupAsRead(r.groupId)
+            AppModule.nostrRepository.setActiveGroup(r?.relayUrl, r?.groupId)
+            if (r != null) AppModule.nostrRepository.markGroupAsRead(r.relayUrl, r.groupId)
         }
     }
 
@@ -466,9 +467,9 @@ fun AppFrame() {
                             name = group.meta.name ?: group.meta.id,
                             picture = group.meta.picture,
                             groupId = group.meta.id,
-                            unread = railUnread[group.meta.id] ?: 0,
+                            unread = railUnread[groupKey(group.relayUrl, group.meta.id)] ?: 0,
                             muted = muteState.isMuted(group.meta.id),
-                            mutedActivity = group.meta.id in railMutedActivity,
+                            mutedActivity = groupKey(group.relayUrl, group.meta.id) in railMutedActivity,
                             onToggleMute = { AppModule.notificationSettings.toggleMute(group.meta.id) },
                             active = activeRootId == group.meta.id &&
                                 activeRelay == group.relayUrl.normalizeRelayUrl() &&

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
@@ -87,6 +87,7 @@ import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.util.grabPointerIcon
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import kotlin.math.roundToInt
 
@@ -113,7 +114,7 @@ fun GroupSidebar(
     val groupMembers by vm.groupMembers.collectAsState()
     val groupAdmins by vm.groupAdmins.collectAsState()
     val joinedGroupsByRelay by vm.joinedGroupsByRelay.collectAsState()
-    val unreadCounts by AppModule.nostrRepository.unreadCounts.collectAsState()
+    val unreadByGroupKey by AppModule.nostrRepository.unreadByGroupKey.collectAsState()
     val muteState by AppModule.notificationSettings.muteState.collectAsState()
     val kind10009Relays by AppModule.nostrRepository.kind10009Relays.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()
@@ -294,7 +295,7 @@ fun GroupSidebar(
                         // First-level channels sit flush; only nesting below them indents.
                         depth = entry.depth - 1,
                         locked = isLockedChannel(channel, isJoined = entry.id in joinedHere),
-                        unread = unreadCounts[entry.id] ?: 0,
+                        unread = unreadByGroupKey[groupKey(route.relayUrl, entry.id)] ?: 0,
                         // Muting the root silences the whole tree, so a channel inside a
                         // muted group reads as muted without an override of its own.
                         muted = muteState.isMuted(entry.id) || muteState.isMuted(rootId),

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -42,6 +42,7 @@ import org.nostr.nostrord.ui.screens.group.model.buildChatItems
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.shortNpub
 
@@ -138,13 +139,15 @@ fun GroupScreen(
     val allGroupAdmins by vm.groupAdmins.collectAsState()
     val loadingMembersSet by vm.loadingMembers.collectAsState()
     val currentRelayUrl by vm.currentRelayUrl.collectAsState()
-    val allRestrictedGroups by vm.restrictedGroups.collectAsState()
     // Orphaned: pinned in kind:10009 but no kind:39000 from the relay (deleted / gone). Shows a
     // "no longer available" panel instead of the perpetual loading skeletons.
     val isOrphaned by vm.isOrphaned.collectAsState()
     val childrenByParent by vm.childrenByParent.collectAsState()
     // Subgroup UI is gated on the relay advertising nip29:{subgroups:true} in its NIP-11 (mirrors GroupSidebar).
     val screenRelay = relayUrl ?: currentRelayUrl
+    // Composer draft and scroll position belong to (relay, group), so the twin group on
+    // another relay never shows this one's half-typed message.
+    val chatKey = groupKey(screenRelay, groupId)
     val supportsSubgroups =
         (relayMetadata[screenRelay] ?: relayMetadata[screenRelay.normalizeRelayUrl()])?.supportsSubgroups == true
     val currentUserPubkey = vm.getPublicKey()
@@ -175,7 +178,7 @@ fun GroupScreen(
                 }.distinctBy { it.id }
         }
 
-    val isGroupRestricted = allRestrictedGroups.containsKey(groupId)
+    val isGroupRestricted by vm.isRestrictedHere.collectAsState()
 
     val parentGroupName =
         remember(groups, currentGroupMetadata?.parent, childrenByParent, groupId) {
@@ -205,9 +208,9 @@ fun GroupScreen(
     // Mention maps are part of the per-group draft: seed from the store on group change so
     // an @user / %group typed before switching is restored (and doesn't bleed into the next
     // group, which the un-keyed remember used to do).
-    var mentions by remember(groupId) { mutableStateOf(AppModule.messageDraftStore.get(groupId).mentions) }
-    var groupMentions by remember(groupId) {
-        mutableStateOf(decodeGroupMentions(AppModule.messageDraftStore.get(groupId).groupMentions))
+    var mentions by remember(chatKey) { mutableStateOf(AppModule.messageDraftStore.get(chatKey).mentions) }
+    var groupMentions by remember(chatKey) {
+        mutableStateOf(decodeGroupMentions(AppModule.messageDraftStore.get(chatKey).groupMentions))
     }
     var replyingToMessage by remember(groupId) { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
     // Bumped on EVERY reply tap so re-replying to the same message still refocuses the
@@ -395,12 +398,12 @@ fun GroupScreen(
     // Persist the per-group draft's mention maps whenever they change (MessageInput owns
     // and persists the text itself). Plain in-memory map writes, no recomposition. When a
     // send clears mentions (and the text), the store entry empties and is dropped.
-    LaunchedEffect(groupId) {
-        snapshotFlow { mentions }.collect { AppModule.messageDraftStore.setMentions(groupId, it) }
+    LaunchedEffect(chatKey) {
+        snapshotFlow { mentions }.collect { AppModule.messageDraftStore.setMentions(chatKey, it) }
     }
-    LaunchedEffect(groupId) {
+    LaunchedEffect(chatKey) {
         snapshotFlow { groupMentions }.collect {
-            AppModule.messageDraftStore.setGroupMentions(groupId, encodeGroupMentions(it))
+            AppModule.messageDraftStore.setGroupMentions(chatKey, encodeGroupMentions(it))
         }
     }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -217,6 +217,7 @@ fun GroupScreenDesktop(
                 ) {
                     MessagesList(
                         groupId = groupId,
+                        hostRelayUrl = relayUrl,
                         chatItems = chatItems,
                         messages = messages,
                         userMetadata = userMetadata,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenDesktop.kt
@@ -273,6 +273,7 @@ fun GroupScreenDesktop(
                         isGroupClosed = isClosed,
                         selectedChannel = selectedChannel,
                         groupId = groupId,
+                        hostRelayUrl = relayUrl,
                         groupName = groupName,
                         messageInput = messageInput,
                         onSendMessage = onSendMessage,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -257,6 +257,7 @@ fun GroupScreenMobile(
                         ) {
                             MessagesList(
                                 groupId = groupId,
+                                hostRelayUrl = relayUrl,
                                 chatItems = chatItems,
                                 messages = messages,
                                 userMetadata = userMetadata,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreenMobile.kt
@@ -314,6 +314,7 @@ fun GroupScreenMobile(
                                 isGroupClosed = isClosed,
                                 selectedChannel = selectedChannel,
                                 groupId = groupId,
+                                hostRelayUrl = relayUrl,
                                 groupName = groupName,
                                 messageInput = messageInput,
                                 onSendMessage = onSendMessage,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -86,6 +86,7 @@ import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.formatTimestamp
+import org.nostr.nostrord.utils.groupKey
 
 /**
  * Message input field with Discord-style keyboard behavior.
@@ -104,6 +105,8 @@ fun MessageInput(
     onCancelJoinRequest: () -> Unit = {},
     selectedChannel: String,
     groupId: String,
+    /** Relay this group is open on; the draft slot is per (relay, group). */
+    hostRelayUrl: String = "",
     groupName: String?,
     messageInput: String,
     onSendMessage: (String) -> Unit,
@@ -182,17 +185,18 @@ fun MessageInput(
     // Seed the field from the saved per-group draft and re-seed when the group changes,
     // so leaving a group and coming back restores the unsent text (text lives here, not
     // hoisted to the screen, so this is the source of truth for the draft body).
-    var textFieldValue by remember(groupId) {
-        val savedText = AppModule.messageDraftStore.get(groupId).text
+    val chatKey = groupKey(hostRelayUrl, groupId)
+    var textFieldValue by remember(chatKey) {
+        val savedText = AppModule.messageDraftStore.get(chatKey).text
         mutableStateOf(TextFieldValue(savedText, TextRange(savedText.length)))
     }
 
     // Persist the text on every change to the in-memory draft store. snapshotFlow keeps
     // this out of composition (a plain map write, no recomposition), so it does not
     // reintroduce the per-keystroke chat re-render this composer was split out to avoid.
-    LaunchedEffect(groupId) {
+    LaunchedEffect(chatKey) {
         snapshotFlow { textFieldValue.text }
-            .collect { AppModule.messageDraftStore.setText(groupId, it) }
+            .collect { AppModule.messageDraftStore.setText(chatKey, it) }
     }
 
     suspend fun handlePastedMedia(bytes: ByteArray, filename: String) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -109,6 +109,8 @@ private fun LazyListState.scrollSearchHitToTop(index: Int) {
 @Composable
 fun MessagesList(
     groupId: String,
+    /** Relay this group is open on. Every copied nevent/link points here. */
+    hostRelayUrl: String = "",
     chatItems: List<ChatItem>,
     messages: List<NostrGroupClient.NostrMessage> = emptyList(),
     userMetadata: Map<String, UserMetadata>,
@@ -205,11 +207,10 @@ fun MessagesList(
     }
     val imageViewerUrl = remember { mutableStateOf<String?>(null) }
     val currentRelayUrl by AppModule.nostrRepository.currentRelayUrl.collectAsState()
-    // Relay that HOSTS this group (its kind:39000 home), which may differ from the relay we're
-    // viewing it through. The copied nevent embeds this so readers fetch from the event's real home.
-    val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
-    val neventRelay =
-        groupsByRelay.entries.firstOrNull { entry -> entry.value.any { it.id == groupId } }?.key ?: currentRelayUrl
+    // Copied nevents and links carry the relay this group is open on. Scanning for "some relay
+    // serving this id" would hand out the other relay's same-id group, and the link would open a
+    // stranger's chat.
+    val neventRelay = hostRelayUrl.ifBlank { currentRelayUrl.orEmpty() }.takeIf { it.isNotBlank() }
     val copyToClipboard = rememberClipboardWriter()
     val shareText = rememberTextSharer()
 
@@ -772,11 +773,11 @@ fun MessagesList(
                                             },
                                             onCopyText = { copyToClipboard(item.message.content) },
                                             onCopyLink = {
-                                                val relay = currentRelayUrl ?: return@MessageItem
+                                                val relay = neventRelay ?: return@MessageItem
                                                 copyToClipboard(buildShareMessageLink(relay, groupId, item.message.id))
                                             },
                                             onShareLink = {
-                                                val relay = currentRelayUrl ?: return@MessageItem
+                                                val relay = neventRelay ?: return@MessageItem
                                                 shareText(buildShareMessageLink(relay, groupId, item.message.id))
                                             },
                                             onCopyJson = {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessagesList.kt
@@ -81,6 +81,7 @@ import org.nostr.nostrord.ui.scroll.JumpPillTarget
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.util.buildShareMessageLink
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.utils.rememberTextSharer
 import kotlin.time.Duration.Companion.milliseconds
@@ -231,7 +232,9 @@ fun MessagesList(
                 LazyListState()
             }
         }
-    val scrollStateHolder = rememberScrollStateHolder(groupId)
+    // Scroll position belongs to (relay, group): the twin group on another relay has its own.
+    val chatKey = groupKey(hostRelayUrl, groupId)
+    val scrollStateHolder = rememberScrollStateHolder(chatKey)
     val isSeekingTarget = targetMessageId != null
 
     // Two-stage jump pill: the first tap focuses the "New messages" divider, the next
@@ -271,7 +274,7 @@ fun MessagesList(
     val currentSearchActive by rememberUpdatedState(searchActive)
 
     ScrollPositionEffect(
-        groupId = groupId,
+        chatKey = chatKey,
         listState = listState,
         items = chatItems,
         stateHolder = scrollStateHolder,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ScrollPositionCache.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/ScrollPositionCache.kt
@@ -32,23 +32,24 @@ data class ScrollPosition(
 )
 
 /**
- * In-memory cache for scroll positions per group.
+ * In-memory cache for scroll positions per group. Keyed by [org.nostr.nostrord.utils.groupKey]:
+ * the same group id on two relays is two chats with their own reading position.
  * Survives navigation but not process death.
  */
 object ScrollPositionCache {
     private val positions = mutableMapOf<String, ScrollPosition>()
 
     fun save(
-        groupId: String,
+        chatKey: String,
         position: ScrollPosition,
     ) {
-        positions[groupId] = position
+        positions[chatKey] = position
     }
 
-    fun get(groupId: String): ScrollPosition? = positions[groupId]
+    fun get(chatKey: String): ScrollPosition? = positions[chatKey]
 
-    fun remove(groupId: String) {
-        positions.remove(groupId)
+    fun remove(chatKey: String) {
+        positions.remove(chatKey)
     }
 
     fun clear() {
@@ -61,7 +62,8 @@ object ScrollPositionCache {
  */
 @Stable
 class ScrollStateHolder(
-    val groupId: String,
+    /** [org.nostr.nostrord.utils.groupKey] of the chat this holder tracks. */
+    val chatKey: String,
     initialPosition: ScrollPosition? = null,
 ) {
     var savedPosition by mutableStateOf(initialPosition)
@@ -116,7 +118,7 @@ class ScrollStateHolder(
     ) {
         val position = ScrollPosition(anchorKey, offset)
         savedPosition = position
-        ScrollPositionCache.save(groupId, position)
+        ScrollPositionCache.save(chatKey, position)
     }
 
     fun markRestored() {
@@ -129,34 +131,34 @@ class ScrollStateHolder(
         fun saver(): Saver<ScrollStateHolder, List<Any?>> = Saver(
             save = { holder ->
                 listOf(
-                    holder.groupId,
+                    holder.chatKey,
                     holder.savedPosition?.anchorKey,
                     holder.savedPosition?.offset,
                 )
             },
             restore = { saved ->
-                val groupId = saved[0] as String
+                val chatKey = saved[0] as String
                 val anchorKey = saved[1] as? String
                 val offset = saved[2] as? Int
                 val position =
                     if (anchorKey != null && offset != null) {
                         ScrollPosition(anchorKey, offset)
                     } else {
-                        ScrollPositionCache.get(groupId)
+                        ScrollPositionCache.get(chatKey)
                     }
-                ScrollStateHolder(groupId, position)
+                ScrollStateHolder(chatKey, position)
             },
         )
     }
 }
 
 @Composable
-fun rememberScrollStateHolder(groupId: String): ScrollStateHolder = rememberSaveable(
-    inputs = arrayOf(groupId),
+fun rememberScrollStateHolder(chatKey: String): ScrollStateHolder = rememberSaveable(
+    inputs = arrayOf(chatKey),
     saver = ScrollStateHolder.saver(),
 ) {
-    val cached = ScrollPositionCache.get(groupId)
-    ScrollStateHolder(groupId, cached)
+    val cached = ScrollPositionCache.get(chatKey)
+    ScrollStateHolder(chatKey, cached)
 }
 
 /**
@@ -165,7 +167,7 @@ fun rememberScrollStateHolder(groupId: String): ScrollStateHolder = rememberSave
  */
 @Composable
 fun <T> ScrollPositionEffect(
-    groupId: String,
+    chatKey: String,
     listState: LazyListState,
     items: List<T>,
     stateHolder: ScrollStateHolder,
@@ -175,7 +177,7 @@ fun <T> ScrollPositionEffect(
     val currentItems by rememberUpdatedState(items)
 
     // initialScrollToEnd is false while a deep-link seek owns positioning, then flips true
-    // once the target is consumed. The effects below are keyed on (groupId, listState), so
+    // once the target is consumed. The effects below are keyed on (chatKey, listState), so
     // they read this LIVE value instead of the launch-time capture: an early `return` on the
     // captured value would disarm bottom-pinning, the restore gate, and the latch tracker for
     // the whole visit (a notification-link entry then never shows the jump pill, never
@@ -187,8 +189,8 @@ fun <T> ScrollPositionEffect(
     // strand the open above the true bottom (the latch can briefly read "not at bottom" mid-reflow).
     // A seek entry gets NO settle window: the seek scrolls mid-history and the window's
     // latch-bypass would fight it toward the bottom.
-    var settling by remember(groupId) { mutableStateOf(initialScrollToEnd) }
-    LaunchedEffect(groupId) {
+    var settling by remember(chatKey) { mutableStateOf(initialScrollToEnd) }
+    LaunchedEffect(chatKey) {
         if (!settling) return@LaunchedEffect
         kotlinx.coroutines.delay(1500)
         settling = false
@@ -197,7 +199,7 @@ fun <T> ScrollPositionEffect(
     // A real user gesture ends the settle window immediately. While it is open the
     // pin ignores the atBottom latch, so a scroll-up right after opening would fight
     // the pin frame by frame (web parity: 712fe5b3).
-    LaunchedEffect(groupId, listState) {
+    LaunchedEffect(chatKey, listState) {
         listState.interactionSource.interactions.collect { interaction ->
             if (interaction is DragInteraction.Start) settling = false
         }
@@ -209,16 +211,16 @@ fun <T> ScrollPositionEffect(
     // auto-pin start applying. Default latch (atBottom = true) means a group with no
     // unread divider simply opens at the bottom via the pin effect below.
     //
-    // Keyed on listState (not just groupId): on a cold load the list starts empty so
+    // Keyed on listState (not just chatKey): on a cold load the list starts empty so
     // MessagesList builds a throwaway LazyListState, then swaps in a new one anchored
-    // at the last item once messages arrive. If this effect stayed keyed on groupId
+    // at the last item once messages arrive. If this effect stayed keyed on chatKey
     // it would keep awaiting totalItemsCount > 0 on the discarded (detached) state
     // forever, so markRestored never fires, the tracker's readings are dropped, and
     // the jump-to-bottom FAB never appears until the group is re-entered.
     // Runs on seek entries too: restoration only opens the user-scroll tracker gate, and a
     // deep-link visit needs the latch/FAB tracking just as much (the seek lands mid-history,
     // which is exactly when the jump pill must be able to appear).
-    LaunchedEffect(groupId, listState) {
+    LaunchedEffect(chatKey, listState) {
         snapshotFlow { listState.layoutInfo.totalItemsCount }
             .first { it > 0 }
         stateHolder.markRestored()
@@ -235,7 +237,7 @@ fun <T> ScrollPositionEffect(
     // Keyed on listState too: it must rebind to the live LazyListState after the
     // cold-load swap described above, otherwise stick-to-bottom would drive the
     // discarded state and never move the visible list.
-    LaunchedEffect(groupId, listState) {
+    LaunchedEffect(chatKey, listState) {
         snapshotFlow {
             // Height-aware key. Re-pin on a new tail item (size) AND on tail height growth
             // (the last visible item's index and measured size), so a late-decoding image,
@@ -288,7 +290,7 @@ fun <T> ScrollPositionEffect(
     // whose target happens to sit within the bottom tolerance is not spuriously
     // promoted back to bottom (web's `wasNotAtBottom` round-trip gate). The pin
     // effect reads the latch, not the layout, so this can never race it.
-    LaunchedEffect(groupId, listState) {
+    LaunchedEffect(chatKey, listState) {
         snapshotFlow {
             val layoutInfo = listState.layoutInfo
             val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
@@ -316,7 +318,7 @@ fun <T> ScrollPositionEffect(
     }
 
     // Continuously save position for group-switch restore.
-    LaunchedEffect(groupId, listState) {
+    LaunchedEffect(chatKey, listState) {
         snapshotFlow {
             Pair(listState.firstVisibleItemIndex, listState.firstVisibleItemScrollOffset)
         }.distinctUntilChanged()
@@ -330,7 +332,7 @@ fun <T> ScrollPositionEffect(
     }
 
     // Save position when leaving group.
-    DisposableEffect(groupId) {
+    DisposableEffect(chatKey) {
         onDispose {
             val index = listState.firstVisibleItemIndex
             if (index < items.size && items.isNotEmpty()) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsSidebar.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.unit.sp
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
 /**
  * Notifications filter column (prototype NotificationsSidebar): the type tabs with counts,
@@ -117,16 +118,19 @@ fun NotificationsSidebar(
             icon = Icons.Default.People,
         ) { vm.setGroupFilter(null) }
         buckets.forEach { bucket ->
+            // This relay's kind:39000 first: a same-id group elsewhere is a different group and
+            // must not lend its avatar to this tab.
             val picture =
-                groupsByRelay.values.firstNotNullOfOrNull { list -> list.firstOrNull { it.id == bucket.groupId }?.picture }
+                groupsByRelay.entries.firstOrNull { it.key.normalizeRelayUrl() == bucket.relayUrl.normalizeRelayUrl() }
+                    ?.value?.firstOrNull { it.id == bucket.groupId }?.picture
             GroupTab(
                 picture = picture,
-                identifier = bucket.groupId,
+                identifier = bucket.key,
                 label = bucket.name,
                 unread = bucket.unread,
-                active = groupFilter == bucket.groupId,
+                active = groupFilter == bucket.key,
                 icon = null,
-            ) { vm.setGroupFilter(bucket.groupId) }
+            ) { vm.setGroupFilter(bucket.key) }
         }
     }
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -390,7 +390,7 @@ val AppFrame =
                     // and the invite-code affordance) instead of the misleading public/open. A plain
                     // unknown group (metadata still loading on a public relay) keeps the permissive
                     // public/open default.
-                    val restricted = r.groupId in restrictedGroups
+                    val restricted = groupKey(r.relayUrl, r.groupId) in restrictedGroups
                     lastGroupRef.current ?: GroupMetadata(
                         id = r.groupId,
                         name = null,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -29,6 +29,7 @@ import org.nostr.nostrord.ui.screens.home.railKey
 import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.accountDisplayLabel
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
@@ -334,10 +335,10 @@ val AppFrame =
         useEffect(groupRoute?.relayUrl, groupRoute?.groupId, groupRoute?.inviteCode) {
             val r = groupRoute
             if (r == null) {
-                repo.setActiveGroup(null)
+                repo.setActiveGroup(null, null)
             } else {
-                repo.setActiveGroup(r.groupId)
-                repo.markGroupAsRead(r.groupId)
+                repo.setActiveGroup(r.relayUrl, r.groupId)
+                repo.markGroupAsRead(r.relayUrl, r.groupId)
                 val code = r.inviteCode
                 if (code != null) {
                     consumeInviteInHash(r)
@@ -513,13 +514,13 @@ val AppFrame =
                                         icon(Ic.NotificationsOff)
                                     }
                                 }
-                                val unread = railUnread[group.meta.id] ?: 0
+                                val unread = railUnread[groupKey(group.relayUrl, group.meta.id)] ?: 0
                                 if (unread > 0) {
                                     span {
                                         className = ClassName("rail-badge")
                                         +(if (unread > 99) "99+" else "$unread")
                                     }
-                                } else if (group.meta.id in railMutedActivity) {
+                                } else if (groupKey(group.relayUrl, group.meta.id) in railMutedActivity) {
                                     // Muted but moving: a dot in the free corner, since the
                                     // bell-off badge owns the bottom one.
                                     span { className = ClassName("rail-badge top muted-dot") }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/GroupSidebar.kt
@@ -15,6 +15,7 @@ import org.nostr.nostrord.ui.screens.group.isLockedChannel
 import org.nostr.nostrord.ui.screens.group.moveChannelBefore
 import org.nostr.nostrord.ui.screens.group.rootGroupId
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
@@ -65,7 +66,7 @@ val GroupSidebar =
         val groupAdmins = useStateFlow(vm.groupAdmins)
         val relayMetadata = useStateFlow(vm.relayMetadata)
         val joinedGroupsByRelay = useStateFlow(vm.joinedGroupsByRelay)
-        val unreadCounts = useStateFlow(AppModule.nostrRepository.unreadCounts)
+        val unreadByGroupKey = useStateFlow(AppModule.nostrRepository.unreadByGroupKey)
         val muteState = useStateFlow(AppModule.notificationSettings.muteState)
         // Open group context menu: which row, and where it was right-clicked.
         val (groupMenu, setGroupMenu) = useState<GroupMenuAnchor?> { null }
@@ -369,7 +370,7 @@ val GroupSidebar =
                                     icon(Ic.NotificationsOff)
                                 }
                             }
-                            val unread = unreadCounts[entry.id] ?: 0
+                            val unread = unreadByGroupKey[groupKey(route.relayUrl, entry.id)] ?: 0
                             if (unread > 0) {
                                 if (channelMuted) {
                                     // Dot, not a count: the number is exactly the noise muting removes.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/ShareGroupModal.kt
@@ -16,6 +16,9 @@ import web.cssom.ClassName
 
 external interface ShareGroupModalProps : Props {
     var group: GroupMetadata
+
+    /** Relay the group is open on. The shared address must point at this relay's copy of it. */
+    var relayUrl: String
     var onClose: () -> Unit
 }
 
@@ -26,7 +29,7 @@ external interface ShareGroupModalProps : Props {
 val ShareGroupModal =
     FC<ShareGroupModalProps> { props ->
         val group = props.group
-        val relayUrl = useStateFlow(AppModule.nostrRepository.currentRelayUrl)
+        val relayUrl = props.relayUrl
         val relayMetadata = useStateFlow(AppModule.nostrRepository.relayMetadata)
         // Author = NIP-11 `self` (relay signing key), else `pubkey`; falls back to zero bytes inside encodeNaddr.
         val relayPubkey = relayMetadata[relayUrl]?.groupNaddrAuthor ?: relayMetadata[relayUrl.trimEnd('/')]?.groupNaddrAuthor

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -975,6 +975,11 @@ val ChatScreen =
         val allGroups = useStateFlow(vm.mentionableGroups)
         val relayMetadata = useStateFlow(vm.relayMetadata)
         val relayUrl = useStateFlow(vm.currentRelayUrl)
+        // Relay this group is OPEN on. `relayUrl` above is merely the connected one, which drifts
+        // to whichever relay was focused last; anything that identifies the group - shared links,
+        // nevent hints, quote resolution - must use the route's relay or it points at the other
+        // relay's same-id group.
+        val hostRelay = (props.relayUrl ?: relayUrl).normalizeRelayUrl()
         val isLoadingMore = useStateFlow(vm.isLoadingMore)[group.id] ?: false
         val hasMore = useStateFlow(vm.hasMoreMessages)[group.id] ?: true
         // Per-group GroupLoadingState. Only the Exhausted state means the relay
@@ -1009,22 +1014,19 @@ val ChatScreen =
         // would otherwise re-sort the whole list 15+ times during a group switch).
         val messages = useMemo(rawMessages) { rawMessages.sortedBy { it.createdAt } }
         val messagesById = useMemo(messages) { messages.associateBy { it.id } }
-        // The relay that actually HOSTS this group (where its kind:39000 lives), which may differ
-        // from the relay we're viewing it through. The copied nevent embeds this so readers fetch
-        // the event from its real home, not from wherever we happened to be connected.
-        val allGroupsByRelay = useStateFlow(AppModule.nostrRepository.groupsByRelay)
-        val neventRelay =
-            allGroupsByRelay.entries.firstOrNull { it.value.any { g -> g.id == group.id } }?.key ?: relayUrl
+        // Copied nevents and links embed the relay this group is open on. Scanning for "some relay
+        // serving this id" would hand out the other relay's same-id group, and the link would open
+        // a stranger's chat.
         // Pure per-message values (bech32 nevent, the event JSON, the share link): expensive to
         // compute and constant for a message, so build them once per message-list change instead of
         // re-encoding/re-serializing all 200 rows on every re-render.
         val rowMeta =
-            useMemo(messages, group.id, relayUrl, neventRelay) {
-                val host = relayUrl.removePrefix("wss://").removePrefix("ws://")
+            useMemo(messages, group.id, hostRelay) {
+                val host = hostRelay.removePrefix("wss://").removePrefix("ws://")
                 messages.associate { m ->
                     m.id to
                         RowMeta(
-                            nevent = Nip19.encodeNevent(m.id, relays = listOf(neventRelay), authorHex = m.pubkey, kind = m.kind),
+                            nevent = Nip19.encodeNevent(m.id, relays = listOf(hostRelay), authorHex = m.pubkey, kind = m.kind),
                             eventJson = m.toEventJson(),
                             link = "https://nostrord.com/open/?relay=$host&group=${group.id}&e=${m.id}",
                         )
@@ -2125,6 +2127,7 @@ val ChatScreen =
                                             val zapInfo = zapsByMsg[message.id]
                                             val meta = rowMeta[message.id]
                                             MessageRow {
+                                                this.relayUrl = hostRelay
                                                 key = message.id
                                                 domId = "msg-${message.id}"
                                                 highlighted = message.id == highlightId
@@ -2454,6 +2457,7 @@ val ChatScreen =
                 "share" ->
                     ShareGroupModal {
                         this.group = group
+                        this.relayUrl = hostRelay
                         onClose = { setModal(null) }
                     }
                 "members" ->
@@ -2750,6 +2754,9 @@ external interface MessageRowProps : Props {
 
     /** Group this row belongs to; scopes a quoted event's by-id REQ with `#h`. */
     var groupId: String
+
+    /** Relay that group is open on; copied links and quote resolution are scoped to it. */
+    var relayUrl: String
     var onEventRef: (String) -> Unit
     var onGroupRef: (String, String?) -> Unit
     var replyTo: ReplyPreviewData?
@@ -3092,6 +3099,7 @@ private val MessageRow =
                         props.onEventRef,
                         props.onGroupRef,
                         props.groupId,
+                        props.relayUrl,
                     )
                     // Send-state icon (own messages: clock while sending, check when
                     // delivered) flows inline after the content so no extra line shifts
@@ -3447,6 +3455,9 @@ internal fun ChildrenBuilder.renderMessageContent(
     /** Group this message was read in: a quoted event is looked up with `#h`, which some
      *  NIP-29 relays require even for a lookup by id. */
     groupId: String?,
+    /** Relay that group is open on. A quote of the same id on another relay is a quote of a
+     *  different group, so the card must forward instead of resolving locally. */
+    hostRelay: String,
 ) {
     // Markdown image embeds collapse to their bare url so URL_REGEX sees a plain link; the
     // surrounding `![alt](` / `)` would otherwise render as literal text. Mirrors native.
@@ -3459,16 +3470,16 @@ internal fun ChildrenBuilder.renderMessageContent(
     var qLast = 0
     for (q in BLOCKQUOTE_REGEX.findAll(content)) {
         if (q.range.first > qLast) {
-            renderBody(content.substring(qLast, q.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
+            renderBody(content.substring(qLast, q.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId, hostRelay)
         }
         div {
             className = ClassName("msg-quote")
-            renderBody(q.value.replace(BLOCKQUOTE_LINE_PREFIX, ""), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
+            renderBody(q.value.replace(BLOCKQUOTE_LINE_PREFIX, ""), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId, hostRelay)
         }
         qLast = q.range.last + 1
     }
     if (qLast < content.length) {
-        renderBody(content.substring(qLast), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
+        renderBody(content.substring(qLast), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId, hostRelay)
     }
 }
 
@@ -3486,11 +3497,14 @@ private fun ChildrenBuilder.renderBody(
     /** Group this message was read in: a quoted event is looked up with `#h`, which some
      *  NIP-29 relays require even for a lookup by id. */
     groupId: String?,
+    /** Relay that group is open on. A quote of the same id on another relay is a quote of a
+     *  different group, so the card must forward instead of resolving locally. */
+    hostRelay: String,
 ) {
     var last = 0
     for (block in CODE_BLOCK_REGEX.findAll(content)) {
         if (block.range.first > last) {
-            renderInline(content.substring(last, block.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
+            renderInline(content.substring(last, block.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId, hostRelay)
         }
         val lang = block.groupValues[1].takeIf { it.isNotBlank() }
         div {
@@ -3509,7 +3523,7 @@ private fun ChildrenBuilder.renderBody(
         last = block.range.last + 1
     }
     if (last < content.length) {
-        renderInline(content.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
+        renderInline(content.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId, hostRelay)
     }
 }
 
@@ -3527,11 +3541,14 @@ private fun ChildrenBuilder.renderInline(
     /** Group this message was read in: a quoted event is looked up with `#h`, which some
      *  NIP-29 relays require even for a lookup by id. */
     groupId: String?,
+    /** Relay that group is open on. A quote of the same id on another relay is a quote of a
+     *  different group, so the card must forward instead of resolving locally. */
+    hostRelay: String,
 ) {
     var last = 0
     for (m in INLINE_CODE_REGEX.findAll(text)) {
         if (m.range.first > last) {
-            renderEntities(text.substring(last, m.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
+            renderEntities(text.substring(last, m.range.first), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId, hostRelay)
         }
         code {
             className = ClassName("msg-code")
@@ -3540,7 +3557,7 @@ private fun ChildrenBuilder.renderInline(
         last = m.range.last + 1
     }
     if (last < text.length) {
-        renderEntities(text.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId)
+        renderEntities(text.substring(last), emojiMap, posters, dims, userMetadata, messagesById, onUser, onEventRef, onGroupRef, groupId, hostRelay)
     }
 }
 
@@ -3557,6 +3574,9 @@ private fun ChildrenBuilder.renderEntities(
     /** Group this message was read in: a quoted event is looked up with `#h`, which some
      *  NIP-29 relays require even for a lookup by id. */
     groupId: String?,
+    /** Relay that group is open on. A quote of the same id on another relay is a quote of a
+     *  different group, so the card must forward instead of resolving locally. */
+    hostRelay: String,
 ) {
     var last = 0
     for (match in URL_REGEX.findAll(content)) {
@@ -3641,6 +3661,7 @@ private fun ChildrenBuilder.renderEntities(
                         kind = entity.kind
                         localById = messagesById
                         this.groupId = groupId
+                        this.relayUrl = hostRelay
                         onScrollTo = onEventRef
                         this.onUser = onUser
                         this.onGroupRef = onGroupRef
@@ -3653,6 +3674,7 @@ private fun ChildrenBuilder.renderEntities(
                         kind = null
                         localById = messagesById
                         this.groupId = groupId
+                        this.relayUrl = hostRelay
                         onScrollTo = onEventRef
                         this.onUser = onUser
                         this.onGroupRef = onGroupRef
@@ -3753,6 +3775,9 @@ private external interface QuotedEventProps : Props {
 
     /** Group the reference was read in; scopes the by-id REQ with `#h`. */
     var groupId: String?
+
+    /** Relay that group is open on, for telling a local quote from a same-id cross-relay one. */
+    var relayUrl: String
     var onScrollTo: (String) -> Unit
     var onUser: (String) -> Unit
     var onGroupRef: (String, String?) -> Unit
@@ -3834,13 +3859,21 @@ private val QuotedEvent =
         val groupsByRelay = useStateFlow(repo.groupsByRelay)
         val refGroupId =
             cachedEv?.tags?.firstOrNull { it.size >= 2 && it.getOrNull(0) == "h" }?.getOrNull(1)
-        val isForwarded = local == null && refGroupId != null
-        // Navigate using the nevent's own relay hint — that's where the event lives. The
-        // navigation effect connects that relay on demand if it isn't already, then loads the
-        // group + scrolls to the message. (The group name/avatar below resolve from any relay we
-        // already know the group on, so the header still fills in.)
-        val fwdRelay = props.relays.firstOrNull()
-        val fwdGroupMeta = refGroupId?.let { gid -> groupsByRelay.values.flatten().firstOrNull { it.id == gid } }
+        // Navigate using the nevent's own relay hint — that's where the event lives. Normalized so
+        // a hint like "wss://Relay/" routes to the same slot as the connected relay. The navigation
+        // effect connects that relay on demand, then loads the group + scrolls to the message.
+        val fwdRelay = props.relays.firstOrNull()?.normalizeRelayUrl()
+        // A quote of the same group id on a DIFFERENT relay is a quote of a different group, so it
+        // forwards too: otherwise it renders as local and the click never leaves this chat.
+        val isForwarded =
+            refGroupId != null && (local == null || (fwdRelay != null && fwdRelay != props.relayUrl.normalizeRelayUrl()))
+        // The source relay's own kind:39000 names the card; a same-id group elsewhere is a
+        // different group and must not paint it.
+        val fwdGroupMeta =
+            refGroupId?.let { gid ->
+                val onSource = fwdRelay?.let { r -> groupsByRelay.entries.firstOrNull { it.key.normalizeRelayUrl() == r }?.value }
+                onSource?.firstOrNull { it.id == gid } ?: groupsByRelay.values.flatten().firstOrNull { it.id == gid }
+            }
         val fwdGroupName = fwdGroupMeta?.name?.takeIf { it.isNotBlank() } ?: refGroupId.orEmpty()
         useEffect(refGroupId, fwdRelay, fwdGroupMeta?.name) {
             if (isForwarded && refGroupId != null && fwdRelay != null && fwdGroupMeta?.name == null) {
@@ -4050,6 +4083,7 @@ private val QuotedEvent =
                                 props.onScrollTo,
                                 props.onGroupRef,
                                 props.groupId,
+                                props.relayUrl,
                             )
                         }
                     }
@@ -4086,6 +4120,7 @@ private val QuotedEvent =
                             props.onScrollTo,
                             props.onGroupRef,
                             props.groupId,
+                            props.relayUrl,
                         )
                     }
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -44,6 +44,7 @@ import org.nostr.nostrord.utils.epochSeconds
 import org.nostr.nostrord.utils.formatDateTime
 import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.utils.formatTimestamp
+import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeForSearch
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.shortNpub
@@ -290,7 +291,6 @@ private val ChatComposer =
         val members = props.members
         val userMetadata = props.userMetadata
         val allGroups = props.allGroups
-        val relayUrl = props.relayUrl
         val groupName = props.groupName
 
         val (draft, setDraft) = useState { "" }
@@ -327,11 +327,12 @@ private val ChatComposer =
         val composerInputRef = useRef<HTMLTextAreaElement>(null)
         val composerHighlightRef = useRef<HTMLDivElement>(null)
 
-        // Per-group draft: restore what was being typed when this group was last open.
-        // Runs on group change only (the same component is reused across groups, so the
-        // draft state would otherwise leak from one group to the next).
-        useEffect(props.groupId) {
-            val draftEntry = AppModule.messageDraftStore.get(props.groupId)
+        // Per-chat draft: restore what was being typed when this chat was last open. Keyed by
+        // (relay, group) so the same group id on another relay keeps its own draft. Runs on chat
+        // change only (the same component is reused, so the state would otherwise leak forward).
+        val draftKey = groupKey(props.relayUrl, props.groupId)
+        useEffect(draftKey) {
+            val draftEntry = AppModule.messageDraftStore.get(draftKey)
             setDraft(draftEntry.text)
             setMentions(draftEntry.mentions)
             setGroupMentions(draftEntry.groupMentions)
@@ -340,9 +341,9 @@ private val ChatComposer =
         // on every keystroke is free. On group switch this effect's deps are still the old
         // group's values, so it does not fire until the load effect above swaps them in.
         useEffect(draft, mentions, groupMentions) {
-            AppModule.messageDraftStore.setText(props.groupId, draft)
-            AppModule.messageDraftStore.setMentions(props.groupId, mentions)
-            AppModule.messageDraftStore.setGroupMentions(props.groupId, groupMentions)
+            AppModule.messageDraftStore.setText(draftKey, draft)
+            AppModule.messageDraftStore.setMentions(draftKey, mentions)
+            AppModule.messageDraftStore.setGroupMentions(draftKey, groupMentions)
         }
 
         // Autocomplete suggestions for the active mention (members for @, groups for %).
@@ -1078,8 +1079,7 @@ val ChatScreen =
         // Restricted: relay returned a CLOSED "restricted" frame for this group.
         // Used to render the "Private group" UI in place of skeletons when the
         // account has no read access (NIP-29 private+closed group).
-        val restrictedGroups = useStateFlow(vm.restrictedGroups)
-        val isGroupRestricted = group.id in restrictedGroups
+        val isGroupRestricted = useStateFlow(vm.isRestrictedHere)
         // Orphaned: pinned in kind:10009 but the relay served no kind:39000 after its group list
         // finished, i.e. the group was deleted / no longer exists. Drives the "no longer available"
         // panel instead of perpetual loading skeletons.
@@ -2271,7 +2271,7 @@ val ChatScreen =
                         this.members = members
                         this.allGroups = allGroups
                         this.userMetadata = userMetadata
-                        this.relayUrl = relayUrl
+                        this.relayUrl = hostRelay
                         this.relayPubkeyOf = { r -> relayMetadata[r]?.groupNaddrAuthor ?: relayMetadata[r.normalizeRelayUrl()]?.groupNaddrAuthor }
                         this.replyingToId = replyingToId
                         this.replyNonce = replyNonce

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -432,8 +432,10 @@ val DmPage =
                                             { props.onOpenProfile(UserRoute(it)) },
                                             {},
                                             { gid, relay -> relay?.let { props.onOpenGroup(GroupRoute(it, gid)) } },
-                                            // A DM is not in a group: the by-id REQ stays unscoped.
+                                            // A DM is not in a group: the by-id REQ stays unscoped
+                                            // and there is no host relay to compare a quote against.
                                             null,
+                                            "",
                                         )
                                     }
                                     if (invite != null) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
@@ -8,6 +8,7 @@ import org.nostr.nostrord.ui.screens.notifications.NotifFilter
 import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
 import org.nostr.nostrord.ui.screens.notifications.notificationActionLabel
 import org.nostr.nostrord.utils.formatTimestamp
+import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.shortNpub
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.components.AvatarKind
@@ -229,12 +230,14 @@ val NotificationsSidebar =
             }
             ngroupTab(null, "all", "All groups", 0, groupFilter == null, Ic.People) { vm.setGroupFilter(null) }
             buckets.forEach { bucket ->
+                // This relay's kind:39000 first: a same-id group elsewhere is a different group and
+                // must not lend its avatar to this tab.
                 val picture =
-                    groupsByRelay.values.firstNotNullOfOrNull { list ->
-                        list.firstOrNull { it.id == bucket.groupId }?.picture
-                    }
-                ngroupTab(picture, bucket.groupId, bucket.name, bucket.unread, groupFilter == bucket.groupId, null) {
-                    vm.setGroupFilter(bucket.groupId)
+                    groupsByRelay.entries
+                        .firstOrNull { it.key.normalizeRelayUrl() == bucket.relayUrl.normalizeRelayUrl() }
+                        ?.value?.firstOrNull { it.id == bucket.groupId }?.picture
+                ngroupTab(picture, bucket.key, bucket.name, bucket.unread, groupFilter == bucket.key, null) {
+                    vm.setGroupFilter(bucket.key)
                 }
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -767,6 +767,7 @@ val ThreadsScreen =
                                     ?.let { parentId -> { jumpToMessage(parentId) } },
                                 // A group ref in the body opens that group's chat page.
                                 onGroupRef = { gid, relay -> props.onNavigate(GroupRoute(relay ?: route.relayUrl, gid)) },
+                                hostRelayUrl = route.relayUrl,
                                 onRetry = { vm.retrySend(msg.id) },
                                 onDismiss = { vm.dismissFailed(msg.id) },
                             )
@@ -1006,6 +1007,8 @@ private fun ChildrenBuilder.threadMessage(
     // Tapping the quoted parent scrolls to it; null when the parent is not in this thread.
     onJumpToParent: (() -> Unit)?,
     onGroupRef: (String, String?) -> Unit,
+    /** Relay this thread's group is open on, for resolving quoted references against it. */
+    hostRelayUrl: String,
     onRetry: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -1102,6 +1105,7 @@ private fun ChildrenBuilder.threadMessage(
                     onGroupRef = onGroupRef,
                     // The event's own NIP-29 `h` tag scopes a quoted reference's by-id REQ.
                     groupId = msg.tags.firstOrNull { it.size >= 2 && it[0] == "h" }?.get(1),
+                    hostRelay = hostRelayUrl,
                 )
                 // Inline send-state icon (clock/check) so no extra line shifts the list.
                 if (myPubkey != null && myPubkey == msg.pubkey) {


### PR DESCRIPTION
A NIP-29 group id is only unique within one relay, but most per-group state was still keyed on the bare id. `nostrord` on chat.wisp.talk and `nostrord` on groups.0xchat.com therefore shared one unread counter, one read anchor, one composer draft, one scroll position and one "restricted" marker. Traffic on either raised a badge on both rail chips, opening one cleared the other's, and a copied link or nevent could hand out the other relay's group. #206 split messages, members and metadata per relay but explicitly deferred this set.

Every per-group store now keys on `groupKey(relayUrl, groupId)` (relay normalized, relay first so ids containing `|` still round-trip).

| Symptom | Cause | Fix |
|---|---|---|
| Badge on wisp for traffic in 0xchat | `unreadCounts[groupId]`; `unreadByRelay` summed the same count into every relay whose joined set held that id | keyed by `groupKey`; a flush splits by each message's own `relayUrl`, reactions take the delivering client's relay |
| Reading one cleared its twin | `markAsRead` / `setActiveGroup` / `markReadForGroup` took only an id | all take the route's relay |
| Copied link/nevent pointed at the wrong relay | web read the *connected* relay (`vm.currentRelayUrl`), native scanned for "some relay serving this id" | both use the route relay |
| An nevent hinting 0xchat opened wisp | the forwarded gate compared group ids and never the hint against the open relay | same id + different relay counts as forwarded and routes to the hint, normalized first |
| Draft and scroll position bled across | `MessageDraftStore` / `ScrollPositionCache` keyed on the id | keyed on (relay, group) |
| "Private group" placeholder over a public twin | a CLOSE "restricted" marked the bare id, and dropped it from the other relay's mux batch too | markers key on (relay, group); both UIs read `GroupViewModel.isRestrictedHere` instead of the raw map |

`fetchGroupPreview` no longer treats another relay's same-id group as a cache hit, which had left the hinted one permanently nameless. `getRelayForGroup` returns null when several relays serve an id and no open-group hint breaks the tie, instead of taking the first match: callers already fall back to the connected relay, which is at least one the user picked. The invite DM resolves its naddr relay on the add path, where the group is unambiguous.

Unread counters persisted before the split are dropped on load, since their relay is unknowable and attributing them to a guess is the bug. The read anchor survives through a legacy bare-id fallback in `lastReadFor`, so no group replays its history as unread; the badges reseed from live traffic.

Not addressed here, all pre-existing:

- Mute levels (`NotificationSettings.groupLevels`) stay keyed on the bare id, so muting one twin mutes both. That map is NIP-78-synced as kind:30078, so re-keying it is a cross-device format migration and wants its own PR.
- Pagination state (`_groupStates`, `_isLoadingMore`, `_hasMoreMessages`) is still flat, as #206 left it.
- `getRelayForGroup` is tightened but not removed; ~40 send paths still resolve a relay from a bare id, relying on the open-group hint.
- `ui/components/sidebars/GroupSidebar.kt` is an unreferenced duplicate of `components/layout/GroupSidebar.kt` and still reads bare-id counts. Dead, but the next search will find it.

`UnreadManager.isRestricted` now receives the relay, but no test covers the badge path for a private twin, so that one wants a look on device.