### PR TITLE
fix(dm): make NIP-4e device pairing actually hand over the key

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2511,9 +2511,14 @@ class NostrRepository(
                 ?: return Result.Error(AppError.Auth.NotAuthenticated)
         val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
         return try {
+            // The previous attempt's request is dead the moment a new throwaway key exists: only
+            // this device can open its answer, and it no longer holds that key. Left on the relay
+            // it prompts every holding device again, once per launch, forever.
+            val superseded = pendingPairingRequestId
             val throwaway = dmPairingManager.beginRequest()
             val signed = signer.signEvent(Nip4e.buildClientKeyRequest(myPub, throwaway, epochSeconds()))
             pendingPairingRequestId = signed.id
+            superseded?.let { scope.launch { publishDeletion(myPub, signer, listOf(it)) } }
             // Our own request must never prompt us: the throwaway-key guard is in-memory only, so
             // after a restart the relay replays this event back to us like any other.
             signed.id?.let { dmPairingManager.markProcessed(it) }
@@ -2528,9 +2533,9 @@ class NostrRepository(
     }
 
     /** Send our encryption key to the device that asked for it (NIP-4e kind:4455). */
-    override suspend fun approveDmPairing(): Result<Unit> {
+    override suspend fun approveDmPairing(throwawayPubkey: String): Result<Unit> {
         val incoming =
-            dmPairingManager.state.value as? DmPairingManager.State.IncomingRequest
+            dmPairingManager.pendingRequest(throwawayPubkey)
                 ?: return Result.Error(AppError.Unknown("There is no pairing request to approve."))
         val signer =
             ActiveAccountManager.session.value?.signer
@@ -2559,10 +2564,28 @@ class NostrRepository(
         }
     }
 
-    override fun declineDmPairing() {
-        (dmPairingManager.state.value as? DmPairingManager.State.IncomingRequest)?.let {
-            dmPairingManager.resolveIncoming(it.throwawayPubkey)
-        }
+    override fun declineDmPairing(throwawayPubkey: String) {
+        val declined = dmPairingManager.pendingRequest(throwawayPubkey)
+        dmPairingManager.resolveIncoming(throwawayPubkey)
+        declined?.let { withdrawRequests(listOf(it.eventId)) }
+    }
+
+    override fun declineAllDmPairing() {
+        val pending = (dmPairingManager.state.value as? DmPairingManager.State.IncomingRequests)?.requests.orEmpty()
+        dmPairingManager.resolveAllIncoming()
+        withdrawRequests(pending.map { it.eventId })
+    }
+
+    /**
+     * Delete declined kind:4454s. Both devices are the same identity, so this deletion is the
+     * account withdrawing its own request: it tells the waiting device it was turned down, and it
+     * stops the request prompting every other device of the account on their next launch.
+     */
+    private fun withdrawRequests(eventIds: List<String>) {
+        if (eventIds.isEmpty()) return
+        val signer = ActiveAccountManager.session.value?.signer ?: return
+        val myPub = sessionManager.getPublicKey() ?: return
+        scope.launch { publishDeletion(myPub, signer, eventIds) }
     }
 
     override fun dismissDmPairing() {
@@ -2628,6 +2651,9 @@ class NostrRepository(
                 putJsonArray("kinds") {
                     add(Nip4e.KIND_CLIENT_KEY)
                     add(Nip4e.KIND_KEY_SHARE)
+                    // Deletions too: a declined request is withdrawn by a kind:5 from this same
+                    // identity, which is what tells the waiting device it was turned down.
+                    add(5)
                 }
                 putJsonArray("authors") { add(myPub) }
                 put("since", epochSeconds() - PAIRING_LOOKBACK_SECONDS)
@@ -5977,6 +6003,19 @@ class NostrRepository(
                     }
                 }
                 return
+            }
+            // Our own kind:5 on the request we are waiting for: another device declined it. NIP-4e
+            // has no rejection event, and the deletion is the account withdrawing its own request,
+            // so this is the only signal that ends the wait instead of leaving it hanging.
+            if (kind == 5 && pendingPairingRequestId != null) {
+                val pending = pendingPairingRequestId
+                val myPub = sessionManager.getPublicKey()
+                runCatching { parseSignedEventJson(event.toString()) }.getOrNull()?.let {
+                    if (it.pubkey == myPub && it.tags.any { tag -> tag.firstOrNull() == "e" && tag.getOrNull(1) == pending }) {
+                        pendingPairingRequestId = null
+                        dmPairingManager.failed("Your other device dismissed the request.")
+                    }
+                }
             }
             // NIP-4e device pairing, our own account only: a device asking for the encryption key
             // (4454) and a device answering with it (4455).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2548,9 +2548,9 @@ class NostrRepository(
                 )
             publishEventToRelays(pairingRelays(myPub), signed)
             dmPairingManager.resolveIncoming(incoming.throwawayPubkey)
-            // The share is single-use: once the requester holds the key, leaving a copy of the
-            // ciphertext on relays only widens the window for offline attacks on the throwaway keys.
-            signed.id?.let { scope.launch { publishDeletion(myPub, signer, listOf(it)) } }
+            // No deletion from this side: the requester deletes the share (and its own request)
+            // once it holds the key. Deleting here races the delivery — relays honour the kind:5
+            // before the waiting device has read the share, so the pairing never completes.
             Result.Success(Unit)
         } catch (e: kotlinx.coroutines.CancellationException) {
             throw e
@@ -2571,8 +2571,13 @@ class NostrRepository(
 
     /** A kind:4455 answering our own outstanding request: decrypt, validate, hold. */
     private fun handleKeyShare(event: Event, myPub: String) {
+        val recipient = Nip4e.keyShareRecipientFrom(event) ?: return
+        // Every device of the account sees the answer. One still prompting for that same request
+        // drops it here: the key is already on its way, and a second share would put another copy
+        // of the ciphertext on the relays for a request nobody is waiting on.
+        dmPairingManager.resolveIncoming(recipient)
         val ours = dmPairingManager.requestThrowawayKey() ?: return
-        if (Nip4e.keyShareRecipientFrom(event) != ours.publicKeyHex) return
+        if (recipient != ours.publicKeyHex) return
         val senderThrowaway = Nip4e.throwawayPubkeyFrom(event) ?: return
         val keyHex =
             runCatching { Nip44.decrypt(event.content, ours.privateKeyHex, senderThrowaway) }.getOrNull()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -263,11 +263,14 @@ interface NostrRepositoryApi {
     /** Ask another device of this account for the encryption key (kind:4454). */
     suspend fun requestDmEncryptionKey(): Result<Unit>
 
-    /** Send our encryption key to the device that asked (kind:4455). */
-    suspend fun approveDmPairing(): Result<Unit>
+    /** Send our encryption key to the device waiting on [throwawayPubkey] (kind:4455). */
+    suspend fun approveDmPairing(throwawayPubkey: String): Result<Unit>
 
-    /** Refuse the pending request; the asking device keeps waiting. */
-    fun declineDmPairing()
+    /** Refuse one pending request; the asking device keeps waiting. */
+    fun declineDmPairing(throwawayPubkey: String)
+
+    /** Refuse every pending request at once. */
+    fun declineAllDmPairing()
 
     /** Clear a finished or failed pairing back to idle. */
     fun dismissDmPairing()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmPairingManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmPairingManager.kt
@@ -26,13 +26,20 @@ class DmPairingManager {
         /** This device asked for the key and is waiting for another device to answer. */
         data class Requesting(val code: String) : State
 
-        /** Another device of this account is asking us for the key. */
-        data class IncomingRequest(val code: String, val throwawayPubkey: String, val eventId: String) : State
+        /**
+         * Devices of this account asking us for the key, oldest first. A list, not a slot: the
+         * relay serves every request it still holds, and a slot kept only the last one, so the
+         * others came back one per launch with no way to decide them.
+         */
+        data class IncomingRequests(val requests: List<Request>) : State
 
         data object Completed : State
 
         data class Failed(val reason: String) : State
     }
+
+    /** One device asking for the key. [code] is what the user compares against that device. */
+    data class Request(val code: String, val throwawayPubkey: String, val eventId: String)
 
     private val _state = MutableStateFlow<State>(State.Idle)
     val state: StateFlow<State> = _state.asStateFlow()
@@ -74,7 +81,10 @@ class DmPairingManager {
         if (throwaway == requestKey?.publicKeyHex) return
         if (eventId in processed) return
         if (_state.value is State.Requesting) return
-        _state.value = State.IncomingRequest(Nip4e.pairingCode(throwaway), throwaway, eventId)
+        val pending = (_state.value as? State.IncomingRequests)?.requests.orEmpty()
+        // The same request arrives once per relay; both keys identify it.
+        if (pending.any { it.eventId == eventId || it.throwawayPubkey == throwaway }) return
+        _state.value = State.IncomingRequests(pending + Request(Nip4e.pairingCode(throwaway), throwaway, eventId))
     }
 
     /**
@@ -87,13 +97,23 @@ class DmPairingManager {
         onProcessedChanged?.invoke(processed)
     }
 
-    /** Mark an incoming request handled (approved and answered, or declined). */
+    /** The pending request for [throwawayPubkey], if it is still waiting on a decision. */
+    fun pendingRequest(throwawayPubkey: String): Request? = (_state.value as? State.IncomingRequests)?.requests?.firstOrNull { it.throwawayPubkey == throwawayPubkey }
+
+    /** Mark one incoming request handled (approved and answered, or declined). */
     fun resolveIncoming(throwawayPubkey: String) {
-        val incoming = _state.value as? State.IncomingRequest
-        if (incoming?.throwawayPubkey == throwawayPubkey) {
-            markProcessed(incoming.eventId)
-            _state.value = State.Idle
-        }
+        val pending = (_state.value as? State.IncomingRequests)?.requests ?: return
+        val match = pending.firstOrNull { it.throwawayPubkey == throwawayPubkey } ?: return
+        markProcessed(match.eventId)
+        val rest = pending - match
+        _state.value = if (rest.isEmpty()) State.Idle else State.IncomingRequests(rest)
+    }
+
+    /** Decline everything pending at once, for the pile a device leaves behind after retrying. */
+    fun resolveAllIncoming() {
+        val pending = (_state.value as? State.IncomingRequests)?.requests ?: return
+        pending.forEach { markProcessed(it.eventId) }
+        _state.value = State.Idle
     }
 
     /** Drop decisions older than the window the pairing subscription can still deliver. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/settings/DmEncryptionViewModel.kt
@@ -190,18 +190,34 @@ class DmEncryptionViewModel(
         }
     }
 
-    fun approvePairing() {
+    /** Which request is being answered, so only that card says so while the signer works. */
+    private val _approving = MutableStateFlow<String?>(null)
+    val approving: StateFlow<String?> = _approving.asStateFlow()
+
+    /**
+     * Sending the key is a signer round trip, which on a remote signer is seconds at best. Without
+     * [approving] the click has no visible effect at all and reads as a dead button.
+     */
+    fun approvePairing(throwawayPubkey: String) {
+        if (_approving.value != null) return
+        _approving.value = throwawayPubkey
         _error.value = null
         viewModelScope.launch {
-            when (val result = repo.approveDmPairing()) {
+            when (val result = repo.approveDmPairing(throwawayPubkey)) {
                 is Result.Error -> _error.value = result.error.message
                 else -> {}
             }
+            _approving.value = null
         }
     }
 
-    fun declinePairing() {
-        repo.declineDmPairing()
+    fun declinePairing(throwawayPubkey: String) {
+        repo.declineDmPairing(throwawayPubkey)
+    }
+
+    /** One action for the pile an earlier device left behind after retrying its request. */
+    fun declineAllPairing() {
+        repo.declineAllDmPairing()
     }
 
     fun dismissPairing() {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -225,13 +225,17 @@ class FakeNostrRepository : NostrRepositoryApi {
         return requestDmEncryptionKeyResult
     }
 
-    override suspend fun approveDmPairing(): Result<Unit> {
-        calls += "approveDmPairing"
+    override suspend fun approveDmPairing(throwawayPubkey: String): Result<Unit> {
+        calls += "approveDmPairing:$throwawayPubkey"
         return approveDmPairingResult
     }
 
-    override fun declineDmPairing() {
-        calls += "declineDmPairing"
+    override fun declineDmPairing(throwawayPubkey: String) {
+        calls += "declineDmPairing:$throwawayPubkey"
+    }
+
+    override fun declineAllDmPairing() {
+        calls += "declineAllDmPairing"
     }
 
     override fun dismissDmPairing() {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
@@ -45,10 +45,51 @@ class DmPairingManagerTest {
         manager.onRequestSeen(request(other.publicKeyHex))
 
         val state = manager.state.value
-        assertIs<DmPairingManager.State.IncomingRequest>(state)
-        assertEquals(other.publicKeyHex, state.throwawayPubkey)
+        assertIs<DmPairingManager.State.IncomingRequests>(state)
+        assertEquals(other.publicKeyHex, state.requests.single().throwawayPubkey)
         // Both devices derive the code from the same value, so comparing them is meaningful.
-        assertEquals(Nip4e.pairingCode(other.publicKeyHex), state.code)
+        assertEquals(Nip4e.pairingCode(other.publicKeyHex), state.requests.single().code)
+    }
+
+    @Test
+    fun `every pending request is offered, and deciding one keeps the rest`() {
+        val manager = DmPairingManager()
+        val first = KeyPair.generate()
+        val second = KeyPair.generate()
+
+        // A device that retried published one request per attempt, and the relay still serves both.
+        manager.onRequestSeen(request(first.publicKeyHex))
+        manager.onRequestSeen(request(second.publicKeyHex))
+        assertEquals(
+            listOf(first.publicKeyHex, second.publicKeyHex),
+            assertIs<DmPairingManager.State.IncomingRequests>(manager.state.value).requests.map { it.throwawayPubkey },
+        )
+
+        manager.resolveIncoming(first.publicKeyHex)
+        assertEquals(
+            listOf(second.publicKeyHex),
+            assertIs<DmPairingManager.State.IncomingRequests>(manager.state.value).requests.map { it.throwawayPubkey },
+        )
+    }
+
+    @Test
+    fun `declining all decides every pending request at once`() {
+        val manager = DmPairingManager()
+        val first = KeyPair.generate()
+        val second = KeyPair.generate()
+        var persisted: Map<String, Long> = emptyMap()
+        manager.onProcessedChanged = { persisted = it }
+
+        manager.onRequestSeen(request(first.publicKeyHex))
+        manager.onRequestSeen(request(second.publicKeyHex))
+        manager.resolveAllIncoming()
+
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
+        // Each one is recorded, or the relay serving it again re-prompts on the next launch.
+        assertEquals(2, persisted.size)
+        manager.onRequestSeen(request(first.publicKeyHex))
+        manager.onRequestSeen(request(second.publicKeyHex))
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
     }
 
     @Test
@@ -115,7 +156,7 @@ class DmPairingManagerTest {
 
         // Past the window the relay no longer serves it either; a request this old arriving now is
         // a new one worth showing.
-        assertIs<DmPairingManager.State.IncomingRequest>(manager.state.value)
+        assertIs<DmPairingManager.State.IncomingRequests>(manager.state.value)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmPairingManagerTest.kt
@@ -66,6 +66,24 @@ class DmPairingManagerTest {
     }
 
     @Test
+    fun `a share published by another holder drops our prompt for the same request`() {
+        val manager = DmPairingManager()
+        val requester = KeyPair.generate()
+        val holder = KeyPair.generate()
+        manager.onRequestSeen(request(requester.publicKeyHex))
+
+        // A third device answered first. Its kind:4455 reaches every device of the account, and the
+        // recipient tag says which request it settles.
+        val share = Nip4e.buildKeyShare(identity, holder.publicKeyHex, requester.publicKeyHex, "ciphertext", createdAt = 2L)
+        manager.resolveIncoming(Nip4e.keyShareRecipientFrom(share)!!)
+
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
+        // And it stays gone: the relay keeps serving the request until it is deleted or expires.
+        manager.onRequestSeen(request(requester.publicKeyHex))
+        assertIs<DmPairingManager.State.Idle>(manager.state.value)
+    }
+
+    @Test
     fun `a declined request stays declined across a restart`() {
         val other = KeyPair.generate()
         val event = request(other.publicKeyHex)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/settings/SettingsScreen.kt
@@ -1492,6 +1492,7 @@ private fun DmEncryptionPanelContent() {
     val revealedKey by vm.revealedKey.collectAsState()
     val importInput by vm.importInput.collectAsState()
     val pairingState by vm.pairingState.collectAsState()
+    val approving by vm.approving.collectAsState()
     val resetConfirmOpen by vm.resetConfirmOpen.collectAsState()
 
     // Nothing to offload when signing is already local.
@@ -1529,22 +1530,25 @@ private fun DmEncryptionPanelContent() {
                             "messages sent to the old key will not be readable.",
                         isCompact = false,
                     )
-                    when (val pairing = pairingState) {
-                        is DmPairingManager.State.Requesting ->
-                            Text(
-                                text = "Waiting for your other device. Approve the request showing code " +
-                                    "${pairing.code} there.",
-                                style = NostrordTypography.Caption,
-                                color = NostrordColors.TextSecondary,
-                            )
-                        is DmPairingManager.State.Failed ->
-                            Text(text = pairing.reason, style = NostrordTypography.Caption, color = NostrordColors.Error)
-                        else ->
-                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                                TextButton(onClick = { vm.requestKeyFromOtherDevice() }) {
-                                    Text("Ask my other device", color = NostrordColors.Primary, style = NostrordTypography.Button)
-                                }
+                    val pairing = pairingState
+                    if (pairing is DmPairingManager.State.Requesting) {
+                        Text(
+                            text = "Waiting for your other device. Approve the request showing code " +
+                                "${pairing.code} there.",
+                            style = NostrordTypography.Caption,
+                            color = NostrordColors.TextSecondary,
+                        )
+                    } else {
+                        // A failed or declined attempt keeps the button: the answer to "that device
+                        // said no" is asking a different one, not a dead end.
+                        (pairing as? DmPairingManager.State.Failed)?.let {
+                            Text(text = it.reason, style = NostrordTypography.Caption, color = NostrordColors.Error)
+                        }
+                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                            TextButton(onClick = { vm.requestKeyFromOtherDevice() }) {
+                                Text("Ask my other device", color = NostrordColors.Primary, style = NostrordTypography.Button)
                             }
+                        }
                     }
                     OutlinedTextField(
                         value = importInput,
@@ -1604,20 +1608,45 @@ private fun DmEncryptionPanelContent() {
                     )
                     // Another device of this account is asking for the key. The code comes from the
                     // request itself, so matching it against the other screen proves which one asked.
-                    (pairingState as? DmPairingManager.State.IncomingRequest)?.let { request ->
-                        InfoCard(
-                            title = "Another device wants this key",
-                            titleColor = NostrordColors.Warning,
-                            icon = Icons.Default.Key,
-                            content = "Approve only if that device is showing code ${request.code}.",
-                            isCompact = false,
-                        )
-                        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
-                            TextButton(onClick = { vm.declinePairing() }) {
-                                Text("Decline", color = NostrordColors.TextSecondary, style = NostrordTypography.Button)
+                    (pairingState as? DmPairingManager.State.IncomingRequests)?.requests?.let { requests ->
+                        requests.forEach { request ->
+                            InfoCard(
+                                title = "Another device wants this key",
+                                titleColor = NostrordColors.Warning,
+                                icon = Icons.Default.Key,
+                                content = "Approve only if that device is showing code ${request.code}.",
+                                isCompact = false,
+                            )
+                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                                TextButton(
+                                    onClick = { vm.declinePairing(request.throwawayPubkey) },
+                                    enabled = approving == null,
+                                ) {
+                                    Text("Decline", color = NostrordColors.TextSecondary, style = NostrordTypography.Button)
+                                }
+                                TextButton(
+                                    onClick = { vm.approvePairing(request.throwawayPubkey) },
+                                    enabled = approving == null,
+                                ) {
+                                    Text(
+                                        if (approving == request.throwawayPubkey) "Sending…" else "Send key",
+                                        color = NostrordColors.Primary,
+                                        style = NostrordTypography.Button,
+                                    )
+                                }
                             }
-                            TextButton(onClick = { vm.approvePairing() }) {
-                                Text("Send key", color = NostrordColors.Primary, style = NostrordTypography.Button)
+                        }
+                        // A device that retried leaves one request per attempt, and each has to be
+                        // decided or it comes back on the next launch.
+                        if (requests.size > 1) {
+                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                                TextButton(onClick = { vm.declineAllPairing() }, enabled = approving == null) {
+                                    Text(
+                                        "Decline all ${requests.size}",
+                                        color = NostrordColors.TextSecondary,
+                                        style = NostrordTypography.Button,
+                                    )
+                                }
                             }
                         }
                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/SettingsScreen.kt
@@ -1304,6 +1304,7 @@ private val DmEncryptionPanel =
         val archiveConfirmOpen = useStateFlow(vm.archiveConfirmOpen)
         val archivableCount = useStateFlow(vm.archivableCount)
         val pairingState = useStateFlow(vm.pairingState)
+        val approving = useStateFlow(vm.approving)
         val resetConfirmOpen = useStateFlow(vm.resetConfirmOpen)
 
         // Nothing to offload when signing is already local.
@@ -1332,26 +1333,28 @@ private val DmEncryptionPanel =
                             alert = true,
                             ic = Ic.Key,
                         )
-                        when (pairingState) {
-                            is DmPairingManager.State.Requesting ->
-                                div {
-                                    className = ClassName("settings-status-line")
-                                    +"Waiting for your other device. Approve the request showing code ${pairingState.code} there."
-                                }
-                            is DmPairingManager.State.Failed ->
+                        if (pairingState is DmPairingManager.State.Requesting) {
+                            div {
+                                className = ClassName("settings-status-line")
+                                +"Waiting for your other device. Approve the request showing code ${pairingState.code} there."
+                            }
+                        } else {
+                            // A failed or declined attempt keeps the button: the answer to "that
+                            // device said no" is asking a different one, not a dead end.
+                            (pairingState as? DmPairingManager.State.Failed)?.let {
                                 div {
                                     className = ClassName("settings-error")
-                                    +pairingState.reason
+                                    +it.reason
                                 }
-                            else ->
-                                div {
-                                    className = ClassName("settings-form-actions")
-                                    button {
-                                        className = ClassName("btn-text btn-sm accent")
-                                        onClick = { vm.requestKeyFromOtherDevice() }
-                                        +"Ask my other device"
-                                    }
+                            }
+                            div {
+                                className = ClassName("settings-form-actions")
+                                button {
+                                    className = ClassName("btn-text btn-sm accent")
+                                    onClick = { vm.requestKeyFromOtherDevice() }
+                                    +"Ask my other device"
                                 }
+                            }
                         }
                         input {
                             className = ClassName("modal-input")
@@ -1419,24 +1422,42 @@ private val DmEncryptionPanel =
                         }
                         // Another device of this account is asking for the key. The code comes from
                         // the request itself, so matching it proves which device asked.
-                        (pairingState as? DmPairingManager.State.IncomingRequest)?.let { request ->
-                            noticeCard(
-                                title = "Another device wants this key",
-                                body = "Approve only if that device is showing code ${request.code}.",
-                                alert = true,
-                                ic = Ic.Key,
-                            )
-                            div {
-                                className = ClassName("settings-form-actions")
-                                button {
-                                    className = ClassName("btn-text btn-sm")
-                                    onClick = { vm.declinePairing() }
-                                    +"Decline"
+                        (pairingState as? DmPairingManager.State.IncomingRequests)?.requests?.let { requests ->
+                            requests.forEach { request ->
+                                noticeCard(
+                                    title = "Another device wants this key",
+                                    body = "Approve only if that device is showing code ${request.code}.",
+                                    alert = true,
+                                    ic = Ic.Key,
+                                )
+                                div {
+                                    className = ClassName("settings-form-actions")
+                                    key = request.throwawayPubkey
+                                    button {
+                                        className = ClassName("btn-text btn-sm")
+                                        disabled = approving != null
+                                        onClick = { vm.declinePairing(request.throwawayPubkey) }
+                                        +"Decline"
+                                    }
+                                    button {
+                                        className = ClassName("btn-primary btn-sm")
+                                        disabled = approving != null
+                                        onClick = { vm.approvePairing(request.throwawayPubkey) }
+                                        +(if (approving == request.throwawayPubkey) "Sending…" else "Send key")
+                                    }
                                 }
-                                button {
-                                    className = ClassName("btn-primary btn-sm")
-                                    onClick = { vm.approvePairing() }
-                                    +"Send key"
+                            }
+                            // A device that retried leaves one request per attempt, and each has to
+                            // be decided or it comes back on the next launch.
+                            if (requests.size > 1) {
+                                div {
+                                    className = ClassName("settings-form-actions")
+                                    button {
+                                        className = ClassName("btn-text btn-sm")
+                                        disabled = approving != null
+                                        onClick = { vm.declineAllPairing() }
+                                        +"Decline all ${requests.size}"
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Asking another device for the fast decryption key produced a request the other device could see and approve, and a key that never arrived: not in Nostrord, not in Jumble. Approving published the kind:4455 and, in the same action, a kind:5 deleting it, so relays honoured the deletion before the waiting device had read the share. The requester already deletes both events once it holds the key, which is the only moment "already consumed" is true.

Fixing delivery surfaced the second half. `DmPairingManager` held ONE incoming request, so each kind:4454 the relay served overwrote the last: only the newest was decidable, and the rest came back one per launch forever (declining on web decides nothing on native, since a decline was a local record). It is a list now, with a card per request and one "Decline all" for the pile a retrying device leaves behind. Declining also withdraws the request: NIP-4e defines no rejection event, but both devices are the same identity, so the kind:5 is the account retiring its own kind:4454 — it ends the asking device's wait and stops the request prompting every other device.

| Bug | Fix |
|---|---|
| The approved key never reached the asker | the approver no longer deletes the share it just published |
| A share left other devices still prompting | its `p` tag settles that request everywhere |
| Only the newest request was decidable | `IncomingRequests(List<Request>)`, deduped by event id and throwaway key |
| Declining left the asker waiting forever | kind:5 on the kind:4454, read back as "Your other device dismissed the request." |
| Each retry left another live request | asking again withdraws the previous attempt |
| "Send key" looked dead on a remote signer | per-request `approving` state, "Sending…" on the card being answered |
| A refusal was a dead end | "Ask my other device" stays available after a failure |

The pairing subscription watches kind:5 alongside 4454/4455, matched against this device's pending request id so the rest of the account's deletions pass through. Withdrawal is best-effort like any NIP-09 delete; a relay that ignores kind:5 keeps serving the request, and the local 24h `processed` window is what holds the prompt back. Simultaneous decline/approve fails closed: if the kind:5 lands first the ephemeral key is gone and a later 4455 cannot be opened, so the user asks again.

Both UIs, one ViewModel. `compileKotlinJvm`, `compileKotlinJs` and `:composeApp:jvmTest` green, with three new `DmPairingManagerTest` cases (a share drops the prompt; deciding one request keeps the rest; decline-all records every one).

Not covered here: on desktop native "Send key" and "Turn off" both stall on the bunker's `signEvent` round trip. That looks like NIP-46 on JVM rather than this flow, and needs its own branch.

- 8bc9ab00 fix(dm): let the shared encryption key reach the device that asked
- 91bfb846 fix(dm): offer every pending pairing request, and answer a declined one