### PR TITLE
DM attachments, reactions and replies (NIP-17 kind:15 + kind:7)

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.android.kt
+++ b/composeApp/src/androidMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.android.kt
@@ -34,6 +34,7 @@ actual fun StaticImage(
     contentScale: ContentScale,
     onClick: () -> Unit,
     onError: () -> Unit,
+    onIntrinsicSize: (width: Int, height: Int) -> Unit,
 ) {
     val context = LocalPlatformContext.current
     // Inline base64 image: decode to bytes and hand them straight to Coil (no proxy/retry).
@@ -68,6 +69,7 @@ actual fun StaticImage(
             when (state) {
                 is AsyncImagePainter.State.Success -> {
                     loading = false
+                    onIntrinsicSize(state.result.image.width, state.result.image.height)
                     backdrop = sampleImageArgb(state.result.image)?.let(::decideImageBackdrop)
                 }
                 is AsyncImagePainter.State.Error -> {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -65,6 +65,9 @@ import org.nostr.nostrord.network.managers.SessionManager
 import org.nostr.nostrord.network.managers.UnreadManager
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
+import org.nostr.nostrord.network.upload.decodeImageDimensions
+import org.nostr.nostrord.network.upload.uploadMedia
+import org.nostr.nostrord.nostr.Crypto
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip11RelayInfo
@@ -74,6 +77,7 @@ import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip44
 import org.nostr.nostrord.nostr.Nip4e
 import org.nostr.nostrord.nostr.Nip78
+import org.nostr.nostrord.nostr.toHexString
 import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
@@ -92,6 +96,7 @@ import org.nostr.nostrord.storage.loadDmLastRead
 import org.nostr.nostrord.storage.loadDmMessages
 import org.nostr.nostrord.storage.loadDmPairingProcessedFor
 import org.nostr.nostrord.storage.loadDmProcessedWrapIds
+import org.nostr.nostrord.storage.loadDmReactions
 import org.nostr.nostrord.storage.loadDmSeenRelays
 import org.nostr.nostrord.storage.loadDmSendQueue
 import org.nostr.nostrord.storage.loadDmSyncCursor
@@ -107,6 +112,7 @@ import org.nostr.nostrord.storage.saveDmEncKeys
 import org.nostr.nostrord.storage.saveDmLastRead
 import org.nostr.nostrord.storage.saveDmPairingProcessedFor
 import org.nostr.nostrord.storage.saveDmProcessedWrapIds
+import org.nostr.nostrord.storage.saveDmReactions
 import org.nostr.nostrord.storage.saveDmSeenRelays
 import org.nostr.nostrord.storage.saveDmSendQueue
 import org.nostr.nostrord.storage.saveDmSyncCursor
@@ -119,6 +125,7 @@ import org.nostr.nostrord.storage.saveMuteListSnapshotFor
 import org.nostr.nostrord.storage.saveRelayListFor
 import org.nostr.nostrord.storage.setDmCacheMigratedFor
 import org.nostr.nostrord.ui.screens.dm.eventJson
+import org.nostr.nostrord.utils.AesGcm
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
@@ -2122,6 +2129,8 @@ class NostrRepository(
 
     override val dmFileStates: StateFlow<Map<String, DmFileManager.FileState>> = dmFileManager.states
 
+    override val dmReactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = dmManager.reactions
+
     override fun loadDmFile(rumorId: String, file: Nip17File) = dmFileManager.load(rumorId, file)
 
     override fun retryDmFile(rumorId: String, file: Nip17File) = dmFileManager.retry(rumorId, file)
@@ -2184,8 +2193,110 @@ class NostrRepository(
         // defaults only, which for a first contact means it is published where they never look and
         // is lost silently. Their kind:10044 rides the same REQ, so addressing improves too.
         awaitPeerDmRelays(recipientPubkey)
+        return publishDmRumor(Nip17.buildRumor(myPub, recipientPubkey, content), recipientPubkey, myPub, signer)
+    }
+
+    /**
+     * Send an image or other file as a NIP-17 kind:15 message: encrypt it, upload the ciphertext,
+     * and put the url plus the decryption material in the rumor. The media server only ever holds
+     * bytes it cannot read, unlike a plain url in a text message, which anyone who learns it can
+     * fetch. [width] and [height] let the reader reserve the right slot before the bytes land.
+     */
+    override suspend fun sendDmFile(
+        recipientPubkey: String,
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        width: Int?,
+        height: Int?,
+    ): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        if (bytes.isEmpty()) return Result.Error(AppError.Unknown("The file is empty"))
+        // A private key is 32 bytes off the platform CSPRNG, which is exactly what the cipher
+        // wants; drawing from it keeps randomness on one primitive instead of a fifth expect/actual.
+        val key = Crypto.generatePrivateKey()
+        val nonce = Crypto.generatePrivateKey().copyOf(AesGcm.NONCE_SIZE)
+        val encrypted =
+            AesGcm.encrypt(key, nonce, bytes)
+                ?: return Result.Error(AppError.Unknown("Could not encrypt the file"))
+        val uploaded = uploadMedia(encrypted, "$filename.bin", "application/octet-stream")
+        val upload = uploaded.getOrNull() ?: return Result.Error(uploaded.errorOrNull() ?: AppError.Unknown("Upload failed"))
+        awaitPeerDmRelays(recipientPubkey)
+        // Without a `dim` the reader cannot reserve the image's box and the thread jumps when the
+        // bytes land. The server cannot supply one here (it only sees ciphertext), so decode it.
+        val (dimWidth, dimHeight) =
+            if (width != null && height != null) {
+                width to height
+            } else {
+                decodeImageDimensions(bytes, mimeType) ?: (null to null)
+            }
+        val tags =
+            buildList {
+                add(listOf("file-type", mimeType))
+                add(listOf("encryption-algorithm", Nip17File.ALGORITHM_AES_GCM))
+                add(listOf(Nip17File.TAG_DECRYPTION_KEY, key.toHexString()))
+                add(listOf("decryption-nonce", nonce.toHexString()))
+                // Hash of the plaintext: what the reader checks the decrypted bytes against.
+                add(listOf("ox", Crypto.sha256(bytes).toHexString()))
+                add(listOf("x", Crypto.sha256(encrypted).toHexString()))
+                add(listOf("size", bytes.size.toString()))
+                if (dimWidth != null && dimHeight != null && dimWidth > 0 && dimHeight > 0) {
+                    add(listOf("dim", "${dimWidth}x$dimHeight"))
+                }
+            }
+        return publishDmRumor(
+            Nip17.buildRumor(myPub, recipientPubkey, upload.url, extraTags = tags, kind = Nip17.KIND_FILE),
+            recipientPubkey,
+            myPub,
+            signer,
+        )
+    }
+
+    /**
+     * React to a DM with [emoji] (NIP-25 inside the gift wrap). [emojiUrl] carries a custom emoji's
+     * image (NIP-30). The reaction is not a message, so it never enters the thread or the unread
+     * count; it shows under the bubble it targets.
+     */
+    override suspend fun sendDmReaction(
+        recipientPubkey: String,
+        messageId: String,
+        emoji: String,
+        emojiUrl: String?,
+    ): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        awaitPeerDmRelays(recipientPubkey)
+        val tags =
+            buildList {
+                add(listOf("e", messageId, dmRelaysFor(recipientPubkey).firstOrNull() ?: ""))
+                if (emojiUrl != null) add(listOf("emoji", emoji.trim(':'), emojiUrl))
+            }
+        val rumor = Nip17.buildRumor(myPub, recipientPubkey, emoji, extraTags = tags, kind = Nip17.KIND_REACTION)
+        dmManager.addOptimisticReaction(rumor, recipientPubkey, myPub)
+        return publishDmRumor(rumor, recipientPubkey, myPub, signer, optimistic = false)
+    }
+
+    /**
+     * Seal and gift-wrap [rumor] for the recipient plus a self-copy, and publish each to its side's
+     * DM relays. Shared by text, file messages and reactions: only the rumor differs, so the NIP-4e
+     * addressing, the send queue and the delivery tracking are written once.
+     *
+     * [optimistic] shows the message in the thread before any relay answers. A reaction turns it
+     * off: it is not a bubble, and it reaches the thread through the reaction map instead.
+     */
+    private suspend fun publishDmRumor(
+        rumor: Event,
+        recipientPubkey: String,
+        myPub: String,
+        signer: NostrSigner,
+        optimistic: Boolean = true,
+    ): Result<Unit> {
         return try {
-            val rumor = Nip17.buildRumor(myPub, recipientPubkey, content)
             // NIP-4e: a recipient who announced an encryption key gets both NIP-44 layers addressed
             // to it, tagged with the key they must ECDH the seal against. Until we hold an
             // encryption key of our own that key is our identity pubkey, which is what makes this
@@ -2227,7 +2338,7 @@ class NostrRepository(
                 } else {
                     Nip17.wrap(rumor, myPub, signer)
                 }
-            dmManager.addOptimistic(rumor, recipientPubkey, myPub)
+            if (optimistic) dmManager.addOptimistic(rumor, recipientPubkey, myPub)
             val rumorId = rumor.id ?: return Result.Error(AppError.Unknown("Failed to build the message"))
             // Enqueue both wraps (recipient + self-copy) in the persisted send queue, then publish.
             // The message shows as Sending and flips to Delivered on the first relay OK (or when the
@@ -3081,6 +3192,7 @@ class NostrRepository(
                 emptyList()
             }
         dmPersistedIds = cached.mapTo(HashSet()) { it.id }
+        dmManager.hydrateReactions(SecureStorage.loadDmReactions(myPub))
         dmManager.hydrate(
             cached.map { it.toDmMessage(myPub) },
             SecureStorage.loadDmLastRead(myPub),
@@ -3121,6 +3233,15 @@ class NostrRepository(
             scope.launch {
                 dmManager.lastReadByPeer.drop(1).collect { reads ->
                     SecureStorage.saveDmLastRead(myPub, reads)
+                }
+            }
+        // Reactions are small and rarely change, so the whole set is rewritten rather than
+        // diffed. They must be persisted at all: the inbox never re-decrypts a wrap it has
+        // already processed, so a reaction only in memory is gone after a restart.
+        dmPersistenceJobs +=
+            scope.launch {
+                dmManager.reactionRumorsByPeer.drop(1).collect { byPeer ->
+                    SecureStorage.saveDmReactions(myPub, byPeer.values.flatten().sortedBy { it.createdAt })
                 }
             }
         // Persist the "seen on" relay map (debounced) so View source keeps it across restarts.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -46,6 +46,7 @@ import org.nostr.nostrord.network.managers.ConnectionStats
 import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmFileManager
 import org.nostr.nostrord.network.managers.DmHistoryFile
 import org.nostr.nostrord.network.managers.DmManager
 import org.nostr.nostrord.network.managers.DmMessage
@@ -68,6 +69,7 @@ import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17
+import org.nostr.nostrord.nostr.Nip17File
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip44
 import org.nostr.nostrord.nostr.Nip4e
@@ -2052,11 +2054,15 @@ class NostrRepository(
         // Relay-keyed, not account-keyed: left intact it holds the previous account's
         // fetched ids and the growth collector skips re-fetching kind:39000 for the new one.
         sentKnownGroupFetch.clear()
+        // Decrypted DM attachments are the previous account's private files.
+        dmFileManager.clear()
     }
 
     // ===== Direct messages (NIP-17 over NIP-59 gift wraps) =====
 
     private val dmManager = DmManager(scope, mutedPubkeys)
+
+    private val dmFileManager = DmFileManager(scope)
 
     private val dmEncryptionManager = DmEncryptionManager()
 
@@ -2111,6 +2117,12 @@ class NostrRepository(
     override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmManager.dmRelaysByPubkey
 
     override val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = dmManager.messageStatus
+
+    override val dmFileStates: StateFlow<Map<String, DmFileManager.FileState>> = dmFileManager.states
+
+    override fun loadDmFile(rumorId: String, file: Nip17File) = dmFileManager.load(rumorId, file)
+
+    override fun retryDmFile(rumorId: String, file: Nip17File) = dmFileManager.retry(rumorId, file)
 
     override fun requestPeerDmRelays(pubkey: String) {
         scope.launch { fetchDmRelays(pubkey) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2992,6 +2992,7 @@ class NostrRepository(
         // never gates the messages appearing.
         scope.launch { sendPairingReq(myPub) }
 
+        refreshDmSyncing()
         dmBacklogHoldUntilMs = org.nostr.nostrord.utils.epochMillis() + DM_BACKLOG_BOOT_HOLD_MS
         dmTrickleMutex.withLock {
             dmEagerDecryptCount = 0
@@ -3099,6 +3100,7 @@ class NostrRepository(
     private fun stopDmInbox() {
         if (!dmInboxStarted) return
         dmInboxStarted = false
+        _dmSyncing.value = false
         dmPersistenceWired = false
         dmPersistenceJobs.forEach { it.cancel() }
         dmPersistenceJobs.clear()
@@ -3312,6 +3314,25 @@ class NostrRepository(
     // DM relays the inbox sub is currently subscribed on, so a re-derived (but unchanged)
     // relay list doesn't re-issue the REQ and re-stream the whole backlog at the bunker.
     private var dmInboxSubscribedRelays: Set<String> = emptySet()
+
+    private val _dmSyncing = MutableStateFlow(false)
+
+    override val dmSyncing: StateFlow<Boolean> = _dmSyncing.asStateFlow()
+
+    /**
+     * Recompute whether the inbox is still catching up: a relay has not EOSEd yet, or a delivered
+     * wrap is still waiting to be decrypted. Called wherever that bookkeeping moves.
+     *
+     * The UI shows this instead of blocking the composer. "Everything has arrived" is not something
+     * a Nostr client can assert: NIP-59 backdates a gift wrap by up to two days, so a relay can
+     * hand over an old message at any moment. Saying so is honest; refusing to send would not be.
+     */
+    private fun refreshDmSyncing() {
+        val subscribed = dmInboxSubscribedRelays
+        val awaitingEose = subscribed.isEmpty() || !dmInboxEosedRelays.containsAll(subscribed)
+        val awaitingDecrypt = dmReceivedWrapIds.any { it !in dmProcessedWrapIds && it !in dmGivenUpWrapIds }
+        _dmSyncing.value = dmInboxStarted && (awaitingEose || awaitingDecrypt)
+    }
 
     private suspend fun resendDmInboxReq(myPub: String) {
         // Sync the whole inbox until it has EOSEd with every delivered wrap decrypted (dmFullSyncKey),
@@ -5944,6 +5965,7 @@ class NostrRepository(
                 if (myPub != null) {
                     dmInboxEosedRelays = dmInboxEosedRelays + url.normalizeRelayUrl()
                     maybeLatchDmFullSync(myPub)
+                    refreshDmSyncing()
                 }
             }
             // Fall through — handleMessage also needs EOSE for group pagination
@@ -6034,13 +6056,17 @@ class NostrRepository(
                 val signer = ActiveAccountManager.session.value?.signer ?: return
                 val wrapId = giftWrap.id
                 if (wrapId != null) {
-                    if (wrapId !in dmReceivedWrapIds) dmReceivedWrapIds = dmReceivedWrapIds + wrapId
+                    if (wrapId !in dmReceivedWrapIds) {
+                        dmReceivedWrapIds = dmReceivedWrapIds + wrapId
+                        refreshDmSyncing()
+                    }
                     // Before any dedup skip: the same wrap sits on several DM relays, and every
                     // delivery counts for the message's "seen on" relay list.
                     dmManager.recordWrapRelay(wrapId, client.getRelayUrl().normalizeRelayUrl())
                     // Already decrypted, or given up this session: skip the (expensive) round-trip.
                     if (wrapId in dmProcessedWrapIds || wrapId in dmGivenUpWrapIds) {
                         maybeLatchDmFullSync(myPub)
+                        refreshDmSyncing()
                         return
                     }
                     // Already being decrypted by an in-flight coroutine: don't spawn a duplicate.
@@ -6081,6 +6107,7 @@ class NostrRepository(
                             }
                             if (wrapId != null) dmInFlightWrapIds = dmInFlightWrapIds - wrapId
                             maybeLatchDmFullSync(myPub)
+                            refreshDmSyncing()
                             return@launch
                         }
                     }
@@ -6149,6 +6176,7 @@ class NostrRepository(
                             dmFailCounts = dmFailCounts - wrapId
                             scheduleSaveProcessedWrapIds(myPub)
                             maybeLatchDmFullSync(myPub)
+                            refreshDmSyncing()
                         } else if (!handled && wrapId != null) {
                             // Transient failure (signer timeout/unresponsive, or a malformed wrap).
                             // Count it; after the cap, give up for this session so the retry loop
@@ -6158,6 +6186,7 @@ class NostrRepository(
                             dmFailCounts = dmFailCounts + (wrapId to fails)
                             if (fails >= DM_MAX_DECRYPT_ATTEMPTS) {
                                 dmGivenUpWrapIds = dmGivenUpWrapIds + wrapId
+                                refreshDmSyncing()
                             }
                         }
                     } finally {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -3013,24 +3013,37 @@ class NostrRepository(
     /** Every cached DM row for [myPub]: text and file messages live under different kinds. */
     private suspend fun loadCachedDms(myPub: String): List<org.nostr.nostrord.storage.cache.CachedMsg> = DM_CACHE_KINDS.flatMap { cacheStore.loadByKind(myPub, it) }
 
-    private fun org.nostr.nostrord.storage.cache.CachedMsg.toDmMessage(myPubkey: String): DmMessage = DmMessage(
-        id = id,
-        peerPubkey = groupId,
-        senderPubkey = pubkey,
-        content = content,
-        createdAt = createdAt,
-        mine = pubkey == myPubkey,
-        kind = kind,
-        rumorJson =
-        buildJsonObject {
-            put("id", id)
-            put("pubkey", pubkey)
-            put("created_at", createdAt)
-            put("kind", kind)
-            put("tags", runCatching { Json.parseToJsonElement(tagsJson) }.getOrElse { JsonArray(emptyList()) })
-            put("content", content)
-        }.toString(),
-    )
+    private fun org.nostr.nostrord.storage.cache.CachedMsg.toDmMessage(myPubkey: String): DmMessage {
+        val tags = runCatching { Json.parseToJsonElement(tagsJson) }.getOrElse { JsonArray(emptyList()) }
+        val rumorKind = if (kind == DM_FILE_CACHE_KIND || tags.carriesFileMessageTags()) Nip17.KIND_FILE else Nip17.KIND_CHAT
+        return DmMessage(
+            id = id,
+            peerPubkey = groupId,
+            senderPubkey = pubkey,
+            content = content,
+            createdAt = createdAt,
+            mine = pubkey == myPubkey,
+            kind = rumorKind,
+            rumorJson =
+            buildJsonObject {
+                put("id", id)
+                put("pubkey", pubkey)
+                put("created_at", createdAt)
+                put("kind", rumorKind)
+                put("tags", tags)
+                put("content", content)
+            }.toString(),
+        )
+    }
+
+    /**
+     * Whether cached tags are a NIP-17 file message's. Rows written before file messages had their
+     * own cache kind all claim kind:14, so the decryption tags are what identifies an attachment;
+     * without this an existing one hydrates as text and renders its blob url.
+     */
+    private fun JsonElement.carriesFileMessageTags(): Boolean = runCatching {
+        jsonArray.any { tag -> tag.jsonArray.firstOrNull()?.jsonPrimitive?.content == Nip17File.TAG_DECRYPTION_KEY }
+    }.getOrDefault(false)
 
     /**
      * Load DM history from the CacheStore (migrating the legacy SecureStorage blob the first time).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -78,6 +78,8 @@ import org.nostr.nostrord.settings.NotificationLevel
 import org.nostr.nostrord.startup.StartupResolver
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.cache.DM_CACHE_KIND
+import org.nostr.nostrord.storage.cache.DM_CACHE_KINDS
+import org.nostr.nostrord.storage.cache.DM_FILE_CACHE_KIND
 import org.nostr.nostrord.storage.clearCurrentRelayUrlFor
 import org.nostr.nostrord.storage.clearDmMessages
 import org.nostr.nostrord.storage.getLastActiveAt
@@ -2414,7 +2416,7 @@ class NostrRepository(
     private suspend fun pendingArchiveRumors(myPub: String): List<Event> {
         val cached =
             try {
-                cacheStore.loadByKind(myPub, DM_CACHE_KIND)
+                loadCachedDms(myPub)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (_: Exception) {
@@ -2480,7 +2482,7 @@ class NostrRepository(
         val myPub = sessionManager.getPublicKey() ?: return ""
         val cached =
             try {
-                cacheStore.loadByKind(myPub, DM_CACHE_KIND)
+                loadCachedDms(myPub)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (_: Exception) {
@@ -2886,6 +2888,17 @@ class NostrRepository(
             SecureStorage.saveBooleanPref(dmFullSyncKey(myPub), false)
         }
 
+        // One-shot rescan: kind:15 file messages used to be decrypted, discarded and then marked
+        // processed, so every attachment already received is invisible AND permanently skipped by
+        // the dedup. Drop the progress once so the REQ streams from 0 and the backlog is decrypted
+        // again, this time keeping the file messages.
+        if (!SecureStorage.getBooleanPref(dmFileRescanKey(myPub), false)) {
+            dmProcessedWrapIds = emptySet()
+            SecureStorage.saveDmProcessedWrapIds(myPub, emptySet())
+            SecureStorage.saveBooleanPref(dmFullSyncKey(myPub), false)
+            SecureStorage.saveBooleanPref(dmFileRescanKey(myPub), true)
+        }
+
         _myDmRelays.value = dmRelaysFor(myPub)
         fetchDmRelays(myPub)
         resendDmInboxReq(myPub)
@@ -2986,14 +2999,19 @@ class NostrRepository(
         groupId = peerPubkey,
         pubkey = senderPubkey,
         createdAt = createdAt,
-        kind = DM_CACHE_KIND,
+        // A file message keeps its own kind so the hydrated row still renders as an attachment
+        // instead of falling back to its blob url as text.
+        kind = if (kind == Nip17.KIND_FILE) DM_FILE_CACHE_KIND else DM_CACHE_KIND,
         content = content,
-        // The rumor's real tags: with them the row IS the kind:14 rumor (DM_CACHE_KIND = 14),
-        // so toDmMessage can rebuild the exact event JSON across restarts.
+        // The rumor's real tags: with them the row IS the rumor, so toDmMessage can rebuild the
+        // exact event JSON across restarts.
         tagsJson = rumorJson?.let { rj ->
             runCatching { Json.parseToJsonElement(rj).jsonObject["tags"]?.toString() }.getOrNull()
         } ?: "[]",
     )
+
+    /** Every cached DM row for [myPub]: text and file messages live under different kinds. */
+    private suspend fun loadCachedDms(myPub: String): List<org.nostr.nostrord.storage.cache.CachedMsg> = DM_CACHE_KINDS.flatMap { cacheStore.loadByKind(myPub, it) }
 
     private fun org.nostr.nostrord.storage.cache.CachedMsg.toDmMessage(myPubkey: String): DmMessage = DmMessage(
         id = id,
@@ -3002,6 +3020,7 @@ class NostrRepository(
         content = content,
         createdAt = createdAt,
         mine = pubkey == myPubkey,
+        kind = kind,
         rumorJson =
         buildJsonObject {
             put("id", id)
@@ -3042,7 +3061,7 @@ class NostrRepository(
         }
         val cached =
             try {
-                cacheStore.loadByKind(myPub, DM_CACHE_KIND)
+                loadCachedDms(myPub)
             } catch (e: kotlinx.coroutines.CancellationException) {
                 throw e
             } catch (_: Exception) {
@@ -3111,6 +3130,9 @@ class NostrRepository(
     // v2: the v1 flag was latched on bare EOSE (before decryption finished), so it could be stuck
     // true with an incomplete backlog. v2 latches only when every delivered wrap is processed.
     private fun dmFullSyncKey(pubkey: String) = "dm_full_synced_v2_$pubkey"
+
+    /** Marks the one-shot backlog rescan that recovers kind:15 file messages. */
+    private fun dmFileRescanKey(pubkey: String) = "dm_file_rescan_$pubkey"
 
     // Persist decrypt progress, debounced so a streaming backlog doesn't hammer storage.
     private fun scheduleSaveProcessedWrapIds(myPub: String) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2184,7 +2184,7 @@ class NostrRepository(
      * self-copy for us, and publish each to its side's DM relays. The seal's NIP-44 encrypt and
      * signature run through the active signer, so local, bunker, and NIP-07 accounts all work.
      */
-    override suspend fun sendDm(recipientPubkey: String, content: String): Result<Unit> {
+    override suspend fun sendDm(recipientPubkey: String, content: String, replyToId: String?): Result<Unit> {
         val signer =
             ActiveAccountManager.session.value?.signer
                 ?: return Result.Error(AppError.Auth.NotAuthenticated)
@@ -2193,7 +2193,15 @@ class NostrRepository(
         // defaults only, which for a first contact means it is published where they never look and
         // is lost silently. Their kind:10044 rides the same REQ, so addressing improves too.
         awaitPeerDmRelays(recipientPubkey)
-        return publishDmRumor(Nip17.buildRumor(myPub, recipientPubkey, content), recipientPubkey, myPub, signer)
+        // A reply is an `e` tag on the rumor, with no relay hint: the rumor's id is computed
+        // before any relay lookup, and the reply never leaves the conversation anyway.
+        val replyTags = replyToId?.let { listOf(listOf("e", it)) } ?: emptyList()
+        return publishDmRumor(
+            Nip17.buildRumor(myPub, recipientPubkey, content, extraTags = replyTags),
+            recipientPubkey,
+            myPub,
+            signer,
+        )
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2797,13 +2797,21 @@ class NostrRepository(
                 add("nip4e_pair")
                 add(filter)
             }.toString()
-        pairingRelays(myPub).forEach { url ->
-            val client =
-                connectionManager.getClientForRelay(url)
-                    ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
-            try {
-                client?.send(req)
-            } catch (_: Throwable) {
+        // Fan out concurrently: a cold pool pays a connect per relay, and serially that is one
+        // handshake (or dead-relay timeout) after another.
+        coroutineScope {
+            pairingRelays(myPub).forEach { url ->
+                launch {
+                    val client =
+                        connectionManager.getClientForRelay(url)
+                            ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+                    try {
+                        client?.send(req)
+                    } catch (e: kotlinx.coroutines.CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                    }
+                }
             }
         }
     }
@@ -2962,7 +2970,6 @@ class NostrRepository(
         dmInboxStarted = true
 
         dmArchiveManager.hydrate(SecureStorage.loadDmArchivedRumorIdsFor(myPub))
-        sendPairingReq(myPub)
 
         // Seed the follow set from its persisted cache before the DM list partitions, so
         // conversations land in Follows/Others immediately instead of all falling in Others until
@@ -2974,11 +2981,16 @@ class NostrRepository(
         }
 
         // Hydrate from the CacheStore before the inbox streams so old conversations render instantly
-        // and already-seen gift wraps are never re-decrypted.
+        // and already-seen gift wraps are never re-decrypted. Nothing that touches a relay may run
+        // ahead of this: a cold pool pays a connect (or a timeout) per relay, and the conversations
+        // are on disk the whole time.
         val hydratedCount = hydrateDmCache(myPub)
         wireDmPersistence(myPub)
         // Resume any wraps that never reached a relay before the app last closed.
         resumeDmSendQueue(myPub)
+        // NIP-4e pairing listens for our own key-share events; it is not on the read path, so it
+        // never gates the messages appearing.
+        scope.launch { sendPairingReq(myPub) }
 
         dmBacklogHoldUntilMs = org.nostr.nostrord.utils.epochMillis() + DM_BACKLOG_BOOT_HOLD_MS
         dmTrickleMutex.withLock {
@@ -3133,8 +3145,16 @@ class NostrRepository(
     private suspend fun loadCachedDms(myPub: String): List<org.nostr.nostrord.storage.cache.CachedMsg> = DM_CACHE_KINDS.flatMap { cacheStore.loadByKind(myPub, it) }
 
     private fun org.nostr.nostrord.storage.cache.CachedMsg.toDmMessage(myPubkey: String): DmMessage {
-        val tags = runCatching { Json.parseToJsonElement(tagsJson) }.getOrElse { JsonArray(emptyList()) }
-        val rumorKind = if (kind == DM_FILE_CACHE_KIND || tags.carriesFileMessageTags()) Nip17.KIND_FILE else Nip17.KIND_CHAT
+        // Rows written before file messages had their own cache kind all claim kind:14, so the
+        // decryption tag is what identifies an attachment; without this an existing one hydrates
+        // as text and renders its blob url. Matched on the raw json: hydration runs over the whole
+        // history at startup, and parsing every row's tags to answer this costs more than it saves.
+        val rumorKind =
+            if (kind == DM_FILE_CACHE_KIND || tagsJson.contains("\"${Nip17File.TAG_DECRYPTION_KEY}\"")) {
+                Nip17.KIND_FILE
+            } else {
+                Nip17.KIND_CHAT
+            }
         return DmMessage(
             id = id,
             peerPubkey = groupId,
@@ -3143,26 +3163,12 @@ class NostrRepository(
             createdAt = createdAt,
             mine = pubkey == myPubkey,
             kind = rumorKind,
+            // Assembled as text around the tags exactly as they were stored, rather than parsed
+            // into a tree and re-serialized: only the content needs escaping.
             rumorJson =
-            buildJsonObject {
-                put("id", id)
-                put("pubkey", pubkey)
-                put("created_at", createdAt)
-                put("kind", rumorKind)
-                put("tags", tags)
-                put("content", content)
-            }.toString(),
+            """{"id":"$id","pubkey":"$pubkey","created_at":$createdAt,"kind":$rumorKind,"tags":$tagsJson,"content":${JsonPrimitive(content)}}""",
         )
     }
-
-    /**
-     * Whether cached tags are a NIP-17 file message's. Rows written before file messages had their
-     * own cache kind all claim kind:14, so the decryption tags are what identifies an attachment;
-     * without this an existing one hydrates as text and renders its blob url.
-     */
-    private fun JsonElement.carriesFileMessageTags(): Boolean = runCatching {
-        jsonArray.any { tag -> tag.jsonArray.firstOrNull()?.jsonPrimitive?.content == Nip17File.TAG_DECRYPTION_KEY }
-    }.getOrDefault(false)
 
     /**
      * Load DM history from the CacheStore (migrating the legacy SecureStorage blob the first time).

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -225,6 +225,12 @@ interface NostrRepositoryApi {
         emojiUrl: String? = null,
     ): Result<Unit>
 
+    /**
+     * The inbox is still catching up: a DM relay has not EOSEd, or a delivered gift wrap is still
+     * waiting to be decrypted. Older messages can still land above what is already on screen.
+     */
+    val dmSyncing: StateFlow<Boolean>
+
     /** Reactions on DM messages, keyed by the message they target, then by emoji. */
     val dmReactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>>
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -204,6 +204,30 @@ interface NostrRepositoryApi {
     /** Send status of our own DM messages, keyed by rumor id (Sending until a relay OKs). */
     val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>>
 
+    /**
+     * Send a file as an encrypted kind:15 message: the bytes are encrypted before upload, so the
+     * media server holds ciphertext and only the recipient can read the file.
+     */
+    suspend fun sendDmFile(
+        recipientPubkey: String,
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        width: Int? = null,
+        height: Int? = null,
+    ): Result<Unit>
+
+    /** React to a DM message with [emoji] (NIP-25 rumor); [emojiUrl] for a custom emoji. */
+    suspend fun sendDmReaction(
+        recipientPubkey: String,
+        messageId: String,
+        emoji: String,
+        emojiUrl: String? = null,
+    ): Result<Unit>
+
+    /** Reactions on DM messages, keyed by the message they target, then by emoji. */
+    val dmReactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>>
+
     /** Download + decryption state of kind:15 attachments, keyed by rumor id. */
     val dmFileStates: StateFlow<Map<String, DmFileManager.FileState>>
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -311,7 +311,8 @@ interface NostrRepositoryApi {
     fun dismissDmPairing()
 
     /** Send a NIP-17 direct message to [recipientPubkey]. */
-    suspend fun sendDm(recipientPubkey: String, content: String): Result<Unit>
+    /** [replyToId] marks this message as a reply to another one in the same conversation. */
+    suspend fun sendDm(recipientPubkey: String, content: String, replyToId: String? = null): Result<Unit>
 
     /** Mark a DM conversation read up to its newest message (clears its unread badge). */
     suspend fun markDmRead(peerPubkey: String)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -8,6 +8,7 @@ import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmFileManager
 import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.managers.GroupManager
@@ -15,6 +16,7 @@ import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
+import org.nostr.nostrord.nostr.Nip17File
 import org.nostr.nostrord.nostr.Nip46Client
 import org.nostr.nostrord.utils.Result
 
@@ -201,6 +203,15 @@ interface NostrRepositoryApi {
 
     /** Send status of our own DM messages, keyed by rumor id (Sending until a relay OKs). */
     val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>>
+
+    /** Download + decryption state of kind:15 attachments, keyed by rumor id. */
+    val dmFileStates: StateFlow<Map<String, DmFileManager.FileState>>
+
+    /** Start reading a kind:15 attachment (idempotent; safe to call on every render). */
+    fun loadDmFile(rumorId: String, file: Nip17File)
+
+    /** Re-attempt a failed attachment load. */
+    fun retryDmFile(rumorId: String, file: Nip17File)
 
     /** Fetch a peer's kind:10050 so [dmRelaysByPubkey] gains its entry (fire-and-forget). */
     fun requestPeerDmRelays(pubkey: String)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmFileManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmFileManager.kt
@@ -1,0 +1,151 @@
+package org.nostr.nostrord.network.managers
+
+import io.ktor.client.request.get
+import io.ktor.client.request.url
+import io.ktor.client.statement.readRawBytes
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withTimeout
+import org.nostr.nostrord.network.createHttpClient
+import org.nostr.nostrord.nostr.Crypto
+import org.nostr.nostrord.nostr.Nip17File
+import org.nostr.nostrord.nostr.hexToByteArray
+import org.nostr.nostrord.nostr.toHexString
+import org.nostr.nostrord.utils.AesGcm
+
+/**
+ * Reads the attachments behind NIP-17 kind:15 messages: download the blob, decrypt it with the
+ * key from the rumor, hand the plaintext bytes to the UI (Compose feeds them to Coil, the web
+ * wraps them in an object url).
+ *
+ * State is per rumor id and in-memory only: the plaintext of a private file has no business
+ * being written to disk, and a re-open re-fetches. [MAX_CACHED_BYTES] bounds what a long
+ * conversation can pin, evicting whole files oldest-first.
+ */
+class DmFileManager(
+    private val scope: CoroutineScope,
+) {
+    /** What the UI knows about one attachment. */
+    sealed class FileState {
+        data object Loading : FileState()
+
+        /** Decrypted bytes plus the mime type to render them as. */
+        data class Ready(val bytes: ByteArray, val mimeType: String?) : FileState() {
+            override fun equals(other: Any?): Boolean = this === other
+
+            override fun hashCode(): Int = bytes.size * 31 + mimeType.hashCode()
+        }
+
+        data class Failed(val reason: String) : FileState()
+    }
+
+    private val _states = MutableStateFlow<Map<String, FileState>>(emptyMap())
+    val states: StateFlow<Map<String, FileState>> = _states.asStateFlow()
+
+    // Insertion order of ready files, for byte-bounded eviction. Every mutation of the
+    // bookkeeping goes through [lock]: loads are started from the UI and finish on the manager
+    // scope, so these are touched from more than one thread.
+    private val loaded = mutableListOf<String>()
+    private var loadedBytes = 0L
+    private val inFlight = MutableStateFlow<Map<String, Job>>(emptyMap())
+    private val lock = Mutex()
+    private val http = createHttpClient()
+
+    /**
+     * Fetch and decrypt [file] for the message [rumorId], unless it is already loaded or in
+     * flight. Idempotent, so a composable can call it on every recomposition.
+     */
+    fun load(rumorId: String, file: Nip17File) {
+        if (_states.value[rumorId] is FileState.Ready || rumorId in inFlight.value) return
+        if (!file.isDecryptable) {
+            _states.update { it + (rumorId to FileState.Failed("Unsupported encryption")) }
+            return
+        }
+        _states.update { it + (rumorId to FileState.Loading) }
+        val job =
+            scope.launch {
+                val state =
+                    try {
+                        fetchAndDecrypt(file)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                        FileState.Failed("Could not load this file")
+                    }
+                inFlight.update { it - rumorId }
+                _states.update { it + (rumorId to state) }
+                if (state is FileState.Ready) remember(rumorId, state.bytes.size)
+            }
+        inFlight.update { it + (rumorId to job) }
+    }
+
+    /** Drop a failed load so the UI's retry starts a fresh attempt. */
+    fun retry(rumorId: String, file: Nip17File) {
+        _states.update { it - rumorId }
+        load(rumorId, file)
+    }
+
+    private suspend fun fetchAndDecrypt(file: Nip17File): FileState {
+        val encrypted =
+            withTimeout(DOWNLOAD_TIMEOUT_MS) {
+                http.get { url(file.url) }.readRawBytes()
+            }
+        if (encrypted.isEmpty()) return FileState.Failed("The file is no longer on the server")
+        val key = file.decryptionKeyHex?.decodeHexOrNull() ?: return FileState.Failed("Missing decryption key")
+        val nonce = file.decryptionNonceHex?.decodeHexOrNull() ?: return FileState.Failed("Missing decryption nonce")
+        val plaintext =
+            AesGcm.decryptUnauthenticated(key, nonce, encrypted)
+                ?: return FileState.Failed("Could not decrypt this file")
+        // AesGcm skips the GCM tag, so the sender's `ox` is what authenticates the bytes: it
+        // travels inside the sealed rumor, which makes it the stronger of the two anyway. A
+        // sender that published no hash leaves the file unverified rather than unreadable.
+        val expected = file.originalHashHex
+        if (expected != null && Crypto.sha256(plaintext).toHexString() != expected.lowercase()) {
+            return FileState.Failed("This file was altered on the server")
+        }
+        return FileState.Ready(plaintext, file.mimeType)
+    }
+
+    /** Record a newly loaded file and evict oldest-first until the cache fits again. */
+    private suspend fun remember(rumorId: String, size: Int) = lock.withLock {
+        loaded.remove(rumorId)
+        loaded += rumorId
+        loadedBytes += size
+        while (loadedBytes > MAX_CACHED_BYTES && loaded.size > 1) {
+            val evicted = loaded.removeAt(0)
+            val bytes = (_states.value[evicted] as? FileState.Ready)?.bytes?.size ?: 0
+            loadedBytes -= bytes
+            _states.update { it - evicted }
+        }
+    }
+
+    /** Drop everything on logout / account switch: another account must not see these bytes. */
+    fun clear() {
+        inFlight.value.values.forEach { it.cancel() }
+        inFlight.value = emptyMap()
+        scope.launch {
+            lock.withLock {
+                loaded.clear()
+                loadedBytes = 0
+            }
+        }
+        _states.value = emptyMap()
+    }
+
+    private fun String.decodeHexOrNull(): ByteArray? = runCatching { hexToByteArray() }.getOrNull()
+
+    private companion object {
+        const val DOWNLOAD_TIMEOUT_MS = 60_000L
+
+        /** Plaintext held in memory across all open conversations. */
+        const val MAX_CACHED_BYTES = 48L * 1024 * 1024
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -13,9 +13,10 @@ import kotlinx.serialization.Serializable
 import org.nostr.nostrord.auth.NostrSigner
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip17
+import org.nostr.nostrord.nostr.Nip17File
 import org.nostr.nostrord.nostr.Nip4e
 
-/** One decrypted NIP-17 chat message, scoped to a conversation with [peerPubkey]. */
+/** One decrypted NIP-17 message, scoped to a conversation with [peerPubkey]. */
 @Serializable
 data class DmMessage(
     val id: String,
@@ -24,13 +25,35 @@ data class DmMessage(
     val content: String,
     val createdAt: Long,
     val mine: Boolean,
-    /** Full decrypted kind:14 rumor as NIP-01 JSON (unsigned). Null on messages cached
+    /** Full decrypted rumor as NIP-01 JSON (unsigned). Null on messages cached
      *  before this field existed; DmMessage.eventJson() reconstructs a fallback. */
     val rumorJson: String? = null,
     /** Normalized relay urls this message's gift wrap was seen on. In-memory only
      *  (session-accumulated); empty for messages hydrated from cache. */
     val relays: List<String> = emptyList(),
-)
+    /** Rumor kind: [Nip17.KIND_CHAT] text, or [Nip17.KIND_FILE] for an encrypted attachment. */
+    val kind: Int = Nip17.KIND_CHAT,
+) {
+    /**
+     * Attachment payload for a kind:15 message, null for plain chat. Lazy because the render
+     * loops touch it per frame and parsing means re-reading the rumor JSON.
+     */
+    val file: Nip17File? by lazy {
+        if (kind != Nip17.KIND_FILE) null else rumorJson?.let { Nip17.parseRumor(it) }?.let { Nip17File.fromRumor(it) }
+    }
+}
+
+/**
+ * The conversation-list line for a message. A file message carries the blob url as its content,
+ * which is unreadable without the key and says nothing to the reader, so it names the attachment.
+ */
+fun DmMessage.previewText(): String = when {
+    kind != Nip17.KIND_FILE -> content
+    file?.isImage == true -> "Photo"
+    file?.isVideo == true -> "Video"
+    file?.isAudio == true -> "Audio"
+    else -> "File"
+}
 
 /**
  * A signed gift wrap awaiting relay acceptance, persisted per account so a send survives an app
@@ -95,7 +118,7 @@ class DmManager(
                     val last = msgs.maxByOrNull { it.createdAt } ?: return@mapNotNull null
                     val lastRead = reads[peer] ?: 0L
                     val unread = msgs.count { !it.mine && it.createdAt > lastRead }
-                    DmConversation(peer, last.content, last.createdAt, unread)
+                    DmConversation(peer, last.previewText(), last.createdAt, unread)
                 }
                 .sortedByDescending { it.lastAt }
         }
@@ -213,7 +236,7 @@ class DmManager(
             return false
         }
         val rumor = unwrapped.rumor
-        if (rumor.kind != Nip17.KIND_CHAT) return true
+        if (!isConversationRumor(rumor)) return true
         val rumorId = rumor.id ?: return true
         val sender = unwrapped.senderPubkey
         // The conversation peer is the other party: for my own (self-copy) messages that's the
@@ -242,6 +265,7 @@ class DmManager(
                 createdAt = rumor.createdAt,
                 mine = sender == myPubkey,
                 rumorJson = rumor.toJsonString(),
+                kind = rumor.kind,
             )
         addMessage(peer, message)
         linkWrapToRumor(giftWrap.id, rumorId, peer)
@@ -251,10 +275,10 @@ class DmManager(
     /**
      * File a rumor restored from a backup file. Same shape as an unwrapped one, minus everything
      * that only a relay delivery can mean: no delivery status, no wrap link, no seen-on relay.
-     * Returns false when the rumor is not a chat message for this account, or is already known.
+     * Returns false when the rumor is not a conversation message for this account, or is known.
      */
     fun importRumor(rumor: Event, myPubkey: String): Boolean {
-        if (rumor.kind != Nip17.KIND_CHAT) return false
+        if (!isConversationRumor(rumor)) return false
         val rumorId = rumor.id ?: return false
         val recipient = rumor.getTag("p")?.getOrNull(1)
         // The peer is the other party, and one side of the pair must be us, or the file is
@@ -276,6 +300,7 @@ class DmManager(
                 createdAt = rumor.createdAt,
                 mine = rumor.pubkey == myPubkey,
                 rumorJson = rumor.toJsonString(),
+                kind = rumor.kind,
             ),
         )
         return true
@@ -296,9 +321,17 @@ class DmManager(
                 createdAt = rumor.createdAt,
                 mine = true,
                 rumorJson = rumor.toJsonString(),
+                kind = rumor.kind,
             ),
         )
     }
+
+    /**
+     * Kinds that belong in a conversation thread. Everything else inside a gift wrap (reactions,
+     * receipts, protocol rumors) is filed elsewhere or ignored; a kind:15 file message is a
+     * message like any other, so dropping it would silently lose the sender's attachment.
+     */
+    private fun isConversationRumor(rumor: Event): Boolean = rumor.kind == Nip17.KIND_CHAT || rumor.kind == Nip17.KIND_FILE
 
     private fun addMessage(peer: String, message: DmMessage) {
         peerByRumor.update { it + (message.id to peer) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -41,6 +41,18 @@ data class DmMessage(
     val file: Nip17File? by lazy {
         if (kind != Nip17.KIND_FILE) null else rumorJson?.let { Nip17.parseRumor(it) }?.let { Nip17File.fromRumor(it) }
     }
+
+    /**
+     * Id of the message this one replies to, from the rumor's `e` tag. Null for a message that
+     * starts its own exchange.
+     */
+    val replyToId: String? by lazy {
+        rumorJson
+            ?.let { Nip17.parseAnyRumor(it) }
+            ?.getTag("e")
+            ?.getOrNull(1)
+            ?.takeIf { it.isNotBlank() }
+    }
 }
 
 /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -43,15 +43,19 @@ data class DmMessage(
     }
 
     /**
+     * The rumor's tags, for the renderers: NIP-30 custom emoji and the NIP-68 `imeta` hints that
+     * pre-size an inline image. Empty on messages cached before rumorJson existed.
+     */
+    val tags: List<List<String>> by lazy {
+        rumorJson?.let { Nip17.parseAnyRumor(it) }?.tags ?: emptyList()
+    }
+
+    /**
      * Id of the message this one replies to, from the rumor's `e` tag. Null for a message that
      * starts its own exchange.
      */
     val replyToId: String? by lazy {
-        rumorJson
-            ?.let { Nip17.parseAnyRumor(it) }
-            ?.getTag("e")
-            ?.getOrNull(1)
-            ?.takeIf { it.isNotBlank() }
+        tags.firstOrNull { it.size >= 2 && it[0] == "e" }?.get(1)?.takeIf { it.isNotBlank() }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -106,6 +106,19 @@ class DmManager(
     private val _messagesByPeer = MutableStateFlow<Map<String, List<DmMessage>>>(emptyMap())
     val messagesByPeer: StateFlow<Map<String, List<DmMessage>>> = _messagesByPeer.asStateFlow()
 
+    // Reaction rumors (kind:7) kept per peer, apart from the messages: they are not bubbles, so
+    // they must not reach the thread, the conversation preview or the unread counts. Held in the
+    // same DmMessage shape because they persist through the same cache path.
+    private val _reactionRumorsByPeer = MutableStateFlow<Map<String, List<DmMessage>>>(emptyMap())
+    val reactionRumorsByPeer: StateFlow<Map<String, List<DmMessage>>> = _reactionRumorsByPeer.asStateFlow()
+
+    // Aggregated on every change rather than derived through a flow operator: the UI reads this
+    // in the same frame a reaction is filed, and a stateIn would only catch up a dispatch later.
+    private val _reactions = MutableStateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>>(emptyMap())
+
+    /** Reactions keyed by the rumor they target, then by emoji. Same shape as group chat's. */
+    val reactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = _reactions.asStateFlow()
+
     // Read high-water per peer: createdAt of the newest message marked read. Persisted by the repo.
     private val _lastReadByPeer = MutableStateFlow<Map<String, Long>>(emptyMap())
     val lastReadByPeer: StateFlow<Map<String, Long>> = _lastReadByPeer.asStateFlow()
@@ -236,6 +249,10 @@ class DmManager(
             return false
         }
         val rumor = unwrapped.rumor
+        if (rumor.kind == Nip17.KIND_REACTION) {
+            fileReaction(rumor, unwrapped.senderPubkey, myPubkey)
+            return true
+        }
         if (!isConversationRumor(rumor)) return true
         val rumorId = rumor.id ?: return true
         val sender = unwrapped.senderPubkey
@@ -332,6 +349,83 @@ class DmManager(
      * message like any other, so dropping it would silently lose the sender's attachment.
      */
     private fun isConversationRumor(rumor: Event): Boolean = rumor.kind == Nip17.KIND_CHAT || rumor.kind == Nip17.KIND_FILE
+
+    /** File an incoming kind:7 rumor under its conversation. Ignores one we already hold. */
+    private fun fileReaction(rumor: Event, sender: String, myPubkey: String) {
+        val rumorId = rumor.id ?: return
+        val peer = (if (sender == myPubkey) rumor.getTag("p")?.getOrNull(1) else sender) ?: return
+        if (!markRumorSeen(rumorId)) return
+        addReactionRumor(
+            peer,
+            DmMessage(
+                id = rumorId,
+                peerPubkey = peer,
+                senderPubkey = sender,
+                content = rumor.content,
+                createdAt = rumor.createdAt,
+                mine = sender == myPubkey,
+                rumorJson = rumor.toJsonString(),
+                kind = Nip17.KIND_REACTION,
+            ),
+        )
+    }
+
+    /** Show our own reaction before its wrap round-trips; the echo dedups on the rumor id. */
+    fun addOptimisticReaction(rumor: Event, recipientPubkey: String, myPubkey: String) {
+        val rumorId = rumor.id ?: return
+        if (!markRumorSeen(rumorId)) return
+        addReactionRumor(
+            recipientPubkey,
+            DmMessage(
+                id = rumorId,
+                peerPubkey = recipientPubkey,
+                senderPubkey = myPubkey,
+                content = rumor.content,
+                createdAt = rumor.createdAt,
+                mine = true,
+                rumorJson = rumor.toJsonString(),
+                kind = Nip17.KIND_REACTION,
+            ),
+        )
+    }
+
+    /** Restore reaction rumors from the cache. */
+    fun hydrateReactions(rumors: List<DmMessage>) {
+        if (rumors.isEmpty()) return
+        seenRumorIds.update { it + rumors.map { r -> r.id } }
+        _reactionRumorsByPeer.value = rumors.groupBy { it.peerPubkey }
+        _reactions.value = aggregateReactions(rumors)
+    }
+
+    private fun addReactionRumor(peer: String, reaction: DmMessage) {
+        _reactionRumorsByPeer.update { current ->
+            current + (peer to (current[peer].orEmpty() + reaction))
+        }
+        _reactions.value = aggregateReactions(_reactionRumorsByPeer.value.values.flatten())
+    }
+
+    /**
+     * Collapse reaction rumors into per-target emoji counts. A reactor is counted once per emoji,
+     * and a custom emoji's url comes from the rumor's own NIP-30 tag.
+     */
+    private fun aggregateReactions(rumors: List<DmMessage>): Map<String, Map<String, GroupManager.ReactionInfo>> {
+        val out = mutableMapOf<String, MutableMap<String, GroupManager.ReactionInfo>>()
+        for (r in rumors) {
+            val rumor = r.rumorJson?.let { Nip17.parseAnyRumor(it) } ?: continue
+            val target = rumor.getTag("e")?.getOrNull(1)?.takeIf { it.isNotBlank() } ?: continue
+            val emoji = r.content.takeIf { it.isNotBlank() } ?: continue
+            val byEmoji = out.getOrPut(target) { mutableMapOf() }
+            val existing = byEmoji[emoji]
+            if (existing != null && r.senderPubkey in existing.reactors) continue
+            val emojiTag = rumor.getTag("emoji")
+            byEmoji[emoji] =
+                GroupManager.ReactionInfo(
+                    emojiUrl = emojiTag?.getOrNull(2) ?: existing?.emojiUrl,
+                    reactors = (existing?.reactors ?: emptyList()) + r.senderPubkey,
+                )
+        }
+        return out
+    }
 
     private fun addMessage(peer: String, message: DmMessage) {
         peerByRumor.update { it + (message.id to peer) }
@@ -499,6 +593,8 @@ class DmManager(
         relaysByRumor.value = emptyMap()
         _messageStatus.value = emptyMap()
         _messagesByPeer.value = emptyMap()
+        _reactionRumorsByPeer.value = emptyMap()
+        _reactions.value = emptyMap()
         _dmRelaysByPubkey.value = emptyMap()
         _encKeyByPubkey.value = emptyMap()
         _lastReadByPeer.value = emptyMap()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
@@ -30,6 +30,9 @@ object Nip17 {
 
     /** File message: content is the url of an encrypted blob, tags hold the key. See [Nip17File]. */
     const val KIND_FILE = 15
+
+    /** NIP-25 reaction, gift-wrapped like any other rumor: content is the emoji, `e` its target. */
+    const val KIND_REACTION = 7
     const val KIND_SEAL = 13
     const val KIND_GIFT_WRAP = 1059
     const val KIND_DM_RELAYS = 10050
@@ -40,8 +43,9 @@ object Nip17 {
     fun randomizedWrapTime(now: Long = epochSeconds()): Long = now - Random.nextLong(0, TWO_DAYS_SECONDS)
 
     /**
-     * Unsigned kind:14 chat rumor (id computed, no signature) from [senderPubkey] to
-     * [recipientPubkey]. [extraTags] can carry a reply `["e", id, relay]` etc.
+     * Unsigned rumor (id computed, no signature) from [senderPubkey] to [recipientPubkey]:
+     * chat by default, or [KIND_FILE] / [KIND_REACTION] via [kind]. [extraTags] can carry a reply
+     * `["e", id, relay]`, a file message's decryption material, etc.
      */
     fun buildRumor(
         senderPubkey: String,
@@ -49,12 +53,13 @@ object Nip17 {
         content: String,
         createdAt: Long = epochSeconds(),
         extraTags: List<List<String>> = emptyList(),
+        kind: Int = KIND_CHAT,
     ): Event {
         val rumor =
             Event(
                 pubkey = senderPubkey,
                 createdAt = createdAt,
-                kind = KIND_CHAT,
+                kind = kind,
                 tags = listOf(listOf("p", recipientPubkey)) + extraTags,
                 content = content,
             )
@@ -251,6 +256,12 @@ object Nip17 {
         }
         return null
     }
+
+    /**
+     * Parse any stored rumor JSON back into an [Event], whatever its kind. [parseRumor] is the
+     * conversation-message variant; a reaction has to come through here.
+     */
+    fun parseAnyRumor(json: String): Event? = runCatching { parseEvent(json) }.getOrNull()
 
     /** Parse a stored kind:14 / kind:15 rumor back into an [Event]; null when the JSON is unusable. */
     fun parseRumor(json: String): Event? = runCatching { parseEvent(json) }.getOrNull()?.takeIf { it.kind == KIND_CHAT || it.kind == KIND_FILE }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17.kt
@@ -27,6 +27,9 @@ import kotlin.random.Random
  */
 object Nip17 {
     const val KIND_CHAT = 14
+
+    /** File message: content is the url of an encrypted blob, tags hold the key. See [Nip17File]. */
+    const val KIND_FILE = 15
     const val KIND_SEAL = 13
     const val KIND_GIFT_WRAP = 1059
     const val KIND_DM_RELAYS = 10050
@@ -249,8 +252,8 @@ object Nip17 {
         return null
     }
 
-    /** Parse a stored kind:14 rumor back into an [Event]; null when the JSON is unusable. */
-    fun parseRumor(json: String): Event? = runCatching { parseEvent(json) }.getOrNull()?.takeIf { it.kind == KIND_CHAT }
+    /** Parse a stored kind:14 / kind:15 rumor back into an [Event]; null when the JSON is unusable. */
+    fun parseRumor(json: String): Event? = runCatching { parseEvent(json) }.getOrNull()?.takeIf { it.kind == KIND_CHAT || it.kind == KIND_FILE }
 
     private val lenientJson = Json { ignoreUnknownKeys = true }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17File.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17File.kt
@@ -1,0 +1,68 @@
+package org.nostr.nostrord.nostr
+
+/**
+ * A NIP-17 kind:15 file message: the rumor's content is the URL of an AES-GCM encrypted blob on a
+ * media server, and its tags carry everything needed to read it back. Nothing about the file is
+ * public - the server holds ciphertext only, and the key never leaves the sealed rumor.
+ *
+ * Tag names follow what NIP-17 specifies and what other clients (Jumble, 0xchat) actually publish:
+ * `file-type` for the mime type, `encryption-algorithm`, `decryption-key`, `decryption-nonce`,
+ * `ox` (SHA-256 of the plaintext), `x` (SHA-256 of the ciphertext), plus optional `size`, `dim`
+ * and `thumbhash` hints for laying the bubble out before the bytes arrive.
+ */
+data class Nip17File(
+    val url: String,
+    val mimeType: String?,
+    val algorithm: String?,
+    val decryptionKeyHex: String?,
+    val decryptionNonceHex: String?,
+    /** SHA-256 of the decrypted file, hex. The integrity check after decryption. */
+    val originalHashHex: String?,
+    /** SHA-256 of the encrypted blob, hex. */
+    val encryptedHashHex: String?,
+    val size: Long?,
+    val width: Int?,
+    val height: Int?,
+) {
+    val isImage: Boolean get() = mimeType?.startsWith("image/") == true
+
+    val isVideo: Boolean get() = mimeType?.startsWith("video/") == true
+
+    val isAudio: Boolean get() = mimeType?.startsWith("audio/") == true
+
+    /** The dim hint, when the sender published one, for reserving the bubble's slot. */
+    val dimensions: Pair<Int, Int>? get() = if (width != null && height != null) width to height else null
+
+    /** False when a tag is missing or names an algorithm we cannot read, so the UI offers the raw link instead. */
+    val isDecryptable: Boolean
+        get() = decryptionKeyHex != null &&
+            decryptionNonceHex != null &&
+            (algorithm == null || algorithm == ALGORITHM_AES_GCM)
+
+    companion object {
+        const val ALGORITHM_AES_GCM = "aes-gcm"
+
+        /** Parse a kind:15 rumor. Null for any other kind, or when the content is not a url. */
+        fun fromRumor(rumor: Event): Nip17File? {
+            if (rumor.kind != Nip17.KIND_FILE) return null
+            val url = rumor.content.trim()
+            if (!url.startsWith("http://") && !url.startsWith("https://")) return null
+            val dim = rumor.tagValue("dim")?.split("x")
+            return Nip17File(
+                url = url,
+                // `m` is the NIP-94 spelling; some clients send that instead of `file-type`.
+                mimeType = rumor.tagValue("file-type") ?: rumor.tagValue("m"),
+                algorithm = rumor.tagValue("encryption-algorithm")?.lowercase(),
+                decryptionKeyHex = rumor.tagValue("decryption-key"),
+                decryptionNonceHex = rumor.tagValue("decryption-nonce"),
+                originalHashHex = rumor.tagValue("ox"),
+                encryptedHashHex = rumor.tagValue("x"),
+                size = rumor.tagValue("size")?.toLongOrNull(),
+                width = dim?.getOrNull(0)?.toIntOrNull(),
+                height = dim?.getOrNull(1)?.toIntOrNull(),
+            )
+        }
+
+        private fun Event.tagValue(name: String): String? = getTag(name)?.getOrNull(1)?.takeIf { it.isNotBlank() }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17File.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17File.kt
@@ -42,6 +42,9 @@ data class Nip17File(
     companion object {
         const val ALGORITHM_AES_GCM = "aes-gcm"
 
+        /** Tag holding the AES key; its presence is what marks a rumor as a file message. */
+        const val TAG_DECRYPTION_KEY = "decryption-key"
+
         /** Parse a kind:15 rumor. Null for any other kind, or when the content is not a url. */
         fun fromRumor(rumor: Event): Nip17File? {
             if (rumor.kind != Nip17.KIND_FILE) return null
@@ -53,7 +56,7 @@ data class Nip17File(
                 // `m` is the NIP-94 spelling; some clients send that instead of `file-type`.
                 mimeType = rumor.tagValue("file-type") ?: rumor.tagValue("m"),
                 algorithm = rumor.tagValue("encryption-algorithm")?.lowercase(),
-                decryptionKeyHex = rumor.tagValue("decryption-key"),
+                decryptionKeyHex = rumor.tagValue(TAG_DECRYPTION_KEY),
                 decryptionNonceHex = rumor.tagValue("decryption-nonce"),
                 originalHashHex = rumor.tagValue("ox"),
                 encryptedHashHex = rumor.tagValue("x"),

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/SecureStorage.kt
@@ -1185,6 +1185,33 @@ fun SecureStorage.saveDmWrapRumor(
     }
 }
 
+// DM reactions (kind:7 rumors). Kept here rather than in the message cache because that table
+// buckets rows by kind, and kind:7 there already means a group reaction. Newest-first capped:
+// the inbox never re-decrypts a wrap it has processed, so an unpersisted reaction is lost for good.
+private fun dmReactionsKey(pubkey: String): String = "dm_reactions_${pubkeyDigest(pubkey)}"
+
+const val DM_REACTIONS_KEPT = 2000
+
+fun SecureStorage.loadDmReactions(pubkey: String): List<org.nostr.nostrord.network.managers.DmMessage> {
+    if (pubkey.isBlank()) return emptyList()
+    val raw = getStringPref(dmReactionsKey(pubkey), "") ?: ""
+    if (raw.isBlank()) return emptyList()
+    return runCatching {
+        Json.decodeFromString<List<org.nostr.nostrord.network.managers.DmMessage>>(raw)
+    }.getOrDefault(emptyList())
+}
+
+fun SecureStorage.saveDmReactions(
+    pubkey: String,
+    reactions: List<org.nostr.nostrord.network.managers.DmMessage>,
+) {
+    if (pubkey.isBlank()) return
+    try {
+        saveStringPref(dmReactionsKey(pubkey), Json.encodeToString(reactions.takeLast(DM_REACTIONS_KEPT)))
+    } catch (_: Exception) {
+    }
+}
+
 // Peer NIP-4e encryption keys (kind:10044), so the first send after a cold start addresses a
 // peer's encryption key instead of racing the announcement fetch and falling back to identity.
 private fun dmEncKeysKey(pubkey: String): String = "dm_enc_keys_${pubkeyDigest(pubkey)}"

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/cache/CacheStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/cache/CacheStore.kt
@@ -7,6 +7,16 @@ package org.nostr.nostrord.storage.cache
 const val DM_CACHE_KIND = 14
 
 /**
+ * NIP-17 file message kind. Cached in the same table as [DM_CACHE_KIND] and treated as a DM
+ * everywhere (never evicted by the group-message budget); the kind is kept so a hydrated row
+ * still knows it carries an attachment rather than text.
+ */
+const val DM_FILE_CACHE_KIND = 15
+
+/** Every kind the message table holds as a direct message. */
+val DM_CACHE_KINDS = listOf(DM_CACHE_KIND, DM_FILE_CACHE_KIND)
+
+/**
  * Bulk, queryable, bounded cache for chat messages and generic events — the persistence
  * seam for "never wait on the relay for something you've seen". Separate from [SecureStorage]
  * (which stays for small KV slots and credentials): message/event history is large and needs

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/cache/InMemoryCacheStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/storage/cache/InMemoryCacheStore.kt
@@ -114,8 +114,8 @@ class InMemoryCacheStore : CacheStore {
     ) = mutex.withLock {
         val rows = mutableListOf<Evictable>()
         messages[account]?.forEach { (_, byId) ->
-            // DMs (kind 14) are excluded from the group-message byte budget, so they're never evicted.
-            byId.values.filter { it.kind != DM_CACHE_KIND }.forEach { m ->
+            // DMs are excluded from the group-message byte budget, so they're never evicted.
+            byId.values.filter { it.kind !in DM_CACHE_KINDS }.forEach { m ->
                 rows.add(Evictable(m.createdAt, estimateBytes(m.content, m.tagsJson)) { byId.remove(m.id) })
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.nostr.nostrord.network.managers.DmMessage
-import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.utils.getDateLabel
 
 /**
@@ -27,7 +26,7 @@ fun DmMessage.eventJson(): String = rumorJson ?: buildJsonObject {
     put("id", id)
     put("pubkey", senderPubkey)
     put("created_at", createdAt)
-    put("kind", Nip17.KIND_CHAT)
+    put("kind", kind)
     putJsonArray("tags") {
         if (mine) {
             addJsonArray {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.network.managers.DmConversation
+import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.Result
 
@@ -37,6 +38,24 @@ class DmViewModel(
 
     /** Send status of our own messages (Sending → Delivered), keyed by rumor id. */
     val messageStatus = repo.dmMessageStatus
+
+    /** Download + decryption state of kind:15 attachments, keyed by rumor id. */
+    val fileStates = repo.dmFileStates
+
+    /**
+     * Start reading the attachment on [message], if it has one. Idempotent, so both UIs can call
+     * it from the bubble as it renders and let the manager decide whether there is work to do.
+     */
+    fun loadFile(message: DmMessage) {
+        val file = message.file ?: return
+        repo.loadDmFile(message.id, file)
+    }
+
+    /** Re-attempt an attachment whose download or decryption failed. */
+    fun retryFile(message: DmMessage) {
+        val file = message.file ?: return
+        repo.retryDmFile(message.id, file)
+    }
 
     val followsConversations: StateFlow<List<DmConversation>> =
         partition(keepFollowed = true)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -42,6 +42,9 @@ class DmViewModel(
     /** Download + decryption state of kind:15 attachments, keyed by rumor id. */
     val fileStates = repo.dmFileStates
 
+    /** True while the inbox is still catching up, so older messages may still land above. */
+    val syncing = repo.dmSyncing
+
     /** Reactions keyed by the message they target, then by emoji. */
     val reactions = repo.dmReactions
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -42,6 +42,33 @@ class DmViewModel(
     /** Download + decryption state of kind:15 attachments, keyed by rumor id. */
     val fileStates = repo.dmFileStates
 
+    /** Reactions keyed by the message they target, then by emoji. */
+    val reactions = repo.dmReactions
+
+    /**
+     * Send [bytes] as an encrypted kind:15 attachment. Unlike pasting a url into the text, the
+     * file is unreadable to anyone who has not been sent the key.
+     */
+    fun sendFile(
+        recipientPubkey: String,
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        width: Int? = null,
+        height: Int? = null,
+        onFailure: (String) -> Unit = {},
+    ) {
+        viewModelScope.launch {
+            val result = repo.sendDmFile(recipientPubkey, bytes, filename, mimeType, width, height)
+            if (result is Result.Error) onFailure(result.error.message)
+        }
+    }
+
+    /** React to [messageId] in the conversation with [peerPubkey]. */
+    fun react(peerPubkey: String, messageId: String, emoji: String, emojiUrl: String? = null) {
+        viewModelScope.launch { repo.sendDmReaction(peerPubkey, messageId, emoji, emojiUrl) }
+    }
+
     /**
      * Start reading the attachment on [message], if it has one. Idempotent, so both UIs can call
      * it from the bubble as it renders and let the manager decide whether there is work to do.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -120,13 +120,14 @@ class DmViewModel(
     fun send(
         recipientPubkey: String,
         content: String,
+        replyToId: String? = null,
         onSuccess: () -> Unit = {},
         onFailure: () -> Unit = {},
     ) {
         val text = content.trim()
         if (text.isEmpty()) return
         viewModelScope.launch {
-            val result = withMinDuration { repo.sendDm(recipientPubkey, text) }
+            val result = withMinDuration { repo.sendDm(recipientPubkey, text, replyToId) }
             when (result) {
                 is Result.Error -> onFailure()
                 is Result.Success -> onSuccess()

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/AesGcm.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/AesGcm.kt
@@ -7,11 +7,15 @@ package org.nostr.nostrord.utils
  * Common code rather than four platform actuals so JVM, Android, JS and iOS behave identically
  * and the NIST vectors in `AesGcmTest` cover every target at once.
  *
- * Only GCM's confidentiality layer (CTR) is implemented; see [decryptUnauthenticated].
+ * Reading skips the authentication tag (see [decryptUnauthenticated]); writing produces one,
+ * because the browsers on the other end verify it before handing the file to their user.
  */
 object AesGcm {
     /** Web Crypto appends the 16-byte GCM tag to the ciphertext. */
     const val TAG_SIZE = 16
+
+    /** GCM's standard 96-bit IV, the only length these helpers accept. */
+    const val NONCE_SIZE = 12
 
     /**
      * Decrypt a GCM blob WITHOUT verifying its authentication tag: the trailing tag is stripped
@@ -25,12 +29,138 @@ object AesGcm {
      * the blob held the key. See `DmFileManager`.
      */
     fun decryptUnauthenticated(key: ByteArray, nonce: ByteArray, data: ByteArray): ByteArray? {
-        if (nonce.size != 12) return null
+        if (nonce.size != NONCE_SIZE) return null
         if (data.size < TAG_SIZE) return null
         val schedule = expandKey(key) ?: return null
         val body = data.copyOfRange(0, data.size - TAG_SIZE)
         // For a 96-bit IV, J0 = IV || 1 and the payload counter starts at J0 + 1.
         return ctr(schedule, nonce, startCounter = 2, data = body)
+    }
+
+    /**
+     * Encrypt [data] into `ciphertext || tag`, the layout Web Crypto produces and expects.
+     * [key] is 16/24/32 bytes, [nonce] the 12-byte IV, which MUST never repeat for a given key
+     * (callers draw both fresh per file). No additional authenticated data, matching NIP-17.
+     * Null when the sizes are wrong.
+     */
+    fun encrypt(key: ByteArray, nonce: ByteArray, data: ByteArray): ByteArray? {
+        if (nonce.size != NONCE_SIZE) return null
+        val schedule = expandKey(key) ?: return null
+        val ciphertext = ctr(schedule, nonce, startCounter = 2, data = data)
+        val out = ByteArray(ciphertext.size + TAG_SIZE)
+        ciphertext.copyInto(out)
+        tag(schedule, nonce, ciphertext).copyInto(out, ciphertext.size)
+        return out
+    }
+
+    /**
+     * GCM tag over [ciphertext] with no AAD: `GHASH(H, C || pad || len(A) || len(C))` masked with
+     * the keystream block of J0 (the counter value before the payload's).
+     */
+    private fun tag(schedule: KeySchedule, nonce: ByteArray, ciphertext: ByteArray): ByteArray {
+        val h = ByteArray(16)
+        encryptBlock(schedule, ByteArray(16), h)
+        val ghash = GHash(h)
+        ghash.update(ciphertext)
+        val lengths = ByteArray(16)
+        // len(A) = 0; len(C) in bits, big-endian across the second half.
+        val bits = ciphertext.size.toLong() * 8
+        for (i in 0 until 8) lengths[15 - i] = (bits ushr (8 * i)).toByte()
+        ghash.updateBlock(lengths, 0, 16)
+        val mask = ByteArray(16)
+        val j0 = ByteArray(16)
+        nonce.copyInto(j0, 0, 0, 12)
+        j0[15] = 1
+        encryptBlock(schedule, j0, mask)
+        val out = ghash.digest()
+        for (i in 0 until 16) out[i] = (out[i].toInt() xor mask[i].toInt()).toByte()
+        return out
+    }
+
+    /**
+     * GHASH: the accumulator is multiplied by H in GF(2^128) once per 16-byte block. Held as four
+     * Ints rather than two Longs because Kotlin/JS emulates Long, and this runs over whole images.
+     */
+    private class GHash(hBytes: ByteArray) {
+        private val h0 = beInt(hBytes, 0)
+        private val h1 = beInt(hBytes, 4)
+        private val h2 = beInt(hBytes, 8)
+        private val h3 = beInt(hBytes, 12)
+        private var y0 = 0
+        private var y1 = 0
+        private var y2 = 0
+        private var y3 = 0
+
+        /** Absorb [data], zero-padding a trailing partial block as GCM specifies. */
+        fun update(data: ByteArray) {
+            var offset = 0
+            while (offset + 16 <= data.size) {
+                updateBlock(data, offset, 16)
+                offset += 16
+            }
+            if (offset < data.size) updateBlock(data, offset, data.size - offset)
+        }
+
+        fun updateBlock(data: ByteArray, offset: Int, length: Int) {
+            val block = if (length == 16) data else ByteArray(16).also { data.copyInto(it, 0, offset, offset + length) }
+            val base = if (length == 16) offset else 0
+            y0 = y0 xor beInt(block, base)
+            y1 = y1 xor beInt(block, base + 4)
+            y2 = y2 xor beInt(block, base + 8)
+            y3 = y3 xor beInt(block, base + 12)
+            multiplyByH()
+        }
+
+        fun digest(): ByteArray {
+            val out = ByteArray(16)
+            putInt(out, 0, y0)
+            putInt(out, 4, y1)
+            putInt(out, 8, y2)
+            putInt(out, 12, y3)
+            return out
+        }
+
+        /** Y = Y * H, the shift-and-add square-free multiplication with the GCM reduction poly. */
+        private fun multiplyByH() {
+            var z0 = 0
+            var z1 = 0
+            var z2 = 0
+            var z3 = 0
+            var v0 = h0
+            var v1 = h1
+            var v2 = h2
+            var v3 = h3
+            for (i in 0 until 128) {
+                val word = when (i shr 5) {
+                    0 -> y0
+                    1 -> y1
+                    2 -> y2
+                    else -> y3
+                }
+                // Bit 0 of GHASH is the most significant bit of the first byte.
+                if ((word ushr (31 - (i and 31))) and 1 == 1) {
+                    z0 = z0 xor v0
+                    z1 = z1 xor v1
+                    z2 = z2 xor v2
+                    z3 = z3 xor v3
+                }
+                val lsb = v3 and 1
+                v3 = (v3 ushr 1) or (v2 shl 31)
+                v2 = (v2 ushr 1) or (v1 shl 31)
+                v1 = (v1 ushr 1) or (v0 shl 31)
+                v0 = v0 ushr 1
+                if (lsb == 1) v0 = v0 xor R
+            }
+            y0 = z0
+            y1 = z1
+            y2 = z2
+            y3 = z3
+        }
+
+        private companion object {
+            /** x^128 + x^7 + x^2 + x + 1, as the top word of the reduction constant. */
+            const val R = -0x1F000000
+        }
     }
 
     /** AES-CTR over [data] in place of a fresh copy of it; counter block is [nonce] || 32-bit BE. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/AesGcm.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/utils/AesGcm.kt
@@ -1,0 +1,179 @@
+package org.nostr.nostrord.utils
+
+/**
+ * AES in pure Kotlin, enough to read the AES-GCM blobs behind NIP-17 kind:15 file messages:
+ * the media server holds ciphertext and the key/nonce ride in the rumor's tags.
+ *
+ * Common code rather than four platform actuals so JVM, Android, JS and iOS behave identically
+ * and the NIST vectors in `AesGcmTest` cover every target at once.
+ *
+ * Only GCM's confidentiality layer (CTR) is implemented; see [decryptUnauthenticated].
+ */
+object AesGcm {
+    /** Web Crypto appends the 16-byte GCM tag to the ciphertext. */
+    const val TAG_SIZE = 16
+
+    /**
+     * Decrypt a GCM blob WITHOUT verifying its authentication tag: the trailing tag is stripped
+     * and the body run through CTR. [key] is 16/24/32 bytes, [nonce] the 12-byte IV. Null when
+     * the sizes are wrong.
+     *
+     * Callers MUST authenticate the result themselves. For file messages that is the rumor's `ox`
+     * (SHA-256 of the plaintext), which is both cheaper here (the platform's native SHA-256 beats
+     * a GHASH written in Kotlin, and these are multi-megabyte images) and a stronger binding: `ox`
+     * comes from the sender's sealed, signed rumor, whereas the GCM tag only proves whoever wrote
+     * the blob held the key. See `DmFileManager`.
+     */
+    fun decryptUnauthenticated(key: ByteArray, nonce: ByteArray, data: ByteArray): ByteArray? {
+        if (nonce.size != 12) return null
+        if (data.size < TAG_SIZE) return null
+        val schedule = expandKey(key) ?: return null
+        val body = data.copyOfRange(0, data.size - TAG_SIZE)
+        // For a 96-bit IV, J0 = IV || 1 and the payload counter starts at J0 + 1.
+        return ctr(schedule, nonce, startCounter = 2, data = body)
+    }
+
+    /** AES-CTR over [data] in place of a fresh copy of it; counter block is [nonce] || 32-bit BE. */
+    private fun ctr(schedule: KeySchedule, nonce: ByteArray, startCounter: Int, data: ByteArray): ByteArray {
+        val out = ByteArray(data.size)
+        val counterBlock = ByteArray(16)
+        nonce.copyInto(counterBlock, 0, 0, 12)
+        val keystream = ByteArray(16)
+        var counter = startCounter
+        var offset = 0
+        while (offset < data.size) {
+            counterBlock[12] = (counter ushr 24).toByte()
+            counterBlock[13] = (counter ushr 16).toByte()
+            counterBlock[14] = (counter ushr 8).toByte()
+            counterBlock[15] = counter.toByte()
+            encryptBlock(schedule, counterBlock, keystream)
+            val n = minOf(16, data.size - offset)
+            for (i in 0 until n) {
+                out[offset + i] = (data[offset + i].toInt() xor keystream[i].toInt()).toByte()
+            }
+            offset += n
+            counter++
+        }
+        return out
+    }
+
+    private class KeySchedule(val roundKeys: IntArray, val rounds: Int)
+
+    private fun expandKey(key: ByteArray): KeySchedule? {
+        val nk =
+            when (key.size) {
+                16 -> 4
+                24 -> 6
+                32 -> 8
+                else -> return null
+            }
+        val rounds = nk + 6
+        val w = IntArray(4 * (rounds + 1))
+        for (i in 0 until nk) {
+            w[i] =
+                (key[4 * i].toInt() and 0xff shl 24) or
+                (key[4 * i + 1].toInt() and 0xff shl 16) or
+                (key[4 * i + 2].toInt() and 0xff shl 8) or
+                (key[4 * i + 3].toInt() and 0xff)
+        }
+        for (i in nk until w.size) {
+            var t = w[i - 1]
+            if (i % nk == 0) {
+                t = subWord((t shl 8) or (t ushr 24)) xor (RCON[i / nk] shl 24)
+            } else if (nk > 6 && i % nk == 4) {
+                t = subWord(t)
+            }
+            w[i] = w[i - nk] xor t
+        }
+        return KeySchedule(w, rounds)
+    }
+
+    private fun subWord(w: Int): Int = (SBOX[(w ushr 24) and 0xff] shl 24) or
+        (SBOX[(w ushr 16) and 0xff] shl 16) or
+        (SBOX[(w ushr 8) and 0xff] shl 8) or
+        SBOX[w and 0xff]
+
+    private fun encryptBlock(schedule: KeySchedule, input: ByteArray, output: ByteArray) {
+        val rk = schedule.roundKeys
+        var s0 = beInt(input, 0) xor rk[0]
+        var s1 = beInt(input, 4) xor rk[1]
+        var s2 = beInt(input, 8) xor rk[2]
+        var s3 = beInt(input, 12) xor rk[3]
+        var k = 4
+        repeat(schedule.rounds - 1) {
+            val t0 = TE0[(s0 ushr 24) and 0xff] xor TE1[(s1 ushr 16) and 0xff] xor TE2[(s2 ushr 8) and 0xff] xor TE3[s3 and 0xff] xor rk[k]
+            val t1 = TE0[(s1 ushr 24) and 0xff] xor TE1[(s2 ushr 16) and 0xff] xor TE2[(s3 ushr 8) and 0xff] xor TE3[s0 and 0xff] xor rk[k + 1]
+            val t2 = TE0[(s2 ushr 24) and 0xff] xor TE1[(s3 ushr 16) and 0xff] xor TE2[(s0 ushr 8) and 0xff] xor TE3[s1 and 0xff] xor rk[k + 2]
+            val t3 = TE0[(s3 ushr 24) and 0xff] xor TE1[(s0 ushr 16) and 0xff] xor TE2[(s1 ushr 8) and 0xff] xor TE3[s2 and 0xff] xor rk[k + 3]
+            s0 = t0
+            s1 = t1
+            s2 = t2
+            s3 = t3
+            k += 4
+        }
+        // Final round: SubBytes + ShiftRows + AddRoundKey, no MixColumns.
+        putInt(output, 0, finalRound(s0, s1, s2, s3) xor rk[k])
+        putInt(output, 4, finalRound(s1, s2, s3, s0) xor rk[k + 1])
+        putInt(output, 8, finalRound(s2, s3, s0, s1) xor rk[k + 2])
+        putInt(output, 12, finalRound(s3, s0, s1, s2) xor rk[k + 3])
+    }
+
+    private fun finalRound(a: Int, b: Int, c: Int, d: Int): Int = (SBOX[(a ushr 24) and 0xff] shl 24) or
+        (SBOX[(b ushr 16) and 0xff] shl 16) or
+        (SBOX[(c ushr 8) and 0xff] shl 8) or
+        SBOX[d and 0xff]
+
+    private fun beInt(b: ByteArray, i: Int): Int = (b[i].toInt() and 0xff shl 24) or
+        (b[i + 1].toInt() and 0xff shl 16) or
+        (b[i + 2].toInt() and 0xff shl 8) or
+        (b[i + 3].toInt() and 0xff)
+
+    private fun putInt(b: ByteArray, i: Int, v: Int) {
+        b[i] = (v ushr 24).toByte()
+        b[i + 1] = (v ushr 16).toByte()
+        b[i + 2] = (v ushr 8).toByte()
+        b[i + 3] = v.toByte()
+    }
+
+    private val RCON = intArrayOf(0x00, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36, 0x6c, 0xd8, 0xab, 0x4d)
+
+    private val SBOX =
+        intArrayOf(
+            0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+            0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+            0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+            0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+            0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+            0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+            0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+            0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+            0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+            0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+            0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+            0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+            0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+            0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+            0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+            0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16,
+        )
+
+    // Round tables: TE0[x] = [2s, s, s, 3s] for s = SBOX[x]; TE1..TE3 are byte rotations of it.
+    private val TE0 =
+        IntArray(256) { x ->
+            val s = SBOX[x]
+            val s2 = xtime(s)
+            val s3 = s2 xor s
+            (s2 shl 24) or (s shl 16) or (s shl 8) or s3
+        }
+    private val TE1 = IntArray(256) { rotr8(TE0[it]) }
+    private val TE2 = IntArray(256) { rotr8(TE1[it]) }
+    private val TE3 = IntArray(256) { rotr8(TE2[it]) }
+
+    private fun rotr8(v: Int): Int = (v ushr 8) or (v shl 24)
+
+    /** Multiply by x in GF(2^8) with the AES reduction polynomial. */
+    private fun xtime(b: Int): Int {
+        val shifted = b shl 1
+        return if (b and 0x80 != 0) (shifted xor 0x1b) and 0xff else shifted and 0xff
+    }
+}

--- a/composeApp/src/commonMain/sqldelight/org/nostr/nostrord/storage/cache/db/CacheDb.sq
+++ b/composeApp/src/commonMain/sqldelight/org/nostr/nostrord/storage/cache/db/CacheDb.sq
@@ -60,15 +60,15 @@ FROM message
 WHERE account = ? AND kind = ?
 ORDER BY created_at ASC;
 
--- Byte budget + eviction cover group history only; DMs (kind 14) are excluded so the
--- group-message budget never evicts a conversation.
+-- Byte budget + eviction cover group history only; DMs (kinds 14 and 15) are excluded so
+-- the group-message budget never evicts a conversation.
 totalMessageBytes:
-SELECT COALESCE(SUM(length(content) + length(tags_json) + 120), 0) FROM message WHERE account = ? AND kind != 14;
+SELECT COALESCE(SUM(length(content) + length(tags_json) + 120), 0) FROM message WHERE account = ? AND kind NOT IN (14, 15);
 
 messageSizesOldestFirst:
 SELECT id, created_at, CAST(length(content) + length(tags_json) + 120 AS INTEGER) AS bytes
 FROM message
-WHERE account = ? AND kind != 14
+WHERE account = ? AND kind NOT IN (14, 15)
 ORDER BY created_at ASC;
 
 deleteMessageById:

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -614,7 +614,13 @@ class FakeNostrRepository : NostrRepositoryApi {
 
     var sendDmAction: (String, String) -> Result<Unit> = { _, _ -> Result.Success(Unit) }
 
-    override suspend fun sendDm(recipientPubkey: String, content: String): Result<Unit> = sendDmAction(recipientPubkey, content)
+    /** Reply targets passed to [sendDm], in call order (null when the message starts a thread). */
+    val sentDmReplyTargets = mutableListOf<String?>()
+
+    override suspend fun sendDm(recipientPubkey: String, content: String, replyToId: String?): Result<Unit> {
+        sentDmReplyTargets += replyToId
+        return sendDmAction(recipientPubkey, content)
+    }
 
     override suspend fun markDmRead(peerPubkey: String) {}
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -153,6 +153,37 @@ class FakeNostrRepository : NostrRepositoryApi {
     val dmRelaysByPubkeyFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmRelaysByPubkeyFlow
     override val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = MutableStateFlow(emptyMap())
+    val dmReactionsFlow = MutableStateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>>(emptyMap())
+    override val dmReactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = dmReactionsFlow
+
+    /** Files sent through [sendDmFile], as (recipient, mimeType, size). */
+    val sentDmFiles = mutableListOf<Triple<String, String, Int>>()
+
+    override suspend fun sendDmFile(
+        recipientPubkey: String,
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        width: Int?,
+        height: Int?,
+    ): Result<Unit> {
+        sentDmFiles += Triple(recipientPubkey, mimeType, bytes.size)
+        return Result.Success(Unit)
+    }
+
+    /** Reactions sent through [sendDmReaction], as (messageId, emoji). */
+    val sentDmReactions = mutableListOf<Pair<String, String>>()
+
+    override suspend fun sendDmReaction(
+        recipientPubkey: String,
+        messageId: String,
+        emoji: String,
+        emojiUrl: String?,
+    ): Result<Unit> {
+        sentDmReactions += messageId to emoji
+        return Result.Success(Unit)
+    }
+
     val dmFileStatesFlow = MutableStateFlow<Map<String, DmFileManager.FileState>>(emptyMap())
     override val dmFileStates: StateFlow<Map<String, DmFileManager.FileState>> = dmFileStatesFlow
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -11,6 +11,7 @@ import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.DmArchiveManager
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmEncryptionManager
+import org.nostr.nostrord.network.managers.DmFileManager
 import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.managers.GroupManager
@@ -18,6 +19,7 @@ import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.nostr.Nip11RelayInfo
+import org.nostr.nostrord.nostr.Nip17File
 import org.nostr.nostrord.nostr.Nip46Client
 import org.nostr.nostrord.utils.AppError
 import org.nostr.nostrord.utils.Result
@@ -151,6 +153,20 @@ class FakeNostrRepository : NostrRepositoryApi {
     val dmRelaysByPubkeyFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmRelaysByPubkeyFlow
     override val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = MutableStateFlow(emptyMap())
+    val dmFileStatesFlow = MutableStateFlow<Map<String, DmFileManager.FileState>>(emptyMap())
+    override val dmFileStates: StateFlow<Map<String, DmFileManager.FileState>> = dmFileStatesFlow
+
+    /** Rumor ids the screen asked to load, in call order. */
+    val loadedDmFiles = mutableListOf<String>()
+
+    override fun loadDmFile(rumorId: String, file: Nip17File) {
+        loadedDmFiles += rumorId
+    }
+
+    override fun retryDmFile(rumorId: String, file: Nip17File) {
+        loadedDmFiles += rumorId
+    }
+
     override fun requestPeerDmRelays(pubkey: String) {}
 
     val dmEncryptionStateFlow = MutableStateFlow<DmEncryptionManager.State>(DmEncryptionManager.State.Unavailable)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -153,6 +153,8 @@ class FakeNostrRepository : NostrRepositoryApi {
     val dmRelaysByPubkeyFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())
     override val dmRelaysByPubkey: StateFlow<Map<String, List<String>>> = dmRelaysByPubkeyFlow
     override val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>> = MutableStateFlow(emptyMap())
+    val dmSyncingFlow = MutableStateFlow(false)
+    override val dmSyncing: StateFlow<Boolean> = dmSyncingFlow
     val dmReactionsFlow = MutableStateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>>(emptyMap())
     override val dmReactions: StateFlow<Map<String, Map<String, GroupManager.ReactionInfo>>> = dmReactionsFlow
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
@@ -157,6 +157,28 @@ class DmFileMessageTest {
         assertNull(dm.messagesByPeer.value[alice.pubkey]?.single()?.replyToId)
     }
 
+    @Test
+    fun `a message keeps its custom emoji tags for the renderer`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val rumor =
+            Nip17.buildRumor(
+                senderPubkey = alice.pubkey,
+                recipientPubkey = bob.pubkey,
+                content = "nice :party:",
+                createdAt = 3000L,
+                extraTags = listOf(listOf("emoji", "party", "https://cdn.example/party.png")),
+            )
+        dm.ingestGiftWrap(Nip17.wrap(rumor, bob.pubkey, alice), bob.pubkey, bob)
+
+        val tags = dm.messagesByPeer.value[alice.pubkey]?.single()?.tags.orEmpty()
+        assertEquals(
+            listOf("emoji", "party", "https://cdn.example/party.png"),
+            tags.firstOrNull { it.firstOrNull() == "emoji" },
+        )
+    }
+
     private companion object {
         val FILE_TAGS =
             listOf(

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
@@ -1,0 +1,142 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.auth.NostrSigner
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.Nip17
+import org.nostr.nostrord.nostr.Nip17File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * NIP-17 kind:15 file messages, the shape Jumble and 0xchat send an image in: the blob on the
+ * media server is AES-GCM ciphertext and the rumor carries its key. Dropping the kind would lose
+ * the message entirely, which is what a reader that only accepts kind:14 does.
+ */
+class DmFileMessageTest {
+    private fun signer() = NostrSigner.Local(KeyPair.generate())
+
+    private fun fileRumor(
+        sender: String,
+        recipient: String,
+        url: String = "https://blossom.example/abc.bin",
+        tags: List<List<String>> = FILE_TAGS,
+    ): Event {
+        val rumor =
+            Event(
+                pubkey = sender,
+                createdAt = 1000L,
+                kind = Nip17.KIND_FILE,
+                tags = listOf(listOf("p", recipient)) + tags,
+                content = url,
+            )
+        return rumor.copy(id = rumor.calculateId())
+    }
+
+    @Test
+    fun `a kind 15 rumor reaches the conversation`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val wrap = Nip17.wrap(fileRumor(alice.pubkey, bob.pubkey), bob.pubkey, alice)
+
+        assertTrue(dm.ingestGiftWrap(wrap, bob.pubkey, bob))
+
+        val message = dm.messagesByPeer.value[alice.pubkey]?.singleOrNull()
+        assertNotNull(message, "the file message must show up in the conversation")
+        assertEquals(Nip17.KIND_FILE, message.kind)
+        assertEquals("https://blossom.example/abc.bin", message.content)
+    }
+
+    @Test
+    fun `the attachment payload is readable off the stored message`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val wrap = Nip17.wrap(fileRumor(alice.pubkey, bob.pubkey), bob.pubkey, alice)
+        dm.ingestGiftWrap(wrap, bob.pubkey, bob)
+
+        val file = dm.messagesByPeer.value[alice.pubkey]?.single()?.file
+        assertNotNull(file)
+        assertEquals("image/jpeg", file.mimeType)
+        assertEquals("aes-gcm", file.algorithm)
+        assertEquals("a".repeat(64), file.decryptionKeyHex)
+        assertEquals("b".repeat(24), file.decryptionNonceHex)
+        assertEquals("c".repeat(64), file.originalHashHex)
+        assertEquals(800 to 600, file.dimensions)
+        assertEquals(12345L, file.size)
+        assertTrue(file.isImage)
+        assertTrue(file.isDecryptable)
+    }
+
+    @Test
+    fun `a chat message carries no attachment`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val rumor = Nip17.buildRumor(alice.pubkey, bob.pubkey, "just text")
+        dm.ingestGiftWrap(Nip17.wrap(rumor, bob.pubkey, alice), bob.pubkey, bob)
+
+        val message = dm.messagesByPeer.value[alice.pubkey]?.single()
+        assertNotNull(message)
+        assertEquals(Nip17.KIND_CHAT, message.kind)
+        assertNull(message.file)
+    }
+
+    @Test
+    fun `the conversation preview names the attachment instead of its url`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        dm.ingestGiftWrap(Nip17.wrap(fileRumor(alice.pubkey, bob.pubkey), bob.pubkey, alice), bob.pubkey, bob)
+
+        assertEquals("Photo", dm.messagesByPeer.value[alice.pubkey]?.single()?.previewText())
+    }
+
+    @Test
+    fun `an unreadable encryption scheme is flagged rather than rendered`() {
+        val sender = signer().pubkey
+        val rumor =
+            fileRumor(
+                sender,
+                signer().pubkey,
+                tags = listOf(listOf("file-type", "image/png"), listOf("encryption-algorithm", "chacha20")),
+            )
+        val file = Nip17File.fromRumor(rumor)
+        assertNotNull(file)
+        assertTrue(!file.isDecryptable)
+    }
+
+    @Test
+    fun `a rumor whose content is not a url is not a file message`() {
+        val rumor = fileRumor(signer().pubkey, signer().pubkey, url = "not a url")
+        assertNull(Nip17File.fromRumor(rumor))
+    }
+
+    @Test
+    fun `a kind 15 rumor restored from a backup file is filed too`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+
+        assertTrue(dm.importRumor(fileRumor(alice.pubkey, bob.pubkey), bob.pubkey))
+        assertEquals(Nip17.KIND_FILE, dm.messagesByPeer.value[alice.pubkey]?.single()?.kind)
+    }
+
+    private companion object {
+        val FILE_TAGS =
+            listOf(
+                listOf("file-type", "image/jpeg"),
+                listOf("encryption-algorithm", "aes-gcm"),
+                listOf("decryption-key", "a".repeat(64)),
+                listOf("decryption-nonce", "b".repeat(24)),
+                listOf("ox", "c".repeat(64)),
+                listOf("dim", "800x600"),
+                listOf("size", "12345"),
+            )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
@@ -127,6 +127,36 @@ class DmFileMessageTest {
         assertEquals(Nip17.KIND_FILE, dm.messagesByPeer.value[alice.pubkey]?.single()?.kind)
     }
 
+    @Test
+    fun `a reply carries the id of the message it answers`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val reply =
+            Nip17.buildRumor(
+                senderPubkey = alice.pubkey,
+                recipientPubkey = bob.pubkey,
+                content = "answering that",
+                createdAt = 2000L,
+                extraTags = listOf(listOf("e", "parent-1")),
+            )
+        dm.ingestGiftWrap(Nip17.wrap(reply, bob.pubkey, alice), bob.pubkey, bob)
+
+        val message = dm.messagesByPeer.value[alice.pubkey]?.single()
+        assertNotNull(message)
+        assertEquals("parent-1", message.replyToId)
+    }
+
+    @Test
+    fun `a plain message answers nothing`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        dm.ingestGiftWrap(Nip17.wrap(Nip17.buildRumor(alice.pubkey, bob.pubkey, "hi"), bob.pubkey, alice), bob.pubkey, bob)
+
+        assertNull(dm.messagesByPeer.value[alice.pubkey]?.single()?.replyToId)
+    }
+
     private companion object {
         val FILE_TAGS =
             listOf(

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmReactionTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmReactionTest.kt
@@ -1,0 +1,140 @@
+package org.nostr.nostrord.network.managers
+
+import kotlinx.coroutines.test.runTest
+import org.nostr.nostrord.auth.NostrSigner
+import org.nostr.nostrord.nostr.Event
+import org.nostr.nostrord.nostr.KeyPair
+import org.nostr.nostrord.nostr.Nip17
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Reactions inside NIP-17: a kind:7 rumor in the same gift wrap, `e`-tagging the message it
+ * targets. They are not messages, so they must reach the reaction map and nothing else.
+ */
+class DmReactionTest {
+    private fun signer() = NostrSigner.Local(KeyPair.generate())
+
+    private fun reaction(
+        sender: String,
+        recipient: String,
+        targetId: String,
+        emoji: String = "👍",
+        emojiTag: List<String>? = null,
+    ): Event = Nip17.buildRumor(
+        senderPubkey = sender,
+        recipientPubkey = recipient,
+        content = emoji,
+        createdAt = 1000L,
+        extraTags = listOfNotNull(listOf("e", targetId, ""), emojiTag),
+        kind = Nip17.KIND_REACTION,
+    )
+
+    @Test
+    fun `an incoming reaction lands on the message it targets`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val wrap = Nip17.wrap(reaction(alice.pubkey, bob.pubkey, "msg-1"), bob.pubkey, alice)
+
+        assertTrue(dm.ingestGiftWrap(wrap, bob.pubkey, bob))
+
+        val info = dm.reactions.value["msg-1"]?.get("👍")
+        assertNotNull(info, "the reaction must be filed under its target")
+        assertEquals(listOf(alice.pubkey), info.reactors)
+    }
+
+    @Test
+    fun `a reaction is not a message`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        dm.ingestGiftWrap(Nip17.wrap(reaction(alice.pubkey, bob.pubkey, "msg-1"), bob.pubkey, alice), bob.pubkey, bob)
+
+        assertNull(dm.messagesByPeer.value[alice.pubkey], "a reaction must not open a thread")
+        assertEquals(emptyList(), dm.conversations.value, "a reaction must not create a conversation")
+        assertEquals(emptyMap(), dm.unreadByPeer.value, "a reaction must not count as unread")
+    }
+
+    @Test
+    fun `two reactors on the same emoji are counted once each`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val carol = signer()
+        val bob = signer()
+        dm.ingestGiftWrap(Nip17.wrap(reaction(alice.pubkey, bob.pubkey, "msg-1"), bob.pubkey, alice), bob.pubkey, bob)
+        dm.ingestGiftWrap(Nip17.wrap(reaction(carol.pubkey, bob.pubkey, "msg-1"), bob.pubkey, carol), bob.pubkey, bob)
+        // The same wrap redelivered from a second relay must not double-count.
+        val repeat = reaction(alice.pubkey, bob.pubkey, "msg-1")
+        dm.ingestGiftWrap(Nip17.wrap(repeat, bob.pubkey, alice), bob.pubkey, bob)
+
+        assertEquals(setOf(alice.pubkey, carol.pubkey), dm.reactions.value["msg-1"]?.get("👍")?.reactors?.toSet())
+    }
+
+    @Test
+    fun `distinct emojis are kept apart`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        dm.ingestGiftWrap(Nip17.wrap(reaction(alice.pubkey, bob.pubkey, "msg-1", "👍"), bob.pubkey, alice), bob.pubkey, bob)
+        dm.ingestGiftWrap(Nip17.wrap(reaction(alice.pubkey, bob.pubkey, "msg-1", "🔥"), bob.pubkey, alice), bob.pubkey, bob)
+
+        assertEquals(setOf("👍", "🔥"), dm.reactions.value["msg-1"]?.keys)
+    }
+
+    @Test
+    fun `a custom emoji keeps its image url`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val rumor =
+            reaction(alice.pubkey, bob.pubkey, "msg-1", ":party:", listOf("emoji", "party", "https://cdn.example/party.png"))
+        dm.ingestGiftWrap(Nip17.wrap(rumor, bob.pubkey, alice), bob.pubkey, bob)
+
+        assertEquals("https://cdn.example/party.png", dm.reactions.value["msg-1"]?.get(":party:")?.emojiUrl)
+    }
+
+    @Test
+    fun `our own reaction shows before its wrap round-trips`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val me = signer()
+        val peer = signer()
+        val rumor = reaction(me.pubkey, peer.pubkey, "msg-1")
+
+        dm.addOptimisticReaction(rumor, peer.pubkey, me.pubkey)
+        assertEquals(listOf(me.pubkey), dm.reactions.value["msg-1"]?.get("👍")?.reactors)
+
+        // The self-copy echoing back off a relay must not add a second reactor.
+        dm.ingestGiftWrap(Nip17.wrap(rumor, me.pubkey, me), me.pubkey, me)
+        assertEquals(listOf(me.pubkey), dm.reactions.value["msg-1"]?.get("👍")?.reactors)
+    }
+
+    @Test
+    fun `reactions restored from storage are filed again`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        val rumor = reaction(alice.pubkey, bob.pubkey, "msg-1")
+        dm.ingestGiftWrap(Nip17.wrap(rumor, bob.pubkey, alice), bob.pubkey, bob)
+        val stored = dm.reactionRumorsByPeer.value.values.flatten()
+        assertEquals(1, stored.size)
+
+        val restored = DmManager(backgroundScope)
+        restored.hydrateReactions(stored)
+        assertEquals(listOf(alice.pubkey), restored.reactions.value["msg-1"]?.get("👍")?.reactors)
+    }
+
+    @Test
+    fun `reactions are dropped on account switch`() = runTest {
+        val dm = DmManager(backgroundScope)
+        val alice = signer()
+        val bob = signer()
+        dm.ingestGiftWrap(Nip17.wrap(reaction(alice.pubkey, bob.pubkey, "msg-1"), bob.pubkey, alice), bob.pubkey, bob)
+
+        dm.clear()
+        assertEquals(emptyMap(), dm.reactions.value)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/AesGcmTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/AesGcmTest.kt
@@ -114,4 +114,84 @@ class AesGcmTest {
             plaintext?.toHexString(),
         )
     }
+
+    @Test
+    fun `encrypts to the AES-128 vector, tag included`() {
+        val out =
+            AesGcm.encrypt(
+                key = "feffe9928665731c6d6a8f9467308308".hexToByteArray(),
+                nonce = "cafebabefacedbaddecaf888".hexToByteArray(),
+                data = (
+                    "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a72" +
+                        "1c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255"
+                    ).hexToByteArray(),
+            )
+        assertEquals(
+            "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e" +
+                "21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985" +
+                "4d5c2af327cd64a62cf35abd2ba6fab4",
+            out?.toHexString(),
+        )
+    }
+
+    @Test
+    fun `encrypts to the AES-256 vector, tag included`() {
+        val out =
+            AesGcm.encrypt(
+                key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308".hexToByteArray(),
+                nonce = "cafebabefacedbaddecaf888".hexToByteArray(),
+                data = (
+                    "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a72" +
+                        "1c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255"
+                    ).hexToByteArray(),
+            )
+        assertEquals(
+            "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa" +
+                "8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015ad" +
+                "b094dac5d93471bdec1a502270e3cc6c",
+            out?.toHexString(),
+        )
+    }
+
+    @Test
+    fun `encrypts an empty payload to the bare tag`() {
+        val out =
+            AesGcm.encrypt(
+                key = "00000000000000000000000000000000".hexToByteArray(),
+                nonce = "000000000000000000000000".hexToByteArray(),
+                data = ByteArray(0),
+            )
+        assertEquals("58e2fccefa7e3061367f1d57a4e7455a", out?.toHexString())
+    }
+
+    @Test
+    fun `encrypts a payload with a partial trailing block`() {
+        // 70 bytes: the tag has to zero-pad the last 6-byte block before absorbing it.
+        val out =
+            AesGcm.encrypt(
+                key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".hexToByteArray(),
+                nonce = "0102030405060708090a0b0c".hexToByteArray(),
+                data = (
+                    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+                        "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f" +
+                        "404142434445"
+                    ).hexToByteArray(),
+            )
+        assertEquals(
+            "c7bc994c11a6daaf79962ebfdfa587a4d26960c2c1d91e2b4ba05c7adec35369" +
+                "feeb6a59ecabd6fe085933ec423636258e83abf2c50415367aefbced4ce3140f" +
+                "bacb9dab3fc1bd9aef93c9a11ca4b928ee58854015b5",
+            out?.toHexString(),
+        )
+    }
+
+    @Test
+    fun `round-trips a payload through encrypt and decrypt`() {
+        val key = ByteArray(32) { (it * 7 + 3).toByte() }
+        val nonce = ByteArray(12) { (it * 11).toByte() }
+        val plaintext = ByteArray(5000) { (it % 251).toByte() }
+        val encrypted = AesGcm.encrypt(key, nonce, plaintext)
+        assertEquals(plaintext.size + AesGcm.TAG_SIZE, encrypted?.size)
+        assertEquals(plaintext.toHexString(), AesGcm.decryptUnauthenticated(key, nonce, encrypted!!)?.toHexString())
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/AesGcmTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/utils/AesGcmTest.kt
@@ -1,0 +1,117 @@
+package org.nostr.nostrord.utils
+
+import org.nostr.nostrord.nostr.hexToByteArray
+import org.nostr.nostrord.nostr.toHexString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * NIST SP 800-38D / GCM test vectors, 96-bit IVs and no additional data, which is exactly the
+ * shape Web Crypto produces for the file blobs behind NIP-17 kind:15 messages.
+ *
+ * Each vector is fed as ciphertext || tag, the layout the browser writes.
+ */
+class AesGcmTest {
+    @Test
+    fun `decrypts the AES-128 vector`() {
+        val plaintext =
+            AesGcm.decryptUnauthenticated(
+                key = "feffe9928665731c6d6a8f9467308308".hexToByteArray(),
+                nonce = "cafebabefacedbaddecaf888".hexToByteArray(),
+                data = (
+                    "42831ec2217774244b7221b784d0d49ce3aa212f2c02a4e035c17e2329aca12e" +
+                        "21d514b25466931c7d8f6a5aac84aa051ba30b396a0aac973d58e091473f5985" +
+                        "4d5c2af327cd64a62cf35abd2ba6fab4"
+                    ).hexToByteArray(),
+            )
+        assertEquals(
+            "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255",
+            plaintext?.toHexString(),
+        )
+    }
+
+    @Test
+    fun `decrypts the AES-256 vector`() {
+        val plaintext =
+            AesGcm.decryptUnauthenticated(
+                key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308".hexToByteArray(),
+                nonce = "cafebabefacedbaddecaf888".hexToByteArray(),
+                data = (
+                    "522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa" +
+                        "8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662898015ad" +
+                        "b094dac5d93471bdec1a502270e3cc6c"
+                    ).hexToByteArray(),
+            )
+        assertEquals(
+            "d9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255",
+            plaintext?.toHexString(),
+        )
+    }
+
+    @Test
+    fun `decrypts an empty payload`() {
+        val plaintext =
+            AesGcm.decryptUnauthenticated(
+                key = "00000000000000000000000000000000".hexToByteArray(),
+                nonce = "000000000000000000000000".hexToByteArray(),
+                data = "58e2fccefa7e3061367f1d57a4e7455a".hexToByteArray(),
+            )
+        assertEquals("", plaintext?.toHexString())
+    }
+
+    @Test
+    fun `rejects a nonce that is not 96 bits`() {
+        assertNull(
+            AesGcm.decryptUnauthenticated(
+                key = ByteArray(32),
+                nonce = ByteArray(16),
+                data = ByteArray(32),
+            ),
+        )
+    }
+
+    @Test
+    fun `rejects a key of the wrong size`() {
+        assertNull(
+            AesGcm.decryptUnauthenticated(
+                key = ByteArray(20),
+                nonce = ByteArray(12),
+                data = ByteArray(32),
+            ),
+        )
+    }
+
+    @Test
+    fun `rejects a payload too short to hold a tag`() {
+        assertNull(
+            AesGcm.decryptUnauthenticated(
+                key = ByteArray(32),
+                nonce = ByteArray(12),
+                data = ByteArray(8),
+            ),
+        )
+    }
+
+    @Test
+    fun `decrypts a payload spanning several counter blocks`() {
+        // 70 bytes: five AES blocks with a partial last one, so the CTR counter has to advance
+        // and the tail has to stop mid-block.
+        val plaintext =
+            AesGcm.decryptUnauthenticated(
+                key = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".hexToByteArray(),
+                nonce = "0102030405060708090a0b0c".hexToByteArray(),
+                data = (
+                    "c7bc994c11a6daaf79962ebfdfa587a4d26960c2c1d91e2b4ba05c7adec35369" +
+                        "feeb6a59ecabd6fe085933ec423636258e83abf2c50415367aefbced4ce3140f" +
+                        "bacb9dab3fc1bd9aef93c9a11ca4b928ee58854015b5"
+                    ).hexToByteArray(),
+            )
+        assertEquals(
+            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f" +
+                "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f" +
+                "404142434445",
+            plaintext?.toHexString(),
+        )
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.ios.kt
@@ -31,6 +31,7 @@ actual fun StaticImage(
     contentScale: ContentScale,
     onClick: () -> Unit,
     onError: () -> Unit,
+    onIntrinsicSize: (width: Int, height: Int) -> Unit,
 ) {
     val context = LocalPlatformContext.current
     // Inline base64 image: decode to bytes for Coil; otherwise use the optimized URL.
@@ -58,6 +59,7 @@ actual fun StaticImage(
             when (state) {
                 is AsyncImagePainter.State.Success -> {
                     loading = false
+                    onIntrinsicSize(state.result.image.width, state.result.image.height)
                     backdrop = sampleImageArgb(state.result.image)?.let(::decideImageBackdrop)
                 }
                 is AsyncImagePainter.State.Error -> {

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/cache/IndexedDbCacheStore.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/cache/IndexedDbCacheStore.js.kt
@@ -31,12 +31,23 @@ class IndexedDbCacheStore : CacheStore {
         val existing = cachedDb
         if (existing != null) return existing
         val idb = window.asDynamic().indexedDB
-        val req = idb.open(DB_NAME, 1)
+        val req = idb.open(DB_NAME, DB_VERSION)
         req.onupgradeneeded = { _: dynamic ->
             val database = req.result
-            if (!database.objectStoreNames.contains(MESSAGE).unsafeCast<Boolean>()) {
-                val store = database.createObjectStore(MESSAGE, json("keyPath" to arrayOf("account", "id")))
-                store.createIndex(MSG_GROUP_TIME, arrayOf("account", "group_id", "created_at"), json("unique" to false))
+            val store =
+                if (!database.objectStoreNames.contains(MESSAGE).unsafeCast<Boolean>()) {
+                    val created = database.createObjectStore(MESSAGE, json("keyPath" to arrayOf("account", "id")))
+                    created.createIndex(MSG_GROUP_TIME, arrayOf("account", "group_id", "created_at"), json("unique" to false))
+                    created
+                } else {
+                    // Existing database: the store is only reachable through the upgrade transaction.
+                    req.transaction.objectStore(MESSAGE)
+                }
+            // Without this, reading one kind means stepping a cursor over every message the account
+            // has cached, group history included: a DM inbox that should hydrate instantly instead
+            // waits on tens of thousands of cursor hops.
+            if (!store.indexNames.contains(MSG_KIND_TIME).unsafeCast<Boolean>()) {
+                store.createIndex(MSG_KIND_TIME, arrayOf("account", "kind", "created_at"), json("unique" to false))
             }
             if (!database.objectStoreNames.contains(EVENT).unsafeCast<Boolean>()) {
                 database.createObjectStore(EVENT, json("keyPath" to arrayOf("account", "id")))
@@ -112,12 +123,13 @@ class IndexedDbCacheStore : CacheStore {
         val database = db()
         val store = database.transaction(MESSAGE, "readonly").objectStore(MESSAGE)
         val out = ArrayList<CachedMsg>()
-        drainCursor(store.openCursor(boundAccount(account), "next")) { cursor ->
-            val v = cursor.value
-            if (v.kind.unsafeCast<Int>() == kind) out.add(toCachedMsg(v))
+        // The index is already ordered by created_at within the kind, so the cursor visits only
+        // this kind's rows and they come out sorted.
+        drainCursor(store.index(MSG_KIND_TIME).openCursor(boundKind(account, kind), "next")) { cursor ->
+            out.add(toCachedMsg(cursor.value))
             true
         }
-        return out.sortedBy { it.createdAt }
+        return out
     }
 
     override suspend fun upsertEvents(
@@ -303,6 +315,16 @@ class IndexedDbCacheStore : CacheStore {
         return keyRange.bound(lower, upper, false, upperExclusive)
     }
 
+    private fun boundKind(account: String, kind: Int): dynamic {
+        val keyRange = window.asDynamic().IDBKeyRange
+        return keyRange.bound(
+            arrayOf<dynamic>(account, kind, MIN_TIME),
+            arrayOf<dynamic>(account, kind, MAX_TIME),
+            false,
+            false,
+        )
+    }
+
     private fun boundAccount(account: String): dynamic {
         val keyRange = window.asDynamic().IDBKeyRange
         // Compound-key prefix range: [account] .. [account, "￿"].
@@ -341,9 +363,13 @@ class IndexedDbCacheStore : CacheStore {
 
     private companion object {
         const val DB_NAME = "nostrord_cache_db"
+
+        /** 2 added the (account, kind, created_at) index the DM hydration reads. */
+        const val DB_VERSION = 2
         const val MESSAGE = "message"
         const val EVENT = "event"
         const val MSG_GROUP_TIME = "group_time"
+        const val MSG_KIND_TIME = "kind_time"
 
         // created_at bounds for compound-key ranges (nostr seconds sit well inside).
         const val MIN_TIME = 0.0

--- a/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/cache/IndexedDbCacheStore.js.kt
+++ b/composeApp/src/jsMain/kotlin/org/nostr/nostrord/storage/cache/IndexedDbCacheStore.js.kt
@@ -242,8 +242,8 @@ class IndexedDbCacheStore : CacheStore {
         val out = ArrayList<SizeRow>()
         drainCursor(store.openCursor(boundAccount(account), "next")) { cursor ->
             val v = cursor.value
-            // DMs (kind 14) are excluded from the byte budget so a conversation is never evicted.
-            if (!(storeName == MESSAGE && v.kind.unsafeCast<Int>() == DM_CACHE_KIND)) {
+            // DMs are excluded from the byte budget so a conversation is never evicted.
+            if (!(storeName == MESSAGE && v.kind.unsafeCast<Int>() in DM_CACHE_KINDS)) {
                 val bytes = (v.content.unsafeCast<String>().length + v.tags_json.unsafeCast<String>().length + 120).toLong()
                 out.add(SizeRow(storeName, v.id.unsafeCast<String>(), (v.created_at.unsafeCast<Double>()).toLong(), bytes))
             }

--- a/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.jvm.kt
+++ b/composeApp/src/jvmMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.jvm.kt
@@ -33,6 +33,7 @@ actual fun StaticImage(
     contentScale: ContentScale,
     onClick: () -> Unit,
     onError: () -> Unit,
+    onIntrinsicSize: (width: Int, height: Int) -> Unit,
 ) {
     val context = LocalPlatformContext.current
     // Inline base64 image: decode to bytes and hand them straight to Coil (no proxy/retry).
@@ -67,6 +68,7 @@ actual fun StaticImage(
             when (state) {
                 is AsyncImagePainter.State.Success -> {
                     loading = false
+                    onIntrinsicSize(state.result.image.width, state.result.image.height)
                     backdrop = sampleImageArgb(state.result.image)?.let(::decideImageBackdrop)
                 }
                 is AsyncImagePainter.State.Error -> {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmAttachment.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmAttachment.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.ui.components.chat
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -88,6 +92,8 @@ private fun Attachment(
     dimensions: Pair<Int, Int>?,
     modifier: Modifier,
 ) {
+    var fullscreen by remember(file.url) { mutableStateOf(false) }
+
     when (state) {
         is DmFileManager.FileState.Ready ->
             if (file.isImage) {
@@ -95,8 +101,22 @@ private fun Attachment(
                     model = state.bytes,
                     contentDescription = null,
                     contentScale = if (dimensions != null) ContentScale.FillWidth else ContentScale.Fit,
-                    modifier = modifier.then(slot).clip(NostrordShapes.imageShape),
+                    modifier =
+                    modifier
+                        .then(slot)
+                        .clip(NostrordShapes.imageShape)
+                        .clickable { fullscreen = true },
                 )
+                if (fullscreen) {
+                    // The viewer takes the plaintext: the url on the media server is ciphertext.
+                    ImageViewerModal(
+                        imageUrl = file.url,
+                        imageBytes = state.bytes,
+                        fileName = "attachment" + extensionFor(state.mimeType ?: file.mimeType),
+                        mimeType = state.mimeType ?: file.mimeType,
+                        onDismiss = { fullscreen = false },
+                    )
+                }
             } else {
                 AttachmentNote(label(file) + " (" + readableSize(state.bytes.size.toLong()) + ")", textColor, modifier)
             }
@@ -151,4 +171,14 @@ private fun readableSize(bytes: Long): String = when {
     bytes >= 1024 * 1024 -> "${bytes / (1024 * 1024)} MB"
     bytes >= 1024 -> "${bytes / 1024} KB"
     else -> "$bytes B"
+}
+
+/** File extension for a saved attachment, from its mime type. Empty when it is not an image. */
+private fun extensionFor(mimeType: String?): String = when (mimeType) {
+    "image/png" -> ".png"
+    "image/gif" -> ".gif"
+    "image/webp" -> ".webp"
+    "image/avif" -> ".avif"
+    "image/jpeg", "image/jpg" -> ".jpg"
+    else -> ""
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmAttachment.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmAttachment.kt
@@ -1,0 +1,154 @@
+package org.nostr.nostrord.ui.components.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil3.compose.AsyncImage
+import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.managers.DmFileManager
+import org.nostr.nostrord.nostr.Nip17File
+import org.nostr.nostrord.ui.components.buttons.AppButton
+import org.nostr.nostrord.ui.components.buttons.AppButtonSize
+import org.nostr.nostrord.ui.components.buttons.AppButtonVariant
+import org.nostr.nostrord.ui.components.loading.shimmerEffect
+import org.nostr.nostrord.ui.media.INLINE_MEDIA_MAX_HEIGHT
+import org.nostr.nostrord.ui.media.INLINE_MEDIA_MAX_WIDTH
+import org.nostr.nostrord.ui.media.INLINE_MEDIA_MIN_SIDE
+import org.nostr.nostrord.ui.theme.NostrordColors
+import org.nostr.nostrord.ui.theme.NostrordShapes
+import org.nostr.nostrord.ui.theme.Spacing
+
+/**
+ * The body of a NIP-17 kind:15 message: an attachment whose bytes live encrypted on a media
+ * server. [onLoad] starts the download and decryption; the plaintext never touches the URL, so
+ * an image is handed to Coil as bytes rather than as a link.
+ *
+ * The sender's `dim` hint reserves the slot at the right aspect ratio before the bytes arrive,
+ * the same trick the inline images in group chat use, so the bubble doesn't jump on load.
+ */
+@Composable
+fun DmAttachment(
+    file: Nip17File,
+    state: DmFileManager.FileState?,
+    onLoad: () -> Unit,
+    onRetry: () -> Unit,
+    onImage: Boolean = false,
+    modifier: Modifier = Modifier,
+) {
+    val autoLoad by AppModule.mediaSettings.autoLoadMedia.collectAsState()
+    val dimensions = file.dimensions
+    val slot =
+        if (dimensions != null && dimensions.first > 0 && dimensions.second > 0) {
+            Modifier
+                .widthIn(max = INLINE_MEDIA_MAX_WIDTH.dp)
+                .aspectRatio(
+                    dimensions.first.toFloat() / dimensions.second.toFloat(),
+                    matchHeightConstraintsFirst = dimensions.first < dimensions.second,
+                )
+        } else {
+            Modifier
+                .widthIn(max = INLINE_MEDIA_MAX_WIDTH.dp)
+                .heightIn(max = INLINE_MEDIA_MAX_HEIGHT.dp)
+                .defaultMinSize(minWidth = INLINE_MEDIA_MIN_SIDE.dp, minHeight = INLINE_MEDIA_MIN_SIDE.dp)
+        }
+    val textColor = if (onImage) Color.White.copy(alpha = 0.85f) else NostrordColors.TextMuted
+
+    // The gate keeps this composable out of the tree entirely until the user reveals it, so a
+    // gated attachment costs no download and no decrypt.
+    GatedMedia(autoLoad = autoLoad, label = gateLabel(file)) {
+        LaunchedEffect(file.url) { onLoad() }
+        Attachment(file, state, onRetry, slot, textColor, dimensions, modifier)
+    }
+}
+
+@Composable
+private fun Attachment(
+    file: Nip17File,
+    state: DmFileManager.FileState?,
+    onRetry: () -> Unit,
+    slot: Modifier,
+    textColor: Color,
+    dimensions: Pair<Int, Int>?,
+    modifier: Modifier,
+) {
+    when (state) {
+        is DmFileManager.FileState.Ready ->
+            if (file.isImage) {
+                AsyncImage(
+                    model = state.bytes,
+                    contentDescription = null,
+                    contentScale = if (dimensions != null) ContentScale.FillWidth else ContentScale.Fit,
+                    modifier = modifier.then(slot).clip(NostrordShapes.imageShape),
+                )
+            } else {
+                AttachmentNote(label(file) + " (" + readableSize(state.bytes.size.toLong()) + ")", textColor, modifier)
+            }
+
+        is DmFileManager.FileState.Failed ->
+            Column(
+                modifier = modifier.then(slot),
+                verticalArrangement = Arrangement.spacedBy(Spacing.xs),
+            ) {
+                Text(state.reason, color = textColor, fontSize = 13.sp)
+                AppButton(text = "Retry", onClick = onRetry, variant = AppButtonVariant.Secondary, size = AppButtonSize.Small)
+            }
+
+        else ->
+            Box(
+                modifier =
+                modifier
+                    .then(slot)
+                    .fillMaxWidth()
+                    .clip(NostrordShapes.imageShape)
+                    .shimmerEffect(),
+            )
+    }
+}
+
+@Composable
+private fun AttachmentNote(text: String, color: Color, modifier: Modifier = Modifier) {
+    Text(
+        text,
+        color = color,
+        fontSize = 13.sp,
+        modifier = modifier.padding(vertical = Spacing.xxs),
+    )
+}
+
+/** Matches the wording of the inline-media gate: "Tap to load image". */
+private fun gateLabel(file: Nip17File): String = when {
+    file.isVideo -> "video"
+    file.isAudio -> "audio"
+    file.isImage -> "image"
+    else -> "file"
+}
+
+private fun label(file: Nip17File): String = when {
+    file.isVideo -> "Video"
+    file.isAudio -> "Audio"
+    file.isImage -> "Photo"
+    else -> "File"
+}
+
+private fun readableSize(bytes: Long): String = when {
+    bytes >= 1024 * 1024 -> "${bytes / (1024 * 1024)} MB"
+    bytes >= 1024 -> "${bytes / 1024} KB"
+    else -> "$bytes B"
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Reply
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Visibility
 import androidx.compose.runtime.Composable
@@ -49,6 +50,7 @@ fun DmMessageContextMenu(
     onCopyText: () -> Unit,
     onReact: (String) -> Unit,
     onOpenReactionPicker: () -> Unit,
+    onReply: () -> Unit,
 ) {
     if (!visible) return
     val marginPx = with(LocalDensity.current) { 8.dp.roundToPx() }
@@ -110,6 +112,14 @@ fun DmMessageContextMenu(
                         },
                         onOpenPicker = {
                             onOpenReactionPicker()
+                            onDismiss()
+                        },
+                    )
+                    ContextMenuItem(
+                        icon = Icons.AutoMirrored.Outlined.Reply,
+                        label = "Reply",
+                        onClick = {
+                            onReply()
                             onDismiss()
                         },
                     )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt
@@ -47,6 +47,8 @@ fun DmMessageContextMenu(
     onDismiss: () -> Unit,
     onViewSource: () -> Unit,
     onCopyText: () -> Unit,
+    onReact: (String) -> Unit,
+    onOpenReactionPicker: () -> Unit,
 ) {
     if (!visible) return
     val marginPx = with(LocalDensity.current) { 8.dp.roundToPx() }
@@ -101,6 +103,16 @@ fun DmMessageContextMenu(
                             detectTapGestures { /* consume */ }
                         },
                 ) {
+                    QuickReactionsRow(
+                        onQuickReact = {
+                            onReact(it)
+                            onDismiss()
+                        },
+                        onOpenPicker = {
+                            onOpenReactionPicker()
+                            onDismiss()
+                        },
+                    )
                     ContextMenuItem(
                         icon = Icons.Outlined.Visibility,
                         label = "View source",

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ImageViewerModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ImageViewerModal.kt
@@ -59,12 +59,23 @@ import org.nostr.nostrord.utils.supportsImageDownload
 fun ImageViewerModal(
     imageUrl: String,
     onDismiss: () -> Unit,
+    /**
+     * Plaintext of an image with no fetchable url: a NIP-17 attachment is ciphertext on the media
+     * server, so the viewer is handed the decrypted bytes and [imageUrl] serves only as identity.
+     * [fileName] and [mimeType] then describe what a download would save.
+     */
+    imageBytes: ByteArray? = null,
+    fileName: String? = null,
+    mimeType: String? = null,
 ) {
     val uriHandler = LocalUriHandler.current
     val context = LocalPlatformContext.current
-    val isAnimated = isAnimatedImageUrl(imageUrl)
-    // Inline base64 image: decode to bytes for Coil; remote URLs use the optimized URL.
-    val imageModel: Any = remember(imageUrl) { decodeDataImageUri(imageUrl) ?: getImageUrl(imageUrl) }
+    // Bytes go through Coil, which animates a GIF on Android but not on desktop/iOS; the
+    // frame-by-frame AnimatedImage path fetches by url and has nothing to fetch here.
+    val isAnimated = imageBytes == null && isAnimatedImageUrl(imageUrl)
+    // Decrypted bytes win; then an inline base64 image decoded for Coil; else the optimized URL.
+    val imageModel: Any =
+        remember(imageUrl, imageBytes) { imageBytes ?: decodeDataImageUri(imageUrl) ?: getImageUrl(imageUrl) }
 
     val scope = rememberCoroutineScope()
     val downloadImage = rememberImageDownloader()
@@ -204,8 +215,16 @@ fun ImageViewerModal(
                             isDownloading = true
                             scope.launch {
                                 try {
-                                    resolveDownloadableImage(imageUrl)?.let { (bytes, fileName, mimeType) ->
-                                        downloadImage(bytes, fileName, mimeType)
+                                    if (imageBytes != null) {
+                                        downloadImage(
+                                            imageBytes,
+                                            fileName ?: "attachment",
+                                            mimeType ?: "application/octet-stream",
+                                        )
+                                    } else {
+                                        resolveDownloadableImage(imageUrl)?.let { (bytes, name, mime) ->
+                                            downloadImage(bytes, name, mime)
+                                        }
                                     }
                                 } finally {
                                     isDownloading = false
@@ -236,8 +255,9 @@ fun ImageViewerModal(
                     }
                 }
 
-                // Inline base64 images have no external URL to open.
-                if (!isDataImageUri(imageUrl)) {
+                // Inline base64 images have no external URL to open, and an encrypted attachment's
+                // url serves ciphertext a browser cannot render.
+                if (!isDataImageUri(imageUrl) && imageBytes == null) {
                     IconButton(
                         onClick = {
                             try {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
@@ -113,6 +113,9 @@ fun MessageComposer(
     // groupName -> the mentioned group, resolved to nostr:naddr in the content by the caller.
     groupMentions: Map<String, GroupInfo> = emptyMap(),
     onGroupMentionsChange: (Map<String, GroupInfo>) -> Unit = {},
+    // Set by callers that own the upload themselves (DMs encrypt the bytes first). Picked and
+    // pasted files are handed over raw instead of being uploaded and appended as a url.
+    onFilePicked: ((ByteArray, String) -> Unit)? = null,
 ) {
     var showEmojiPicker by remember { mutableStateOf(false) }
     var isUploadingPaste by remember { mutableStateOf(false) }
@@ -183,6 +186,11 @@ fun MessageComposer(
             pasteError = "This file is too large. The maximum upload size is 20 MB."
             return
         }
+        if (onFilePicked != null) {
+            isUploadingPaste = false
+            onFilePicked(bytes, filename)
+            return
+        }
         try {
             val mime = mimeTypeForFilename(filename)
             when (val result = uploadMedia(bytes, filename, mime)) {
@@ -228,6 +236,7 @@ fun MessageComposer(
                 MessageUploadButton(
                     externalBusy = isUploadingPaste,
                     onUploadComplete = { uploadResult -> appendUploadedUrl(uploadResult.url) },
+                    onFilePicked = onFilePicked,
                 )
             }
             val emojiButton: @Composable () -> Unit = {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.outlined.EmojiEmotions
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
@@ -116,6 +117,10 @@ fun MessageComposer(
     // Set by callers that own the upload themselves (DMs encrypt the bytes first). Picked and
     // pasted files are handed over raw instead of being uploaded and appended as a url.
     onFilePicked: ((ByteArray, String) -> Unit)? = null,
+    // Message being replied to. Non-null shows its quote above the input with a way out.
+    replyAuthorName: String? = null,
+    replySnippet: String? = null,
+    onCancelReply: (() -> Unit)? = null,
 ) {
     var showEmojiPicker by remember { mutableStateOf(false) }
     var isUploadingPaste by remember { mutableStateOf(false) }
@@ -222,6 +227,28 @@ fun MessageComposer(
                     onGroupSelect = { selectGroup(it) },
                     modifier = Modifier.fillMaxWidth(),
                 )
+            }
+        }
+        if (replyAuthorName != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(bottom = Spacing.xs),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                ReplyQuote(
+                    authorName = replyAuthorName,
+                    snippet = replySnippet.orEmpty(),
+                    modifier = Modifier.weight(1f),
+                )
+                onCancelReply?.let { cancel ->
+                    IconButton(onClick = cancel, modifier = Modifier.size(32.dp)) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Cancel reply",
+                            tint = NostrordColors.TextMuted,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    }
+                }
             }
         }
         Box(modifier = Modifier.fillMaxWidth()) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -1165,9 +1165,10 @@ private fun SafeEmojiImage(
  * Wraps inline chat media with the Settings > Media "auto-load" gate. When
  * [autoLoad] is true (default) [content] renders immediately; when off, a
  * tap-to-load placeholder is shown until the user reveals this single item.
+ * [content] is not composed until then, so a gated item fetches nothing.
  */
 @Composable
-private fun GatedMedia(
+internal fun GatedMedia(
     autoLoad: Boolean,
     label: String,
     content: @Composable () -> Unit,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -336,7 +336,9 @@ fun MessageContent(
                 if (group.size == 1 && isBlockPart(firstPart!!)) {
                     when (firstPart) {
                         is ImagePart -> {
-                            Spacer(modifier = Modifier.height(8.dp))
+                            // 4dp above and nothing below: the web's `.msg-image { margin-top: 4px }`,
+                            // whose own bottom spacing comes from whatever follows it.
+                            Spacer(modifier = Modifier.height(4.dp))
                             GatedMedia(
                                 autoLoad = autoLoadMedia,
                                 label = "image",
@@ -347,7 +349,6 @@ fun MessageContent(
                                     onClick = { selectedImageUrl = firstPart.url },
                                 )
                             }
-                            Spacer(modifier = Modifier.height(4.dp))
                         }
                         is CodeBlockPart -> {
                             Spacer(modifier = Modifier.height(8.dp))
@@ -1235,6 +1236,10 @@ private fun ChatImage(
     modifier: Modifier = Modifier,
 ) {
     var showError by remember(imageUrl) { mutableStateOf(false) }
+    // The decoded size, once known. It stands in for a missing imeta hint: without either, the
+    // slot keeps its square placeholder floor, and a wide, short image sits letterboxed in it
+    // with the bubble padded out around the empty space. Mirrors the web reading naturalWidth.
+    var decodedSize by remember(imageUrl) { mutableStateOf<Pair<Int, Int>?>(null) }
 
     if (showError) {
         Text(
@@ -1251,17 +1256,20 @@ private fun ChatImage(
     // of filling the column. When NIP-68 dimensions are known we also fix the
     // aspect ratio so the slot is reserved before the load resolves; portrait
     // images match the height cap first, landscape the width cap.
+    val slotSize = dimensions ?: decodedSize
     val sizeModifier =
-        if (dimensions != null) {
-            val (w, h) = dimensions
+        if (slotSize != null) {
+            val (w, h) = slotSize
             val ratio = w.toFloat() / h.toFloat()
             Modifier
                 .widthIn(max = INLINE_MEDIA_MAX_WIDTH.dp)
                 .heightIn(max = INLINE_MEDIA_MAX_HEIGHT.dp)
                 .aspectRatio(ratio, matchHeightConstraintsFirst = ratio < 1f)
         } else {
-            // No imeta hint: floor the slot so the loading skeleton is visible and the row
-            // doesn't grow from nothing when the bitmap resolves.
+            // Size unknown so far: floor the slot so the loading skeleton is visible and the row
+            // doesn't grow from nothing when the bitmap resolves. Dropped the moment the decode
+            // reports a real size, which is what keeps a wide image from sitting letterboxed in a
+            // square box with the bubble padded out around it.
             Modifier
                 .widthIn(max = INLINE_MEDIA_MAX_WIDTH.dp)
                 .heightIn(max = INLINE_MEDIA_MAX_HEIGHT.dp)
@@ -1280,6 +1288,7 @@ private fun ChatImage(
         )
     } else {
         StaticImage(
+            onIntrinsicSize = { w, h -> if (w > 0 && h > 0) decodedSize = w to h },
             url = imageUrl,
             modifier =
             modifier

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContextMenu.kt
@@ -541,7 +541,7 @@ private fun ContextMenuContent(
  * `.ctx-reactions` row.
  */
 @Composable
-private fun QuickReactionsRow(
+internal fun QuickReactionsRow(
     onQuickReact: (String) -> Unit,
     onOpenPicker: () -> Unit,
 ) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt
@@ -189,9 +189,30 @@ fun ReplyPreview(
                 .replace('\n', ' ')
         }
 
-    ReplyPreviewContainer(
+    ReplyQuote(
+        authorName = authorName,
+        snippet = processedContent,
         onClick = onReplyClick,
         onLongClick = onReplyLongClick,
+        modifier = modifier,
+    )
+}
+
+/**
+ * The quote box itself, over already-resolved strings. Callers that hold something other than a
+ * group message (a DM being replied to, say) render through this rather than restating the box.
+ */
+@Composable
+fun ReplyQuote(
+    authorName: String,
+    snippet: String,
+    onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    ReplyPreviewContainer(
+        onClick = onClick,
+        onLongClick = onLongClick,
         modifier = modifier,
     ) {
         Text(
@@ -206,7 +227,7 @@ fun ReplyPreview(
         Spacer(modifier = Modifier.height(2.dp))
 
         Text(
-            text = processedContent.take(100),
+            text = snippet.take(100),
             color = NostrordColors.TextSecondary,
             style = NostrordTypography.Caption,
             maxLines = 1,

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/StaticImage.kt
@@ -24,6 +24,8 @@ import org.nostr.nostrord.ui.image.ImageBackdrop
  * [contentScale] How to scale the image within its bounds.
  * [onClick]      Invoked when the user taps/clicks the image.
  * [onError]      Invoked if the image fails to load (so the caller can show a fallback).
+ * [onIntrinsicSize] Reports the decoded pixel size, which stands in for a missing NIP-68 `imeta`
+ *                 hint so the slot can take the image's real shape instead of the square floor.
  */
 @Composable
 expect fun StaticImage(
@@ -32,6 +34,7 @@ expect fun StaticImage(
     contentScale: ContentScale = ContentScale.Fit,
     onClick: () -> Unit = {},
     onError: () -> Unit = {},
+    onIntrinsicSize: (width: Int, height: Int) -> Unit = { _, _ -> },
 )
 
 /**

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
@@ -28,6 +28,10 @@ import org.nostr.nostrord.utils.Result
  * Attach/upload button for the message input row.
  * Picks a file, uploads to nostr.build, and returns the full upload result
  * (URL + NIP-68 metadata) so the caller can build imeta tags.
+ *
+ * [onFilePicked] takes the picked bytes instead, leaving the upload to the caller. DMs use it:
+ * their attachments are encrypted before they reach a media server, so the plain upload here
+ * would defeat the point.
  */
 @Composable
 fun MessageUploadButton(
@@ -36,6 +40,7 @@ fun MessageUploadButton(
     // Upload owned by the caller (paste / drag-and-drop) that doesn't go through
     // this button's picker. When true, the spinner shows here on the attach icon.
     externalBusy: Boolean = false,
+    onFilePicked: ((ByteArray, String) -> Unit)? = null,
 ) {
     val scope = rememberCoroutineScope()
     var isUploading by remember { mutableStateOf(false) }
@@ -54,6 +59,11 @@ fun MessageUploadButton(
                 uploadError = it
             },
         ) { bytes, filename ->
+            if (onFilePicked != null) {
+                isUploading = false
+                onFilePicked(bytes, filename)
+                return@rememberMediaPickerLauncher
+            }
             scope.launch {
                 try {
                     val mime = mimeTypeForFilename(filename)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -52,6 +52,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.network.managers.previewText
 import org.nostr.nostrord.network.upload.mimeTypeForFilename
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
@@ -64,6 +67,7 @@ import org.nostr.nostrord.ui.components.chat.GroupInviteCard
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.chat.MessageContent
 import org.nostr.nostrord.ui.components.chat.ReactionBadges
+import org.nostr.nostrord.ui.components.chat.ReplyQuote
 import org.nostr.nostrord.ui.components.chat.SendStateIcon
 import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
 import org.nostr.nostrord.ui.components.emoji.EmojiPicker
@@ -166,6 +170,8 @@ fun DmPageScreen(
         // Message the emoji picker was opened for; null while it is closed.
         var reactingTo by remember { mutableStateOf<String?>(null) }
         var uploadError by remember { mutableStateOf<String?>(null) }
+        // Message being replied to; the composer shows its quote until it is sent or cancelled.
+        var replyingTo by remember { mutableStateOf<String?>(null) }
         // Resolve where this peer reads before the first message is written, not after their reply.
         LaunchedEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -197,6 +203,9 @@ fun DmPageScreen(
             if (pinnedToBottom.value) messagesScroll.scrollTo(messagesScroll.maxValue)
         }
 
+        // The message the composer is answering, if it is still in the thread.
+        val replyParent = messages.firstOrNull { it.id == replyingTo }
+
         val send = {
             val body = textFieldValue.text.trim()
             if (body.isNotBlank() && !isSending) {
@@ -204,8 +213,10 @@ fun DmPageScreen(
                 dmVm.send(
                     pubkey,
                     body,
+                    replyToId = replyParent?.id,
                     onSuccess = {
                         textFieldValue = TextFieldValue("")
+                        replyingTo = null
                         isSending = false
                     },
                     onFailure = { isSending = false },
@@ -400,6 +411,7 @@ fun DmPageScreen(
                                 onCopyText = { copyToClipboard(m.content) },
                                 onReact = { dmVm.react(pubkey, m.id, it) },
                                 onOpenReactionPicker = { reactingTo = m.id },
+                                onReply = { replyingTo = m.id },
                             )
                             // Web parity (.dm-bubble max-width 75%): the spacer eats the other
                             // 25% on the bubble's growth side; the Box owns the 75% slot and
@@ -416,6 +428,15 @@ fun DmPageScreen(
                                     Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
                                         // A group naddr on its own line renders as the prototype
                                         // invite card (text above, card + View group button below).
+                                        // Quote of the message this one answers, above its body.
+                                        m.replyToId?.let { parentId ->
+                                            val parent = messages.firstOrNull { it.id == parentId }
+                                            ReplyQuote(
+                                                authorName = replyAuthorName(parent, userMetadata, name, myPubkey),
+                                                snippet = parent?.previewText() ?: "Message not loaded",
+                                                modifier = Modifier.padding(bottom = Spacing.xxs),
+                                            )
+                                        }
                                         val attachment = m.file
                                         val invite = remember(m.content) { extractDmGroupInvite(m.content) }
                                         val body = if (attachment != null) "" else invite?.remainingText ?: m.content
@@ -490,6 +511,9 @@ fun DmPageScreen(
             placeholder = "Message $name",
             isSending = isSending,
             modifier = Modifier.padding(horizontal = Spacing.lg).padding(bottom = Spacing.xl, top = Spacing.xs),
+            replyAuthorName = replyParent?.let { replyAuthorName(it, userMetadata, name, myPubkey) },
+            replySnippet = replyParent?.previewText(),
+            onCancelReply = { replyingTo = null },
             // A DM attachment is encrypted before it reaches a media server, so the picked bytes
             // go out as a kind:15 message instead of being uploaded and pasted as a url.
             onFilePicked = { bytes, filename ->
@@ -538,4 +562,22 @@ fun DmPageScreen(
             }
         }
     }
+}
+
+/**
+ * Name to show on a reply quote. The peer's own name is already in the header, so an unknown
+ * parent falls back to it rather than to a raw npub.
+ */
+private fun replyAuthorName(
+    parent: DmMessage?,
+    metadata: Map<String, UserMetadata>,
+    peerName: String,
+    myPubkey: String?,
+): String = when {
+    parent == null -> peerName
+    parent.senderPubkey == myPubkey -> "You"
+    else ->
+        metadata[parent.senderPubkey]?.displayName
+            ?: metadata[parent.senderPubkey]?.name
+            ?: peerName
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.ui.screens.dm
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -51,6 +52,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.upload.mimeTypeForFilename
+import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.chat.DateSeparator
 import org.nostr.nostrord.ui.components.chat.DmAttachment
@@ -60,8 +63,10 @@ import org.nostr.nostrord.ui.components.chat.DmRelaysDialog
 import org.nostr.nostrord.ui.components.chat.GroupInviteCard
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.chat.MessageContent
+import org.nostr.nostrord.ui.components.chat.ReactionBadges
 import org.nostr.nostrord.ui.components.chat.SendStateIcon
 import org.nostr.nostrord.ui.components.chat.rightClickContextMenuModifier
+import org.nostr.nostrord.ui.components.emoji.EmojiPicker
 import org.nostr.nostrord.ui.components.layout.DmConversationList
 import org.nostr.nostrord.ui.components.layout.FrameMenuButton
 import org.nostr.nostrord.ui.components.layout.PageHeader
@@ -155,6 +160,12 @@ fun DmPageScreen(
         val messages = messagesByPeer[pubkey].orEmpty()
         val dmStatus by dmVm.messageStatus.collectAsState()
         val dmFiles by dmVm.fileStates.collectAsState()
+        val dmReactions by dmVm.reactions.collectAsState()
+        val userMetadata by dmVm.userMetadata.collectAsState()
+        val myPubkey = remember { dmVm.getPublicKey() }
+        // Message the emoji picker was opened for; null while it is closed.
+        var reactingTo by remember { mutableStateOf<String?>(null) }
+        var uploadError by remember { mutableStateOf<String?>(null) }
         // Resolve where this peer reads before the first message is written, not after their reply.
         LaunchedEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -387,6 +398,8 @@ fun DmPageScreen(
                                 onDismiss = { menuForId = null },
                                 onViewSource = { sourceForId = m.id },
                                 onCopyText = { copyToClipboard(m.content) },
+                                onReact = { dmVm.react(pubkey, m.id, it) },
+                                onOpenReactionPicker = { reactingTo = m.id },
                             )
                             // Web parity (.dm-bubble max-width 75%): the spacer eats the other
                             // 25% on the bubble's growth side; the Box owns the 75% slot and
@@ -449,6 +462,17 @@ fun DmPageScreen(
                                                 }
                                             }
                                         }
+                                        // Reactions sit inside the bubble so they follow its edge,
+                                        // the way the group chat hangs them under a message.
+                                        dmReactions[m.id]?.let { byEmoji ->
+                                            ReactionBadges(
+                                                reactions = byEmoji,
+                                                currentUserPubkey = myPubkey,
+                                                resolveMetadata = { userMetadata[it] },
+                                                onReactionClick = { emoji -> dmVm.react(pubkey, m.id, emoji) },
+                                                modifier = Modifier.padding(top = Spacing.xxs),
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -466,6 +490,52 @@ fun DmPageScreen(
             placeholder = "Message $name",
             isSending = isSending,
             modifier = Modifier.padding(horizontal = Spacing.lg).padding(bottom = Spacing.xl, top = Spacing.xs),
+            // A DM attachment is encrypted before it reaches a media server, so the picked bytes
+            // go out as a kind:15 message instead of being uploaded and pasted as a url.
+            onFilePicked = { bytes, filename ->
+                dmVm.sendFile(
+                    recipientPubkey = pubkey,
+                    bytes = bytes,
+                    filename = filename,
+                    mimeType = mimeTypeForFilename(filename),
+                    onFailure = { uploadError = it },
+                )
+            },
         )
+
+        uploadError?.let { error ->
+            ConfirmDialog(
+                title = "Could not send the file",
+                message = error,
+                confirmLabel = "OK",
+                cancelLabel = null,
+                onConfirm = { uploadError = null },
+                onDismiss = { uploadError = null },
+            )
+        }
+
+        // Full emoji picker for a reaction, opened from a bubble's context menu. Tapping the
+        // scrim closes it, same as the group chat's.
+        if (reactingTo != null) {
+            Box(
+                modifier =
+                Modifier
+                    .fillMaxSize()
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = { reactingTo = null },
+                    ),
+            ) {
+                EmojiPicker(
+                    onEmojiSelect = { emoji ->
+                        reactingTo?.let { dmVm.react(pubkey, it, emoji) }
+                        reactingTo = null
+                    },
+                    onDismiss = { reactingTo = null },
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
+        }
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -68,6 +69,9 @@ import org.nostr.nostrord.ui.components.chat.DmEventSourceDialog
 import org.nostr.nostrord.ui.components.chat.DmMessageContextMenu
 import org.nostr.nostrord.ui.components.chat.DmRelaysDialog
 import org.nostr.nostrord.ui.components.chat.GroupInviteCard
+import org.nostr.nostrord.ui.components.chat.ImageViewerModal
+import org.nostr.nostrord.ui.components.chat.LocalAnimatedImageHidden
+import org.nostr.nostrord.ui.components.chat.LocalImageViewerUrl
 import org.nostr.nostrord.ui.components.chat.MessageComposer
 import org.nostr.nostrord.ui.components.chat.MessageContent
 import org.nostr.nostrord.ui.components.chat.ReactionBadges
@@ -205,6 +209,11 @@ fun DmPageScreen(
                 pinnedToBottom.value = messagesScroll.value >= messagesScroll.maxValue - 40
             }
         }
+        // Inline images in a message body report their tap through LocalImageViewerUrl. Its default
+        // is a throwaway state nobody reads, so a screen that renders message bodies has to provide
+        // one and show the viewer, or every tap on an image is silently dropped.
+        val imageViewerUrl = remember { mutableStateOf<String?>(null) }
+
         // Messages FROM THE PEER that landed while the reader stayed up in the history. Reported
         // on the jump pill so going back down is their decision with the count in hand. Own
         // messages are never counted: the reader wrote them, and writing already returns the view
@@ -378,194 +387,206 @@ fun DmPageScreen(
         HorizontalDivider(color = NostrordColors.Divider)
 
         Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
-            Column(
-                modifier = Modifier.fillMaxSize().verticalScroll(messagesScroll).padding(Spacing.lg),
-                horizontalAlignment = Alignment.CenterHorizontally,
+            CompositionLocalProvider(
+                LocalAnimatedImageHidden provides (imageViewerUrl.value != null),
+                LocalImageViewerUrl provides imageViewerUrl,
             ) {
-                // Avatar + name open the peer's profile, like the header peer button.
-                OptimizedSmallAvatar(
-                    imageUrl = metadata?.picture,
-                    identifier = pubkey,
-                    displayName = name,
-                    size = 64.dp,
-                    shape = CircleShape,
-                    modifier = Modifier.clip(CircleShape).clickable { onOpenProfile(UserRoute(pubkey)) },
-                )
-                Spacer(modifier = Modifier.height(Spacing.sm))
-                Text(
-                    name,
-                    color = NostrordColors.TextPrimary,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Bold,
-                    modifier =
-                    Modifier
-                        .clip(NostrordShapes.shapeSmall)
-                        .clickable { onOpenProfile(UserRoute(pubkey)) }
-                        .padding(horizontal = Spacing.xs, vertical = Spacing.xxs),
-                )
-                Text(
-                    "Beginning of your direct conversation with $name. Direct messages are encrypted (NIP-17).",
-                    color = NostrordColors.TextMuted,
-                    fontSize = 13.sp,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.widthIn(max = 320.dp),
-                )
-                // Sitting above the thread, so older messages landing in are expected rather than
-                // startling. Sending stays available: no client can promise it holds every message.
-                if (syncing) {
-                    Row(
-                        modifier = Modifier.padding(vertical = Spacing.xs),
-                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(12.dp),
-                            color = NostrordColors.TextMuted,
-                            strokeWidth = 1.5.dp,
-                        )
-                        Text(
-                            "Catching up on older messages",
-                            color = NostrordColors.TextMuted,
-                            fontSize = 12.sp,
+                Column(
+                    modifier = Modifier.fillMaxSize().verticalScroll(messagesScroll).padding(Spacing.lg),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    // Avatar + name open the peer's profile, like the header peer button.
+                    OptimizedSmallAvatar(
+                        imageUrl = metadata?.picture,
+                        identifier = pubkey,
+                        displayName = name,
+                        size = 64.dp,
+                        shape = CircleShape,
+                        modifier = Modifier.clip(CircleShape).clickable { onOpenProfile(UserRoute(pubkey)) },
+                    )
+                    Spacer(modifier = Modifier.height(Spacing.sm))
+                    Text(
+                        name,
+                        color = NostrordColors.TextPrimary,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier =
+                        Modifier
+                            .clip(NostrordShapes.shapeSmall)
+                            .clickable { onOpenProfile(UserRoute(pubkey)) }
+                            .padding(horizontal = Spacing.xs, vertical = Spacing.xxs),
+                    )
+                    Text(
+                        "Beginning of your direct conversation with $name. Direct messages are encrypted (NIP-17).",
+                        color = NostrordColors.TextMuted,
+                        fontSize = 13.sp,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.widthIn(max = 320.dp),
+                    )
+                    // Sitting above the thread, so older messages landing in are expected rather than
+                    // startling. Sending stays available: no client can promise it holds every message.
+                    if (syncing) {
+                        Row(
+                            modifier = Modifier.padding(vertical = Spacing.xs),
+                            horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(12.dp),
+                                color = NostrordColors.TextMuted,
+                                strokeWidth = 1.5.dp,
+                            )
+                            Text(
+                                "Catching up on older messages",
+                                color = NostrordColors.TextMuted,
+                                fontSize = 12.sp,
+                            )
+                        }
+                    }
+                    val chatItems = remember(messages) { buildDmChatItems(messages) }
+                    var menuForId by remember { mutableStateOf<String?>(null) }
+                    var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
+                    var sourceForId by remember { mutableStateOf<String?>(null) }
+                    messages.firstOrNull { it.id == sourceForId }?.let { src ->
+                        DmEventSourceDialog(
+                            json = src.prettyEventJson(),
+                            relays = src.relays,
+                            onCopyJson = { copyToClipboard(src.eventJson()) },
+                            onDismiss = { sourceForId = null },
                         )
                     }
-                }
-                val chatItems = remember(messages) { buildDmChatItems(messages) }
-                var menuForId by remember { mutableStateOf<String?>(null) }
-                var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
-                var sourceForId by remember { mutableStateOf<String?>(null) }
-                messages.firstOrNull { it.id == sourceForId }?.let { src ->
-                    DmEventSourceDialog(
-                        json = src.prettyEventJson(),
-                        relays = src.relays,
-                        onCopyJson = { copyToClipboard(src.eventJson()) },
-                        onDismiss = { sourceForId = null },
-                    )
-                }
-                chatItems.forEach { item ->
-                    when (item) {
-                        is DmChatItem.DateSeparator -> DateSeparator(item.label)
-                        is DmChatItem.Message -> {
-                            val m = item.message
-                            // WhatsApp/Telegram-style: a small clock inside every bubble,
-                            // bottom-right under the text.
-                            Row(
-                                modifier =
-                                Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs)
-                                    // Tap (mobile) / right-click (desktop) opens the context menu
-                                    // at the pointer, same interaction as group chat rows.
-                                    .then(
-                                        rightClickContextMenuModifier { clickOffset ->
-                                            menuAnchorPx = clickOffset
-                                            menuForId = m.id
-                                        },
-                                    ),
-                                verticalAlignment = Alignment.Bottom,
-                            ) {
-                                DmMessageContextMenu(
-                                    visible = menuForId == m.id,
-                                    anchorOffsetPx = menuAnchorPx,
-                                    onDismiss = { menuForId = null },
-                                    onViewSource = { sourceForId = m.id },
-                                    onCopyText = { copyToClipboard(m.content) },
-                                    onReact = { dmVm.react(pubkey, m.id, it) },
-                                    onOpenReactionPicker = { reactingTo = m.id },
-                                    onReply = { replyingTo = m.id },
-                                )
-                                // Web parity (.dm-bubble max-width 75%): the spacer eats the other
-                                // 25% on the bubble's growth side; the Box owns the 75% slot and
-                                // pins the bubble to the correct edge inside it.
-                                if (m.mine) Spacer(modifier = Modifier.weight(0.25f))
-                                Box(
-                                    modifier = Modifier.weight(0.75f),
-                                    contentAlignment = if (m.mine) Alignment.BottomEnd else Alignment.BottomStart,
+                    chatItems.forEach { item ->
+                        when (item) {
+                            is DmChatItem.DateSeparator -> DateSeparator(item.label)
+                            is DmChatItem.Message -> {
+                                val m = item.message
+                                // WhatsApp/Telegram-style: a small clock inside every bubble,
+                                // bottom-right under the text.
+                                Row(
+                                    modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs)
+                                        // Tap (mobile) / right-click (desktop) opens the context menu
+                                        // at the pointer, same interaction as group chat rows.
+                                        .then(
+                                            rightClickContextMenuModifier { clickOffset ->
+                                                menuAnchorPx = clickOffset
+                                                menuForId = m.id
+                                            },
+                                        ),
+                                    verticalAlignment = Alignment.Bottom,
                                 ) {
-                                    Surface(
-                                        shape = NostrordShapes.shapeMedium,
-                                        color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
+                                    DmMessageContextMenu(
+                                        visible = menuForId == m.id,
+                                        anchorOffsetPx = menuAnchorPx,
+                                        onDismiss = { menuForId = null },
+                                        onViewSource = { sourceForId = m.id },
+                                        onCopyText = { copyToClipboard(m.content) },
+                                        onReact = { dmVm.react(pubkey, m.id, it) },
+                                        onOpenReactionPicker = { reactingTo = m.id },
+                                        onReply = { replyingTo = m.id },
+                                    )
+                                    // Web parity (.dm-bubble max-width 75%): the spacer eats the other
+                                    // 25% on the bubble's growth side; the Box owns the 75% slot and
+                                    // pins the bubble to the correct edge inside it.
+                                    if (m.mine) Spacer(modifier = Modifier.weight(0.25f))
+                                    Box(
+                                        modifier = Modifier.weight(0.75f),
+                                        contentAlignment = if (m.mine) Alignment.BottomEnd else Alignment.BottomStart,
                                     ) {
-                                        Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
-                                            // A group naddr on its own line renders as the prototype
-                                            // invite card (text above, card + View group button below).
-                                            // Quote of the message this one answers, above its body.
-                                            m.replyToId?.let { parentId ->
-                                                val parent = messages.firstOrNull { it.id == parentId }
-                                                ReplyQuote(
-                                                    authorName = replyAuthorName(parent, userMetadata, name, myPubkey),
-                                                    snippet = parent?.previewText() ?: "Message not loaded",
-                                                    modifier = Modifier.padding(bottom = Spacing.xxs),
-                                                )
-                                            }
-                                            val attachment = m.file
-                                            val invite = remember(m.content) { extractDmGroupInvite(m.content) }
-                                            val body = if (attachment != null) "" else invite?.remainingText ?: m.content
-                                            if (attachment != null) {
-                                                DmAttachment(
-                                                    file = attachment,
-                                                    state = dmFiles[m.id],
-                                                    onLoad = { dmVm.loadFile(m) },
-                                                    onRetry = { dmVm.retryFile(m) },
-                                                    onImage = m.mine,
-                                                )
-                                            }
-                                            if (body.isNotBlank()) {
-                                                // Rich body: inline images/video/audio/links/mentions/markdown,
-                                                // reusing the group chat renderer. White text on the "mine" bubble.
-                                                MessageContent(
-                                                    content = body,
-                                                    // The rumor's own tags: custom emoji and the imeta
-                                                    // hints that pre-size an inline image, same as chat.
-                                                    tags = m.tags,
-                                                    onMentionClick = { onOpenProfile(UserRoute(it)) },
-                                                    textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
-                                                )
-                                            }
-                                            if (invite != null) {
-                                                GroupInviteCard(
-                                                    groupId = invite.groupId,
-                                                    relayUrl = invite.relayUrl,
-                                                    onOpen = { onOpenGroup(invite.relayUrl, invite.groupId) },
-                                                    modifier = Modifier.padding(vertical = Spacing.xxs),
-                                                )
-                                            }
-                                            // Time + send-state (clock while Sending, check once Delivered),
-                                            // reusing the group chat's SendStateIcon on own messages.
-                                            Row(
-                                                modifier = Modifier.align(Alignment.End).padding(top = Spacing.xxs),
-                                                verticalAlignment = Alignment.CenterVertically,
-                                            ) {
-                                                Text(
-                                                    formatTime(m.createdAt),
-                                                    color = if (m.mine) Color.White.copy(alpha = 0.7f) else NostrordColors.TextMuted,
-                                                    fontSize = 10.sp,
-                                                )
-                                                if (m.mine) {
-                                                    dmStatus[m.id]?.let { st ->
-                                                        SendStateIcon(status = st, tint = Color.White.copy(alpha = 0.7f))
+                                        Surface(
+                                            shape = NostrordShapes.shapeMedium,
+                                            color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
+                                        ) {
+                                            Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
+                                                // A group naddr on its own line renders as the prototype
+                                                // invite card (text above, card + View group button below).
+                                                // Quote of the message this one answers, above its body.
+                                                m.replyToId?.let { parentId ->
+                                                    val parent = messages.firstOrNull { it.id == parentId }
+                                                    ReplyQuote(
+                                                        authorName = replyAuthorName(parent, userMetadata, name, myPubkey),
+                                                        snippet = parent?.previewText() ?: "Message not loaded",
+                                                        modifier = Modifier.padding(bottom = Spacing.xxs),
+                                                    )
+                                                }
+                                                val attachment = m.file
+                                                val invite = remember(m.content) { extractDmGroupInvite(m.content) }
+                                                val body = if (attachment != null) "" else invite?.remainingText ?: m.content
+                                                if (attachment != null) {
+                                                    DmAttachment(
+                                                        file = attachment,
+                                                        state = dmFiles[m.id],
+                                                        onLoad = { dmVm.loadFile(m) },
+                                                        onRetry = { dmVm.retryFile(m) },
+                                                        onImage = m.mine,
+                                                    )
+                                                }
+                                                if (body.isNotBlank()) {
+                                                    // Rich body: inline images/video/audio/links/mentions/markdown,
+                                                    // reusing the group chat renderer. White text on the "mine" bubble.
+                                                    MessageContent(
+                                                        content = body,
+                                                        // The rumor's own tags: custom emoji and the imeta
+                                                        // hints that pre-size an inline image, same as chat.
+                                                        tags = m.tags,
+                                                        onMentionClick = { onOpenProfile(UserRoute(it)) },
+                                                        textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
+                                                    )
+                                                }
+                                                if (invite != null) {
+                                                    GroupInviteCard(
+                                                        groupId = invite.groupId,
+                                                        relayUrl = invite.relayUrl,
+                                                        onOpen = { onOpenGroup(invite.relayUrl, invite.groupId) },
+                                                        modifier = Modifier.padding(vertical = Spacing.xxs),
+                                                    )
+                                                }
+                                                // Time + send-state (clock while Sending, check once Delivered),
+                                                // reusing the group chat's SendStateIcon on own messages.
+                                                Row(
+                                                    modifier = Modifier.align(Alignment.End).padding(top = Spacing.xxs),
+                                                    verticalAlignment = Alignment.CenterVertically,
+                                                ) {
+                                                    Text(
+                                                        formatTime(m.createdAt),
+                                                        color = if (m.mine) Color.White.copy(alpha = 0.7f) else NostrordColors.TextMuted,
+                                                        fontSize = 10.sp,
+                                                    )
+                                                    if (m.mine) {
+                                                        dmStatus[m.id]?.let { st ->
+                                                            SendStateIcon(status = st, tint = Color.White.copy(alpha = 0.7f))
+                                                        }
                                                     }
                                                 }
-                                            }
-                                            // Reactions sit inside the bubble so they follow its edge,
-                                            // the way the group chat hangs them under a message.
-                                            dmReactions[m.id]?.let { byEmoji ->
-                                                ReactionBadges(
-                                                    reactions = byEmoji,
-                                                    currentUserPubkey = myPubkey,
-                                                    resolveMetadata = { userMetadata[it] },
-                                                    onReactionClick = { emoji -> dmVm.react(pubkey, m.id, emoji) },
-                                                    modifier = Modifier.padding(top = Spacing.xxs),
-                                                )
+                                                // Reactions sit inside the bubble so they follow its edge,
+                                                // the way the group chat hangs them under a message.
+                                                dmReactions[m.id]?.let { byEmoji ->
+                                                    ReactionBadges(
+                                                        reactions = byEmoji,
+                                                        currentUserPubkey = myPubkey,
+                                                        resolveMetadata = { userMetadata[it] },
+                                                        onReactionClick = { emoji -> dmVm.react(pubkey, m.id, emoji) },
+                                                        modifier = Modifier.padding(top = Spacing.xxs),
+                                                    )
+                                                }
                                             }
                                         }
                                     }
+                                    if (!m.mine) Spacer(modifier = Modifier.weight(0.25f))
                                 }
-                                if (!m.mine) Spacer(modifier = Modifier.weight(0.25f))
                             }
                         }
                     }
                 }
+            } // CompositionLocalProvider
+
+            imageViewerUrl.value?.let { url ->
+                ImageViewerModal(
+                    imageUrl = url,
+                    onDismiss = { imageViewerUrl.value = null },
+                )
             }
 
             // Returning to the newest message is a tap, never something the feed does on its own.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -53,6 +53,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.chat.DateSeparator
+import org.nostr.nostrord.ui.components.chat.DmAttachment
 import org.nostr.nostrord.ui.components.chat.DmEventSourceDialog
 import org.nostr.nostrord.ui.components.chat.DmMessageContextMenu
 import org.nostr.nostrord.ui.components.chat.DmRelaysDialog
@@ -153,6 +154,7 @@ fun DmPageScreen(
         val messagesByPeer by dmVm.messagesByPeer.collectAsState()
         val messages = messagesByPeer[pubkey].orEmpty()
         val dmStatus by dmVm.messageStatus.collectAsState()
+        val dmFiles by dmVm.fileStates.collectAsState()
         // Resolve where this peer reads before the first message is written, not after their reply.
         LaunchedEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -401,8 +403,18 @@ fun DmPageScreen(
                                     Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
                                         // A group naddr on its own line renders as the prototype
                                         // invite card (text above, card + View group button below).
+                                        val attachment = m.file
                                         val invite = remember(m.content) { extractDmGroupInvite(m.content) }
-                                        val body = invite?.remainingText ?: m.content
+                                        val body = if (attachment != null) "" else invite?.remainingText ?: m.content
+                                        if (attachment != null) {
+                                            DmAttachment(
+                                                file = attachment,
+                                                state = dmFiles[m.id],
+                                                onLoad = { dmVm.loadFile(m) },
+                                                onRetry = { dmVm.retryFile(m) },
+                                                onImage = m.mine,
+                                            )
+                                        }
                                         if (body.isNotBlank()) {
                                             // Rich body: inline images/video/audio/links/mentions/markdown,
                                             // reusing the group chat renderer. White text on the "mine" bubble.

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.Mail
 import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.MoreVert
@@ -39,6 +40,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,6 +54,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.DmMessage
@@ -186,6 +189,7 @@ fun DmPageScreen(
 
         // Open a conversation pinned to the latest message (scroll to the bottom), like a chat.
         val messagesScroll = rememberScrollState()
+        val scrollScope = rememberCoroutineScope()
         // True while the user rests at the bottom; drives whether async media growth keeps the view
         // pinned. Recomputed only when a scroll gesture settles, so programmatic follow-scrolls (and
         // the moment media grows maxValue) don't flip it off.
@@ -200,6 +204,16 @@ fun DmPageScreen(
             if (!messagesScroll.isScrollInProgress) {
                 pinnedToBottom.value = messagesScroll.value >= messagesScroll.maxValue - 40
             }
+        }
+        // Messages FROM THE PEER that landed while the reader stayed up in the history. Reported
+        // on the jump pill so going back down is their decision with the count in hand. Own
+        // messages are never counted: the reader wrote them, and writing already returns the view
+        // to the bottom.
+        val peerCount = messages.count { !it.mine }
+        var seenPeerCount by remember(pubkey) { mutableStateOf(peerCount) }
+        val newWhileAway = (peerCount - seenPeerCount).coerceAtLeast(0)
+        LaunchedEffect(peerCount, pinnedToBottom.value) {
+            if (pinnedToBottom.value) seenPeerCount = peerCount
         }
         // Our own send always returns to the bottom: the reader caused this one.
         val newestOwnId = messages.lastOrNull()?.takeIf { it.mine }?.id
@@ -363,192 +377,228 @@ fun DmPageScreen(
         }
         HorizontalDivider(color = NostrordColors.Divider)
 
-        Column(
-            modifier = Modifier.weight(1f).fillMaxWidth().verticalScroll(messagesScroll).padding(Spacing.lg),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            // Avatar + name open the peer's profile, like the header peer button.
-            OptimizedSmallAvatar(
-                imageUrl = metadata?.picture,
-                identifier = pubkey,
-                displayName = name,
-                size = 64.dp,
-                shape = CircleShape,
-                modifier = Modifier.clip(CircleShape).clickable { onOpenProfile(UserRoute(pubkey)) },
-            )
-            Spacer(modifier = Modifier.height(Spacing.sm))
-            Text(
-                name,
-                color = NostrordColors.TextPrimary,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold,
-                modifier =
-                Modifier
-                    .clip(NostrordShapes.shapeSmall)
-                    .clickable { onOpenProfile(UserRoute(pubkey)) }
-                    .padding(horizontal = Spacing.xs, vertical = Spacing.xxs),
-            )
-            Text(
-                "Beginning of your direct conversation with $name. Direct messages are encrypted (NIP-17).",
-                color = NostrordColors.TextMuted,
-                fontSize = 13.sp,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.widthIn(max = 320.dp),
-            )
-            // Sitting above the thread, so older messages landing in are expected rather than
-            // startling. Sending stays available: no client can promise it holds every message.
-            if (syncing) {
-                Row(
-                    modifier = Modifier.padding(vertical = Spacing.xs),
-                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(12.dp),
-                        color = NostrordColors.TextMuted,
-                        strokeWidth = 1.5.dp,
-                    )
-                    Text(
-                        "Catching up on older messages",
-                        color = NostrordColors.TextMuted,
-                        fontSize = 12.sp,
+        Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+            Column(
+                modifier = Modifier.fillMaxSize().verticalScroll(messagesScroll).padding(Spacing.lg),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Avatar + name open the peer's profile, like the header peer button.
+                OptimizedSmallAvatar(
+                    imageUrl = metadata?.picture,
+                    identifier = pubkey,
+                    displayName = name,
+                    size = 64.dp,
+                    shape = CircleShape,
+                    modifier = Modifier.clip(CircleShape).clickable { onOpenProfile(UserRoute(pubkey)) },
+                )
+                Spacer(modifier = Modifier.height(Spacing.sm))
+                Text(
+                    name,
+                    color = NostrordColors.TextPrimary,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    modifier =
+                    Modifier
+                        .clip(NostrordShapes.shapeSmall)
+                        .clickable { onOpenProfile(UserRoute(pubkey)) }
+                        .padding(horizontal = Spacing.xs, vertical = Spacing.xxs),
+                )
+                Text(
+                    "Beginning of your direct conversation with $name. Direct messages are encrypted (NIP-17).",
+                    color = NostrordColors.TextMuted,
+                    fontSize = 13.sp,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.widthIn(max = 320.dp),
+                )
+                // Sitting above the thread, so older messages landing in are expected rather than
+                // startling. Sending stays available: no client can promise it holds every message.
+                if (syncing) {
+                    Row(
+                        modifier = Modifier.padding(vertical = Spacing.xs),
+                        horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(12.dp),
+                            color = NostrordColors.TextMuted,
+                            strokeWidth = 1.5.dp,
+                        )
+                        Text(
+                            "Catching up on older messages",
+                            color = NostrordColors.TextMuted,
+                            fontSize = 12.sp,
+                        )
+                    }
+                }
+                val chatItems = remember(messages) { buildDmChatItems(messages) }
+                var menuForId by remember { mutableStateOf<String?>(null) }
+                var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
+                var sourceForId by remember { mutableStateOf<String?>(null) }
+                messages.firstOrNull { it.id == sourceForId }?.let { src ->
+                    DmEventSourceDialog(
+                        json = src.prettyEventJson(),
+                        relays = src.relays,
+                        onCopyJson = { copyToClipboard(src.eventJson()) },
+                        onDismiss = { sourceForId = null },
                     )
                 }
-            }
-            val chatItems = remember(messages) { buildDmChatItems(messages) }
-            var menuForId by remember { mutableStateOf<String?>(null) }
-            var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
-            var sourceForId by remember { mutableStateOf<String?>(null) }
-            messages.firstOrNull { it.id == sourceForId }?.let { src ->
-                DmEventSourceDialog(
-                    json = src.prettyEventJson(),
-                    relays = src.relays,
-                    onCopyJson = { copyToClipboard(src.eventJson()) },
-                    onDismiss = { sourceForId = null },
-                )
-            }
-            chatItems.forEach { item ->
-                when (item) {
-                    is DmChatItem.DateSeparator -> DateSeparator(item.label)
-                    is DmChatItem.Message -> {
-                        val m = item.message
-                        // WhatsApp/Telegram-style: a small clock inside every bubble,
-                        // bottom-right under the text.
-                        Row(
-                            modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs)
-                                // Tap (mobile) / right-click (desktop) opens the context menu
-                                // at the pointer, same interaction as group chat rows.
-                                .then(
-                                    rightClickContextMenuModifier { clickOffset ->
-                                        menuAnchorPx = clickOffset
-                                        menuForId = m.id
-                                    },
-                                ),
-                            verticalAlignment = Alignment.Bottom,
-                        ) {
-                            DmMessageContextMenu(
-                                visible = menuForId == m.id,
-                                anchorOffsetPx = menuAnchorPx,
-                                onDismiss = { menuForId = null },
-                                onViewSource = { sourceForId = m.id },
-                                onCopyText = { copyToClipboard(m.content) },
-                                onReact = { dmVm.react(pubkey, m.id, it) },
-                                onOpenReactionPicker = { reactingTo = m.id },
-                                onReply = { replyingTo = m.id },
-                            )
-                            // Web parity (.dm-bubble max-width 75%): the spacer eats the other
-                            // 25% on the bubble's growth side; the Box owns the 75% slot and
-                            // pins the bubble to the correct edge inside it.
-                            if (m.mine) Spacer(modifier = Modifier.weight(0.25f))
-                            Box(
-                                modifier = Modifier.weight(0.75f),
-                                contentAlignment = if (m.mine) Alignment.BottomEnd else Alignment.BottomStart,
+                chatItems.forEach { item ->
+                    when (item) {
+                        is DmChatItem.DateSeparator -> DateSeparator(item.label)
+                        is DmChatItem.Message -> {
+                            val m = item.message
+                            // WhatsApp/Telegram-style: a small clock inside every bubble,
+                            // bottom-right under the text.
+                            Row(
+                                modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs)
+                                    // Tap (mobile) / right-click (desktop) opens the context menu
+                                    // at the pointer, same interaction as group chat rows.
+                                    .then(
+                                        rightClickContextMenuModifier { clickOffset ->
+                                            menuAnchorPx = clickOffset
+                                            menuForId = m.id
+                                        },
+                                    ),
+                                verticalAlignment = Alignment.Bottom,
                             ) {
-                                Surface(
-                                    shape = NostrordShapes.shapeMedium,
-                                    color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
+                                DmMessageContextMenu(
+                                    visible = menuForId == m.id,
+                                    anchorOffsetPx = menuAnchorPx,
+                                    onDismiss = { menuForId = null },
+                                    onViewSource = { sourceForId = m.id },
+                                    onCopyText = { copyToClipboard(m.content) },
+                                    onReact = { dmVm.react(pubkey, m.id, it) },
+                                    onOpenReactionPicker = { reactingTo = m.id },
+                                    onReply = { replyingTo = m.id },
+                                )
+                                // Web parity (.dm-bubble max-width 75%): the spacer eats the other
+                                // 25% on the bubble's growth side; the Box owns the 75% slot and
+                                // pins the bubble to the correct edge inside it.
+                                if (m.mine) Spacer(modifier = Modifier.weight(0.25f))
+                                Box(
+                                    modifier = Modifier.weight(0.75f),
+                                    contentAlignment = if (m.mine) Alignment.BottomEnd else Alignment.BottomStart,
                                 ) {
-                                    Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
-                                        // A group naddr on its own line renders as the prototype
-                                        // invite card (text above, card + View group button below).
-                                        // Quote of the message this one answers, above its body.
-                                        m.replyToId?.let { parentId ->
-                                            val parent = messages.firstOrNull { it.id == parentId }
-                                            ReplyQuote(
-                                                authorName = replyAuthorName(parent, userMetadata, name, myPubkey),
-                                                snippet = parent?.previewText() ?: "Message not loaded",
-                                                modifier = Modifier.padding(bottom = Spacing.xxs),
-                                            )
-                                        }
-                                        val attachment = m.file
-                                        val invite = remember(m.content) { extractDmGroupInvite(m.content) }
-                                        val body = if (attachment != null) "" else invite?.remainingText ?: m.content
-                                        if (attachment != null) {
-                                            DmAttachment(
-                                                file = attachment,
-                                                state = dmFiles[m.id],
-                                                onLoad = { dmVm.loadFile(m) },
-                                                onRetry = { dmVm.retryFile(m) },
-                                                onImage = m.mine,
-                                            )
-                                        }
-                                        if (body.isNotBlank()) {
-                                            // Rich body: inline images/video/audio/links/mentions/markdown,
-                                            // reusing the group chat renderer. White text on the "mine" bubble.
-                                            MessageContent(
-                                                content = body,
-                                                // The rumor's own tags: custom emoji and the imeta
-                                                // hints that pre-size an inline image, same as chat.
-                                                tags = m.tags,
-                                                onMentionClick = { onOpenProfile(UserRoute(it)) },
-                                                textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
-                                            )
-                                        }
-                                        if (invite != null) {
-                                            GroupInviteCard(
-                                                groupId = invite.groupId,
-                                                relayUrl = invite.relayUrl,
-                                                onOpen = { onOpenGroup(invite.relayUrl, invite.groupId) },
-                                                modifier = Modifier.padding(vertical = Spacing.xxs),
-                                            )
-                                        }
-                                        // Time + send-state (clock while Sending, check once Delivered),
-                                        // reusing the group chat's SendStateIcon on own messages.
-                                        Row(
-                                            modifier = Modifier.align(Alignment.End).padding(top = Spacing.xxs),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                        ) {
-                                            Text(
-                                                formatTime(m.createdAt),
-                                                color = if (m.mine) Color.White.copy(alpha = 0.7f) else NostrordColors.TextMuted,
-                                                fontSize = 10.sp,
-                                            )
-                                            if (m.mine) {
-                                                dmStatus[m.id]?.let { st ->
-                                                    SendStateIcon(status = st, tint = Color.White.copy(alpha = 0.7f))
+                                    Surface(
+                                        shape = NostrordShapes.shapeMedium,
+                                        color = if (m.mine) NostrordColors.Primary else NostrordColors.BackgroundFloating,
+                                    ) {
+                                        Column(modifier = Modifier.padding(horizontal = Spacing.md, vertical = Spacing.sm)) {
+                                            // A group naddr on its own line renders as the prototype
+                                            // invite card (text above, card + View group button below).
+                                            // Quote of the message this one answers, above its body.
+                                            m.replyToId?.let { parentId ->
+                                                val parent = messages.firstOrNull { it.id == parentId }
+                                                ReplyQuote(
+                                                    authorName = replyAuthorName(parent, userMetadata, name, myPubkey),
+                                                    snippet = parent?.previewText() ?: "Message not loaded",
+                                                    modifier = Modifier.padding(bottom = Spacing.xxs),
+                                                )
+                                            }
+                                            val attachment = m.file
+                                            val invite = remember(m.content) { extractDmGroupInvite(m.content) }
+                                            val body = if (attachment != null) "" else invite?.remainingText ?: m.content
+                                            if (attachment != null) {
+                                                DmAttachment(
+                                                    file = attachment,
+                                                    state = dmFiles[m.id],
+                                                    onLoad = { dmVm.loadFile(m) },
+                                                    onRetry = { dmVm.retryFile(m) },
+                                                    onImage = m.mine,
+                                                )
+                                            }
+                                            if (body.isNotBlank()) {
+                                                // Rich body: inline images/video/audio/links/mentions/markdown,
+                                                // reusing the group chat renderer. White text on the "mine" bubble.
+                                                MessageContent(
+                                                    content = body,
+                                                    // The rumor's own tags: custom emoji and the imeta
+                                                    // hints that pre-size an inline image, same as chat.
+                                                    tags = m.tags,
+                                                    onMentionClick = { onOpenProfile(UserRoute(it)) },
+                                                    textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
+                                                )
+                                            }
+                                            if (invite != null) {
+                                                GroupInviteCard(
+                                                    groupId = invite.groupId,
+                                                    relayUrl = invite.relayUrl,
+                                                    onOpen = { onOpenGroup(invite.relayUrl, invite.groupId) },
+                                                    modifier = Modifier.padding(vertical = Spacing.xxs),
+                                                )
+                                            }
+                                            // Time + send-state (clock while Sending, check once Delivered),
+                                            // reusing the group chat's SendStateIcon on own messages.
+                                            Row(
+                                                modifier = Modifier.align(Alignment.End).padding(top = Spacing.xxs),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                            ) {
+                                                Text(
+                                                    formatTime(m.createdAt),
+                                                    color = if (m.mine) Color.White.copy(alpha = 0.7f) else NostrordColors.TextMuted,
+                                                    fontSize = 10.sp,
+                                                )
+                                                if (m.mine) {
+                                                    dmStatus[m.id]?.let { st ->
+                                                        SendStateIcon(status = st, tint = Color.White.copy(alpha = 0.7f))
+                                                    }
                                                 }
                                             }
-                                        }
-                                        // Reactions sit inside the bubble so they follow its edge,
-                                        // the way the group chat hangs them under a message.
-                                        dmReactions[m.id]?.let { byEmoji ->
-                                            ReactionBadges(
-                                                reactions = byEmoji,
-                                                currentUserPubkey = myPubkey,
-                                                resolveMetadata = { userMetadata[it] },
-                                                onReactionClick = { emoji -> dmVm.react(pubkey, m.id, emoji) },
-                                                modifier = Modifier.padding(top = Spacing.xxs),
-                                            )
+                                            // Reactions sit inside the bubble so they follow its edge,
+                                            // the way the group chat hangs them under a message.
+                                            dmReactions[m.id]?.let { byEmoji ->
+                                                ReactionBadges(
+                                                    reactions = byEmoji,
+                                                    currentUserPubkey = myPubkey,
+                                                    resolveMetadata = { userMetadata[it] },
+                                                    onReactionClick = { emoji -> dmVm.react(pubkey, m.id, emoji) },
+                                                    modifier = Modifier.padding(top = Spacing.xxs),
+                                                )
+                                            }
                                         }
                                     }
                                 }
+                                if (!m.mine) Spacer(modifier = Modifier.weight(0.25f))
                             }
-                            if (!m.mine) Spacer(modifier = Modifier.weight(0.25f))
                         }
                     }
+                }
+            }
+
+            // Returning to the newest message is a tap, never something the feed does on its own.
+            if (!pinnedToBottom.value) {
+                Row(
+                    modifier =
+                    Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(end = Spacing.lg, bottom = Spacing.md)
+                        .clip(NostrordShapes.shapeXLarge)
+                        .background(NostrordColors.BackgroundFloating)
+                        .clickable {
+                            pinnedToBottom.value = true
+                            scrollScope.launch { messagesScroll.animateScrollTo(messagesScroll.maxValue) }
+                        }
+                        .padding(horizontal = Spacing.md, vertical = Spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.xs),
+                ) {
+                    if (newWhileAway > 0) {
+                        Text(
+                            text = if (newWhileAway > 99) "99+ new" else "$newWhileAway new",
+                            color = NostrordColors.TextSecondary,
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                    }
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowDown,
+                        contentDescription = "Jump to latest message",
+                        tint = NostrordColors.TextSecondary,
+                        modifier = Modifier.size(16.dp),
+                    )
                 }
             }
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -546,7 +546,7 @@ fun DmPageScreen(
                                                 // Time + send-state (clock while Sending, check once Delivered),
                                                 // reusing the group chat's SendStateIcon on own messages.
                                                 Row(
-                                                    modifier = Modifier.align(Alignment.End).padding(top = Spacing.xxs),
+                                                    modifier = Modifier.align(Alignment.End).padding(top = Spacing.xs),
                                                     verticalAlignment = Alignment.CenterVertically,
                                                 ) {
                                                     Text(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material.icons.outlined.PersonAdd
 import androidx.compose.material.icons.outlined.PersonRemove
 import androidx.compose.material.icons.outlined.Public
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
@@ -165,6 +166,7 @@ fun DmPageScreen(
         val dmStatus by dmVm.messageStatus.collectAsState()
         val dmFiles by dmVm.fileStates.collectAsState()
         val dmReactions by dmVm.reactions.collectAsState()
+        val syncing by dmVm.syncing.collectAsState()
         val userMetadata by dmVm.userMetadata.collectAsState()
         val myPubkey = remember { dmVm.getPublicKey() }
         // Message the emoji picker was opened for; null while it is closed.
@@ -188,7 +190,9 @@ fun DmPageScreen(
         // pinned. Recomputed only when a scroll gesture settles, so programmatic follow-scrolls (and
         // the moment media grows maxValue) don't flip it off.
         val pinnedToBottom = remember { mutableStateOf(true) }
-        LaunchedEffect(pubkey, messages.size) {
+        // Opening a conversation lands on the newest message; after that the position is the
+        // reader's, not the stream's.
+        LaunchedEffect(pubkey) {
             messagesScroll.scrollTo(messagesScroll.maxValue)
             pinnedToBottom.value = true
         }
@@ -197,10 +201,32 @@ fun DmPageScreen(
                 pinnedToBottom.value = messagesScroll.value >= messagesScroll.maxValue - 40
             }
         }
-        // Inline media (images/video) loads after render and raises maxValue; follow it to the
-        // bottom when the user was pinned, so the newest message stays in view.
+        // Our own send always returns to the bottom: the reader caused this one.
+        val newestOwnId = messages.lastOrNull()?.takeIf { it.mine }?.id
+        LaunchedEffect(newestOwnId) {
+            if (newestOwnId != null) {
+                pinnedToBottom.value = true
+                messagesScroll.scrollTo(messagesScroll.maxValue)
+            }
+        }
+        // The oldest message on screen: it changes exactly when the backlog inserts something
+        // ABOVE what is rendered, which is the case the reader must not be dragged through.
+        val oldestId = messages.firstOrNull()?.id
+        val prependPending = remember { mutableStateOf(false) }
+        LaunchedEffect(oldestId) { prependPending.value = true }
+        // Growth from inline media loading, a new message, or the backlog filling in. Pinned to
+        // the bottom means follow it. Reading further up means hold the reading position: when
+        // the growth was above (a decrypted older message), the content the reader was on has
+        // moved down by exactly that much, so compensating puts it back under their eyes.
+        var lastMax by remember { mutableStateOf(0) }
         LaunchedEffect(messagesScroll.maxValue) {
-            if (pinnedToBottom.value) messagesScroll.scrollTo(messagesScroll.maxValue)
+            val delta = messagesScroll.maxValue - lastMax
+            lastMax = messagesScroll.maxValue
+            when {
+                pinnedToBottom.value -> messagesScroll.scrollTo(messagesScroll.maxValue)
+                delta > 0 && prependPending.value -> messagesScroll.scrollTo(messagesScroll.value + delta)
+            }
+            prependPending.value = false
         }
 
         // The message the composer is answering, if it is still in the thread.
@@ -369,6 +395,26 @@ fun DmPageScreen(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.widthIn(max = 320.dp),
             )
+            // Sitting above the thread, so older messages landing in are expected rather than
+            // startling. Sending stays available: no client can promise it holds every message.
+            if (syncing) {
+                Row(
+                    modifier = Modifier.padding(vertical = Spacing.xs),
+                    horizontalArrangement = Arrangement.spacedBy(Spacing.sm),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(12.dp),
+                        color = NostrordColors.TextMuted,
+                        strokeWidth = 1.5.dp,
+                    )
+                    Text(
+                        "Catching up on older messages",
+                        color = NostrordColors.TextMuted,
+                        fontSize = 12.sp,
+                    )
+                }
+            }
             val chatItems = remember(messages) { buildDmChatItems(messages) }
             var menuForId by remember { mutableStateOf<String?>(null) }
             var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -454,6 +454,9 @@ fun DmPageScreen(
                                             // reusing the group chat renderer. White text on the "mine" bubble.
                                             MessageContent(
                                                 content = body,
+                                                // The rumor's own tags: custom emoji and the imeta
+                                                // hints that pre-size an inline image, same as chat.
+                                                tags = m.tags,
                                                 onMentionClick = { onOpenProfile(UserRoute(it)) },
                                                 textColor = if (m.mine) Color.White else NostrordColors.TextPrimary,
                                             )

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatImage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatImage.kt
@@ -42,10 +42,12 @@ val ChatImage =
         val (loaded, setLoaded) = useState { false }
         // Settings → Media: when auto-load is off we show a "Tap to load" placeholder
         // and fetch nothing until the user reveals this image. data: URIs are already
-        // embedded in the event (no network), so they're never gated.
+        // embedded in the event and blob: urls are bytes this tab already holds (a DM
+        // attachment past its own gate), so neither costs a fetch and neither is gated.
         val autoLoad = useAutoLoadMedia()
         val (revealed, setRevealed) = useState { false }
-        if (!autoLoad && !revealed && !props.imageUrl.startsWith("data:")) {
+        val isLocal = props.imageUrl.startsWith("data:") || props.imageUrl.startsWith("blob:")
+        if (!autoLoad && !revealed && !isLocal) {
             mediaGatePlaceholder("image") { setRevealed(true) }
             return@FC
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatImage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/ChatImage.kt
@@ -40,6 +40,11 @@ val ChatImage =
         // Drives the shimmer skeleton: the reserved slot animates until the bitmap paints,
         // so a slow image reads as loading instead of as an empty box that pops.
         val (loaded, setLoaded) = useState { false }
+        // The decoded bitmap's own size, read on load. It stands in for a missing imeta hint:
+        // without either, the placeholder floor stays in force and a wide image is cropped to
+        // it (object-fit) while the bubble still stretches to the image's intrinsic width.
+        val (natural, setNatural) = useState<Pair<Int, Int>?> { null }
+        val slot = props.dimensions ?: natural
         // Settings → Media: when auto-load is off we show a "Tap to load" placeholder
         // and fetch nothing until the user reveals this image. data: URIs are already
         // embedded in the event and blob: urls are bytes this tab already holds (a DM
@@ -56,14 +61,14 @@ val ChatImage =
             className = ClassName(
                 "msg-image " + (if (loaded) "is-loaded" else "is-loading") + (backdrop?.let { " $it" } ?: ""),
             )
-            // With an imeta dim hint, reserve the exact box before load so the row keeps its
-            // height (no reflow under the reader) and drop the placeholder floor that would
-            // distort a small image. The width must be explicit: an <img> with alt="" has no
-            // intrinsic size until it decodes, and `aspect-ratio` alone then resolves against
-            // a zero width, collapsing the slot to 0x0 (nothing to reserve, nothing to
-            // shimmer). Without a hint, the CSS min-height floor stays and the list's
-            // ResizeObserver re-pins as the image grows.
-            props.dimensions?.let { (w, h) ->
+            // Known size (imeta hint, or the bitmap's own once decoded): pin the exact box so
+            // the row keeps its height (no reflow under the reader) and drop the placeholder
+            // floor, which would otherwise crop a wide image to its 120px minimum. The width
+            // must be explicit: an <img> with alt="" has no intrinsic size until it decodes,
+            // and `aspect-ratio` alone then resolves against a zero width, collapsing the slot
+            // to 0x0 (nothing to reserve, nothing to shimmer). Until either is known the floor
+            // stays and the list's ResizeObserver re-pins as the image grows.
+            slot?.let { (w, h) ->
                 val displayWidth = reservedWidthPx(w, h)
                 style = unsafeJso {
                     asDynamic().aspectRatio = "$w / $h"
@@ -79,6 +84,12 @@ val ChatImage =
             onClick = { ImageViewer.show(props.imageUrl, backdrop) }
             onLoad = { event ->
                 setLoaded(true)
+                if (props.dimensions == null) {
+                    val el = event.currentTarget.asDynamic()
+                    val w = el.naturalWidth.unsafeCast<Int>()
+                    val h = el.naturalHeight.unsafeCast<Int>()
+                    if (w > 0 && h > 0) setNatural(w to h)
+                }
                 if (!corsBlocked) setBackdrop(analyzeBackdrop(event.currentTarget))
                 // Re-pinning the feed on media load is handled by the list's ResizeObserver
                 // (and, for imeta media, by the reserved box), so nothing is needed here.

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/DmAttachment.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/DmAttachment.kt
@@ -1,0 +1,127 @@
+package org.nostr.nostrord.web.components
+
+import js.objects.unsafeJso
+import kotlinx.coroutines.awaitCancellation
+import org.nostr.nostrord.network.managers.DmFileManager
+import org.nostr.nostrord.nostr.Nip17File
+import react.FC
+import react.Props
+import react.dom.html.ReactHTML.button
+import react.dom.html.ReactHTML.div
+import react.dom.html.ReactHTML.span
+import react.useEffect
+import react.useState
+import web.blob.Blob
+import web.blob.BlobPart
+import web.blob.BlobPropertyBag
+import web.cssom.ClassName
+import web.url.URL
+
+external interface DmAttachmentProps : Props {
+    var file: Nip17File
+
+    /** Null until the first load is started; see [DmFileManager]. */
+    var state: DmFileManager.FileState?
+    var onLoad: () -> Unit
+    var onRetry: () -> Unit
+}
+
+/**
+ * The body of a NIP-17 kind:15 message: an attachment the media server only holds encrypted.
+ * The decrypted bytes are wrapped in an object url so the browser can paint them, which is
+ * revoked on unmount rather than left to leak, and the blob url is what an image src gets. The
+ * plaintext never becomes a link anyone else can follow.
+ */
+val DmAttachment =
+    FC<DmAttachmentProps> { props ->
+        val file = props.file
+        val state = props.state
+        val (objectUrl, setObjectUrl) = useState<String?> { null }
+        // Settings > Media: with auto-load off nothing is fetched or decrypted until the
+        // reader asks for this one attachment.
+        val autoLoad = useAutoLoadMedia()
+        val (revealed, setRevealed) = useState { false }
+        val allowed = autoLoad || revealed
+
+        useEffect(file.url, allowed) { if (allowed) props.onLoad() }
+
+        // Bytes -> object url, torn down when the message scrolls out or new bytes replace it.
+        useEffect(state) {
+            val ready = state as? DmFileManager.FileState.Ready
+            if (ready == null) {
+                setObjectUrl(null)
+                return@useEffect
+            }
+            val url = objectUrlFor(ready.bytes, ready.mimeType ?: file.mimeType)
+            setObjectUrl(url)
+            try {
+                awaitCancellation()
+            } finally {
+                URL.revokeObjectURL(url)
+            }
+        }
+
+        when {
+            !allowed -> mediaGatePlaceholder(gateLabel(file)) { setRevealed(true) }
+
+            state is DmFileManager.FileState.Failed ->
+                div {
+                    className = ClassName("dm-attachment dm-attachment-failed")
+                    span { +state.reason }
+                    button {
+                        className = ClassName("btn btn-secondary btn-sm")
+                        onClick = { props.onRetry() }
+                        +"Retry"
+                    }
+                }
+
+            objectUrl == null ->
+                div {
+                    className = ClassName("dm-attachment dm-attachment-loading")
+                    style = unsafeJso { asDynamic().aspectRatio = file.aspectRatioCss() }
+                }
+
+            file.isImage ->
+                ChatImage {
+                    imageUrl = objectUrl
+                    dimensions = file.dimensions
+                }
+
+            file.isVideo ->
+                react.dom.html.ReactHTML.video {
+                    className = ClassName("msg-video")
+                    src = objectUrl
+                    controls = true
+                }
+
+            file.isAudio ->
+                react.dom.html.ReactHTML.audio {
+                    className = ClassName("msg-audio")
+                    src = objectUrl
+                    controls = true
+                }
+
+            else ->
+                div {
+                    className = ClassName("dm-attachment")
+                    +"File"
+                }
+        }
+    }
+
+/** Matches the wording of the inline-media gate: "Tap to load image". */
+private fun gateLabel(file: Nip17File): String = when {
+    file.isVideo -> "video"
+    file.isAudio -> "audio"
+    file.isImage -> "image"
+    else -> "file"
+}
+
+/** CSS `aspect-ratio` for the reserved slot, square when the sender published no dim hint. */
+private fun Nip17File.aspectRatioCss(): String = dimensions?.let { (w, h) -> "$w / $h" } ?: "1 / 1"
+
+private fun objectUrlFor(bytes: ByteArray, mimeType: String?): String {
+    val options = unsafeJso<BlobPropertyBag> { type = mimeType ?: "application/octet-stream" }
+    // A Kotlin/JS ByteArray is an Int8Array, which is already a valid BlobPart.
+    return URL.createObjectURL(Blob(arrayOf(bytes.unsafeCast<BlobPart>()), options))
+}

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
@@ -71,7 +71,20 @@ external interface UploadButtonProps : Props {
      * MediaAccept.Images. Defaults to the full image/video/audio set used by the composer.
      */
     var imagesOnly: Boolean?
+
+    /**
+     * Takes the validated bytes instead of uploading them. DMs use it: their attachments are
+     * encrypted before they reach a media server, so the plain upload here would defeat the point.
+     */
+    var onPicked: ((PickedFile) -> Unit)?
 }
+
+/** A picked file that passed validation, with the mime the upload should carry. */
+data class PickedFile(
+    val bytes: ByteArray,
+    val name: String,
+    val mimeType: String,
+)
 
 /**
  * Upload button — a styled `<label>` wrapping a hidden file input. On pick it validates
@@ -128,9 +141,17 @@ val UploadButton =
                         props.onBusyChange?.invoke(true)
                         launchApp {
                             try {
-                                when (val r = uploadBlob(f, props.imagesOnly == true)) {
-                                    is Result.Success -> props.onUploaded(r.data)
-                                    is Result.Error -> props.onError(r.error.message)
+                                val handOver = props.onPicked
+                                if (handOver != null) {
+                                    when (val picked = readPickedFile(f, props.imagesOnly == true)) {
+                                        is Result.Success -> handOver(picked.data)
+                                        is Result.Error -> props.onError(picked.error.message)
+                                    }
+                                } else {
+                                    when (val r = uploadBlob(f, props.imagesOnly == true)) {
+                                        is Result.Success -> props.onUploaded(r.data)
+                                        is Result.Error -> props.onError(r.error.message)
+                                    }
                                 }
                             } finally {
                                 setPicking(false)
@@ -152,6 +173,17 @@ val UploadButton =
  * [Result.Error] to surface. Reusable by the file picker and Ctrl+V paste / drag-and-drop.
  */
 suspend fun uploadBlob(file: dynamic, imagesOnly: Boolean = false): Result<UploadResult> {
+    val picked = readPickedFile(file, imagesOnly)
+    val data = picked.getOrNull() ?: return Result.Error(picked.errorOrNull() ?: AppError.Unknown("Upload failed"))
+    return uploadMedia(data.bytes, data.name, data.mimeType)
+}
+
+/**
+ * Validate a picked/pasted File (or Blob) and read its bytes: the 20 MB cap and the supported
+ * image/video/audio formats, with the same user-facing messages as the native picker. The step
+ * before an upload, and all a caller that encrypts the bytes itself needs.
+ */
+suspend fun readPickedFile(file: dynamic, imagesOnly: Boolean = false): Result<PickedFile> {
     val name = (file.name.unsafeCast<String?>())?.takeIf { it.isNotBlank() } ?: "file"
     val size = (file.size.unsafeCast<Double?>())?.toLong() ?: 0L
     if (size > MAX_UPLOAD_BYTES) {
@@ -180,7 +212,7 @@ suspend fun uploadBlob(file: dynamic, imagesOnly: Boolean = false): Result<Uploa
     }
     val bytes = readFileBytes(file)
     if (bytes.isEmpty()) return Result.Error(AppError.Unknown("Could not read the selected file."))
-    return uploadMedia(bytes, name, mime)
+    return Result.Success(PickedFile(bytes, name, mime))
 }
 
 /** Read a picked file's bytes via the Blob arrayBuffer() promise. */

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -4,6 +4,9 @@ import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.awaitCancellation
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.network.UserMetadata
+import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.network.managers.previewText
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.extractDmGroupInvite
 import org.nostr.nostrord.ui.navigation.DmRoute
@@ -125,6 +128,8 @@ val DmPage =
         // Message the full emoji picker was opened for; null while it is closed.
         val (reactingTo, setReactingTo) = useState<String?> { null }
         val myPubkey = dmVm.getPublicKey()
+        // Message being replied to; the composer keeps its chip until the reply is sent.
+        val (replyingTo, setReplyingTo) = useState<String?> { null }
         // Resolve where this peer reads before the first message is written, not after their reply.
         useEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -165,8 +170,10 @@ val DmPage =
                 dmVm.send(
                     pubkey,
                     text,
+                    replyToId = replyingTo,
                     onSuccess = {
                         setText("")
+                        setReplyingTo(null)
                         setSending(false)
                     },
                     onFailure = { setSending(false) },
@@ -447,6 +454,27 @@ val DmPage =
                                     title = formatDateTime(m.createdAt)
                                     // A group naddr on its own line renders as the prototype
                                     // invite card (text above, card + View group button below).
+                                    // Quote of the message this one answers, above its body.
+                                    m.replyToId?.let { parentId ->
+                                        val parent = messages.firstOrNull { it.id == parentId }
+                                        div {
+                                            className = ClassName("msg-reply")
+                                            div { className = ClassName("msg-reply-bar") }
+                                            div {
+                                                className = ClassName("msg-reply-content")
+                                                div {
+                                                    className = ClassName("msg-reply-author")
+                                                    +dmReplyAuthorName(parent, userMetadata, name, myPubkey)
+                                                }
+                                                parent?.let { p ->
+                                                    div {
+                                                        className = ClassName("msg-reply-text")
+                                                        +p.previewText()
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                     val attachment = m.file
                                     val invite = extractDmGroupInvite(m.content)
                                     val body = if (attachment != null) "" else invite?.remainingText ?: m.content
@@ -547,6 +575,10 @@ val DmPage =
                             icon(Ic.EmojiEmotions)
                         }
                     }
+                    ctxItem(Ic.Reply, "Reply") {
+                        setReplyingTo(menuMsg.id)
+                        setMenuFor(null)
+                    }
                     ctxItem(Ic.Visibility, "View source") {
                         setSourceFor(menuMsg.id)
                         setMenuFor(null)
@@ -591,6 +623,33 @@ val DmPage =
 
             div {
                 className = ClassName("dm-composer-wrap")
+                // Reply chip above the input, same markup as the group composer's.
+                replyingTo?.let { targetId ->
+                    val parent = messages.firstOrNull { it.id == targetId }
+                    div {
+                        className = ClassName("composer-reply")
+                        icon(Ic.Reply)
+                        span {
+                            className = ClassName("composer-reply-label")
+                            +"Replying to"
+                        }
+                        span {
+                            className = ClassName("composer-reply-name")
+                            +dmReplyAuthorName(parent, userMetadata, name, myPubkey)
+                        }
+                        parent?.previewText()?.takeIf { it.isNotBlank() }?.let { preview ->
+                            span {
+                                className = ClassName("composer-reply-text")
+                                +preview
+                            }
+                        }
+                        button {
+                            className = ClassName("composer-reply-close")
+                            onClick = { setReplyingTo(null) }
+                            icon(Ic.Close)
+                        }
+                    }
+                }
                 div {
                     className = ClassName("dm-composer")
                     UploadButton {
@@ -702,4 +761,22 @@ private fun ChildrenBuilder.uploadErrorDialog(message: String, onDismiss: () -> 
             }
         }
     }
+}
+
+/**
+ * Name to show on a reply quote. The peer's own name is already in the header, so an unknown
+ * parent falls back to it rather than to a raw npub.
+ */
+private fun dmReplyAuthorName(
+    parent: DmMessage?,
+    metadata: Map<String, UserMetadata>,
+    peerName: String,
+    myPubkey: String?,
+): String = when {
+    parent == null -> peerName
+    parent.senderPubkey == myPubkey -> "You"
+    else ->
+        metadata[parent.senderPubkey]?.displayName
+            ?: metadata[parent.senderPubkey]?.name
+            ?: peerName
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -158,12 +158,9 @@ val DmPage =
         // the bottom for a message they did not send is what makes a backfill feel like a bug.
         useLayoutEffect(messages.size) {
             val el = messagesRef.current ?: return@useLayoutEffect
-            if (pinnedToBottom.current == true) {
-                el.asDynamic().style.overflowAnchor = "none"
-                el.scrollTop = el.scrollHeight.toDouble()
-            } else {
-                el.asDynamic().style.overflowAnchor = "auto"
-            }
+            // Reading further up: nothing to do. The anchor is already "auto" (set the moment the
+            // reader left the bottom), so the browser has held their position through the insert.
+            if (pinnedToBottom.current == true) el.scrollTop = el.scrollHeight.toDouble()
         }
         // Our own send always returns to the bottom: the reader caused this one.
         val newestOwnId = messages.lastOrNull()?.takeIf { it.mine }?.id
@@ -379,7 +376,13 @@ val DmPage =
                 onScroll = {
                     val el = messagesRef.current
                     if (el != null) {
-                        pinnedToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80.0
+                        val atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80.0
+                        pinnedToBottom.current = atBottom
+                        // Set here, not when the list next changes: the browser applies its scroll
+                        // anchor while laying out the insertion itself, so switching it afterwards
+                        // (from an effect) arrives one mutation too late and the message that
+                        // arrived still moves the page.
+                        el.asDynamic().style.overflowAnchor = if (atBottom) "none" else "auto"
                     }
                 }
                 // Sitting above the thread, so older messages landing in are expected rather than

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -143,6 +143,14 @@ val DmPage =
         // True while the user is at (or near) the bottom; drives whether async media growth keeps
         // the view pinned. Updated on scroll; seeded true so a fresh conversation stays pinned.
         val pinnedToBottom = useRef(true)
+        // Same fact as the ref, in state: the jump pill has to re-render when it changes.
+        val (atBottom, setAtBottom) = useState { true }
+        // Messages FROM THE PEER that landed while the reader was up in the history. Reported on
+        // the pill so going back down is their decision with the count in hand. Own messages are
+        // never counted: the reader wrote them, and writing already returns the view to the bottom.
+        val (newWhileAway, setNewWhileAway) = useState { 0 }
+        val seenPeerCount = useRef(0)
+        val peerCount = messages.count { !it.mine }
         // Opening a conversation lands on the newest message; after that the position is the
         // reader's, not the stream's.
         useLayoutEffect(pubkey) {
@@ -162,12 +170,22 @@ val DmPage =
             // reader left the bottom), so the browser has held their position through the insert.
             if (pinnedToBottom.current == true) el.scrollTop = el.scrollHeight.toDouble()
         }
+        useEffect(peerCount, atBottom) {
+            if (atBottom) {
+                seenPeerCount.current = peerCount
+                setNewWhileAway(0)
+            } else {
+                setNewWhileAway((peerCount - (seenPeerCount.current ?: 0)).coerceAtLeast(0))
+            }
+        }
         // Our own send always returns to the bottom: the reader caused this one.
         val newestOwnId = messages.lastOrNull()?.takeIf { it.mine }?.id
         useLayoutEffect(newestOwnId) {
             if (newestOwnId == null) return@useLayoutEffect
             val el = messagesRef.current ?: return@useLayoutEffect
             pinnedToBottom.current = true
+            seenPeerCount.current = peerCount
+            setAtBottom(true)
             el.asDynamic().style.overflowAnchor = "none"
             el.scrollTop = el.scrollHeight.toDouble()
         }
@@ -371,200 +389,207 @@ val DmPage =
             }
 
             div {
-                className = ClassName("dm-messages")
-                ref = messagesRef
-                onScroll = {
-                    val el = messagesRef.current
-                    if (el != null) {
-                        val atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80.0
-                        pinnedToBottom.current = atBottom
-                        // Set here, not when the list next changes: the browser applies its scroll
-                        // anchor while laying out the insertion itself, so switching it afterwards
-                        // (from an effect) arrives one mutation too late and the message that
-                        // arrived still moves the page.
-                        el.asDynamic().style.overflowAnchor = if (atBottom) "none" else "auto"
-                    }
-                }
-                // Sitting above the thread, so older messages landing in are expected rather than
-                // startling. Sending stays available: no client can promise it holds every message.
-                if (syncing) {
-                    div {
-                        className = ClassName("dm-syncing")
-                        span { className = ClassName("upload-spinner") }
-                        +"Catching up on older messages"
-                    }
-                }
+                className = ClassName("dm-messages-wrap")
                 div {
-                    className = ClassName("dm-intro")
-                    WebAvatar {
-                        url = metadata?.picture
-                        seed = pubkey
-                        this.name = name
-                        cls = "dm-intro-avatar link"
-                        onClick = { props.onOpenProfile(UserRoute(pubkey)) }
-                    }
-                    div {
-                        className = ClassName("dm-intro-name link")
-                        onClick = { props.onOpenProfile(UserRoute(pubkey)) }
-                        +name
-                    }
-                    div {
-                        className = ClassName("dm-intro-text")
-                        +"Beginning of your direct conversation with $name. Direct messages are encrypted (NIP-17)."
-                    }
-                }
-                buildDmChatItems(messages).forEach { item ->
-                    when (item) {
-                        is DmChatItem.DateSeparator ->
-                            div {
-                                key = "sep-${item.label}"
-                                className = ClassName("date-sep")
-                                span {
-                                    className = ClassName("date-sep-label")
-                                    +item.label
-                                }
+                    className = ClassName("dm-messages")
+                    ref = messagesRef
+                    onScroll = {
+                        val el = messagesRef.current
+                        if (el != null) {
+                            val nowAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80.0
+                            if (pinnedToBottom.current != nowAtBottom) {
+                                pinnedToBottom.current = nowAtBottom
+                                if (nowAtBottom) seenPeerCount.current = peerCount
+                                setAtBottom(nowAtBottom)
                             }
-                        is DmChatItem.Message -> {
-                            val m = item.message
-                            div {
-                                key = m.id
-                                className =
-                                    ClassName(
-                                        buildString {
-                                            append("dm-msg")
-                                            if (m.mine) append(" mine")
-                                            if (!item.firstInGroup) append(" grouped")
-                                        },
-                                    )
-                                // First right-click opens our menu at the cursor; with it open the
-                                // second lands on the overlay, which closes ours without
-                                // preventDefault so the native menu shows (Telegram-style).
-                                // Right-click directly on a hyperlink always keeps the native menu.
-                                onContextMenu = { event ->
-                                    if (event.target.asDynamic().closest("a") != null) {
-                                        setMenuFor(null)
-                                    } else if (menuFor == null) {
-                                        event.preventDefault()
-                                        menuOpenedAt.current = 0.0
-                                        setMenuAt(event.clientX.toInt() to event.clientY.toInt())
-                                        setMenuFor(m.id)
-                                    } else {
-                                        setMenuFor(null)
-                                    }
-                                }
-                                // Stationary 380ms hold arms the long-press; the menu opens on
-                                // touchend so the page can't jump while the finger is down.
-                                onTouchStart = { event ->
-                                    val t = event.asDynamic().touches[0]
-                                    touchStartX.current = t.clientX as Double
-                                    touchStartY.current = t.clientY as Double
-                                    longPressReady.current = false
-                                    window.clearTimeout(longPressTimer.current ?: 0)
-                                    longPressTimer.current = window.setTimeout({
-                                        longPressReady.current = true
-                                        val nav = window.navigator.asDynamic()
-                                        if (nav.vibrate != null) nav.vibrate(15)
-                                    }, 380)
-                                }
-                                onTouchMove = { event ->
-                                    val t = event.asDynamic().touches[0]
-                                    val dx = (t.clientX as Double) - (touchStartX.current ?: 0.0)
-                                    val dy = (t.clientY as Double) - (touchStartY.current ?: 0.0)
-                                    if (abs(dx) > 10.0 || abs(dy) > 10.0) {
-                                        window.clearTimeout(longPressTimer.current ?: 0)
-                                        longPressReady.current = false
-                                    }
-                                }
-                                onTouchEnd = { event ->
-                                    window.clearTimeout(longPressTimer.current ?: 0)
-                                    if (longPressReady.current == true && menuFor == null) {
-                                        // Suppress the synthesized click so it can't hit the
-                                        // overlay and instantly close the menu we're opening.
-                                        event.preventDefault()
-                                        menuOpenedAt.current = kotlin.js.Date.now()
-                                        setMenuAt(
-                                            (touchStartX.current ?: 0.0).toInt() to (touchStartY.current ?: 0.0).toInt(),
-                                        )
-                                        setMenuFor(m.id)
-                                    }
-                                }
-                                // Clock on its own line below the message, right-aligned (matches
-                                // native); hover shows the full date.
+                            // Set here, not when the list next changes: the browser applies its scroll
+                            // anchor while laying out the insertion itself, so switching it afterwards
+                            // (from an effect) arrives one mutation too late and the message that
+                            // arrived still moves the page.
+                            el.asDynamic().style.overflowAnchor = if (nowAtBottom) "none" else "auto"
+                        }
+                    }
+                    // Sitting above the thread, so older messages landing in are expected rather than
+                    // startling. Sending stays available: no client can promise it holds every message.
+                    if (syncing) {
+                        div {
+                            className = ClassName("dm-syncing")
+                            span { className = ClassName("upload-spinner") }
+                            +"Catching up on older messages"
+                        }
+                    }
+                    div {
+                        className = ClassName("dm-intro")
+                        WebAvatar {
+                            url = metadata?.picture
+                            seed = pubkey
+                            this.name = name
+                            cls = "dm-intro-avatar link"
+                            onClick = { props.onOpenProfile(UserRoute(pubkey)) }
+                        }
+                        div {
+                            className = ClassName("dm-intro-name link")
+                            onClick = { props.onOpenProfile(UserRoute(pubkey)) }
+                            +name
+                        }
+                        div {
+                            className = ClassName("dm-intro-text")
+                            +"Beginning of your direct conversation with $name. Direct messages are encrypted (NIP-17)."
+                        }
+                    }
+                    buildDmChatItems(messages).forEach { item ->
+                        when (item) {
+                            is DmChatItem.DateSeparator ->
                                 div {
-                                    className = ClassName("dm-bubble")
-                                    title = formatDateTime(m.createdAt)
-                                    // A group naddr on its own line renders as the prototype
-                                    // invite card (text above, card + View group button below).
-                                    // Quote of the message this one answers, above its body.
-                                    m.replyToId?.let { parentId ->
-                                        val parent = messages.firstOrNull { it.id == parentId }
-                                        div {
-                                            className = ClassName("msg-reply")
-                                            div { className = ClassName("msg-reply-bar") }
+                                    key = "sep-${item.label}"
+                                    className = ClassName("date-sep")
+                                    span {
+                                        className = ClassName("date-sep-label")
+                                        +item.label
+                                    }
+                                }
+                            is DmChatItem.Message -> {
+                                val m = item.message
+                                div {
+                                    key = m.id
+                                    className =
+                                        ClassName(
+                                            buildString {
+                                                append("dm-msg")
+                                                if (m.mine) append(" mine")
+                                                if (!item.firstInGroup) append(" grouped")
+                                            },
+                                        )
+                                    // First right-click opens our menu at the cursor; with it open the
+                                    // second lands on the overlay, which closes ours without
+                                    // preventDefault so the native menu shows (Telegram-style).
+                                    // Right-click directly on a hyperlink always keeps the native menu.
+                                    onContextMenu = { event ->
+                                        if (event.target.asDynamic().closest("a") != null) {
+                                            setMenuFor(null)
+                                        } else if (menuFor == null) {
+                                            event.preventDefault()
+                                            menuOpenedAt.current = 0.0
+                                            setMenuAt(event.clientX.toInt() to event.clientY.toInt())
+                                            setMenuFor(m.id)
+                                        } else {
+                                            setMenuFor(null)
+                                        }
+                                    }
+                                    // Stationary 380ms hold arms the long-press; the menu opens on
+                                    // touchend so the page can't jump while the finger is down.
+                                    onTouchStart = { event ->
+                                        val t = event.asDynamic().touches[0]
+                                        touchStartX.current = t.clientX as Double
+                                        touchStartY.current = t.clientY as Double
+                                        longPressReady.current = false
+                                        window.clearTimeout(longPressTimer.current ?: 0)
+                                        longPressTimer.current = window.setTimeout({
+                                            longPressReady.current = true
+                                            val nav = window.navigator.asDynamic()
+                                            if (nav.vibrate != null) nav.vibrate(15)
+                                        }, 380)
+                                    }
+                                    onTouchMove = { event ->
+                                        val t = event.asDynamic().touches[0]
+                                        val dx = (t.clientX as Double) - (touchStartX.current ?: 0.0)
+                                        val dy = (t.clientY as Double) - (touchStartY.current ?: 0.0)
+                                        if (abs(dx) > 10.0 || abs(dy) > 10.0) {
+                                            window.clearTimeout(longPressTimer.current ?: 0)
+                                            longPressReady.current = false
+                                        }
+                                    }
+                                    onTouchEnd = { event ->
+                                        window.clearTimeout(longPressTimer.current ?: 0)
+                                        if (longPressReady.current == true && menuFor == null) {
+                                            // Suppress the synthesized click so it can't hit the
+                                            // overlay and instantly close the menu we're opening.
+                                            event.preventDefault()
+                                            menuOpenedAt.current = kotlin.js.Date.now()
+                                            setMenuAt(
+                                                (touchStartX.current ?: 0.0).toInt() to (touchStartY.current ?: 0.0).toInt(),
+                                            )
+                                            setMenuFor(m.id)
+                                        }
+                                    }
+                                    // Clock on its own line below the message, right-aligned (matches
+                                    // native); hover shows the full date.
+                                    div {
+                                        className = ClassName("dm-bubble")
+                                        title = formatDateTime(m.createdAt)
+                                        // A group naddr on its own line renders as the prototype
+                                        // invite card (text above, card + View group button below).
+                                        // Quote of the message this one answers, above its body.
+                                        m.replyToId?.let { parentId ->
+                                            val parent = messages.firstOrNull { it.id == parentId }
                                             div {
-                                                className = ClassName("msg-reply-content")
+                                                className = ClassName("msg-reply")
+                                                div { className = ClassName("msg-reply-bar") }
                                                 div {
-                                                    className = ClassName("msg-reply-author")
-                                                    +dmReplyAuthorName(parent, userMetadata, name, myPubkey)
-                                                }
-                                                parent?.let { p ->
+                                                    className = ClassName("msg-reply-content")
                                                     div {
-                                                        className = ClassName("msg-reply-text")
-                                                        +p.previewText()
+                                                        className = ClassName("msg-reply-author")
+                                                        +dmReplyAuthorName(parent, userMetadata, name, myPubkey)
+                                                    }
+                                                    parent?.let { p ->
+                                                        div {
+                                                            className = ClassName("msg-reply-text")
+                                                            +p.previewText()
+                                                        }
                                                     }
                                                 }
                                             }
                                         }
-                                    }
-                                    val attachment = m.file
-                                    val invite = extractDmGroupInvite(m.content)
-                                    val body = if (attachment != null) "" else invite?.remainingText ?: m.content
-                                    if (attachment != null) {
-                                        DmAttachment {
-                                            file = attachment
-                                            state = dmFiles[m.id]
-                                            onLoad = { dmVm.loadFile(m) }
-                                            onRetry = { dmVm.retryFile(m) }
+                                        val attachment = m.file
+                                        val invite = extractDmGroupInvite(m.content)
+                                        val body = if (attachment != null) "" else invite?.remainingText ?: m.content
+                                        if (attachment != null) {
+                                            DmAttachment {
+                                                file = attachment
+                                                state = dmFiles[m.id]
+                                                onLoad = { dmVm.loadFile(m) }
+                                                onRetry = { dmVm.retryFile(m) }
+                                            }
                                         }
-                                    }
-                                    if (body.isNotBlank()) {
-                                        // Rich body: inline images/video/audio/links/mentions/markdown,
-                                        // reusing the group chat renderer (same package).
-                                        renderMessageContent(
-                                            body,
-                                            // The rumor's own tags: custom emoji and the imeta
-                                            // hints that pre-size an inline image, same as chat.
-                                            m.tags,
-                                            userMetadata,
-                                            emptyMap(),
-                                            { props.onOpenProfile(UserRoute(it)) },
-                                            {},
-                                            { gid, relay -> relay?.let { props.onOpenGroup(GroupRoute(it, gid)) } },
-                                            // A DM is not in a group: the by-id REQ stays unscoped
-                                            // and there is no host relay to compare a quote against.
-                                            null,
-                                            "",
-                                        )
-                                    }
-                                    if (invite != null) {
-                                        GroupInviteCard {
-                                            groupId = invite.groupId
-                                            relayUrl = invite.relayUrl
-                                            onOpen = { props.onOpenGroup(GroupRoute(invite.relayUrl, invite.groupId)) }
+                                        if (body.isNotBlank()) {
+                                            // Rich body: inline images/video/audio/links/mentions/markdown,
+                                            // reusing the group chat renderer (same package).
+                                            renderMessageContent(
+                                                body,
+                                                // The rumor's own tags: custom emoji and the imeta
+                                                // hints that pre-size an inline image, same as chat.
+                                                m.tags,
+                                                userMetadata,
+                                                emptyMap(),
+                                                { props.onOpenProfile(UserRoute(it)) },
+                                                {},
+                                                { gid, relay -> relay?.let { props.onOpenGroup(GroupRoute(it, gid)) } },
+                                                // A DM is not in a group: the by-id REQ stays unscoped
+                                                // and there is no host relay to compare a quote against.
+                                                null,
+                                                "",
+                                            )
                                         }
-                                    }
-                                    span {
-                                        className = ClassName("dm-bubble-time")
-                                        +formatTime(m.createdAt)
-                                        // Send state on own messages: clock while Sending, check
-                                        // once a relay OKs the wrap (reuses the group chat icon).
-                                        if (m.mine) sendStateIcon(dmStatus[m.id])
-                                    }
-                                    // Reactions hang inside the bubble so they follow its edge,
-                                    // the way the group chat renders them under a message.
-                                    dmReactions[m.id]?.let { byEmoji ->
-                                        reactionBadges(byEmoji, emptyList(), myPubkey, userMetadata) { emoji ->
-                                            dmVm.react(pubkey, m.id, emoji)
+                                        if (invite != null) {
+                                            GroupInviteCard {
+                                                groupId = invite.groupId
+                                                relayUrl = invite.relayUrl
+                                                onOpen = { props.onOpenGroup(GroupRoute(invite.relayUrl, invite.groupId)) }
+                                            }
+                                        }
+                                        span {
+                                            className = ClassName("dm-bubble-time")
+                                            +formatTime(m.createdAt)
+                                            // Send state on own messages: clock while Sending, check
+                                            // once a relay OKs the wrap (reuses the group chat icon).
+                                            if (m.mine) sendStateIcon(dmStatus[m.id])
+                                        }
+                                        // Reactions hang inside the bubble so they follow its edge,
+                                        // the way the group chat renders them under a message.
+                                        dmReactions[m.id]?.let { byEmoji ->
+                                            reactionBadges(byEmoji, emptyList(), myPubkey, userMetadata) { emoji ->
+                                                dmVm.react(pubkey, m.id, emoji)
+                                            }
                                         }
                                     }
                                 }
@@ -572,95 +597,122 @@ val DmPage =
                         }
                     }
                 }
-            }
 
-            val menuMsg = messages.firstOrNull { it.id == menuFor }
-            if (menuMsg != null) {
-                div {
-                    className = ClassName("ctx-overlay")
-                    onTouchStart = { it.stopPropagation() }
-                    onTouchMove = { it.stopPropagation() }
-                    onTouchEnd = { it.stopPropagation() }
-                    onClick = {
-                        // Ignore the synthesized click that trails a touch-open.
-                        if (kotlin.js.Date.now() - (menuOpenedAt.current ?: 0.0) > 400.0) setMenuFor(null)
-                    }
-                    // Close without preventDefault so the browser shows its native menu.
-                    onContextMenu = { setMenuFor(null) }
-                }
-                div {
-                    ref = menuRef
-                    className = ClassName("ctx-menu")
-                    onTouchStart = { it.stopPropagation() }
-                    onTouchMove = { it.stopPropagation() }
-                    onTouchEnd = { it.stopPropagation() }
-                    // Quick-reactions row (one tap to react) + the full picker, mirroring the
-                    // group chat menu and the native DM one.
+                val menuMsg = messages.firstOrNull { it.id == menuFor }
+                if (menuMsg != null) {
                     div {
-                        className = ClassName("ctx-reactions")
-                        for (emoji in QuickReactions) {
-                            button {
-                                className = ClassName("ctx-reaction")
-                                onClick = {
-                                    dmVm.react(pubkey, menuMsg.id, emoji)
-                                    setMenuFor(null)
+                        className = ClassName("ctx-overlay")
+                        onTouchStart = { it.stopPropagation() }
+                        onTouchMove = { it.stopPropagation() }
+                        onTouchEnd = { it.stopPropagation() }
+                        onClick = {
+                            // Ignore the synthesized click that trails a touch-open.
+                            if (kotlin.js.Date.now() - (menuOpenedAt.current ?: 0.0) > 400.0) setMenuFor(null)
+                        }
+                        // Close without preventDefault so the browser shows its native menu.
+                        onContextMenu = { setMenuFor(null) }
+                    }
+                    div {
+                        ref = menuRef
+                        className = ClassName("ctx-menu")
+                        onTouchStart = { it.stopPropagation() }
+                        onTouchMove = { it.stopPropagation() }
+                        onTouchEnd = { it.stopPropagation() }
+                        // Quick-reactions row (one tap to react) + the full picker, mirroring the
+                        // group chat menu and the native DM one.
+                        div {
+                            className = ClassName("ctx-reactions")
+                            for (emoji in QuickReactions) {
+                                button {
+                                    className = ClassName("ctx-reaction")
+                                    onClick = {
+                                        dmVm.react(pubkey, menuMsg.id, emoji)
+                                        setMenuFor(null)
+                                    }
+                                    +emoji
                                 }
-                                +emoji
+                            }
+                            button {
+                                className = ClassName("ctx-reaction ctx-reaction-more")
+                                title = "Add reaction"
+                                onClick = {
+                                    setMenuFor(null)
+                                    setReactingTo(menuMsg.id)
+                                }
+                                icon(Ic.EmojiEmotions)
                             }
                         }
-                        button {
-                            className = ClassName("ctx-reaction ctx-reaction-more")
-                            title = "Add reaction"
-                            onClick = {
-                                setMenuFor(null)
-                                setReactingTo(menuMsg.id)
+                        ctxItem(Ic.Reply, "Reply") {
+                            setReplyingTo(menuMsg.id)
+                            setMenuFor(null)
+                        }
+                        ctxItem(Ic.Visibility, "View source") {
+                            setSourceFor(menuMsg.id)
+                            setMenuFor(null)
+                        }
+                        ctxItem(Ic.ContentCopy, "Copy text") {
+                            copyToClipboard(menuMsg.content)
+                            setMenuFor(null)
+                        }
+                    }
+                }
+
+                reactingTo?.let { targetId ->
+                    div {
+                        className = ClassName("emoji-overlay")
+                        onClick = { setReactingTo(null) }
+                        EmojiPicker {
+                            onPick = { emoji ->
+                                dmVm.react(pubkey, targetId, emoji)
+                                setReactingTo(null)
                             }
-                            icon(Ic.EmojiEmotions)
-                        }
-                    }
-                    ctxItem(Ic.Reply, "Reply") {
-                        setReplyingTo(menuMsg.id)
-                        setMenuFor(null)
-                    }
-                    ctxItem(Ic.Visibility, "View source") {
-                        setSourceFor(menuMsg.id)
-                        setMenuFor(null)
-                    }
-                    ctxItem(Ic.ContentCopy, "Copy text") {
-                        copyToClipboard(menuMsg.content)
-                        setMenuFor(null)
-                    }
-                }
-            }
-
-            reactingTo?.let { targetId ->
-                div {
-                    className = ClassName("emoji-overlay")
-                    onClick = { setReactingTo(null) }
-                    EmojiPicker {
-                        onPick = { emoji ->
-                            dmVm.react(pubkey, targetId, emoji)
-                            setReactingTo(null)
                         }
                     }
                 }
-            }
 
-            val sourceMsg = messages.firstOrNull { it.id == sourceFor }
-            if (sourceMsg != null) {
-                DmEventSourceModal {
-                    json = sourceMsg.prettyEventJson()
-                    relays = sourceMsg.relays.toTypedArray()
-                    onCopy = { copyToClipboard(sourceMsg.eventJson()) }
-                    onClose = { setSourceFor(null) }
+                val sourceMsg = messages.firstOrNull { it.id == sourceFor }
+                if (sourceMsg != null) {
+                    DmEventSourceModal {
+                        json = sourceMsg.prettyEventJson()
+                        relays = sourceMsg.relays.toTypedArray()
+                        onCopy = { copyToClipboard(sourceMsg.eventJson()) }
+                        onClose = { setSourceFor(null) }
+                    }
                 }
-            }
-            // Rendered after the message list so toggling it never shifts the list's
-            // sibling position (which would remount it and reset the scroll to the top).
-            if (relaysOpen) {
-                DmRelaysModal {
-                    relays = peerRelays.toTypedArray()
-                    onClose = { setRelaysOpen(false) }
+                // Rendered after the message list so toggling it never shifts the list's
+                // sibling position (which would remount it and reset the scroll to the top).
+                if (relaysOpen) {
+                    DmRelaysModal {
+                        relays = peerRelays.toTypedArray()
+                        onClose = { setRelaysOpen(false) }
+                    }
+                }
+
+                // Returning to the newest message is a tap, never something the feed does on its
+                // own. The count is what arrived while the reader stayed up in the history.
+                if (!atBottom) {
+                    button {
+                        className = ClassName("chat-jump-bottom")
+                        title = "Jump to latest message"
+                        onClick = {
+                            val el = messagesRef.current
+                            if (el != null) {
+                                pinnedToBottom.current = true
+                                seenPeerCount.current = peerCount
+                                setAtBottom(true)
+                                setNewWhileAway(0)
+                                el.asDynamic().style.overflowAnchor = "none"
+                                el.scrollTop = el.scrollHeight.toDouble()
+                            }
+                        }
+                        if (newWhileAway > 0) {
+                            span {
+                                className = ClassName("dm-jump-count")
+                                +(if (newWhileAway > 99) "99+ new" else "$newWhileAway new")
+                            }
+                        }
+                        icon(Ic.ExpandMore)
+                    }
                 }
             }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -4,6 +4,7 @@ import kotlinx.browser.document
 import kotlinx.browser.window
 import kotlinx.coroutines.awaitCancellation
 import org.nostr.nostrord.di.AppModule
+import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.extractDmGroupInvite
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.GroupRoute
@@ -25,12 +26,14 @@ import org.nostr.nostrord.web.components.DmAttachment
 import org.nostr.nostrord.web.components.EmojiPicker
 import org.nostr.nostrord.web.components.GroupInviteCard
 import org.nostr.nostrord.web.components.Ic
+import org.nostr.nostrord.web.components.PickedFile
 import org.nostr.nostrord.web.components.UploadButton
 import org.nostr.nostrord.web.components.WebAvatar
 import org.nostr.nostrord.web.components.copyToClipboard
 import org.nostr.nostrord.web.components.icon
+import org.nostr.nostrord.web.components.reactionBadges
+import org.nostr.nostrord.web.components.readPickedFile
 import org.nostr.nostrord.web.components.sendStateIcon
-import org.nostr.nostrord.web.components.uploadBlob
 import org.nostr.nostrord.web.components.useEscClose
 import org.nostr.nostrord.web.modals.DmEventSourceModal
 import org.nostr.nostrord.web.modals.DmRelaysModal
@@ -118,6 +121,10 @@ val DmPage =
         val userMetadata = useStateFlow(dmVm.userMetadata)
         val dmStatus = useStateFlow(dmVm.messageStatus)
         val dmFiles = useStateFlow(dmVm.fileStates)
+        val dmReactions = useStateFlow(dmVm.reactions)
+        // Message the full emoji picker was opened for; null while it is closed.
+        val (reactingTo, setReactingTo) = useState<String?> { null }
+        val myPubkey = dmVm.getPublicKey()
         // Resolve where this peer reads before the first message is written, not after their reply.
         useEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -223,13 +230,32 @@ val DmPage =
 
         fun isMediaMime(type: String?): Boolean = type != null && (type.startsWith("image/") || type.startsWith("video/") || type.startsWith("audio/"))
 
-        // Upload a pasted / dropped file and append its URL to the draft (parity with the group composer).
+        // Send a picked / pasted / dropped file as an encrypted kind:15 message. It is not appended
+        // to the draft as a url the way the group composer does: a DM attachment is encrypted
+        // before upload, so the server holds bytes nobody else can read.
+        fun sendMediaFile(picked: PickedFile) {
+            setUploadCount { it + 1 }
+            launchApp {
+                try {
+                    dmVm.sendFile(
+                        recipientPubkey = pubkey,
+                        bytes = picked.bytes,
+                        filename = picked.name,
+                        mimeType = picked.mimeType,
+                        onFailure = { setUploadError(it) },
+                    )
+                } finally {
+                    setUploadCount { it - 1 }
+                }
+            }
+        }
+
         fun handleMediaFile(file: dynamic) {
             setUploadCount { it + 1 }
             launchApp {
                 try {
-                    when (val r = uploadBlob(file)) {
-                        is Result.Success -> setText { prev -> if (prev.isBlank()) r.data.url else "$prev ${r.data.url}" }
+                    when (val r = readPickedFile(file)) {
+                        is Result.Success -> sendMediaFile(r.data)
                         is Result.Error -> setUploadError(r.error.message)
                     }
                 } finally {
@@ -463,6 +489,13 @@ val DmPage =
                                         // once a relay OKs the wrap (reuses the group chat icon).
                                         if (m.mine) sendStateIcon(dmStatus[m.id])
                                     }
+                                    // Reactions hang inside the bubble so they follow its edge,
+                                    // the way the group chat renders them under a message.
+                                    dmReactions[m.id]?.let { byEmoji ->
+                                        reactionBadges(byEmoji, emptyList(), myPubkey, userMetadata) { emoji ->
+                                            dmVm.react(pubkey, m.id, emoji)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -490,6 +523,30 @@ val DmPage =
                     onTouchStart = { it.stopPropagation() }
                     onTouchMove = { it.stopPropagation() }
                     onTouchEnd = { it.stopPropagation() }
+                    // Quick-reactions row (one tap to react) + the full picker, mirroring the
+                    // group chat menu and the native DM one.
+                    div {
+                        className = ClassName("ctx-reactions")
+                        for (emoji in QuickReactions) {
+                            button {
+                                className = ClassName("ctx-reaction")
+                                onClick = {
+                                    dmVm.react(pubkey, menuMsg.id, emoji)
+                                    setMenuFor(null)
+                                }
+                                +emoji
+                            }
+                        }
+                        button {
+                            className = ClassName("ctx-reaction ctx-reaction-more")
+                            title = "Add reaction"
+                            onClick = {
+                                setMenuFor(null)
+                                setReactingTo(menuMsg.id)
+                            }
+                            icon(Ic.EmojiEmotions)
+                        }
+                    }
                     ctxItem(Ic.Visibility, "View source") {
                         setSourceFor(menuMsg.id)
                         setMenuFor(null)
@@ -497,6 +554,19 @@ val DmPage =
                     ctxItem(Ic.ContentCopy, "Copy text") {
                         copyToClipboard(menuMsg.content)
                         setMenuFor(null)
+                    }
+                }
+            }
+
+            reactingTo?.let { targetId ->
+                div {
+                    className = ClassName("emoji-overlay")
+                    onClick = { setReactingTo(null) }
+                    EmojiPicker {
+                        onPick = { emoji ->
+                            dmVm.react(pubkey, targetId, emoji)
+                            setReactingTo(null)
+                        }
                     }
                 }
             }
@@ -529,7 +599,8 @@ val DmPage =
                         busy = uploadCount > 0
                         onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
                         onPickerClosed = { composerInputRef.current?.focus() }
-                        onUploaded = { upload -> setText { prev -> if (prev.isBlank()) upload.url else "$prev ${upload.url}" } }
+                        onUploaded = {}
+                        onPicked = { picked -> sendMediaFile(picked) }
                         onError = { setUploadError(it) }
                     }
                     textarea {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -491,7 +491,9 @@ val DmPage =
                                         // reusing the group chat renderer (same package).
                                         renderMessageContent(
                                             body,
-                                            emptyList(),
+                                            // The rumor's own tags: custom emoji and the imeta
+                                            // hints that pre-size an inline image, same as chat.
+                                            m.tags,
                                             userMetadata,
                                             emptyMap(),
                                             { props.onOpenProfile(UserRoute(it)) },

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -50,6 +50,7 @@ import react.dom.html.ReactHTML.p
 import react.dom.html.ReactHTML.span
 import react.dom.html.ReactHTML.textarea
 import react.useEffect
+import react.useLayoutEffect
 import react.useRef
 import react.useState
 import web.cssom.ClassName
@@ -125,6 +126,7 @@ val DmPage =
         val dmStatus = useStateFlow(dmVm.messageStatus)
         val dmFiles = useStateFlow(dmVm.fileStates)
         val dmReactions = useStateFlow(dmVm.reactions)
+        val syncing = useStateFlow(dmVm.syncing)
         // Message the full emoji picker was opened for; null while it is closed.
         val (reactingTo, setReactingTo) = useState<String?> { null }
         val myPubkey = dmVm.getPublicKey()
@@ -141,9 +143,36 @@ val DmPage =
         // True while the user is at (or near) the bottom; drives whether async media growth keeps
         // the view pinned. Updated on scroll; seeded true so a fresh conversation stays pinned.
         val pinnedToBottom = useRef(true)
-        useEffect(pubkey, messages.size) {
-            messagesRef.current?.let { el -> el.scrollTop = el.scrollHeight.toDouble() }
+        // Opening a conversation lands on the newest message; after that the position is the
+        // reader's, not the stream's.
+        useLayoutEffect(pubkey) {
+            messagesRef.current?.let { el ->
+                el.asDynamic().style.overflowAnchor = "none"
+                el.scrollTop = el.scrollHeight.toDouble()
+            }
             pinnedToBottom.current = true
+        }
+        // Following the feed: pinned to the bottom, anchoring off. Reading further up: anchoring
+        // on and scrollTop untouched, so the browser holds the reading position when the backlog
+        // inserts an older message above (same trick the group list uses). Dragging the reader to
+        // the bottom for a message they did not send is what makes a backfill feel like a bug.
+        useLayoutEffect(messages.size) {
+            val el = messagesRef.current ?: return@useLayoutEffect
+            if (pinnedToBottom.current == true) {
+                el.asDynamic().style.overflowAnchor = "none"
+                el.scrollTop = el.scrollHeight.toDouble()
+            } else {
+                el.asDynamic().style.overflowAnchor = "auto"
+            }
+        }
+        // Our own send always returns to the bottom: the reader caused this one.
+        val newestOwnId = messages.lastOrNull()?.takeIf { it.mine }?.id
+        useLayoutEffect(newestOwnId) {
+            if (newestOwnId == null) return@useLayoutEffect
+            val el = messagesRef.current ?: return@useLayoutEffect
+            pinnedToBottom.current = true
+            el.asDynamic().style.overflowAnchor = "none"
+            el.scrollTop = el.scrollHeight.toDouble()
         }
         // Inline media (images/video/audio) loads after render and grows the list; if the user was
         // at the bottom, follow the growth so the newest message stays in view. A capturing listener
@@ -351,6 +380,15 @@ val DmPage =
                     val el = messagesRef.current
                     if (el != null) {
                         pinnedToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80.0
+                    }
+                }
+                // Sitting above the thread, so older messages landing in are expected rather than
+                // startling. Sending stays available: no client can promise it holds every message.
+                if (syncing) {
+                    div {
+                        className = ClassName("dm-syncing")
+                        span { className = ClassName("upload-spinner") }
+                        +"Catching up on older messages"
                     }
                 }
                 div {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -21,6 +21,7 @@ import org.nostr.nostrord.web.DmConversationList
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
+import org.nostr.nostrord.web.components.DmAttachment
 import org.nostr.nostrord.web.components.EmojiPicker
 import org.nostr.nostrord.web.components.GroupInviteCard
 import org.nostr.nostrord.web.components.Ic
@@ -116,6 +117,7 @@ val DmPage =
         // Metadata map for resolving @-mention names inside rich message bodies.
         val userMetadata = useStateFlow(dmVm.userMetadata)
         val dmStatus = useStateFlow(dmVm.messageStatus)
+        val dmFiles = useStateFlow(dmVm.fileStates)
         // Resolve where this peer reads before the first message is written, not after their reply.
         useEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -419,8 +421,17 @@ val DmPage =
                                     title = formatDateTime(m.createdAt)
                                     // A group naddr on its own line renders as the prototype
                                     // invite card (text above, card + View group button below).
+                                    val attachment = m.file
                                     val invite = extractDmGroupInvite(m.content)
-                                    val body = invite?.remainingText ?: m.content
+                                    val body = if (attachment != null) "" else invite?.remainingText ?: m.content
+                                    if (attachment != null) {
+                                        DmAttachment {
+                                            file = attachment
+                                            state = dmFiles[m.id]
+                                            onLoad = { dmVm.loadFile(m) }
+                                            onRetry = { dmVm.retryFile(m) }
+                                        }
+                                    }
                                     if (body.isNotBlank()) {
                                         // Rich body: inline images/video/audio/links/mentions/markdown,
                                         // reusing the group chat renderer (same package).

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3404,10 +3404,15 @@ body {
     }
 }
 
+/* Anchoring on by default (same as .chat-messages-list): the browser holds the row the reader
+   is on when the backlog inserts older messages above, or when media above the viewport settles
+   its height. The component flips it to 'none' only while pinned at the bottom, where anchoring
+   would fight the bottom-pin. */
 .dm-messages {
     flex: 1;
     min-height: 0;
     overflow-y: auto;
+    overflow-anchor: auto;
     padding: var(--space-lg);
 }
 

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3492,6 +3492,17 @@ body {
     background: var(--color-primary);
 }
 
+/* Backlog still draining: sits at the top of the thread, where older messages appear. */
+.dm-syncing {
+    display: flex;
+    gap: var(--space-sm);
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-xs) var(--space-sm);
+    color: var(--color-text-muted);
+    font-size: 12px;
+}
+
 /* NIP-17 kind:15 attachment: the encrypted blob is decrypted in memory and painted from an
    object url, so the slot is reserved from the sender's dim hint while that happens. */
 .dm-attachment {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3404,6 +3404,16 @@ body {
     }
 }
 
+/* Positioned parent for the jump-to-latest pill, which has to sit above the composer rather
+   than scroll away with the messages. */
+.dm-messages-wrap {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+
 /* Anchoring on by default (same as .chat-messages-list): the browser holds the row the reader
    is on when the backlog inserts older messages above, or when media above the viewport settles
    its height. The component flips it to 'none' only while pinned at the bottom, where anchoring
@@ -3411,6 +3421,7 @@ body {
 .dm-messages {
     flex: 1;
     min-height: 0;
+    width: 100%;
     overflow-y: auto;
     overflow-anchor: auto;
     padding: var(--space-lg);
@@ -5757,6 +5768,10 @@ body {
     animation: pop-in 0.14s ease-out;
     transition: color 0.15s;
 }
+.dm-jump-count {
+    font-weight: 600;
+}
+
 .chat-jump-bottom:hover {
     color: var(--color-text-primary);
 }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3492,6 +3492,35 @@ body {
     background: var(--color-primary);
 }
 
+/* NIP-17 kind:15 attachment: the encrypted blob is decrypted in memory and painted from an
+   object url, so the slot is reserved from the sender's dim hint while that happens. */
+.dm-attachment {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-xs);
+    align-items: flex-start;
+    max-width: 100%;
+}
+
+.dm-attachment-loading {
+    width: min(220px, 100%);
+    margin-top: 4px;
+    border-radius: 8px;
+    /* Same sweep as an inline image still decoding (.msg-image.is-loading). */
+    background-image: linear-gradient(
+        100deg,
+        var(--color-input) 32%,
+        var(--color-surface-variant) 50%,
+        var(--color-input) 68%
+    );
+    background-size: 220% 100%;
+    animation: msg-media-shimmer 1.2s linear infinite;
+}
+
+.dm-msg.mine .dm-attachment-failed {
+    color: rgba(255, 255, 255, 0.85);
+}
+
 .dm-intro {
     display: flex;
     flex-direction: column;

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -25,6 +25,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `BunkerStatusBanner` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/BunkerStatusBanner.kt | Floating warning shown when the active account signs through a NIP-46 bunker |
 | `ConfirmDialog` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ConfirmDialog.kt | The single confirm dialog for the native UI (Compose counterpart of the web `confirmDialog` |
 | `DateSeparator` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DateSeparator.kt | — |
+| `DmAttachment` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmAttachment.kt | The body of a NIP-17 kind:15 message: an attachment whose bytes live encrypted on a media |
 | `DmConversationList` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt | The DM conversation list plus its empty state, shared by [DmSidebar] (desktop column) and the |
 | `DmEventSourceDialog` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmEventSourceDialog.kt | "View source" for a DM: the decrypted kind:14 rumor as pretty JSON plus the relays |
 | `DmMessageContextMenu` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/DmMessageContextMenu.kt | Context menu for a DM bubble: the group chat's [MessageContextMenu] shell (same popup, |
@@ -121,6 +122,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `ChatVideo` | webMain/kotlin/org/nostr/nostrord/web/components/ChatVideo.kt | A chat inline video. |
 | `CreateGroupModal` | webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt | Create-group modal — layout-first React port of the Compose [CreateGroupModal]: name, |
 | `CreateThreadModal` | webMain/kotlin/org/nostr/nostrord/web/modals/CreateThreadModal.kt | Compose-a-new-thread modal (kind:11 root): an optional title plus the body, over the threads |
+| `DmAttachment` | webMain/kotlin/org/nostr/nostrord/web/components/DmAttachment.kt | The body of a NIP-17 kind:15 message: an attachment the media server only holds encrypted. |
 | `DmEventSourceModal` | webMain/kotlin/org/nostr/nostrord/web/modals/DmEventSourceModal.kt | "View source" for a DM: the decrypted kind:14 rumor as pretty JSON plus the relays its |
 | `DmRelaysModal` | webMain/kotlin/org/nostr/nostrord/web/modals/DmRelaysModal.kt | Where a peer's DMs route: their published kind:10050 relay list. Empty until the fetch lands, |
 | `EmojiPicker` | webMain/kotlin/org/nostr/nostrord/web/components/EmojiPicker.kt | Emoji picker popover — mirrors the native EmojiPicker: search, category tabs, a recents row, |

--- a/docs/components-index.md
+++ b/docs/components-index.md
@@ -84,6 +84,7 @@ delete the old one in the same change so the catalogue never lists a dead screen
 | `ReactionBadges` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReactionBadges.kt | Displays reaction badges for a message. |
 | `RelayGradientAvatar` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/avatars/GradientAvatar.kt | Deterministic gradient fallback for relay avatars (prototype gradientRelayAvatar): a |
 | `ReplyPreview` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt | Compact reply preview shown above a message that is replying to another message. |
+| `ReplyQuote` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt | The quote box itself, over already-resolved strings. Callers that hold something other than a |
 | `ReportUserModal` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/ReportUserModal.kt | NIP-56 report modal (prototype ReportModal): reason radio cards, optional note, |
 | `RichAboutText` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/RichAboutText.kt | Renders an "about" text with clickable links and resolved nostr mentions. |
 | `SendStateIcon` | uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageStatusIndicator.kt | Inline send-state icon for the author's own message: a muted clock while Sending, a check |


### PR DESCRIPTION
An image sent from Jumble never showed up here: Jumble implements the NIP-17 file message, so the image goes out as a kind:15 rumor whose content is the url of an AES-GCM encrypted blob, and DmManager dropped every rumor that was not kind:14. The wrap was marked handled, so the message was lost silently. Reading those messages is what closes #270; the rest of this branch is the DM surface catching up around it, since an attachment that cannot be reacted to, replied to or opened fullscreen is only half of a message.

Sending changed shape too. A DM attachment is now encrypted before it is uploaded, so the media server holds bytes nobody else can read, where before the image sat on a public url anyone who learned it could fetch. That costs interoperability with clients which do not implement kind:15 (this app until now), which is the tradeoff being made deliberately.

| Area | What changed |
|---|---|
| Read | kind:15 rumors reach the conversation; the blob is downloaded, decrypted and painted from bytes on both UIs |
| Write | Attachments are AES-GCM encrypted before upload, with the key in the sealed rumor and the `dim` decoded locally |
| Reactions | kind:7 rumors in the same gift wrap, kept apart from messages so they never become a bubble, an unread or a preview |
| Replies | A bare `e` tag on the rumor, quoted above the body and in the composer |
| Recovery | A one-shot rescan re-decrypts wraps the old reader discarded, and rows cached as kind:14 are recovered by their decryption tags |
| Reading position | The backlog no longer drags the reader to the bottom; a jump-to-latest pill carries what arrived while they were away |
| Speed | The web message cache is indexed by kind, and hydration no longer waits on a cold relay pool |
| Crypto | AES-GCM in commonMain rather than four platform actuals, covered by NIST vectors |

`AesGcm` skips the GCM tag on read and authenticates against the rumor's `ox` instead: that hash travels inside the sealed, signed rumor, which binds the bytes to the sender rather than to whoever held the key, and it beats a GHASH written in Kotlin over multi-megabyte images. Writing does compute the tag, because the browsers on the other end verify it.

Device-validated: a real Jumble-sent image renders on web and on desktop. Not yet validated: whether Jumble renders what we send, and the reaction / reply round-trips against it.

Closes #270

- feat(dm): read NIP-17 kind:15 file messages
- fix(dm): re-decrypt the backlog so existing kind:15 messages appear
- fix(dm): recover attachments already cached as kind:14 rows
- fix(web): size an inline image from its own bitmap when imeta is missing
- feat(dm): send encrypted kind:15 attachments and react to messages
- perf(web): index the message cache by kind so DMs hydrate on reload
- feat(dm): reply to a message
- perf(dm): stop the cached conversations waiting on relay connects
- fix(dm): render custom emoji and imeta hints in messages
- fix(dm): stop the backlog dragging the reader to the bottom
- fix(web): set the DM scroll anchor before the message lands, not after
- feat(dm): offer a jump-to-latest pill instead of scrolling for the reader
- feat(dm): open an attachment fullscreen on the native UI
- fix(dm): open a linked image fullscreen too, not only an attachment
- fix(native): size an inline image from its own bitmap, like the web