### PR TITLE
Stop a web screen wearing the previous subject's data for a frame

### DIFF
--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -276,15 +277,20 @@ fun DmConversationList(
             }
         } else {
             conversations.forEach { convo ->
-                ConversationRow(
-                    pubkeyHex = convo.peerPubkey,
-                    name = nameOf(convo.peerPubkey),
-                    lastMessage = convo.lastMessage,
-                    pictureUrl = userMetadata[convo.peerPubkey]?.picture,
-                    unread = unreadByPeer[convo.peerPubkey] ?: 0,
-                    selected = activePubkey == convo.peerPubkey,
-                    onClick = { onOpenConversation(DmRoute(convo.peerPubkey)) },
-                )
+                // Keyed on the peer: without it the rows are positional, so switching tab
+                // (Follows <-> Others) reuses each slot for a different person and carries that
+                // row's retained state - its avatar among it - onto the new identity.
+                key(convo.peerPubkey) {
+                    ConversationRow(
+                        pubkeyHex = convo.peerPubkey,
+                        name = nameOf(convo.peerPubkey),
+                        lastMessage = convo.lastMessage,
+                        pictureUrl = userMetadata[convo.peerPubkey]?.picture,
+                        unread = unreadByPeer[convo.peerPubkey] ?: 0,
+                        selected = activePubkey == convo.peerPubkey,
+                        onClick = { onOpenConversation(DmRoute(convo.peerPubkey)) },
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -862,6 +862,9 @@ val AppFrame =
                         }
                     r is UserRoute ->
                         ProfilePage {
+                            // Same reason the DM page and the chat screen are keyed: one profile
+                            // must not inherit the hooks of the one viewed before it.
+                            key = r.pubkey
                             pubkey = r.pubkey
                             onOpenGroup = { pushRoute(it) }
                             onEditProfile = { pushRoute(SettingsRoute) }
@@ -869,6 +872,11 @@ val AppFrame =
                         }
                     r is DmRoute && dmEnabled ->
                         DmPage {
+                            // Keyed on the peer so switching conversation remounts the page
+                            // instead of feeding a new peer into the previous one's hooks: the
+                            // header avatar keeps refs of the last good picture, and the composer
+                            // holds a draft, neither of which belongs to the person just opened.
+                            key = r.pubkey
                             pubkey = r.pubkey
                             onOpenProfile = { pushRoute(it) }
                             onOpenConversation = { pushRoute(it) }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/bridge/FlowHooks.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/bridge/FlowHooks.kt
@@ -3,6 +3,7 @@ package org.nostr.nostrord.web.bridge
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import react.useEffect
+import react.useRef
 import react.useState
 
 /**
@@ -20,23 +21,52 @@ import react.useState
 /**
  * Collect a [StateFlow] into React state. Equivalent of Compose's `collectAsState()`.
  * Seeds from `flow.value` and re-renders on every emission.
+ *
+ * A caller can hand over a DIFFERENT flow (a keyed `useViewModel` rebuilt for the newly opened
+ * peer or group). `useState`'s initializer only runs on mount, so the state would keep the old
+ * flow's value until the effect below re-subscribes, and effects run after paint: the new subject
+ * would paint once wearing the previous one's data (the DM header showing the last peer's avatar
+ * and name). Re-seeding during render discards that frame before it commits.
  */
 fun <T> useStateFlow(flow: StateFlow<T>): T {
     val (state, setState) = useState { flow.value }
+    val lastFlow = useRef<StateFlow<T>>(null)
+    var current = state
+    when {
+        lastFlow.current == null -> lastFlow.current = flow
+        lastFlow.current !== flow -> {
+            lastFlow.current = flow
+            current = flow.value
+            setState(current)
+        }
+    }
     useEffect(flow) {
         flow.collect { setState(it) }
     }
-    return state
+    return current
 }
 
 /**
  * Collect a cold/hot [Flow] with no inherent current value, using [initial] until the
  * first emission.
+ *
+ * A swapped flow falls back to [initial] for the same reason [useStateFlow] re-seeds: carrying
+ * the previous flow's last value into a new subject shows one frame of the wrong thing.
  */
 fun <T> useFlow(flow: Flow<T>, initial: T): T {
     val (state, setState) = useState { initial }
+    val lastFlow = useRef<Flow<T>>(null)
+    var current = state
+    when {
+        lastFlow.current == null -> lastFlow.current = flow
+        lastFlow.current !== flow -> {
+            lastFlow.current = flow
+            current = initial
+            setState(current)
+        }
+    }
     useEffect(flow) {
         flow.collect { setState(it) }
     }
-    return state
+    return current
 }


### PR DESCRIPTION
Opening a DM conversation showed the PREVIOUS peer's avatar in the header and the intro, most visibly when switching between the Follows and Others tabs, and it stayed there rather than flickering.

`useStateFlow` seeded its state with `useState { flow.value }`, whose initializer only runs on mount. A caller handing over a different flow, which is what a keyed `useViewModel` does when the peer changes, kept serving the previous flow's value until the effect re-subscribed, and effects run after paint. The avatar then latched it: during that frame it was handed the new seed with the old url, stored it as the last good picture for that identity (the guard that keeps an avatar from blanking out on metadata churn), and kept painting it even after the metadata was correct.

| Fix | Why there |
|---|---|
| Re-seed both flow hooks during render when the flow identity changes | Discards the wrong frame before it commits; the React-sanctioned adjust-state-on-prop-change pattern |
| Key the DM and profile pages on their subject | Makes the identity structural instead of a prop, so a new peer cannot inherit the previous one's hooks. ChatScreen already does this for the open group |

Compose has no equivalent bug: `collectAsState` keys on the flow, so a new flow re-seeds immediately.

Keying the DM page means a draft typed in the composer does not survive switching conversations. It used to survive, but as one shared draft for every peer, so text started for one person appeared when opening another.

- fix(web): re-seed a flow hook when the flow itself is swapped
- fix(web): key the DM and profile pages on their subject