### PR TITLE
Copy a nevent with its nostr: prefix

### DIFF
--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -53,6 +53,7 @@ import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.ui.components.ReportUserModal
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
@@ -518,14 +519,18 @@ fun MessageItem(
                         MessageContextAction.CopyMessageLink -> currentOnCopyLink()
                         MessageContextAction.ShareMessageLink -> currentOnShareLink()
                         // The message carries id + author + kind; the group relay rides as the
-                        // relay hint so the nevent is fetchable.
+                        // relay hint so the nevent is fetchable. Copied with the NIP-21 prefix:
+                        // pasted into a message it has to read as a reference, and clients that
+                        // follow the spec (Jumble among them) render nothing without it.
                         MessageContextAction.CopyNevent ->
                             copyToClipboard(
-                                Nip19.encodeNevent(
-                                    message.id,
-                                    relays = listOfNotNull(neventRelayHint ?: currentRelayUrl),
-                                    authorHex = message.pubkey,
-                                    kind = message.kind,
+                                Nip27.createUri(
+                                    Nip19.encodeNevent(
+                                        message.id,
+                                        relays = listOfNotNull(neventRelayHint ?: currentRelayUrl),
+                                        authorHex = message.pubkey,
+                                        kind = message.kind,
+                                    ),
                                 ),
                             )
                         MessageContextAction.CopyEventJson -> currentOnCopyJson()

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -78,6 +78,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.buttons.AppButton
@@ -938,9 +939,12 @@ private fun ThreadMessage(
                         writeClipboard(
                             threadShareLink(route.relayUrl, route.groupId, msg.threadRootIdTag() ?: msg.id, messageId = msg.id),
                         )
+                    // Prefixed (NIP-21) so a paste into a message reads as a reference.
                     MessageContextAction.CopyNevent ->
                         writeClipboard(
-                            Nip19.encodeNevent(msg.id, relays = listOf(route.relayUrl), authorHex = msg.pubkey, kind = msg.kind),
+                            Nip27.createUri(
+                                Nip19.encodeNevent(msg.id, relays = listOf(route.relayUrl), authorHex = msg.pubkey, kind = msg.kind),
+                            ),
                         )
                     MessageContextAction.CopyEventJson -> writeClipboard(msg.toEventJson())
                     MessageContextAction.DeleteMessage -> onDelete()

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -3352,6 +3352,14 @@ private fun ChildrenBuilder.systemEventRow(
     }
 }
 
+/**
+ * Every embeddable token in a message body, in ONE regex whose alternatives are ordered on
+ * purpose. A single left-to-right scan takes the alternative that matches earliest, so the url
+ * branches must stay ahead of the bare-bech32 one: `https://njump.me/nevent1…` is a valid nevent
+ * sitting inside a link, and with the order reversed the link would be shredded into a quote card.
+ * The native parser blocks that case with a negative lookbehind instead, which is not an option
+ * here (older Safari throws on lookbehind, taking all rendering with it). Reorder with care.
+ */
 private val URL_REGEX =
     Regex(
         "(data:image/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+)" +
@@ -3359,6 +3367,8 @@ private val URL_REGEX =
             // ws(s):// relay urls, incl. the NIP-29 group address `wss://relay'groupId`
             // (mirrors native MessageContentParser so the apostrophe form renders a group card).
             "|(wss?://[^\\s<>\"]+)" +
+            // Prefixed references (NIP-21) ahead of bare ones, so `nostr:` is consumed with the
+            // identifier rather than left behind as stray text.
             "|(nostr:(?:npub1|nprofile1|nevent1|note1|naddr1)[0-9a-z]+)" +
             "|\\b((?:npub1|nprofile1|nevent1|note1|naddr1)[0-9a-z]{20,})" +
             // Bare NIP-29 group address without the scheme, `relay.host'groupId` (the share field's

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -19,6 +19,7 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.nostr.Nip68
 import org.nostr.nostrord.nostr.Nip84
@@ -3204,9 +3205,11 @@ private val MessageRow =
                         copyToClipboard(props.messageLink)
                         setMenuOpen(false)
                     }
-                    // Prototype: shareable NIP-19 event reference.
+                    // Shareable event reference, carrying the NIP-21 prefix: pasted into a
+                    // message it has to read as a reference, and clients that follow the spec
+                    // (Jumble among them) render nothing without it.
                     ctxItem(Ic.Code, "Copy nevent") {
-                        copyToClipboard(props.nevent)
+                        copyToClipboard(Nip27.createUri(props.nevent))
                         setMenuOpen(false)
                     }
                     ctxItem(Ic.Code, "Copy event JSON") {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -9,6 +9,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.keyboard.VirtualKeyboardPolicy
 import org.nostr.nostrord.ui.mentions.MentionAutocomplete
@@ -869,8 +870,13 @@ val ThreadsScreen =
                         copyToClipboard(threadShareLink(route.relayUrl, route.groupId, m.msg.threadRootIdTag() ?: m.msg.id, messageId = m.msg.id))
                         setCtxMenu(null)
                     }
+                    // Prefixed (NIP-21) so a paste into a message reads as a reference.
                     ctxItem(Ic.Code, "Copy nevent") {
-                        copyToClipboard(Nip19.encodeNevent(m.msg.id, relays = listOf(route.relayUrl), authorHex = m.msg.pubkey, kind = m.msg.kind))
+                        copyToClipboard(
+                            Nip27.createUri(
+                                Nip19.encodeNevent(m.msg.id, relays = listOf(route.relayUrl), authorHex = m.msg.pubkey, kind = m.msg.kind),
+                            ),
+                        )
                         setCtxMenu(null)
                     }
                     ctxItem(Ic.Code, "Copy event JSON") {


### PR DESCRIPTION
Copy nevent handed over a bare bech32, and the obvious destination for it is someone's composer. Pasted there it produced a message only clients that also accept bare identifiers could render: NIP-21 is what marks the text as a reference, and Jumble (whose event regex requires the prefix) shows raw text without it. All four call sites now copy the prefixed form.

Nothing else we write is affected: mentions and group references already go out as `nostr:npub1…` / `nostr:naddr1…`, so this closes the one path that produced bare identifiers.

| Site | File |
|---|---|
| Chat, Compose | `MessageItem.kt` |
| Threads, Compose | `ThreadsScreen.kt` |
| Chat, web | `ChatScreen.kt` |
| Threads, web | `ThreadsScreen.kt` |

The second commit only documents something already load-bearing: the web parses every embeddable token with one regex, and its url branches sit ahead of the bare-bech32 one on purpose. A single left-to-right scan takes the earliest match, so `https://njump.me/nevent1…` stays a link; reorder the alternatives and the link is shredded into a quote card. Native blocks the same case with a negative lookbehind, which this side cannot use because older Safari throws on it.

- docs(web): record why the url branches precede bare bech32
- fix(chat): copy a nevent with its nostr: prefix