### PR TITLE
feat(threads): make thread posts read as forum posts

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -4626,7 +4626,7 @@ class NostrRepository(
 
     override fun dismissFailed(groupId: String, eventId: String) = groupManager.dismissFailed(groupId, eventId)
 
-    override suspend fun requestGroupThreads(groupId: String): Boolean = groupManager.requestGroupThreads(groupId)
+    override suspend fun requestGroupThreads(groupId: String, relayUrl: String?): Boolean = groupManager.requestGroupThreads(groupId, relayUrl)
 
     override fun closeThreadSubscriptions(groupId: String) = groupManager.closeThreadSubscriptions(groupId)
 
@@ -6719,6 +6719,10 @@ class NostrRepository(
             groupManager.handleReconnectForGroups(openedGroupIds.toList())
         }
 
+        // An open threads pane has no mux behind it: its kind:11 / kind:1111 REQs died with the
+        // socket, so without this the pane goes silent until the user leaves and re-enters it.
+        groupManager.resubscribeOpenThreads(relayUrl)
+
         // Fast-lane: direct requests for the ACTIVE group so it renders first.
         // Mux provides breadth for all groups; direct requests provide speed for the
         // group the user is currently looking at. Deduplicator handles overlap.
@@ -6857,7 +6861,7 @@ class NostrRepository(
         }
         // Re-fire forum thread subscriptions: a private group's pre-AUTH thread REQ was CLOSED
         // auth-required, and the threads pane has no mux to refresh it post-AUTH.
-        groupManager.resubscribeOpenThreadsAfterAuth(relayUrl)
+        groupManager.resubscribeOpenThreads(relayUrl)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -695,8 +695,13 @@ interface NostrRepositoryApi {
     /** Drop a failed own message from the chat. */
     fun dismissFailed(groupId: String, eventId: String)
 
-    /** Open the threads-pane subscriptions for a group (kind:11 roots + batched kind:1111 replies). */
-    suspend fun requestGroupThreads(groupId: String): Boolean
+    /**
+     * Open the threads-pane subscriptions for a group (kind:11 roots + batched kind:1111 replies).
+     *
+     * [relayUrl] is the relay the pane's route names. Passing it lets the disk cache hydrate on a
+     * cold open, before the group listings that [getRelayForGroup] would need have arrived.
+     */
+    suspend fun requestGroupThreads(groupId: String, relayUrl: String? = null): Boolean
 
     /** CLOSE the threads-pane subscriptions for a group (on leaving the pane). Fire-and-forget. */
     fun closeThreadSubscriptions(groupId: String)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3436,9 +3436,11 @@ class GroupManager(
      * [hydrateMessagesFromCache]). The live subscriptions then refresh and dedupe by id;
      * deletions were already evicted from the cache when their kind 5/9005 arrived.
      */
-    private suspend fun hydrateThreadsFromCache(groupId: String) {
+    private suspend fun hydrateThreadsFromCache(groupId: String, relayUrl: String?) {
         val account = currentPubkey ?: return
-        val relay = getRelayForGroup(groupId) ?: return
+        // The caller's relay wins: on a cold open getRelayForGroup answers null until the
+        // kind:39000 / kind:10009 listings land, which is exactly the window the cache is for.
+        val relay = relayUrl?.normalizeRelayUrl() ?: getRelayForGroup(groupId) ?: return
         if (!hydratedThreadGroups.add(groupId)) return
         val cached =
             try {
@@ -3465,13 +3467,17 @@ class GroupManager(
      * Open the threads pane for a group: subscribe to kind:11 roots plus the batched kind:1111
      * reply feed (for per-thread counts/previews). Both subscriptions stay open for live updates
      * until [closeThreadSubscriptions]. Waits for AUTH on a private group, like the chat read; if
-     * AUTH lands later, [resubscribeOpenThreadsAfterAuth] re-fires these.
+     * AUTH lands later, [resubscribeOpenThreads] re-fires these.
      */
-    suspend fun requestGroupThreads(groupId: String): Boolean {
+    suspend fun requestGroupThreads(groupId: String, relayUrl: String? = null): Boolean {
+        // The pane's route names the relay the group is open on, which is authoritative: record it
+        // so the cache slot, the client lookup and every later resolution stop depending on a
+        // listing that has not arrived yet (and on getRelayForGroup's single-serving-relay rule).
+        relayUrl?.let { setGroupRelayHint(groupId, it) }
         // Show the known threads instantly from disk (stale-while-revalidate) - before the
         // client check, so a cold or offline open still renders and the VM's retry loop
         // (which re-enters here until the client is ready) hits the hydration guard.
-        hydrateThreadsFromCache(groupId)
+        hydrateThreadsFromCache(groupId, relayUrl)
         val client = clientForGroup(groupId) ?: return false
         openThreadGroups.add(groupId)
         if (client.requiresAuth() && !client.hasAuthSucceeded()) {
@@ -3497,11 +3503,14 @@ class GroupManager(
     }
 
     /**
-     * Re-fire thread subscriptions for any open threads pane on [relayUrl] after NIP-42 AUTH
-     * succeeds. A private group's pre-AUTH thread REQ is CLOSED "auth-required"; this is the
-     * threads analogue of the chat mux's resubscribeAfterAuth.
+     * Re-fire thread subscriptions for any open threads pane on [relayUrl].
+     *
+     * Two callers, both cases where the previous REQ is gone: after NIP-42 AUTH succeeds (a private
+     * group's pre-AUTH thread REQ comes back CLOSED "auth-required"), and after a reconnect, where
+     * the socket that carried the subscription died. Without the reconnect call an open pane keeps
+     * whatever it had and never sees another thread event.
      */
-    suspend fun resubscribeOpenThreadsAfterAuth(relayUrl: String) {
+    suspend fun resubscribeOpenThreads(relayUrl: String) {
         val normalized = relayUrl.normalizeRelayUrl()
         for (groupId in openThreadGroups.toList()) {
             if (getRelayForGroup(groupId)?.normalizeRelayUrl() != normalized) continue

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -294,7 +294,9 @@ class ThreadsViewModel(
         // (leaving the list stuck empty / "No threads yet").
         viewModelScope.launch {
             repeat(THREAD_REQUEST_ATTEMPTS) {
-                if (repo.requestGroupThreads(groupId)) return@launch
+                // The route's relay goes with it: it is what lets the first attempt hydrate the
+                // pane from disk instead of waiting on the group listings.
+                if (repo.requestGroupThreads(groupId, hostRelay)) return@launch
                 delay(THREAD_REQUEST_RETRY_MS)
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -179,11 +179,17 @@ fun threadsPlaceholder(
     isLoading: Boolean,
     isPendingApproval: Boolean,
     isRestricted: Boolean,
+    /**
+     * False during the grace window that the disk hydration is expected to answer within: a pane
+     * whose threads are already cached must open on them, not flash a spinner first. Blank for
+     * those few frames, because "No threads yet" would be a wrong answer, not an early one.
+     */
+    skeletonDue: Boolean = true,
 ): ThreadsPlaceholder? = when {
     hasThreads -> null
     isPendingApproval -> ThreadsPlaceholder.PENDING_APPROVAL
     isRestricted -> ThreadsPlaceholder.PRIVATE
-    isLoading -> ThreadsPlaceholder.LOADING
+    isLoading -> if (skeletonDue) ThreadsPlaceholder.LOADING else null
     else -> ThreadsPlaceholder.EMPTY
 }
 
@@ -272,6 +278,13 @@ class ThreadsViewModel(
     private val _isLoading = MutableStateFlow(true)
     val isLoading: StateFlow<Boolean> = _isLoading
 
+    /**
+     * Whether the skeleton has earned the right to show. The disk hydration answers in
+     * milliseconds, so a pane whose threads are cached opens straight on them instead of flashing
+     * "Loading threads..." first. Flipped once, [SKELETON_GRACE_MS] after the pane opens.
+     */
+    private val skeletonDue = MutableStateFlow(false)
+
     val threads: StateFlow<List<ThreadSummary>> =
         combine(repo.threadRoots, repo.threadReplies) { rootsMap, repliesMap ->
             buildThreadSummaries(scoped(rootsMap[groupId] ?: emptyList()), scoped(repliesMap[groupId] ?: emptyList()))
@@ -289,6 +302,10 @@ class ThreadsViewModel(
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
 
     init {
+        viewModelScope.launch {
+            delay(SKELETON_GRACE_MS)
+            skeletonDue.value = true
+        }
         // Subscribe to the group's threads, retrying until the group client is ready: a cold-start
         // deep link races the relay connection, and a one-shot request would silently no-op
         // (leaving the list stuck empty / "No threads yet").
@@ -476,6 +493,16 @@ class ThreadsViewModel(
             .map { pendingHere(it) }
             .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), pendingHere(repo.pendingApprovalSince.value))
 
+    /**
+     * What the list area shows instead of cards, or null to render the (possibly empty) list.
+     * Derived here so both UIs gate identically, skeleton grace included.
+     */
+    val placeholder: StateFlow<ThreadsPlaceholder?> =
+        combine(threads, isLoading, skeletonDue, isPendingApproval, isRestricted) { list, loading, due, pending, restricted ->
+            threadsPlaceholder(list.isNotEmpty(), loading, pending, restricted, skeletonDue = due)
+            // Starts blank, not LOADING: the grace window is the point.
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
     private val membershipModel = GroupMembershipModel(repo, groupId, hostRelay, viewModelScope)
 
     /** Admin of this group (host-relay scoped): drives the moderation delete affordances. */
@@ -559,6 +586,10 @@ class ThreadsViewModel(
     companion object {
         // Fallback only: the list normally settles on the roots-sub EOSE, not this timer.
         const val THREAD_LOAD_SETTLE_MS = 12_000L
+
+        // Long enough for a disk read (SQLite / IndexedDB), short enough that a genuinely cold
+        // pane still explains itself before the user wonders whether anything is happening.
+        const val SKELETON_GRACE_MS = 400L
         const val THREAD_REQUEST_ATTEMPTS = 12
         const val THREAD_REQUEST_RETRY_MS = 600L
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsViewModel.kt
@@ -140,6 +140,17 @@ fun canDeleteThreadMessage(
     isAdmin: Boolean,
 ): Boolean = myPubkey != null && (authorPubkey == myPubkey || isAdmin)
 
+/**
+ * Whether a keypress in the thread reply box posts it. A forum reply is expected to run to more
+ * than one line, so Enter inserts a newline and only Ctrl/Cmd+Enter posts - deliberately the
+ * inverse of the chat composer, where Enter sends.
+ */
+fun threadComposerSubmits(
+    isEnter: Boolean,
+    ctrlOrMeta: Boolean,
+    shift: Boolean,
+): Boolean = isEnter && ctrlOrMeta && !shift
+
 /** What the threads list shows when it has no cards to render. */
 enum class ThreadsPlaceholder {
     /** Still fetching: roots may yet arrive. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/BlockEmbedText.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/BlockEmbedText.kt
@@ -1,0 +1,21 @@
+package org.nostr.nostrord.ui.text
+
+/**
+ * Whitespace rule for text runs that touch a block embed (image, video, audio, quoted event, code
+ * block, blockquote).
+ *
+ * A block embed opens and closes its own line and carries its own vertical spacing, so the newline
+ * the author typed around it would render as an extra empty line - a wide gap between the media and
+ * the sentence under it. One newline per touching side is absorbed by the block; anything typed
+ * beyond that is a deliberate blank line and survives.
+ *
+ * Shared by the Compose renderer (MessageContent) and the web one (renderMessageContent) so the two
+ * space embeds identically.
+ */
+object BlockEmbedText {
+    /** Text run that ends right before a block embed. */
+    fun trimBefore(text: String): String = if (text.endsWith("\r\n")) text.dropLast(2) else text.removeSuffix("\n")
+
+    /** Text run that starts right after a block embed. */
+    fun trimAfter(text: String): String = if (text.startsWith("\r\n")) text.drop(2) else text.removePrefix("\n")
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/TimeUtils.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/TimeUtils.kt
@@ -73,13 +73,28 @@ fun formatTimestamp(timestamp: Long): String {
     }
 }
 
+/**
+ * Days since 1970-01-01 for a civil date (proleptic Gregorian), by Howard Hinnant's days_from_civil.
+ * Calendar-exact: month lengths and leap years both count, which a fixed 30-day month does not.
+ */
+internal fun daysFromCivil(
+    year: Int,
+    month: Int,
+    day: Int,
+): Long {
+    // March-based year: the leap day lands last, so no month length depends on the leap rule.
+    val y = if (month <= 2) year - 1 else year
+    val era = (if (y >= 0) y else y - 399) / 400
+    val yearOfEra = y - era * 400
+    val monthFromMarch = (month + 9) % 12
+    val dayOfYear = (153 * monthFromMarch + 2) / 5 + day - 1
+    val dayOfEra = yearOfEra * 365L + yearOfEra / 4 - yearOfEra / 100 + dayOfYear
+    return era * 146_097L + dayOfEra - 719_468L
+}
+
 private fun calculateDaysDiff(
     date1: SimpleDateTime,
     date2: SimpleDateTime,
-): Int {
-    // Simple day difference calculation
-    val days1 = date1.year * 365 + date1.month * 30 + date1.day
-    val days2 = date2.year * 365 + date2.month * 30 + date2.day
-
-    return kotlin.math.abs(days1 - days2)
-}
+): Int = kotlin.math.abs(
+    daysFromCivil(date1.year, date1.month, date1.day) - daysFromCivil(date2.year, date2.month, date2.day),
+).toInt()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -388,10 +388,14 @@ class FakeNostrRepository : NostrRepositoryApi {
     /** (groupId, relayUrl) of every joinGroup call, so tests can assert the routing relay. */
     val joinRelays = mutableListOf<Pair<String, String?>>()
 
-    override suspend fun requestGroupThreads(groupId: String): Boolean {
+    override suspend fun requestGroupThreads(groupId: String, relayUrl: String?): Boolean {
         calls += "requestGroupThreads:$groupId"
+        threadRequestRelays += groupId to relayUrl
         return true
     }
+
+    /** (groupId, relayUrl) of every requestGroupThreads call, so tests can assert the route relay. */
+    val threadRequestRelays = mutableListOf<Pair<String, String?>>()
 
     override fun closeThreadSubscriptions(groupId: String) {
         calls += "closeThreadSubscriptions:$groupId"

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/ThreadCacheTest.kt
@@ -60,6 +60,52 @@ class ThreadCacheTest {
     }
 
     @Test
+    fun `the route's relay hydrates the pane before any group listing arrives`() = runTest {
+        val scope = TestScope(testScheduler)
+        val store = InMemoryCacheStore()
+        val writer = makeManager(scope, store)
+        writer.setCurrentPubkey(PUBKEY)
+        writer.setGroupRelayHint(GROUP, RELAY)
+
+        deliver(writer, threadMsg("root1", kind = 11, createdAt = 100))
+        testScheduler.advanceUntilIdle()
+
+        // Cold start proper: no relay hint, no kind:39000 listing, no kind:10009 - the state
+        // getRelayForGroup reads is empty, so only the caller's relay can name the cache slot.
+        val reader = makeManager(scope, store)
+        reader.setCurrentPubkey(PUBKEY)
+        assertEquals(null, reader.getRelayForGroup(GROUP))
+
+        reader.requestGroupThreads(GROUP, RELAY)
+        assertEquals(listOf("root1"), reader.threadRoots.value[GROUP]?.map { it.id })
+        // The route's relay is authoritative, so it is recorded for every later resolution.
+        assertEquals(RELAY, reader.getRelayForGroup(GROUP))
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `without a relay the cold pane cannot hydrate`() = runTest {
+        val scope = TestScope(testScheduler)
+        val store = InMemoryCacheStore()
+        val writer = makeManager(scope, store)
+        writer.setCurrentPubkey(PUBKEY)
+        writer.setGroupRelayHint(GROUP, RELAY)
+
+        deliver(writer, threadMsg("root1", kind = 11, createdAt = 100))
+        testScheduler.advanceUntilIdle()
+
+        // The slot is relay-scoped by design: a caller with no relay has nothing to look up.
+        // Guards the fallback path, so dropping the parameter cannot silently pass.
+        val reader = makeManager(scope, store)
+        reader.setCurrentPubkey(PUBKEY)
+        reader.requestGroupThreads(GROUP)
+        assertTrue(reader.threadRoots.value[GROUP].isNullOrEmpty())
+
+        scope.cancel()
+    }
+
+    @Test
     fun `a deleted thread root does not rehydrate from cache`() = runTest {
         val scope = TestScope(testScheduler)
         val store = InMemoryCacheStore()

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -352,6 +352,28 @@ class ThreadsViewModelTest {
         )
         // Threads already on screen keep rendering even if a restriction marker lands late.
         assertNull(threadsPlaceholder(hasThreads = true, isLoading = false, isPendingApproval = false, isRestricted = true))
+        // Inside the hydration grace the pane stays blank: the skeleton has not earned its place
+        // yet, and "No threads yet" would be a wrong answer rather than an early one.
+        assertNull(
+            threadsPlaceholder(
+                hasThreads = false,
+                isLoading = true,
+                isPendingApproval = false,
+                isRestricted = false,
+                skeletonDue = false,
+            ),
+        )
+        // A gate the user must act on is never withheld for the grace.
+        assertEquals(
+            ThreadsPlaceholder.PRIVATE,
+            threadsPlaceholder(
+                hasThreads = false,
+                isLoading = true,
+                isPendingApproval = false,
+                isRestricted = true,
+                skeletonDue = false,
+            ),
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/ThreadsViewModelTest.kt
@@ -20,6 +20,7 @@ import org.nostr.nostrord.ui.screens.group.deleteThreadConfirmBody
 import org.nostr.nostrord.ui.screens.group.filterMutedReactions
 import org.nostr.nostrord.ui.screens.group.friendlyRelayError
 import org.nostr.nostrord.ui.screens.group.threadAnnouncementsFor
+import org.nostr.nostrord.ui.screens.group.threadComposerSubmits
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.threadsPlaceholder
@@ -318,6 +319,15 @@ class ThreadsViewModelTest {
         // A plain member gets no delete on someone else's thread, and logged out none at all.
         assertFalse(canDeleteThreadMessage(other, me, isAdmin = false))
         assertFalse(canDeleteThreadMessage(other, null, isAdmin = true))
+    }
+
+    @Test
+    fun `threadComposerSubmits posts only on Ctrl or Cmd Enter`() {
+        assertTrue(threadComposerSubmits(isEnter = true, ctrlOrMeta = true, shift = false))
+        // Bare Enter writes a newline: a forum reply is expected to run to more than one line.
+        assertFalse(threadComposerSubmits(isEnter = true, ctrlOrMeta = false, shift = false))
+        assertFalse(threadComposerSubmits(isEnter = true, ctrlOrMeta = true, shift = true))
+        assertFalse(threadComposerSubmits(isEnter = false, ctrlOrMeta = true, shift = false))
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/BlockEmbedTextTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/BlockEmbedTextTest.kt
@@ -1,0 +1,28 @@
+package org.nostr.nostrord.ui.text
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BlockEmbedTextTest {
+    @Test
+    fun `one newline touching the block is absorbed`() {
+        assertEquals("look at this", BlockEmbedText.trimBefore("look at this\n"))
+        assertEquals("and here is why", BlockEmbedText.trimAfter("\nand here is why"))
+        assertEquals("look at this", BlockEmbedText.trimBefore("look at this\r\n"))
+        assertEquals("and here is why", BlockEmbedText.trimAfter("\r\nand here is why"))
+    }
+
+    @Test
+    fun `a deliberate blank line survives`() {
+        assertEquals("look at this\n", BlockEmbedText.trimBefore("look at this\n\n"))
+        assertEquals("\nand here is why", BlockEmbedText.trimAfter("\n\nand here is why"))
+    }
+
+    @Test
+    fun `text not touching a newline is untouched`() {
+        assertEquals("inline ", BlockEmbedText.trimBefore("inline "))
+        assertEquals(" inline", BlockEmbedText.trimAfter(" inline"))
+        assertEquals("", BlockEmbedText.trimBefore(""))
+        assertEquals("", BlockEmbedText.trimAfter(""))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/TimeUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/TimeUtilsTest.kt
@@ -1,0 +1,36 @@
+package org.nostr.nostrord.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TimeUtilsTest {
+    private fun days(from: Triple<Int, Int, Int>, to: Triple<Int, Int, Int>): Long = daysFromCivil(to.first, to.second, to.third) - daysFromCivil(from.first, from.second, from.third)
+
+    @Test
+    fun `the epoch anchors the count`() {
+        assertEquals(0L, daysFromCivil(1970, 1, 1))
+        assertEquals(1L, daysFromCivil(1970, 1, 2))
+        assertEquals(-1L, daysFromCivil(1969, 12, 31))
+    }
+
+    @Test
+    fun `crossing a month counts the real month length`() {
+        // The date labels hang off this: a 30-day-month approximation reported these as 0 and 1,
+        // so a thread from the last day of a long month showed as "Today".
+        assertEquals(1L, days(Triple(2026, 7, 31), Triple(2026, 8, 1)))
+        assertEquals(2L, days(Triple(2026, 8, 30), Triple(2026, 9, 1)))
+        assertEquals(1L, days(Triple(2026, 2, 28), Triple(2026, 3, 1)))
+    }
+
+    @Test
+    fun `a leap day counts as its own day`() {
+        assertEquals(2L, days(Triple(2024, 2, 28), Triple(2024, 3, 1)))
+        assertEquals(366L, days(Triple(2024, 1, 1), Triple(2025, 1, 1)))
+        assertEquals(365L, days(Triple(2025, 1, 1), Triple(2026, 1, 1)))
+    }
+
+    @Test
+    fun `crossing a year is one day, not a jump`() {
+        assertEquals(1L, days(Triple(2025, 12, 31), Triple(2026, 1, 1)))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -36,6 +37,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
@@ -57,12 +59,15 @@ import org.nostr.nostrord.network.upload.mimeTypeForFilename
 import org.nostr.nostrord.network.upload.rememberClipboardImageReader
 import org.nostr.nostrord.network.upload.uploadMedia
 import org.nostr.nostrord.ui.components.ConfirmDialog
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonSize
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.ui.components.upload.MessageUploadButton
 import org.nostr.nostrord.ui.mentions.MentionAutocomplete
 import org.nostr.nostrord.ui.screens.group.components.MentionVisualTransformation
 import org.nostr.nostrord.ui.screens.group.model.GroupInfo
 import org.nostr.nostrord.ui.screens.group.model.MemberInfo
+import org.nostr.nostrord.ui.screens.group.threadComposerSubmits
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
@@ -80,6 +85,9 @@ import org.nostr.nostrord.utils.Result
  * suggestion writes the token into the text and reports it through [onMentionsChange] /
  * [onGroupMentionsChange], which the caller resolves at send time. Left empty (the DM page) the
  * composer behaves as a plain field.
+ *
+ * [sendLabel] + [minLines] + `sendOnEnter = false` turn it into the forum post box the thread
+ * view uses: a tall field with a labeled button, where Enter writes a newline.
  */
 @Composable
 fun MessageComposer(
@@ -89,6 +97,12 @@ fun MessageComposer(
     placeholder: String,
     isSending: Boolean,
     modifier: Modifier = Modifier,
+    // Labeled button instead of the paper-plane glyph ("Post reply"), for a deliberate post.
+    sendLabel: String? = null,
+    // Opening height of the field, in lines.
+    minLines: Int = 1,
+    // false: Enter writes a newline and Ctrl/Cmd+Enter sends (threadComposerSubmits).
+    sendOnEnter: Boolean = true,
     // Lets a caller put the caret here (picking Reply focuses the composer to type into).
     focusRequester: FocusRequester? = null,
     members: List<MemberInfo> = emptyList(),
@@ -203,30 +217,75 @@ fun MessageComposer(
             }
         }
         Box(modifier = Modifier.fillMaxWidth()) {
-            Row(
-                modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .clip(NostrordShapes.inputShape)
-                    .background(NostrordColors.SurfaceVariant)
-                    .padding(horizontal = Spacing.md, vertical = Spacing.sm),
-                horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
+            // Post box (sendLabel != null): field on its own full-width line with the controls in
+            // a row under it, mirroring the web .thread-composer. Chat / DM keep the one-line pill.
+            val boxModifier = Modifier
+                .fillMaxWidth()
+                .clip(NostrordShapes.inputShape)
+                .background(NostrordColors.SurfaceVariant)
+                .padding(horizontal = Spacing.md, vertical = Spacing.sm)
+            val uploadButton: @Composable () -> Unit = {
                 MessageUploadButton(
                     externalBusy = isUploadingPaste,
                     onUploadComplete = { uploadResult -> appendUploadedUrl(uploadResult.url) },
                 )
+            }
+            val emojiButton: @Composable () -> Unit = {
+                IconButton(
+                    onClick = { showEmojiPicker = !showEmojiPicker },
+                    modifier = Modifier.size(width = 26.dp, height = 32.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.EmojiEmotions,
+                        contentDescription = "Emoji",
+                        tint = if (showEmojiPicker) NostrordColors.Primary else NostrordColors.TextMuted,
+                        modifier = Modifier.size(20.dp),
+                    )
+                }
+            }
+            val sendButton: @Composable () -> Unit = {
+                if (sendLabel != null) {
+                    AppButton(
+                        text = sendLabel,
+                        onClick = onSend,
+                        enabled = canSend,
+                        loading = isSending,
+                        size = AppButtonSize.Small,
+                    )
+                } else {
+                    IconButton(
+                        onClick = onSend,
+                        enabled = canSend,
+                        modifier = Modifier.size(width = 26.dp, height = 32.dp),
+                    ) {
+                        if (isSending) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(20.dp),
+                                color = NostrordColors.Primary,
+                                strokeWidth = 2.dp,
+                            )
+                        } else {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.Send,
+                                contentDescription = "Send",
+                                tint = if (value.text.isNotBlank()) NostrordColors.Primary else NostrordColors.TextMuted,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+                }
+            }
+            val textField: @Composable (Modifier) -> Unit = { fieldModifier ->
                 BasicTextField(
                     value = value,
                     onValueChange = { changeText(it) },
                     cursorBrush = SolidColor(NostrordColors.TextContent),
                     textStyle = NostrordTypography.Input.copy(color = NostrordColors.TextContent),
                     visualTransformation = mentionVisualTransformation,
-                    maxLines = 7,
+                    minLines = minLines,
+                    maxLines = if (minLines > 1) 12 else 7,
                     modifier =
-                    Modifier
-                        .weight(1f)
+                    fieldModifier
                         .then(if (focusRequester != null) Modifier.focusRequester(focusRequester) else Modifier)
                         .onFocusChanged { focusState ->
                             // Android drops focus transiently while the IME composes; dismissing there
@@ -277,6 +336,17 @@ fun MessageComposer(
                                         false
                                     }
                                 }
+                                // Post box: only Ctrl/Cmd+Enter sends, every other Enter falls
+                                // through to the field so it writes a newline.
+                                !sendOnEnter && event.type == KeyEventType.KeyDown && event.key == Key.Enter -> {
+                                    val submits = threadComposerSubmits(
+                                        isEnter = true,
+                                        ctrlOrMeta = event.isCtrlPressed || event.isMetaPressed,
+                                        shift = event.isShiftPressed,
+                                    )
+                                    if (submits && canSend) onSend()
+                                    submits
+                                }
                                 event.type == KeyEventType.KeyDown && event.key == Key.Enter && event.isShiftPressed -> {
                                     val sel = value.selection
                                     val t = value.text
@@ -292,7 +362,10 @@ fun MessageComposer(
                             }
                         },
                     decorationBox = { innerTextField ->
-                        Box(contentAlignment = Alignment.CenterStart, modifier = Modifier.padding(vertical = 4.dp)) {
+                        Box(
+                            contentAlignment = if (minLines > 1) Alignment.TopStart else Alignment.CenterStart,
+                            modifier = Modifier.padding(vertical = 4.dp),
+                        ) {
                             if (value.text.isEmpty()) {
                                 Text(
                                     placeholder,
@@ -304,36 +377,31 @@ fun MessageComposer(
                         }
                     },
                 )
-                IconButton(
-                    onClick = { showEmojiPicker = !showEmojiPicker },
-                    modifier = Modifier.size(width = 26.dp, height = 32.dp),
-                ) {
-                    Icon(
-                        imageVector = Icons.Outlined.EmojiEmotions,
-                        contentDescription = "Emoji",
-                        tint = if (showEmojiPicker) NostrordColors.Primary else NostrordColors.TextMuted,
-                        modifier = Modifier.size(20.dp),
-                    )
-                }
-                IconButton(
-                    onClick = onSend,
-                    enabled = canSend,
-                    modifier = Modifier.size(width = 26.dp, height = 32.dp),
-                ) {
-                    if (isSending) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(20.dp),
-                            color = NostrordColors.Primary,
-                            strokeWidth = 2.dp,
-                        )
-                    } else {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.Send,
-                            contentDescription = "Send",
-                            tint = if (value.text.isNotBlank()) NostrordColors.Primary else NostrordColors.TextMuted,
-                            modifier = Modifier.size(20.dp),
-                        )
+            }
+            if (sendLabel != null) {
+                Column(modifier = boxModifier) {
+                    textField(Modifier.fillMaxWidth())
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        uploadButton()
+                        emojiButton()
+                        Spacer(modifier = Modifier.weight(1f))
+                        sendButton()
                     }
+                }
+            } else {
+                Row(
+                    modifier = boxModifier,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    uploadButton()
+                    textField(Modifier.weight(1f))
+                    emojiButton()
+                    sendButton()
                 }
             }
 

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -79,6 +79,7 @@ import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.GroupView
 import org.nostr.nostrord.ui.navigation.LocalFrameNavigator
 import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
+import org.nostr.nostrord.ui.text.BlockEmbedText
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
@@ -201,6 +202,24 @@ private fun isBlockPart(part: ContentPart): Boolean = when (part) {
 }
 
 /**
+ * Absorb the newline the author typed on either side of a block embed: the block already breaks
+ * the line and carries its own spacing, so that newline would render as an empty line under the
+ * media (rules in [BlockEmbedText]). Text parts left empty are dropped so they add no line of
+ * their own.
+ */
+private fun trimAroundBlocks(parts: List<ContentPart>): List<ContentPart> = parts
+    .mapIndexed { index, part ->
+        if (part !is TextPart) {
+            part
+        } else {
+            var text = part.content
+            if (parts.getOrNull(index - 1)?.let { isBlockPart(it) } == true) text = BlockEmbedText.trimAfter(text)
+            if (parts.getOrNull(index + 1)?.let { isBlockPart(it) } == true) text = BlockEmbedText.trimBefore(text)
+            if (text == part.content) part else part.copy(content = text)
+        }
+    }.filter { it !is TextPart || it.content.isNotEmpty() }
+
+/**
  * # MessageContent - Robust Inline Text Rendering
  *
  * This component uses a single AnnotatedString with InlineContent to render
@@ -268,7 +287,7 @@ fun MessageContent(
             val result = mutableListOf<List<ContentPart>>()
             var currentInlineGroup = mutableListOf<ContentPart>()
 
-            parts.forEach { part ->
+            trimAroundBlocks(parts).forEach { part ->
                 if (isBlockPart(part)) {
                     // Flush current inline group if not empty
                     if (currentInlineGroup.isNotEmpty()) {
@@ -2289,7 +2308,7 @@ private fun QuotedEventContent(
             val result = mutableListOf<List<ContentPart>>()
             var currentInlineGroup = mutableListOf<ContentPart>()
 
-            parts.forEach { part ->
+            trimAroundBlocks(parts).forEach { part ->
                 if (isBlockPart(part)) {
                     if (currentInlineGroup.isNotEmpty()) {
                         result.add(currentInlineGroup.toList())

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui.screens.group
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -26,6 +27,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Reply
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
@@ -33,6 +35,7 @@ import androidx.compose.material.icons.filled.Forum
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -55,6 +58,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.text.TextRange
@@ -105,7 +109,7 @@ import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.ui.theme.rememberEmojiFontFamily
-import org.nostr.nostrord.utils.formatTimestamp
+import org.nostr.nostrord.utils.formatDateTime
 import org.nostr.nostrord.utils.getDateLabel
 import org.nostr.nostrord.utils.rememberClipboardWriter
 import org.nostr.nostrord.utils.resolveGroupRef
@@ -348,6 +352,8 @@ fun ThreadsScreen(
                     Column(
                         modifier = Modifier.weight(1f).fillMaxWidth()
                             .verticalScroll(threadScroll).padding(Spacing.md),
+                        // Posts are separated cards, not adjacent chat rows.
+                        verticalArrangement = Arrangement.spacedBy(Spacing.md),
                     ) {
                         CompositionLocalProvider(
                             LocalImageViewerUrl provides imageViewerUrl,
@@ -401,7 +407,6 @@ fun ThreadsScreen(
                                 fontSize = 11.sp,
                                 fontWeight = FontWeight.Bold,
                                 letterSpacing = 0.5.sp,
-                                modifier = Modifier.padding(vertical = Spacing.sm),
                             )
                             detail.replies.forEach { renderMessage(it, false) }
                         }
@@ -413,6 +418,12 @@ fun ThreadsScreen(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
                         ) {
+                            Icon(
+                                Icons.AutoMirrored.Outlined.Reply,
+                                contentDescription = null,
+                                tint = NostrordColors.TextMuted,
+                                modifier = Modifier.size(14.dp),
+                            )
                             Text("Replying to", color = NostrordColors.TextMuted, fontSize = 12.sp)
                             Text(
                                 threadDisplayName(target.pubkey, userMetadata[target.pubkey]),
@@ -461,6 +472,11 @@ fun ThreadsScreen(
                         },
                         placeholder = "Write a reply...",
                         isSending = sending,
+                        // Post box, not a chat pill: it opens three lines tall, posts from a
+                        // labeled button, and Enter writes a newline (issue #267).
+                        sendLabel = "Post reply",
+                        minLines = 3,
+                        sendOnEnter = false,
                         focusRequester = composerFocus,
                         members = mentionMembers,
                         availableGroups = mentionGroups,
@@ -796,6 +812,24 @@ private fun ThreadCard(
     }
 }
 
+/** Text+icon action in a thread post footer ("Reply", "React"). */
+@Composable
+private fun PostAction(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier.clip(NostrordShapes.shapeSmall).clickable(onClick = onClick)
+            .padding(horizontal = Spacing.xs, vertical = 2.dp),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.xxs),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(icon, contentDescription = null, tint = NostrordColors.TextMuted, modifier = Modifier.size(14.dp))
+        Text(label, color = NostrordColors.TextMuted, fontSize = 12.sp, fontWeight = FontWeight.Medium)
+    }
+}
+
 /** Compact emoji+count chip on a thread list card (a root's top reactions, Discord-style). */
 @Composable
 private fun ReactionChipBadge(chip: ReactionChip) {
@@ -851,22 +885,25 @@ private fun ThreadMessage(
     val writeClipboard = rememberClipboardWriter()
     val interaction = remember { MutableInteractionSource() }
     val isHovered by interaction.collectIsHoveredAsState()
-    // Hover tint like chat rows; the deep-link flash overrides it and fades back out.
+    // A post is a card with its own surface, not a hovering chat row: the OP reads as the
+    // subject of the page and each reply as a deliberate contribution to it (issue #267).
+    val cardBackground = if (isRoot) NostrordColors.SurfaceVariant else NostrordColors.Surface
     val rowBackground by animateColorAsState(
         when {
             highlighted -> NostrordColors.Primary.copy(alpha = 0.18f)
             // The open menu keeps its target tinted, so it is obvious which message the
             // actions apply to (chat parity: .msg.menu-open).
             menuVisible || isHovered -> NostrordColors.MessageHover
-            else -> Color.Transparent
+            else -> cardBackground
         },
     )
     Box(
         modifier =
         Modifier
             .fillMaxWidth()
-            .clip(NostrordShapes.shapeMedium)
+            .clip(NostrordShapes.shapeLarge)
             .background(rowBackground)
+            .border(1.dp, NostrordColors.Divider, NostrordShapes.shapeLarge)
             .hoverable(interaction)
             .then(
                 if (onPositioned != null) {
@@ -913,7 +950,7 @@ private fun ThreadMessage(
             },
         )
         Row(
-            modifier = Modifier.fillMaxWidth().padding(vertical = Spacing.sm),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = Spacing.md, vertical = Spacing.md),
             horizontalArrangement = Arrangement.spacedBy(Spacing.md),
         ) {
             // Avatar and author name open the user profile modal (chat parity).
@@ -934,15 +971,16 @@ private fun ThreadMessage(
                         fontWeight = FontWeight.SemiBold,
                         modifier = Modifier.clickable { onUserClick(msg.pubkey) },
                     )
-                    Text(formatTimestamp(msg.createdAt), color = NostrordColors.TextMuted, fontSize = 12.sp)
+                    // Absolute date, not "2h ago": a post is a dated record.
+                    Text(formatDateTime(msg.createdAt), color = NostrordColors.TextMuted, fontSize = 12.sp)
                 }
                 if (isRoot) {
                     Text(
                         msg.threadTitle(),
                         color = NostrordColors.TextPrimary,
-                        fontSize = 18.sp,
+                        fontSize = 20.sp,
                         fontWeight = FontWeight.Bold,
-                        modifier = Modifier.padding(vertical = Spacing.xs),
+                        modifier = Modifier.padding(top = Spacing.xs, bottom = Spacing.sm),
                     )
                 }
                 // Nested reply: quote the answered message above the body (placeholder when the
@@ -976,8 +1014,6 @@ private fun ThreadMessage(
                 if (myPubkey != null && myPubkey == msg.pubkey && status is GroupManager.MessageStatus.Failed) {
                     MessageStatusIndicator(status, onRetry, onDismiss)
                 }
-                // Reaction badges; adding a reaction goes through the context menu (quick row
-                // or the full picker), so there is no always-visible add button.
                 ReactionBadges(
                     reactions = reactions,
                     currentUserPubkey = myPubkey,
@@ -985,6 +1021,16 @@ private fun ThreadMessage(
                     onReactionClick = onReact,
                     pendingEmojis = pendingEmojis,
                 )
+                // Answering a forum post is the primary action, so it is a visible footer button
+                // and not only a context-menu item the way a chat reply is.
+                Row(
+                    modifier = Modifier.padding(top = Spacing.sm),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.md),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    PostAction(Icons.AutoMirrored.Outlined.Reply, "Reply", onReply)
+                    PostAction(Icons.Outlined.EmojiEmotions, "React", onOpenReactionPicker)
+                }
             }
         }
     }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -137,7 +137,7 @@ fun ThreadsScreen(
         ThreadsViewModel(AppModule.nostrRepository, route.groupId, route.relayUrl)
     }
     val threads by vm.threads.collectAsState()
-    val isLoading by vm.isLoading.collectAsState()
+    val placeholder by vm.placeholder.collectAsState()
     val openThread by vm.openThread.collectAsState()
     val userMetadata by vm.userMetadata.collectAsState()
     val messageStatus by vm.messageStatus.collectAsState()
@@ -147,7 +147,6 @@ fun ThreadsScreen(
     val deleteError by vm.deleteError.collectAsState()
     val isAdmin by vm.isAdmin.collectAsState()
     val isRestricted by vm.isRestricted.collectAsState()
-    val isPendingApproval by vm.isPendingApproval.collectAsState()
     val membership by vm.membershipState.collectAsState()
     val groupAccess by vm.groupAccess.collectAsState()
     val joinError by vm.joinError.collectAsState()
@@ -538,7 +537,7 @@ fun ThreadsScreen(
                 }
                 HorizontalDivider(color = NostrordColors.Divider)
 
-                when (threadsPlaceholder(threads.isNotEmpty(), isLoading, isPendingApproval, isRestricted)) {
+                when (placeholder) {
                     ThreadsPlaceholder.LOADING -> EmptyState("Loading threads...")
                     ThreadsPlaceholder.PENDING_APPROVAL ->
                         LockedState(

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -36,6 +36,7 @@ import org.nostr.nostrord.ui.screens.group.classifyReactionError
 import org.nostr.nostrord.ui.screens.group.pluralizeSystemAction
 import org.nostr.nostrord.ui.scroll.ChatScrollPolicy
 import org.nostr.nostrord.ui.scroll.JumpPillTarget
+import org.nostr.nostrord.ui.text.BlockEmbedText
 import org.nostr.nostrord.ui.text.MarkdownEmphasis
 import org.nostr.nostrord.ui.text.MarkdownMedia
 import org.nostr.nostrord.utils.ChatSearch
@@ -3580,11 +3581,17 @@ private fun ChildrenBuilder.renderEntities(
     hostRelay: String,
 ) {
     var last = 0
+    var prevWasBlock = false
     for (match in URL_REGEX.findAll(content)) {
-        if (match.range.first > last) {
-            renderFormattedText(content.substring(last, match.range.first), emojiMap)
-        }
         val token = match.value
+        val blockToken = isBlockEmbedToken(token, content)
+        if (match.range.first > last) {
+            var text = content.substring(last, match.range.first)
+            if (prevWasBlock) text = BlockEmbedText.trimAfter(text)
+            if (blockToken) text = BlockEmbedText.trimBefore(text)
+            if (text.isNotEmpty()) renderFormattedText(text, emojiMap)
+        }
+        prevWasBlock = blockToken
         if (token.startsWith("data:image/")) {
             ChatImage {
                 imageUrl = token
@@ -3709,7 +3716,36 @@ private fun ChildrenBuilder.renderEntities(
         }
         last = match.range.last + 1
     }
-    if (last < content.length) renderFormattedText(content.substring(last), emojiMap)
+    if (last < content.length) {
+        val tail = if (prevWasBlock) BlockEmbedText.trimAfter(content.substring(last)) else content.substring(last)
+        if (tail.isNotEmpty()) renderFormattedText(tail, emojiMap)
+    }
+}
+
+/**
+ * Whether [token] renders as a block (own line, own vertical spacing) instead of inline, so the
+ * newline typed beside it is absorbed rather than painted as an empty line ([BlockEmbedText]).
+ * Mirrors the branches of [renderEntities], and native `isBlockPart`.
+ */
+private fun isBlockEmbedToken(token: String, content: String): Boolean {
+    if (token.startsWith("data:image/")) return true
+    if (token.startsWith("http")) {
+        val url = token.trimEnd('.', ',', ')', '!', '?', ';', ':')
+        return YOUTUBE_REGEX.containsMatchIn(url) ||
+            IMAGE_EXT.containsMatchIn(url) ||
+            VIDEO_EXT.containsMatchIn(url) ||
+            AUDIO_EXT.containsMatchIn(url)
+    }
+    // A group address renders as the full card only when the message IS the link; mixed with
+    // text it is an inline chip.
+    if (token.contains('\'')) return content.trim() == token
+    if (token.startsWith("wss://") || token.startsWith("ws://")) return false
+    val standalone = content.split('\n').any { it.trim() == token }
+    return when (val entity = Nip19.decode(token.removePrefix("nostr:"))) {
+        is Nip19.Entity.Nevent, is Nip19.Entity.Note -> true
+        is Nip19.Entity.Naddr -> entity.kind == 39000 && standalone
+        else -> false
+    }
 }
 
 // Inline formatting tokens: * and ** bold (additive), _ italic, ~~ strike, || spoiler. Shared

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -25,7 +25,6 @@ import org.nostr.nostrord.ui.screens.group.threadComposerSubmits
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.threadTitle
-import org.nostr.nostrord.ui.screens.group.threadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.formatDateTime
@@ -432,7 +431,7 @@ val ThreadsScreen =
         // depending on which affordance the user reached the join from.
         val (showJoinConfirm, setShowJoinConfirm) = useState { false }
         val threads = useStateFlow(vm.threads)
-        val isLoading = useStateFlow(vm.isLoading)
+        val placeholder = useStateFlow(vm.placeholder)
         val openThread = useStateFlow(vm.openThread)
         val userMetadata = useStateFlow(vm.userMetadata)
         val messageStatus = useStateFlow(vm.messageStatus)
@@ -442,7 +441,6 @@ val ThreadsScreen =
         val deleteError = useStateFlow(vm.deleteError)
         val isAdmin = useStateFlow(vm.isAdmin)
         val isRestricted = useStateFlow(vm.isRestricted)
-        val isPendingApproval = useStateFlow(vm.isPendingApproval)
         val membership = useStateFlow(vm.membershipState)
         val groupAccess = useStateFlow(vm.groupAccess)
         val joinError = useStateFlow(vm.joinError)
@@ -598,7 +596,7 @@ val ThreadsScreen =
                         }
                     }
 
-                    when (threadsPlaceholder(threads.isNotEmpty(), isLoading, isPendingApproval, isRestricted)) {
+                    when (placeholder) {
                         ThreadsPlaceholder.LOADING ->
                             div {
                                 className = ClassName("threads-empty")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -10,6 +10,7 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
+import org.nostr.nostrord.ui.keyboard.VirtualKeyboardPolicy
 import org.nostr.nostrord.ui.mentions.MentionAutocomplete
 import org.nostr.nostrord.ui.mentions.MentionCtx
 import org.nostr.nostrord.ui.navigation.GroupRoute
@@ -20,12 +21,14 @@ import org.nostr.nostrord.ui.screens.group.ThreadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.ThreadsViewModel
 import org.nostr.nostrord.ui.screens.group.canDeleteThreadMessage
 import org.nostr.nostrord.ui.screens.group.deleteThreadConfirmBody
+import org.nostr.nostrord.ui.screens.group.threadComposerSubmits
 import org.nostr.nostrord.ui.screens.group.threadParentIdTag
 import org.nostr.nostrord.ui.screens.group.threadRootIdTag
 import org.nostr.nostrord.ui.screens.group.threadTitle
 import org.nostr.nostrord.ui.screens.group.threadsPlaceholder
 import org.nostr.nostrord.ui.screens.group.topReactionChips
 import org.nostr.nostrord.utils.Result
+import org.nostr.nostrord.utils.formatDateTime
 import org.nostr.nostrord.utils.getDateLabel
 import org.nostr.nostrord.utils.normalizeRelayUrl
 import org.nostr.nostrord.web.bridge.VirtualKeyboard
@@ -69,7 +72,6 @@ import web.cssom.ClassName
 import web.dom.ElementId
 import web.html.HTMLDivElement
 import web.html.HTMLTextAreaElement
-import kotlin.js.Date
 
 /** Lock panel for a group the relay withholds; same chrome as the chat gate. */
 private fun ChildrenBuilder.threadsLockedState(title: String, body: String) {
@@ -88,18 +90,6 @@ private fun ChildrenBuilder.threadsLockedState(title: String, body: String) {
 }
 
 private fun threadDisplayName(pubkey: String, meta: UserMetadata?): String = mentionDisplayName(pubkey, meta)
-
-private fun relativeTime(createdAtSeconds: Long): String {
-    val nowSec = (Date.now() / 1000).toLong()
-    val diff = (nowSec - createdAtSeconds).coerceAtLeast(0)
-    return when {
-        diff < 60 -> "now"
-        diff < 3600 -> "${diff / 60}m"
-        diff < 86_400 -> "${diff / 3600}h"
-        diff < 604_800 -> "${diff / 86_400}d"
-        else -> "${diff / 604_800}w"
-    }
-}
 
 // Deep-link flash duration; mirrors the .thread-msg.highlight animation (2.4s msg-flash).
 private const val HIGHLIGHT_FLASH_MS = 2_400
@@ -281,18 +271,13 @@ private val ThreadComposer =
                     }
                 }
             }
+            // Post box, not a chat pill: it opens several lines tall and posts from a labeled
+            // button, so a reply reads as something you compose (issue #267).
             div {
                 key = "composer-pill"
-                className = ClassName("dm-composer")
-                UploadButton {
-                    cls = "dm-composer-btn"
-                    icon = Ic.AttachFile
-                    busy = uploadCount > 0
-                    onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
-                    onPickerClosed = { composerInputRef.current?.focus() }
-                    onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
-                    onError = { props.onUploadError(it) }
-                }
+                // Keeps .dm-composer for the shared box rules (transparent textarea over the
+                // mention mirror, focus ring); .thread-composer restacks it as a post box.
+                className = ClassName("dm-composer thread-composer")
                 div {
                     className = ClassName("composer-input-wrap")
                     // Colored mirror painted behind the transparent textarea: same text, with the
@@ -304,8 +289,8 @@ private val ThreadComposer =
                     }
                     textarea {
                         ref = composerInputRef
-                        className = ClassName("composer-input")
-                        rows = 1
+                        className = ClassName("composer-input thread-composer-input")
+                        rows = 3
                         value = reply
                         placeholder = "Write a reply..."
                         onScroll = {
@@ -337,7 +322,8 @@ private val ThreadComposer =
                                     e.preventDefault()
                                     setMention(null)
                                 }
-                                e.key == "Enter" && !e.shiftKey -> {
+                                // Enter writes a newline here; only Ctrl/Cmd+Enter posts.
+                                threadComposerSubmits(e.key == "Enter", e.ctrlKey || e.metaKey, e.shiftKey) -> {
                                     e.preventDefault()
                                     sendReply()
                                 }
@@ -371,19 +357,38 @@ private val ThreadComposer =
                         }
                     }
                 }
-                button {
-                    className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
-                    title = "Emoji"
-                    onClick = { setEmojiOpen(!emojiOpen) }
-                    icon(Ic.EmojiEmotions)
-                }
-                button {
-                    className = ClassName("dm-composer-btn send")
-                    title = "Send"
-                    disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
-                    onMouseDown = { e -> e.preventDefault() }
-                    onClick = { sendReply() }
-                    if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
+                div {
+                    className = ClassName("thread-composer-bar")
+                    UploadButton {
+                        cls = "dm-composer-btn"
+                        icon = Ic.AttachFile
+                        busy = uploadCount > 0
+                        onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
+                        onPickerClosed = { composerInputRef.current?.focus() }
+                        onUploaded = { upload -> setReply { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
+                        onError = { props.onUploadError(it) }
+                    }
+                    button {
+                        className = ClassName(if (emojiOpen) "dm-composer-btn active" else "dm-composer-btn")
+                        title = "Emoji"
+                        onClick = { setEmojiOpen(!emojiOpen) }
+                        icon(Ic.EmojiEmotions)
+                    }
+                    button {
+                        className = ClassName("btn-primary thread-composer-post")
+                        disabled = (reply.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
+                        // Keyboard-neutral tap: keep textarea focus (so the keyboard stays up)
+                        // only when it is already up; rules in VirtualKeyboardPolicy.
+                        onMouseDown = { e ->
+                            val keep = VirtualKeyboardPolicy.keepComposerFocusOnTap(
+                                keyboardOpen = VirtualKeyboard.isOpen,
+                                touchDevice = window.navigator.maxTouchPoints > 0,
+                            )
+                            if (keep) e.preventDefault()
+                        }
+                        onClick = { sendReply() }
+                        if (sending) span { className = ClassName("btn-spinner") } else +"Post reply"
+                    }
                 }
                 if (emojiOpen) {
                     div {
@@ -759,6 +764,11 @@ val ThreadsScreen =
                                 highlighted = msg.id == highlightId,
                                 menuOpen = ctxMenu?.msg?.id == msg.id,
                                 onReact = { emoji -> vm.sendReaction(msg.id, msg.pubkey, emoji) },
+                                onReply = {
+                                    setReplyingTo(msg)
+                                    setReplyFocusNonce { it + 1 }
+                                },
+                                onAddReaction = { setReactingTo(msg.id to msg.pubkey) },
                                 onOpenMenu = { x, y -> setCtxMenu(ThreadCtxMenu(msg, x, y)) },
                                 onCloseMenu = { setCtxMenu(null) },
                                 onUser = { setProfilePubkey(it) },
@@ -1001,6 +1011,8 @@ private fun ChildrenBuilder.threadMessage(
     // unambiguous (chat parity: .msg.menu-open).
     menuOpen: Boolean,
     onReact: (String) -> Unit,
+    onReply: () -> Unit,
+    onAddReaction: () -> Unit,
     onOpenMenu: (Double, Double) -> Unit,
     onCloseMenu: () -> Unit,
     onUser: (String) -> Unit,
@@ -1057,9 +1069,10 @@ private fun ChildrenBuilder.threadMessage(
                     onClick = { onUser(msg.pubkey) }
                     +threadDisplayName(msg.pubkey, userMetadata[msg.pubkey])
                 }
+                // Absolute date, not "2h": a post is a dated record.
                 span {
                     className = ClassName("thread-msg-time")
-                    +relativeTime(msg.createdAt)
+                    +formatDateTime(msg.createdAt)
                 }
             }
             if (isRoot) {
@@ -1115,9 +1128,24 @@ private fun ChildrenBuilder.threadMessage(
             if (myPubkey != null && myPubkey == msg.pubkey) {
                 messageSendStatus(status, onRetry, onDismiss)
             }
-            // Reaction badges; adding a reaction goes through the context menu (quick row
-            // or the full picker), so there is no always-visible add button.
             reactionBadges(reactions, pendingEmojis, myPubkey, userMetadata, onReact)
+            // Answering a forum post is the primary action, so it is a visible footer button and
+            // not only a context-menu item the way a chat reply is.
+            div {
+                className = ClassName("thread-post-actions")
+                button {
+                    className = ClassName("thread-post-action")
+                    onClick = { onReply() }
+                    icon(Ic.Reply)
+                    span { +"Reply" }
+                }
+                button {
+                    className = ClassName("thread-post-action")
+                    onClick = { onAddReaction() }
+                    icon(Ic.EmojiEmotions)
+                    span { +"React" }
+                }
+            }
         }
     }
 }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -2448,14 +2448,22 @@ body {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    /* Posts are separated cards, not adjacent chat rows. */
+    gap: var(--space-md);
     padding: var(--space-md) var(--space-lg);
 }
 
+/* A post is a card with its own surface, not a hovering chat row: the OP reads as the subject
+   of the page and each reply as a deliberate contribution to it (issue #267). */
 .thread-msg {
     display: flex;
     gap: var(--space-md);
-    padding: var(--space-sm) 0;
-    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    background: var(--color-surface);
+    border: 1px solid var(--color-divider);
+    border-radius: var(--radius-lg);
 }
 
 .thread-msg:hover {
@@ -2468,7 +2476,7 @@ body {
 }
 
 .thread-msg-root {
-    padding-bottom: var(--space-md);
+    background: var(--color-surface-variant);
 }
 
 .thread-msg-main {
@@ -2494,18 +2502,51 @@ body {
 }
 
 .thread-msg-title {
-    margin: var(--space-xs) 0;
-    font-size: 18px;
+    margin: var(--space-xs) 0 var(--space-sm);
+    font-size: 20px;
     font-weight: 700;
     color: var(--color-text-primary);
 }
 
 .thread-msg-content {
-    font-size: 14px;
-    line-height: 1.5;
+    font-size: 15px;
+    line-height: 1.65;
     color: var(--color-text-content);
     white-space: pre-wrap;
     word-break: break-word;
+}
+
+/* Post footer: answering is the primary action on a forum post, so it is visible here and not
+   only in the context menu the way a chat reply is. */
+.thread-post-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+    margin-top: var(--space-sm);
+}
+
+.thread-post-action {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-xxs);
+    padding: 2px var(--space-xs);
+    border: none;
+    border-radius: var(--radius-sm);
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+.thread-post-action:hover {
+    background: var(--color-hover);
+    color: var(--color-text-primary);
+}
+
+.thread-post-action svg {
+    width: 14px;
+    height: 14px;
 }
 
 /* Quoted kind:11 thread card (Share to chat announcement / pasted thread nevent). */
@@ -2613,7 +2654,7 @@ body {
 }
 
 .thread-replies-divider {
-    margin: var(--space-md) 0;
+    /* .thread-detail-body's gap already spaces it from the posts. */
     padding-bottom: var(--space-xs);
     border-bottom: 1px solid var(--color-divider);
     font-size: 12px;
@@ -3576,6 +3617,40 @@ body {
 .dm-composer-btn .ico {
     width: 20px;
     height: 20px;
+}
+
+/* Thread reply box: the chat pill restacked as a post box (issue #267) - opens several lines
+   tall, controls on their own row, posted from a labeled button instead of a paper plane. */
+.thread-composer {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-sm);
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-lg);
+}
+
+/* Three lines of 15px/1.4 text, the same opening height as the native composer's minLines = 3. */
+.thread-composer .thread-composer-input,
+.thread-composer .composer-highlight {
+    min-height: 63px;
+    max-height: 320px;
+}
+
+.thread-composer-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+}
+
+.thread-composer-bar .dm-composer-btn {
+    padding: 0;
+}
+
+.thread-composer-post {
+    flex-shrink: 0;
+    margin-left: auto;
+    padding: var(--space-xs) var(--space-md);
+    font-size: 13px;
 }
 
 /* Inline unread pill (sidebar rows). */


### PR DESCRIPTION
Thread replies rendered as bare chat rows, so people answered them like chat and the pane defeated the point of having threads. Each post is now a card with its own surface, border and padding, separated from its neighbours, with an absolute date and a visible Reply / React footer; the reply composer becomes a post box where Enter writes a newline and Ctrl/Cmd+Enter posts. `MessageComposer` takes that shape through three optional parameters, so chat and DM keep the one-line pill untouched.

Four fixes ride along, all found while testing the pane. Block embeds painted an extra empty line: an image or quoted event already breaks the line, and the newline typed around it was rendered on top of that, leaving a wide gap before the sentence below (this one reaches chat and DM too). The threads disk cache almost never hydrated, because it resolved its relay with `getRelayForGroup`, which answers null until the group listings arrive - exactly the window the cache exists for - and null forever when two relays serve the same group id; the pane's route already names the relay, so it is passed down and recorded. Thread subscriptions were re-fired only after NIP-42 AUTH, so a plain reconnect left an open pane with no subscription until the user navigated away and back. And `getDateLabel` measured day gaps as `year*365 + month*30 + day`, so a thread created on 31 Jul was labeled "Today" on 1 Aug.

| Area | Change |
|---|---|
| Thread post | card surface + border + padding, 20px title, absolute date, Reply / React footer |
| Reply composer | post box: 3 lines, labeled button, Enter newline / Ctrl+Enter post |
| Block embeds | one adjacent newline absorbed per side (`BlockEmbedText`), Compose + web |
| Threads cache | `requestGroupThreads(groupId, relayUrl)` hydrates from the route's relay |
| Reconnect | `resubscribeOpenThreads` also runs from `resubscribeAllGroups` |
| Skeleton | 400ms grace, so a cached pane opens on its cards and never flashes "Loading threads..." |
| Date labels | `days_from_civil`: real month lengths and leap years |

Tests: `threadComposerSubmits`, `BlockEmbedText`, the skeleton grace, relay-scoped thread hydration (plus a guard that dropping the relay parameter cannot silently pass), and `daysFromCivil` across month, leap day and year boundaries. `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid` and `:composeApp:jvmTest` all green; iOS not built (no macOS here).

Not device-validated yet. The composer's mobile focus behaviour and the new embed spacing in chat / DM are what deserve a look first.

Closes #267

- feat(threads): make a thread post read as a forum post, not a chat line
- fix(content): absorb the newline that touches a block embed
- fix(threads): restore the pane from cache on a cold open, and after a reconnect
- fix(threads): open a cached pane on its threads instead of a skeleton
- fix(time): count date labels on the real calendar
