### PR TITLE
Release 2.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,7 +273,7 @@ jobs:
           pkgdesc="Nostr NIP-29 group messaging client"
           arch=('x86_64')
           url="https://github.com/Nostrord/nostrord"
-          license=('MIT')
+          license=('Unlicense')
           provides=('nostrord')
           conflicts=('nostrord')
           depends=('libxtst' 'libxrender' 'fontconfig' 'freetype2')

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 #App Version (single source of truth)
-app.version=2.8.0
-app.versionCode=23
+app.version=2.9.0
+app.versionCode=24
 
 #Kotlin
 kotlin.code.style=official


### PR DESCRIPTION
Prepares the 2.9.0 release. The version bump is the usual two lines in `gradle.properties`; the license fix rides along because it has to land before the tag, otherwise the `.pkg.tar.zst` attached to the release declares MIT again.

The Arch package job builds its PKGBUILD inline and had `license=('MIT')` while the repo is Unlicense. Only the release artifact was affected: the AUR PKGBUILD in the same file already declared `Unlicense`, so anyone installing `nostrord-bin` got the right value. Both now agree with `LICENSE`.

Minor rather than patch: 77 commits since v2.8.0, including kind:15 DM attachments, DM replies, the jump-to-latest pill, and forum-style thread posts.

| change | file | before | after |
|---|---|---|---|
| version | `gradle.properties` | 2.8.0 / 23 | 2.9.0 / 24 |
| release package license | `.github/workflows/release.yml:276` | `MIT` | `Unlicense` |

- `ci(arch): declare the repo's Unlicense on the release package`
- `chore: bump version to 2.9.0`