### PR TITLE
Treat the same group id on two relays as two groups

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.*
 import org.nostr.nostrord.network.livekit.isHexPubkey
 import org.nostr.nostrord.utils.epochMillis
+import org.nostr.nostrord.utils.normalizeRelayUrl
 
 @Serializable
 @Immutable
@@ -128,6 +129,12 @@ data class CachedEvent(
     val content: String,
     val createdAt: Long,
     val tags: List<List<String>>,
+    /**
+     * Relay this copy arrived from, normalized. Null when unknown (restored from the disk cache,
+     * which does not carry it): readers scoping to a relay treat null as "unknown" and accept it,
+     * the same convention as [NostrMessage.relayUrl].
+     */
+    val relayUrl: String? = null,
 )
 
 /**
@@ -141,6 +148,7 @@ fun NostrGroupClient.NostrMessage.toCachedEvent(): CachedEvent = CachedEvent(
     content = content,
     createdAt = createdAt,
     tags = tags,
+    relayUrl = relayUrl?.normalizeRelayUrl(),
 )
 
 /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -6347,7 +6347,7 @@ class NostrRepository(
 
                 // Handle event subscriptions (event_* or e_*) for quotes
                 if (subId.startsWith("event_") || subId.startsWith("e_")) {
-                    metadataManager.parseAndCacheEvent(event)?.let { cachedEvent ->
+                    metadataManager.parseAndCacheEvent(event, client.getRelayUrl())?.let { cachedEvent ->
                         if (!metadataManager.hasMetadata(cachedEvent.pubkey)) {
                             scope.launch {
                                 requestUserMetadata(setOf(cachedEvent.pubkey))
@@ -6530,7 +6530,7 @@ class NostrRepository(
 
                 // Handle event subscriptions (event_* or e_*)
                 if (subId.startsWith("event_") || subId.startsWith("e_")) {
-                    metadataManager.parseAndCacheEvent(event)?.let { cachedEvent ->
+                    metadataManager.parseAndCacheEvent(event, client.getRelayUrl())?.let { cachedEvent ->
                         if (!metadataManager.hasMetadata(cachedEvent.pubkey)) {
                             scope.launch {
                                 requestUserMetadata(setOf(cachedEvent.pubkey))
@@ -6542,7 +6542,7 @@ class NostrRepository(
 
                 // Handle addressable event subscriptions (addr_* or a_*)
                 if (subId.startsWith("addr_") || subId.startsWith("a_")) {
-                    metadataManager.parseAndCacheAddressableEvent(event)?.let { cachedEvent ->
+                    metadataManager.parseAndCacheAddressableEvent(event, client.getRelayUrl())?.let { cachedEvent ->
                         if (!metadataManager.hasMetadata(cachedEvent.pubkey)) {
                             scope.launch {
                                 requestUserMetadata(setOf(cachedEvent.pubkey))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -4190,17 +4190,21 @@ class NostrRepository(
     override suspend fun ensureBunkerConnected(): Boolean = sessionManager.ensureBunkerConnected()
 
     // Group operations
-    override suspend fun joinGroup(groupId: String, inviteCode: String?, listPrivately: Boolean): Result<Unit> {
+    override suspend fun joinGroup(groupId: String, inviteCode: String?, listPrivately: Boolean, relayUrl: String?): Result<Unit> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
-        val joinRelay = connectionManager.currentRelayUrl.value
+        // The caller's relay decides: with the same id on two relays, the focused relay is a
+        // coin flip and the 9021 lands on the group the user is not looking at.
+        val joinRelay = relayUrl?.normalizeRelayUrl()
+            ?: groupManager.getRelayForGroup(groupId)
+            ?: connectionManager.currentRelayUrl.value
         // Before the join publishes the list, not after: a group marked private afterwards would
         // already have gone out in the clear once, and relays keep that version.
         if (listPrivately) outboxManager.setGroupPrivate(joinRelay, groupId, true)
         val result = groupManager.joinGroup(
             groupId = groupId,
             pubKey = pubKey,
-            currentRelayUrl = connectionManager.currentRelayUrl.value,
+            currentRelayUrl = joinRelay,
             signEvent = { sessionManager.signEvent(it) },
             publishJoinedGroups = { publishJoinedGroupsList() },
             inviteCode = inviteCode,
@@ -4209,7 +4213,7 @@ class NostrRepository(
             // Joining a group may have introduced a new joined relay — ensure it's
             // connected with a chat sub so notifications fire even when the user is
             // browsing a different focused.
-            scope.launch { ensureJoinedRelaysConnected(connectionManager.currentRelayUrl.value) }
+            scope.launch { ensureJoinedRelaysConnected(joinRelay) }
         } else if (listPrivately) {
             outboxManager.setGroupPrivate(joinRelay, groupId, false)
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -135,7 +135,7 @@ interface NostrRepositoryApi {
      */
     val groupMembersByRelay: StateFlow<Map<String, Map<String, List<String>>>>
 
-    /** groupId -> epochMillis of our outstanding kind:9021 join request awaiting approval. */
+    /** groupKey(relay, groupId) -> epoch seconds of our outstanding kind:9021 awaiting approval. */
     val pendingApprovalSince: StateFlow<Map<String, Long>>
     val groupAdmins: StateFlow<Map<String, List<String>>>
     val groupAdminsByRelay: StateFlow<Map<String, Map<String, List<String>>>>

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -502,6 +502,9 @@ interface NostrRepositoryApi {
         groupId: String,
         inviteCode: String? = null,
         listPrivately: Boolean = false,
+        /** Relay hosting the group being joined. Null routes by hint / focused relay, which
+         *  picks the wrong twin when the same id exists on two relays. */
+        relayUrl: String? = null,
     ): Result<Unit>
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -653,8 +653,20 @@ class GroupManager(
     // from this LOCAL truth (set on our 9021, cleared on our 9022/leave/approval) instead of the
     // kind:9021 echo in the message feed, which leaveGroup clears and a re-fetch races, leaving a
     // left group stuck on "Request pending" until a reload.
+    /** [groupKey] -> seconds of our outstanding kind:9021 on that relay. */
     private val _pendingApprovalSince = MutableStateFlow<Map<String, Long>>(emptyMap())
     val pendingApprovalSince: StateFlow<Map<String, Long>> = _pendingApprovalSince.asStateFlow()
+
+    /** Drops the pending marker for [groupId] on [relayUrl], or on every relay when it is unknown. */
+    private fun clearPendingApproval(relayUrl: String?, groupId: String) {
+        _pendingApprovalSince.update { pending ->
+            if (relayUrl != null) {
+                pending - groupKey(relayUrl, groupId)
+            } else {
+                pending.filterKeys { groupKeyId(it) != groupId }
+            }
+        }
+    }
 
     // Drops the relay's kind:9022 echo and updated kind:39002 that arrive in
     // the milliseconds after a leave, otherwise they re-populate the lists we
@@ -1706,7 +1718,9 @@ class GroupManager(
 
             clearGroupRestricted(normalizedGroupRelay, groupId)
             // Seconds, to match GroupMembershipState.requestedAtSeconds (the "Requested ..." label).
-            _pendingApprovalSince.update { it + (groupId to epochSeconds()) }
+            // Keyed per relay: a request to this relay says nothing about the same-id group
+            // elsewhere, which otherwise opened already showing "Request pending".
+            _pendingApprovalSince.update { it + (groupKey(normalizedGroupRelay, groupId) to epochSeconds()) }
             refreshMuxSubscriptionsForRelay(groupRelayUrl)
 
             kotlinx.coroutines.delay(500)
@@ -2562,7 +2576,7 @@ class GroupManager(
             memberEventTimestamps.remove(groupId)
             adminEventTimestamps.remove(groupId)
             roleEventTimestamps.remove(groupId)
-            _pendingApprovalSince.update { it - groupId }
+            clearPendingApproval(groupRelayUrl, groupId)
             messageIdIndex.remove(groupId)
             _latestMessageRelayByGroup.update { it - groupId }
             observedGroupsMutex.withLock { observedGroups.remove(groupId) }
@@ -4183,7 +4197,7 @@ class GroupManager(
         if (selfNowMember &&
             selfWasAbsent &&
             (
-                members.groupId in _pendingApprovalSince.value ||
+                (hostRelay != null && groupKey(hostRelay, members.groupId) in _pendingApprovalSince.value) ||
                     (relayUrl != null && groupKey(relayUrl, members.groupId) in _restrictedGroups.value)
                 )
         ) {
@@ -4533,7 +4547,7 @@ class GroupManager(
     // through requestGroupMessages (the state-machine path), NOT a raw _messages fetch /
     // dedup eviction, which is what broke pagination before.
     private fun onApprovalDetected(relayUrl: String?, groupId: String) {
-        _pendingApprovalSince.update { it - groupId }
+        clearPendingApproval(relayUrl ?: getRelayForGroup(groupId), groupId)
         clearGroupRestricted(relayUrl, groupId)
         scope.launch {
             try {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -732,11 +732,21 @@ class MetadataManager(
         },
     )
 
-    fun parseAndCacheEvent(eventJson: JsonObject): CachedEvent? {
+    fun parseAndCacheEvent(eventJson: JsonObject, relayUrl: String? = null): CachedEvent? {
         return try {
             val eventId = eventJson["id"]?.jsonPrimitive?.content ?: return null
 
-            eventsCache.get(eventId)?.let { return it }
+            // A copy already in the cache wins, but an unstamped one (disk restore) takes the
+            // relay this delivery came from: readers scope quote/reply previews on it.
+            eventsCache.get(eventId)?.let { existing ->
+                if (existing.relayUrl == null && relayUrl != null) {
+                    val stamped = existing.copy(relayUrl = relayUrl.normalizeRelayUrl())
+                    eventsCache.put(eventId, stamped)
+                    _cachedEvents.value = eventsCache.toMap()
+                    return stamped
+                }
+                return existing
+            }
 
             val pubkey = eventJson["pubkey"]?.jsonPrimitive?.content ?: return null
             val content = eventJson["content"]?.jsonPrimitive?.content ?: ""
@@ -755,6 +765,7 @@ class MetadataManager(
                     content = content,
                     createdAt = createdAt,
                     tags = tags,
+                    relayUrl = relayUrl?.normalizeRelayUrl(),
                 )
 
             eventsCache.put(eventId, cachedEvent)
@@ -766,7 +777,7 @@ class MetadataManager(
         }
     }
 
-    fun parseAndCacheAddressableEvent(eventJson: JsonObject): CachedEvent? {
+    fun parseAndCacheAddressableEvent(eventJson: JsonObject, relayUrl: String? = null): CachedEvent? {
         return try {
             val eventId = eventJson["id"]?.jsonPrimitive?.content ?: return null
             val pubkey = eventJson["pubkey"]?.jsonPrimitive?.content ?: return null
@@ -790,6 +801,7 @@ class MetadataManager(
                     content = content,
                     createdAt = createdAt,
                     tags = tags,
+                    relayUrl = relayUrl?.normalizeRelayUrl(),
                 )
 
             eventsCache.put(eventId, cachedEvent)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupMembershipModel.kt
@@ -111,7 +111,14 @@ class GroupMembershipModel(
             // a left group is removed from our joined list, so a stale 9021 still echoed in a re-fetched
             // feed no longer reads as pending. (`leaveGroup` clears the feed and a re-fetch races, which
             // is why the feed alone left a left group stuck on "Request pending" until a reload.)
-            val localPendingAt = pendingByGroup[groupId]
+            // Relay-scoped like `joined`: a request sent to another relay's same-id group is a
+            // request to a different group and must not open this one on "Request pending".
+            val localPendingAt =
+                if (hostRelay != null) {
+                    pendingByGroup[groupKey(hostRelay, groupId)]
+                } else {
+                    pendingByGroup.entries.firstOrNull { groupKeyId(it.key) == groupId }?.value
+                }
             val ownEvents = messagesByGroup[groupId].orEmpty().asSequence()
                 .filter { it.pubkey == pubkey }
                 .filter { hostRelay == null || it.relayUrl == null || it.relayUrl == hostRelay }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupViewModel.kt
@@ -489,7 +489,7 @@ class GroupViewModel(
     ) {
         _joinError.value = null
         viewModelScope.launch {
-            val result = repo.joinGroup(groupId, inviteCode, listPrivately)
+            val result = repo.joinGroup(groupId, inviteCode, listPrivately, hostRelay)
             if (result is Result.Error) {
                 val reason = (result.error as? AppError.Group.JoinFailed)?.cause?.message
                 _joinError.value =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -487,7 +487,7 @@ class ThreadsViewModel(
     fun joinGroup(inviteCode: String? = null) {
         _joinError.value = null
         viewModelScope.launch {
-            val result = repo.joinGroup(groupId, inviteCode)
+            val result = repo.joinGroup(groupId, inviteCode, relayUrl = hostRelay)
             if (result is Result.Error) {
                 val reason = (result.error as? AppError.Group.JoinFailed)?.cause?.message
                 _joinError.value =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -451,11 +451,17 @@ class ThreadsViewModel(
             .map { restrictedHere(it) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), restrictedHere(repo.restrictedGroups.value))
 
-    /** A join request is in flight and no admin has answered yet. */
+    private fun pendingHere(pending: Map<String, Long>): Boolean = if (hostRelay != null) {
+        groupKey(hostRelay, groupId) in pending
+    } else {
+        pending.keys.any { groupKeyId(it) == groupId }
+    }
+
+    /** A join request is in flight on this group's relay and no admin has answered yet. */
     val isPendingApproval: StateFlow<Boolean> =
         repo.pendingApprovalSince
-            .map { groupId in it }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), groupId in repo.pendingApprovalSince.value)
+            .map { pendingHere(it) }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), pendingHere(repo.pendingApprovalSince.value))
 
     private val membershipModel = GroupMembershipModel(repo, groupId, hostRelay, viewModelScope)
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupRefLookup.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/GroupRefLookup.kt
@@ -1,0 +1,33 @@
+package org.nostr.nostrord.utils
+
+import org.nostr.nostrord.network.GroupMetadata
+
+/**
+ * Metadata for a group reference (a quoted event's `h` tag, an naddr link, an invite) as the
+ * group exists on the relay the reference points at.
+ *
+ * A group id is unique only within one relay (see [groupKey]), so a relay hint pins the lookup
+ * to that relay's own kind:39000: `nostrord` on groups.0xchat.com is a different group from
+ * `nostrord` on chat.wisp.talk and must not lend the reference its name or picture. A hinted
+ * reference whose relay has no such group stays unresolved (the caller renders the raw id and
+ * a seeded avatar) until [org.nostr.nostrord.network.NostrRepositoryApi.fetchGroupPreview]
+ * brings that relay's copy in.
+ *
+ * Only a reference with no hint at all falls back to a cross-relay scan, [fallback] first.
+ */
+fun resolveGroupRef(
+    groupsByRelay: Map<String, List<GroupMetadata>>,
+    groupId: String,
+    relayHint: String?,
+    fallback: List<GroupMetadata> = emptyList(),
+): GroupMetadata? {
+    if (!relayHint.isNullOrBlank()) {
+        val host = relayHint.normalizeRelayUrl()
+        return groupsByRelay.entries
+            .firstOrNull { it.key.normalizeRelayUrl() == host }
+            ?.value
+            ?.firstOrNull { it.id == groupId }
+    }
+    return fallback.firstOrNull { it.id == groupId }
+        ?: groupsByRelay.values.firstNotNullOfOrNull { list -> list.firstOrNull { it.id == groupId } }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -378,10 +378,15 @@ class FakeNostrRepository : NostrRepositoryApi {
         groupId: String,
         inviteCode: String?,
         listPrivately: Boolean,
+        relayUrl: String?,
     ): Result<Unit> {
         calls += "joinGroup:$groupId:$listPrivately"
+        joinRelays += groupId to relayUrl
         return Result.Success(Unit)
     }
+
+    /** (groupId, relayUrl) of every joinGroup call, so tests can assert the routing relay. */
+    val joinRelays = mutableListOf<Pair<String, String?>>()
 
     override suspend fun requestGroupThreads(groupId: String): Boolean {
         calls += "requestGroupThreads:$groupId"

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -136,7 +136,8 @@ class FakeNostrRepository : NostrRepositoryApi {
     val _groupAdminsByRelay = MutableStateFlow<Map<String, Map<String, List<String>>>>(emptyMap())
     override val groupAdminsByRelay: StateFlow<Map<String, Map<String, List<String>>>> = _groupAdminsByRelay
     override val groupRolesByRelay: StateFlow<Map<String, Map<String, List<RoleDefinition>>>> = MutableStateFlow(emptyMap())
-    override val pendingApprovalSince: StateFlow<Map<String, Long>> = MutableStateFlow(emptyMap())
+    val _pendingApprovalSince = MutableStateFlow<Map<String, Long>>(emptyMap())
+    override val pendingApprovalSince: StateFlow<Map<String, Long>> = _pendingApprovalSince
     override val groupAdmins: StateFlow<Map<String, List<String>>> = _groupAdmins
     override val userMetadata: StateFlow<Map<String, UserMetadata>> = _userMetadata
     override val cachedEvents: StateFlow<Map<String, CachedEvent>> = _cachedEvents

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -16,6 +16,7 @@ import org.nostr.nostrord.ui.screens.group.GroupViewModel
 import org.nostr.nostrord.ui.screens.group.deriveMembershipStatus
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.groupKey
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -166,6 +167,21 @@ class GroupViewModelTest {
 
         assertEquals(listOf<Pair<String, String?>>("dev" to "wss://b"), fake.addedToList.toList())
         assertEquals(false, vm.canAddToMyList.value, "once listed there is nothing to add")
+    }
+
+    @Test
+    fun `a join request on one relay leaves the same id on another relay joinable`() = runTest {
+        val fake = FakeNostrRepository()
+        fake.fakePublicKey = "me"
+        fake._pendingApprovalSince.value = mapOf(groupKey("wss://a", "dev") to 1_000L)
+
+        val onA = GroupViewModel(fake, "dev", "wss://a")
+        val onB = GroupViewModel(fake, "dev", "wss://b")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(GroupMembership.PENDING, onA.membershipState.value.status)
+        assertEquals(1_000L, onA.membershipState.value.requestedAtSeconds)
+        assertEquals(GroupMembership.NONE, onB.membershipState.value.status, "another relay's request is a different group")
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/GroupViewModelTest.kt
@@ -170,6 +170,17 @@ class GroupViewModelTest {
     }
 
     @Test
+    fun `join goes to the screen's own relay, not the focused one`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._currentRelayUrl.value = "wss://a"
+
+        GroupViewModel(fake, "dev", "wss://b").joinGroup()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf<Pair<String, String?>>("dev" to "wss://b"), fake.joinRelays.toList())
+    }
+
+    @Test
     fun `a join request on one relay leaves the same id on another relay joinable`() = runTest {
         val fake = FakeNostrRepository()
         fake.fakePublicKey = "me"

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupRefLookupTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/GroupRefLookupTest.kt
@@ -1,0 +1,43 @@
+package org.nostr.nostrord.utils
+
+import org.nostr.nostrord.network.GroupMetadata
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GroupRefLookupTest {
+    private fun group(id: String, name: String, picture: String?) = GroupMetadata(id = id, name = name, about = null, picture = picture, isPublic = true, isOpen = true)
+
+    private val wisp = group("nostrord", "Nostrord", null)
+    private val zeroX = group("nostrord", "Nostrord", "https://0xchat/pic.png")
+    private val groupsByRelay =
+        mapOf(
+            "wss://chat.wisp.talk" to listOf(wisp),
+            "wss://groups.0xchat.com" to listOf(zeroX),
+        )
+
+    @Test
+    fun `hint picks that relay's copy, not a same-id group elsewhere`() {
+        assertEquals(wisp, resolveGroupRef(groupsByRelay, "nostrord", "wss://chat.wisp.talk"))
+        assertEquals(zeroX, resolveGroupRef(groupsByRelay, "nostrord", "wss://groups.0xchat.com"))
+    }
+
+    @Test
+    fun `hint is normalized before matching`() {
+        assertEquals(zeroX, resolveGroupRef(groupsByRelay, "nostrord", "wss://Groups.0xchat.com/"))
+    }
+
+    @Test
+    fun `hinted relay without the group stays unresolved`() {
+        assertNull(resolveGroupRef(groupsByRelay, "nostrord", "wss://relay.example"))
+        assertNull(resolveGroupRef(groupsByRelay, "other", "wss://chat.wisp.talk"))
+    }
+
+    @Test
+    fun `no hint falls back to the fallback list then any relay`() {
+        val local = group("nostrord", "Local", null)
+        assertEquals(local, resolveGroupRef(groupsByRelay, "nostrord", null, fallback = listOf(local)))
+        assertEquals(wisp, resolveGroupRef(groupsByRelay, "nostrord", null))
+        assertEquals(wisp, resolveGroupRef(groupsByRelay, "nostrord", "  "))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/GroupInviteCard.kt
@@ -34,7 +34,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.Spacing
-import org.nostr.nostrord.utils.normalizeRelayUrl
+import org.nostr.nostrord.utils.resolveGroupRef
 
 /**
  * DM group-invite card (prototype InviteCard): "GROUP INVITE" eyebrow + group avatar/name,
@@ -54,12 +54,9 @@ fun GroupInviteCard(
     val groups by repo.groups.collectAsState()
     val groupsByRelay by repo.groupsByRelay.collectAsState()
 
-    // The card's own relay first: NIP-29 ids are relay-local, and a flattened scan could
-    // resolve a same-id group from another relay.
-    val groupMeta =
-        relayUrl?.let { url -> groupsByRelay[url.normalizeRelayUrl()]?.find { it.id == groupId } }
-            ?: groups.find { it.id == groupId }
-            ?: groupsByRelay.values.flatten().find { it.id == groupId }
+    // The invite's own relay decides: NIP-29 ids are relay-local, so a same-id group from
+    // another relay must not paint this card.
+    val groupMeta = resolveGroupRef(groupsByRelay, groupId, relayUrl, fallback = groups)
 
     LaunchedEffect(groupId, relayUrl) {
         if (relayUrl != null && groupMeta?.name == null) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -92,6 +92,7 @@ import org.nostr.nostrord.utils.isBlockedImageHost
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.proxyViaWeserv
 import org.nostr.nostrord.utils.rememberClipboardWriter
+import org.nostr.nostrord.utils.resolveGroupRef
 import org.nostr.nostrord.utils.shortNpub
 
 // Type alias to bridge new parser to existing rendering code
@@ -1372,12 +1373,7 @@ private fun ThreadQuoteCard(
     // group. Keyed so the scan runs when the lists change, not on every recomposition (this card
     // sits in a scrolling list).
     val groupName = remember(groupsByRelay, groupId, relayHint) {
-        groupId?.let { gid ->
-            val onHint = relayHint?.let { r ->
-                groupsByRelay.entries.firstOrNull { e -> e.key.normalizeRelayUrl() == r.normalizeRelayUrl() }?.value
-            }
-            (onHint?.firstOrNull { it.id == gid } ?: groupsByRelay.values.flatten().firstOrNull { it.id == gid })?.name
-        }?.takeIf { it.isNotBlank() }
+        groupId?.let { gid -> resolveGroupRef(groupsByRelay, gid, relayHint)?.name }?.takeIf { it.isNotBlank() }
     }
 
     val title = event.tags.firstOrNull { it.size >= 2 && (it[0] == "subject" || it[0] == "title") }
@@ -1881,12 +1877,7 @@ private fun QuotedEvent(
                 // preview from the hint when that relay's copy isn't cached yet.
                 val sourceGroup =
                     remember(groupsByRelay, groups, sourceGroupId, sourceRelayUrl) {
-                        val onSource = sourceRelayUrl
-                            ?.let { r -> groupsByRelay.entries.firstOrNull { e -> e.key.normalizeRelayUrl() == r } }
-                            ?.value
-                        onSource?.find { it.id == sourceGroupId }
-                            ?: groupsByRelay.values.flatten().find { it.id == sourceGroupId }
-                            ?: groups.find { it.id == sourceGroupId }
+                        resolveGroupRef(groupsByRelay, sourceGroupId, sourceRelayUrl, fallback = groups)
                     }
                 LaunchedEffect(sourceGroupId, sourceRelayUrl, sourceGroup?.name) {
                     if (sourceGroup?.name == null && sourceRelayUrl != null) {
@@ -2861,9 +2852,9 @@ private fun GroupLinkCard(
     val groups by repo.groups.collectAsState()
     val groupsByRelay by repo.groupsByRelay.collectAsState()
 
-    val groupMeta =
-        groups.find { it.id == groupId }
-            ?: groupsByRelay.values.flatten().find { it.id == groupId }
+    // The naddr's own relay names and paints the card; a same-id group elsewhere is a
+    // different group.
+    val groupMeta = resolveGroupRef(groupsByRelay, groupId, relayUrl, fallback = groups)
 
     LaunchedEffect(groupId, relayUrl) {
         if (relayUrl != null && groupMeta?.name == null) {
@@ -2943,9 +2934,9 @@ private fun GroupMentionChip(
     val repo = AppModule.nostrRepository
     val groups by repo.groups.collectAsState()
     val groupsByRelay by repo.groupsByRelay.collectAsState()
-    val groupMeta =
-        groups.find { it.id == groupId }
-            ?: groupsByRelay.values.flatten().find { it.id == groupId }
+    // Same relay-scoped resolution as the full card: the chip's avatar must come from the
+    // relay the naddr points at.
+    val groupMeta = resolveGroupRef(groupsByRelay, groupId, relayUrl, fallback = groups)
 
     LaunchedEffect(groupId, relayUrl) {
         if (relayUrl != null && groupMeta?.name == null) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -62,6 +62,7 @@ import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.utils.formatTime
+import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.utils.shortNpub
 import kotlin.math.abs
@@ -165,20 +166,31 @@ fun MessageItem(
             if (replyParentId != null) resolveReplyMessage(replyParentId) else null
         }
 
-    // If not in allMessages, check cachedEvents and convert to NostrMessage
+    // If not in allMessages, check cachedEvents and convert to NostrMessage. Only this (relay,
+    // group)'s own events qualify: a `q` tag can point at an event another group put in the
+    // shared by-id cache, and painting that shows a different group's message inside this one.
+    // An unstamped copy (restored from disk) is accepted, like an unstamped NostrMessage.
     val parentFromCache: NostrGroupClient.NostrMessage? =
-        remember(replyParentId, cachedEvents, parentMessage) {
+        remember(replyParentId, cachedEvents, parentMessage, currentGroupId, currentRelayUrl) {
             if (replyParentId != null && parentMessage == null) {
-                cachedEvents[replyParentId]?.let { cached ->
-                    NostrGroupClient.NostrMessage(
-                        id = cached.id,
-                        pubkey = cached.pubkey,
-                        content = cached.content,
-                        createdAt = cached.createdAt,
-                        kind = cached.kind,
-                        tags = cached.tags,
-                    )
-                }
+                cachedEvents[replyParentId]
+                    ?.takeIf { cached ->
+                        val cachedGroup = cached.tags.firstOrNull { it.size >= 2 && it[0] == "h" }?.get(1)
+                        val groupOk = currentGroupId == null || cachedGroup == null || cachedGroup == currentGroupId
+                        val relayOk = currentRelayUrl == null ||
+                            cached.relayUrl == null ||
+                            cached.relayUrl == currentRelayUrl.normalizeRelayUrl()
+                        groupOk && relayOk
+                    }?.let { cached ->
+                        NostrGroupClient.NostrMessage(
+                            id = cached.id,
+                            pubkey = cached.pubkey,
+                            content = cached.content,
+                            createdAt = cached.createdAt,
+                            kind = cached.kind,
+                            tags = cached.tags,
+                        )
+                    }
             } else {
                 null
             }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -360,7 +360,20 @@ fun AppFrame() {
                 AppModule.nostrRepository.switchRelay(r.relayUrl)
             }
             AppModule.nostrRepository.setActiveGroup(r?.relayUrl, r?.groupId)
-            if (r != null) AppModule.nostrRepository.markGroupAsRead(r.relayUrl, r.groupId)
+            if (r != null) {
+                AppModule.nostrRepository.markGroupAsRead(r.relayUrl, r.groupId)
+                // Re-pin routing (sends, joins, member reads) to the relay on screen. The
+                // ViewModel registers this at construction only, so with the same id on two
+                // relays whichever twin was opened LAST kept routing both.
+                AppModule.nostrRepository.setGroupRelayHint(r.groupId, r.relayUrl)
+                // A group this account has not joined never enters the relay's list, so its
+                // kind:39000 is never fetched and the screen has no name, about or avatar to
+                // show. Same on-demand preview the web frame does.
+                val known = AppModule.nostrRepository.groupsByRelay.value
+                    .entries.firstOrNull { it.key.normalizeRelayUrl() == r.relayUrl.normalizeRelayUrl() }
+                    ?.value?.any { it.id == r.groupId } == true
+                if (!known) AppModule.nostrRepository.fetchGroupPreview(r.groupId, r.relayUrl)
+            }
         }
     }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/GroupSidebar.kt
@@ -71,6 +71,7 @@ import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.GroupView
 import org.nostr.nostrord.ui.screens.avspace.LiveSpaceBarViewModel
 import org.nostr.nostrord.ui.screens.group.GroupViewModel
+import org.nostr.nostrord.ui.screens.group.atRelay
 import org.nostr.nostrord.ui.screens.group.channelTree
 import org.nostr.nostrord.ui.screens.group.components.CreateGroupModal
 import org.nostr.nostrord.ui.screens.group.components.ManageGroupModal
@@ -119,7 +120,9 @@ fun GroupSidebar(
     val kind10009Relays by AppModule.nostrRepository.kind10009Relays.collectAsState()
     val relayMetadata by vm.relayMetadata.collectAsState()
 
-    val relayGroups = groupsByRelay[route.relayUrl].orEmpty()
+    // Tolerate a route relay that is not byte-identical to the map key ("wss://Relay/" vs the
+    // connected "wss://relay"); a raw-key miss would empty the whole sidebar.
+    val relayGroups = groupsByRelay.atRelay(route.relayUrl.normalizeRelayUrl()).orEmpty()
     val metaById = relayGroups.associateBy { it.id }
     val currentUserPubkey = remember { vm.getPublicKey() }
     // Discord-style channel model: the sidebar anchors on the ROOT of the open channel's

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -44,6 +44,7 @@ import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
 import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeRelayUrl
+import org.nostr.nostrord.utils.resolveGroupRef
 import org.nostr.nostrord.utils.shortNpub
 
 // Unit separator — safe field delimiter for encoding GroupInfo into the platform-agnostic
@@ -152,15 +153,22 @@ fun GroupScreen(
         (relayMetadata[screenRelay] ?: relayMetadata[screenRelay.normalizeRelayUrl()])?.supportsSubgroups == true
     val currentUserPubkey = vm.getPublicKey()
 
-    // This relay's kind:39000 first: a same-id group on another relay must not paint this
-    // screen's name/about. The flat list stays the fallback while the route has no relay.
+    // Only this relay's kind:39000 may paint this screen. With a route relay there is no flat
+    // fallback: the twin group on another relay would lend its name, about and avatar to a
+    // group whose metadata simply has not arrived yet (a non-member of a private group, or a
+    // preview still in flight). The flat list stays the fallback while the route has no relay.
     val currentGroupMetadata =
         remember(groups, allGroupsByRelay, groupId, relayUrl) {
-            relayUrl?.let { r ->
-                (allGroupsByRelay[r] ?: allGroupsByRelay.entries.firstOrNull { it.key.normalizeRelayUrl() == r.normalizeRelayUrl() }?.value)
-                    ?.firstOrNull { it.id == groupId }
-            } ?: groups.find { it.id == groupId }
+            resolveGroupRef(allGroupsByRelay, groupId, relayUrl, fallback = groups)
         }
+
+    // Nothing from this relay yet (a group the account has not joined never enters the
+    // per-relay list): ask for its kind:39000 so the header stops showing the raw id.
+    LaunchedEffect(groupId, relayUrl, currentGroupMetadata?.name) {
+        if (relayUrl != null && currentGroupMetadata?.name == null) {
+            vm.fetchGroupPreview(groupId, relayUrl)
+        }
+    }
 
     // %group mention candidates: only joined + friends' groups (the new discovery),
     // not every group the relay served.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupScreen.kt
@@ -204,7 +204,7 @@ fun GroupScreen(
 
     // messageInput is only the failure-restore channel into the composer (the live text
     // lives in MessageInput); keyed by groupId so a restore value can't leak across groups.
-    var messageInput by remember(groupId) { mutableStateOf("") }
+    var messageInput by remember(chatKey) { mutableStateOf("") }
     // Mention maps are part of the per-group draft: seed from the store on group change so
     // an @user / %group typed before switching is restored (and doesn't bleed into the next
     // group, which the un-keyed remember used to do).
@@ -212,11 +212,14 @@ fun GroupScreen(
     var groupMentions by remember(chatKey) {
         mutableStateOf(decodeGroupMentions(AppModule.messageDraftStore.get(chatKey).groupMentions))
     }
-    var replyingToMessage by remember(groupId) { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
+    // Keyed by (relay, group) like the draft: the twin group on another relay is a different
+    // group, and a reply target carried across sent the `q` tag pointing at a message the
+    // destination group never had.
+    var replyingToMessage by remember(chatKey) { mutableStateOf<NostrGroupClient.NostrMessage?>(null) }
     // Bumped on EVERY reply tap so re-replying to the same message still refocuses the
     // composer and re-summons the keyboard (the message alone doesn't change then).
-    var replyNonce by remember(groupId) { mutableStateOf(0) }
-    var pendingUploads by remember { mutableStateOf<List<UploadResult>>(emptyList()) }
+    var replyNonce by remember(chatKey) { mutableStateOf(0) }
+    var pendingUploads by remember(chatKey) { mutableStateOf<List<UploadResult>>(emptyList()) }
     var showLeaveDialog by remember { mutableStateOf(false) }
     var showGroupInfoModal by remember { mutableStateOf(false) }
     var showEditGroupModal by remember { mutableStateOf(false) }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -108,6 +108,7 @@ import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
 import org.nostr.nostrord.utils.formatTimestamp
 import org.nostr.nostrord.utils.getDateLabel
 import org.nostr.nostrord.utils.rememberClipboardWriter
+import org.nostr.nostrord.utils.resolveGroupRef
 import org.nostr.nostrord.utils.shortNpub
 
 /**
@@ -268,8 +269,7 @@ fun ThreadsScreen(
         // Desktop skips it - the sidebar already names the group.
         if (onOpenDrawer != null) {
             val groupsByRelay by AppModule.nostrRepository.groupsByRelay.collectAsState()
-            val groupMeta = groupsByRelay[route.relayUrl]?.firstOrNull { it.id == route.groupId }
-                ?: groupsByRelay.values.flatten().firstOrNull { it.id == route.groupId }
+            val groupMeta = resolveGroupRef(groupsByRelay, route.groupId, route.relayUrl)
             val groupName = groupMeta?.name?.takeIf { it.isNotBlank() } ?: "#${route.groupId.take(8)}"
             Row(
                 modifier = Modifier.fillMaxWidth().height(Spacing.headerHeight).padding(horizontal = Spacing.sm),

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/notifications/NotificationsPage.kt
@@ -50,6 +50,7 @@ import org.nostr.nostrord.ui.navigation.notificationRoute
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.utils.formatTimestamp
+import org.nostr.nostrord.utils.resolveGroupRef
 import org.nostr.nostrord.utils.shortNpub
 
 /**
@@ -130,9 +131,9 @@ fun NotificationsPage(
                             meta?.displayName?.takeIf { it.isNotBlank() }
                                 ?: meta?.name?.takeIf { it.isNotBlank() }
                                 ?: shortNpub(entry.actorPubkey)
-                        val groupMeta =
-                            groupsByRelay[entry.relayUrl]?.firstOrNull { it.id == entry.groupId }
-                                ?: groupsByRelay.values.firstNotNullOfOrNull { list -> list.firstOrNull { it.id == entry.groupId } }
+                        // The entry's own relay decides: NIP-29 group ids are relay-local, so a
+                        // same-id group elsewhere must not name or paint this row.
+                        val groupMeta = resolveGroupRef(groupsByRelay, entry.groupId, entry.relayUrl)
                         // Live metadata first: the snapshot taken at notification time can be
                         // the truncated id (metadata hadn't landed yet, e.g. a private group
                         // pre-AUTH) and would otherwise shadow the real name forever.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -339,6 +339,10 @@ val AppFrame =
             } else {
                 repo.setActiveGroup(r.relayUrl, r.groupId)
                 repo.markGroupAsRead(r.relayUrl, r.groupId)
+                // Re-pin routing (sends, joins, member reads) to the relay on screen: the
+                // ViewModel registers the hint at construction only, so with the same id on
+                // two relays whichever twin mounted LAST kept routing both.
+                repo.setGroupRelayHint(r.groupId, r.relayUrl)
                 val code = r.inviteCode
                 if (code != null) {
                     consumeInviteInHash(r)
@@ -355,7 +359,7 @@ val AppFrame =
                         // No ViewModel on the deep-link path, so the rejection reason goes to the
                         // system snackbar; swallowing it made a bad invite code look like nothing
                         // happened at all.
-                        val join = repo.joinGroup(r.groupId, code)
+                        val join = repo.joinGroup(r.groupId, code, relayUrl = r.relayUrl)
                         if (join is org.nostr.nostrord.utils.Result.Error) {
                             val reason = (join.error as? AppError.Group.JoinFailed)?.cause?.message
                             AppModule.postSystemMessage(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/GroupInviteCard.kt
@@ -1,7 +1,7 @@
 package org.nostr.nostrord.web.components
 
 import org.nostr.nostrord.di.AppModule
-import org.nostr.nostrord.utils.normalizeRelayUrl
+import org.nostr.nostrord.utils.resolveGroupRef
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import react.FC
@@ -28,11 +28,9 @@ val GroupInviteCard =
     FC<GroupInviteCardProps> { props ->
         val repo = AppModule.nostrRepository
         val groupsByRelay = useStateFlow(repo.groupsByRelay)
-        // The card's own relay first: NIP-29 ids are relay-local, and a flattened scan
-        // could resolve a same-id group from another relay.
-        val meta =
-            props.relayUrl?.let { url -> groupsByRelay[url.normalizeRelayUrl()]?.firstOrNull { it.id == props.groupId } }
-                ?: groupsByRelay.values.flatten().firstOrNull { it.id == props.groupId }
+        // The invite's own relay decides: NIP-29 ids are relay-local, so a same-id group from
+        // another relay must not paint this card.
+        val meta = resolveGroupRef(groupsByRelay, props.groupId, props.relayUrl)
         val name = meta?.name?.takeIf { it.isNotBlank() } ?: props.groupId
 
         useEffect(props.groupId, props.relayUrl, meta?.name) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -4277,8 +4277,8 @@ private val GroupLinkCard =
 
 /**
  * Inline group mention chip (prototype): a decoded naddr (kind 39000) shown compactly with the
- * group's square avatar + name when resolved, or `#name` when it has no picture. Clicking opens
- * the group. Standalone group references still render as the full GroupLinkCard.
+ * group's square avatar + name. Clicking opens the group. Standalone group references still
+ * render as the full GroupLinkCard.
  */
 /** A group reference in message text: the full card when the message is only the link, else the chip. */
 private fun ChildrenBuilder.groupRef(
@@ -4321,19 +4321,16 @@ private val GroupMentionChip =
         span {
             className = ClassName("msg-mention-chip")
             onClick = { props.onNavigate(props.groupId, props.relayUrl) }
-            val picture = meta?.picture
-            if (!picture.isNullOrBlank()) {
-                WebAvatar {
-                    url = picture
-                    seed = props.groupId
-                    this.name = name
-                    kind = AvatarKind.GROUP
-                    cls = "msg-mention-chip-avatar group"
-                }
-                +name
-            } else {
-                +"#$name"
+            // Always an avatar: WebAvatar paints the seeded gradient when the group has no
+            // picture, matching the forwarded-from chip and the native GroupHeaderIcon.
+            WebAvatar {
+                url = meta?.picture
+                seed = props.groupId
+                this.name = name
+                kind = AvatarKind.GROUP
+                cls = "msg-mention-chip-avatar group"
             }
+            +name
         }
     }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -47,6 +47,7 @@ import org.nostr.nostrord.utils.formatTimestamp
 import org.nostr.nostrord.utils.groupKey
 import org.nostr.nostrord.utils.normalizeForSearch
 import org.nostr.nostrord.utils.normalizeRelayUrl
+import org.nostr.nostrord.utils.resolveGroupRef
 import org.nostr.nostrord.utils.shortNpub
 import org.nostr.nostrord.web.bridge.VirtualKeyboard
 import org.nostr.nostrord.web.bridge.launchApp
@@ -3869,11 +3870,7 @@ private val QuotedEvent =
             refGroupId != null && (local == null || (fwdRelay != null && fwdRelay != props.relayUrl.normalizeRelayUrl()))
         // The source relay's own kind:39000 names the card; a same-id group elsewhere is a
         // different group and must not paint it.
-        val fwdGroupMeta =
-            refGroupId?.let { gid ->
-                val onSource = fwdRelay?.let { r -> groupsByRelay.entries.firstOrNull { it.key.normalizeRelayUrl() == r }?.value }
-                onSource?.firstOrNull { it.id == gid } ?: groupsByRelay.values.flatten().firstOrNull { it.id == gid }
-            }
+        val fwdGroupMeta = refGroupId?.let { gid -> resolveGroupRef(groupsByRelay, gid, fwdRelay) }
         val fwdGroupName = fwdGroupMeta?.name?.takeIf { it.isNotBlank() } ?: refGroupId.orEmpty()
         useEffect(refGroupId, fwdRelay, fwdGroupMeta?.name) {
             if (isForwarded && refGroupId != null && fwdRelay != null && fwdGroupMeta?.name == null) {
@@ -4233,7 +4230,9 @@ private val GroupLinkCard =
     FC<GroupLinkCardProps> { props ->
         val repo = AppModule.nostrRepository
         val groupsByRelay = useStateFlow(repo.groupsByRelay)
-        val meta = groupsByRelay.values.flatten().firstOrNull { it.id == props.groupId }
+        // The naddr's own relay names and paints the card; a same-id group elsewhere is a
+        // different group.
+        val meta = resolveGroupRef(groupsByRelay, props.groupId, props.relayUrl)
         val name = meta?.name?.takeIf { it.isNotBlank() } ?: props.groupId
         val relayDisplay = props.relayUrl?.removePrefix("wss://")?.removePrefix("ws://")?.trimEnd('/')
 
@@ -4307,7 +4306,9 @@ private val GroupMentionChip =
     FC<GroupLinkCardProps> { props ->
         val repo = AppModule.nostrRepository
         val groupsByRelay = useStateFlow(repo.groupsByRelay)
-        val meta = groupsByRelay.values.flatten().firstOrNull { it.id == props.groupId }
+        // Same relay-scoped resolution as the full card: the chip's avatar must come from the
+        // relay the naddr points at.
+        val meta = resolveGroupRef(groupsByRelay, props.groupId, props.relayUrl)
         val name = meta?.name?.takeIf { it.isNotBlank() } ?: props.groupId
 
         useEffect(props.groupId, props.relayUrl, meta?.name) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/NotificationsPage.kt
@@ -9,6 +9,7 @@ import org.nostr.nostrord.ui.screens.notifications.NotificationsViewModel
 import org.nostr.nostrord.ui.screens.notifications.notificationActionLabel
 import org.nostr.nostrord.utils.formatTimestamp
 import org.nostr.nostrord.utils.normalizeRelayUrl
+import org.nostr.nostrord.utils.resolveGroupRef
 import org.nostr.nostrord.utils.shortNpub
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.components.AvatarKind
@@ -91,14 +92,10 @@ val NotificationsPage =
                             val meta = userMetadata[entry.actorPubkey]
                             // Live metadata first: the snapshot taken at notification time can
                             // be the truncated id (metadata hadn't landed yet) and would
-                            // otherwise shadow the real name forever. The entry's own relay is
-                            // checked first — NIP-29 group ids are relay-local, and an any-relay
-                            // scan could name a same-id group from another relay.
-                            val groupMeta =
-                                groupsByRelay[entry.relayUrl]?.firstOrNull { it.id == entry.groupId }
-                                    ?: groupsByRelay.values.firstNotNullOfOrNull { list ->
-                                        list.firstOrNull { it.id == entry.groupId }
-                                    }
+                            // otherwise shadow the real name forever. The entry's own relay
+                            // decides: NIP-29 group ids are relay-local, so a same-id group
+                            // elsewhere must not name or paint this row.
+                            val groupMeta = resolveGroupRef(groupsByRelay, entry.groupId, entry.relayUrl)
                             val groupName =
                                 groupMeta?.name?.takeIf { it.isNotBlank() }
                                     ?: entry.groupName?.takeIf { it.isNotBlank() }


### PR DESCRIPTION
A NIP-29 group id is unique only within one relay, but several surfaces still decided by the bare id and fell back to a cross-relay scan. `nostrord` on chat.wisp.talk borrowed the name, about and avatar of `nostrord` on groups.0xchat.com; a 9021 sent to one relay made the twin open on "Request pending" for a request it never received; the composer carried a reply target across a relay switch, so the sent message's `q` tag pointed at a message the destination group does not have; and because the relay hint is a bare-id map written once at ViewModel construction, whichever twin was opened LAST kept routing sends, joins and member reads for both, which is why Join could look dead while its 9021 went to the other relay.

Every reader now resolves on the relay its own reference, route or entry names. `resolveGroupRef` (commonMain) pins a hinted lookup to that relay's kind:39000 and scans across relays only when there is no hint at all, so an unresolved group shows its raw id and a seeded avatar instead of the twin's identity, and the frame asks that relay for a preview to fill it in.

| Surface | Before | Now |
|---|---|---|
| Reference cards (forwarded, thread quote, naddr card + chip, DM invite, notification rows) | bare id, cross-relay fallback | `resolveGroupRef` on the reference's own relay |
| Open group screen | flat group list filled the gap | that relay's kind:39000 only, preview fetched on demand (native had no fetch at all) |
| `pendingApprovalSince` | keyed by group id | keyed by `groupKey(relay, id)` |
| Relay hint / join routing | written once per ViewModel, focused relay as fallback | re-pinned on every route change; `joinGroup` takes the screen's relay |
| Native composer (reply target, restore buffer, staged uploads) | `remember(groupId)` | `remember(chatKey)` |
| By-id event cache | no origin | stamps the serving relay; reply preview needs group + relay to match |

Also: a web group mention chip with no picture rendered as `#name` while every other group surface shows the seeded gradient square; it now renders the avatar like the rest.

Tests: `GroupRefLookupTest` covers relay-pinned resolution (hint wins, hint normalized, hinted relay without the group stays unresolved, hintless falls back); `GroupViewModelTest` gains a join routed to the screen's relay while another is focused, and a 9021 on one relay leaving the twin joinable. `compileKotlinJvm`, `compileKotlinJs` and `:composeApp:jvmTest` green; both fixes validated on the desktop app and the web against the two live `nostrord` groups.

Not in scope, still keyed by bare id: the per-group content maps (`_messages`, `_groupMembers`, `_groupAdmins`, `messageStatus`, the loading registry) with `*ByRelay` mirrors only for members/admins/roles, and `getRelayForGroup` resolving by hint rather than by an explicit relay on the call. The disk event cache also does not persist the serving relay, so a restored event counts as unknown origin.

- 25fa3a4a fix(groups): resolve a group reference on the relay it points at
- 1c05764b fix(web): give the group mention chip its seeded avatar
- b3900df6 fix(join): key the pending join request per relay
- 53baef9e fix(chat): drop the reply target when the (relay, group) changes
- 2ff31b08 fix(cache): stamp the source relay on a cached event
- c4b123c5 fix(groups): pin the open group's screen and routing to its own relay