### PR TITLE
feat(dm): return to the open conversation from the DM nav entry

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2118,6 +2118,10 @@ class NostrRepository(
     /** Total unread DMs across all conversations, for the nav badge. */
     override val totalDmUnread: StateFlow<Int> get() = dmManager.totalUnread
 
+    override val lastDmPeer: StateFlow<String?> get() = dmManager.lastPeer
+
+    override fun rememberDmPeer(pubkey: String) = dmManager.rememberLastPeer(pubkey)
+
     // Our own effective DM relays (kind:10050, or the defaults until we publish one). Drives the
     // Settings editor; kept in sync on inbox open, on our own kind:10050, and on publish.
     private val _myDmRelays = MutableStateFlow<List<String>>(emptyList())

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -195,6 +195,16 @@ interface NostrRepositoryApi {
     /** Total unread DMs across all conversations, for the nav badge. */
     val totalDmUnread: StateFlow<Int>
 
+    /**
+     * Peer of the DM conversation last opened this session, or null for none. The DM nav entry
+     * reopens it, so leaving a conversation for a group and coming back lands on the thread
+     * rather than the list. Session-scoped: an account switch clears it.
+     */
+    val lastDmPeer: StateFlow<String?>
+
+    /** Record [pubkey] as the open DM conversation (see [lastDmPeer]). */
+    fun rememberDmPeer(pubkey: String)
+
     /** Our own effective NIP-17 DM relays (kind:10050, or the defaults until one is published). */
     val myDmRelays: StateFlow<List<String>>
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import org.nostr.nostrord.auth.NostrSigner
 import org.nostr.nostrord.nostr.Event
@@ -165,6 +166,27 @@ class DmManager(
                 .filterValues { it > 0 }
         }
             .stateIn(scope, SharingStarted.Eagerly, emptyMap())
+
+    // The conversation the user has open. Session state, not a preference: it lets the DM nav
+    // entry return to the thread the user was reading instead of the list, and dies with the
+    // account. A muted peer resolves to null so the nav never reopens a conversation the lists hide.
+    private val _lastPeer = MutableStateFlow<String?>(null)
+
+    /** Peer of the conversation last opened this session, or null (never opened, or muted). */
+    val lastPeer: StateFlow<String?> = _lastPeer.asStateFlow()
+
+    init {
+        // Read directly (not through a derived flow) so a nav press sees the current peer in the
+        // same frame; muting is rare enough to fold back into the value here.
+        scope.launch {
+            mutedPubkeys.collect { muted -> if (_lastPeer.value in muted) _lastPeer.value = null }
+        }
+    }
+
+    /** Record [pubkey] as the open conversation. */
+    fun rememberLastPeer(pubkey: String) {
+        _lastPeer.value = pubkey
+    }
 
     /** Total unread across all conversations, for the DM nav badge. */
     val totalUnread: StateFlow<Int> =
@@ -614,5 +636,6 @@ class DmManager(
         _dmRelaysByPubkey.value = emptyMap()
         _encKeyByPubkey.value = emptyMap()
         _lastReadByPeer.value = emptyMap()
+        _lastPeer.value = null
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -93,6 +93,15 @@ class DmViewModel(
     val othersConversations: StateFlow<List<DmConversation>> =
         partition(keepFollowed = false)
 
+    /** NIP-02 follow list, for deciding which inbox tab holds a conversation. */
+    val following: StateFlow<Set<String>> = repo.following
+
+    /**
+     * The conversation with [peerPubkey] sits in the Others inbox (message requests), so the list
+     * must show that tab: an open thread hidden behind the Follows tab reads as an empty inbox.
+     */
+    fun isRequestPeer(peerPubkey: String?, follows: Set<String>): Boolean = peerPubkey != null && peerPubkey !in follows
+
     /** Unread total across the Others inbox, for the requests-tab badge. */
     val othersUnread: StateFlow<Int> =
         othersConversations
@@ -116,7 +125,16 @@ class DmViewModel(
      * before it is written rather than after the reply teaches us. The send waits on this too;
      * asking here means it is usually already answered by the time anyone types.
      */
-    fun openConversation(peerPubkey: String) = repo.requestPeerDmRelays(peerPubkey)
+    fun openConversation(peerPubkey: String) {
+        repo.rememberDmPeer(peerPubkey)
+        repo.requestPeerDmRelays(peerPubkey)
+    }
+
+    /**
+     * Peer the DM nav entry should reopen, or null for the conversation list. Reading a thread and
+     * stepping into a group keeps the thread one click away instead of list-then-peer.
+     */
+    val lastPeer: StateFlow<String?> = repo.lastDmPeer
 
     fun getPublicKey(): String? = repo.getPublicKey()
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -148,6 +148,13 @@ class FakeNostrRepository : NostrRepositoryApi {
     override val dmMessagesByPeer: StateFlow<Map<String, List<DmMessage>>> = MutableStateFlow(emptyMap())
     override val dmUnreadByPeer: StateFlow<Map<String, Int>> = MutableStateFlow(emptyMap())
     override val totalDmUnread: StateFlow<Int> = MutableStateFlow(0)
+    val lastDmPeerFlow = MutableStateFlow<String?>(null)
+    override val lastDmPeer: StateFlow<String?> = lastDmPeerFlow
+
+    override fun rememberDmPeer(pubkey: String) {
+        lastDmPeerFlow.value = pubkey
+    }
+
     val myDmRelaysFlow = MutableStateFlow<List<String>>(emptyList())
     override val myDmRelays: StateFlow<List<String>> = myDmRelaysFlow
     val dmRelaysByPubkeyFlow = MutableStateFlow<Map<String, List<String>>>(emptyMap())

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
@@ -1,5 +1,6 @@
 package org.nostr.nostrord.network.managers
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.nostr.nostrord.auth.NostrSigner
@@ -310,5 +311,28 @@ class DmManagerTest {
         assertEquals(false, dm.importRumor(rumor("3".repeat(64), stranger, peer), me))
 
         assertEquals(2, dm.messagesByPeer.value[peer]?.size)
+    }
+
+    @Test
+    fun `the last opened peer survives until the account is cleared`() = runTest {
+        val dm = DmManager(backgroundScope)
+        assertEquals(null, dm.lastPeer.first())
+
+        dm.rememberLastPeer("alice")
+        assertEquals("alice", dm.lastPeer.first())
+
+        dm.clear()
+        assertEquals(null, dm.lastPeer.first())
+    }
+
+    @Test
+    fun `a muted peer is not offered as the last opened conversation`() = runTest {
+        val muted = MutableStateFlow(emptySet<String>())
+        val dm = DmManager(backgroundScope, muted)
+        dm.rememberLastPeer("alice")
+        assertEquals("alice", dm.lastPeer.first())
+
+        muted.value = setOf("alice")
+        assertEquals(null, dm.lastPeer.first { it == null })
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
@@ -83,4 +83,25 @@ class DmViewModelTest {
         assertEquals(5, vm.othersUnread.value) // bob (3) + carol (2), not alice
         job.cancel()
     }
+
+    @Test
+    fun `opening a conversation records it as the peer the DM nav returns to`() = runTest {
+        val fake = FakeNostrRepository()
+        val vm = DmViewModel(fake)
+        assertEquals(null, vm.lastPeer.value)
+
+        vm.openConversation("alice")
+        assertEquals("alice", vm.lastPeer.value)
+    }
+
+    @Test
+    fun `an unfollowed peer belongs to the requests inbox`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._following.value = setOf("alice")
+        val vm = DmViewModel(fake)
+
+        assertEquals(false, vm.isRequestPeer("alice", vm.following.value))
+        assertEquals(true, vm.isRequestPeer("bob", vm.following.value))
+        assertEquals(false, vm.isRequestPeer(null, vm.following.value))
+    }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/AppFrame.kt
@@ -531,7 +531,7 @@ fun AppFrame() {
             if (dmEnabled) {
                 Box {
                     RailButton(icon = Icons.Default.Mail, label = "Direct messages", active = route is DmRoute && !showNotifications) {
-                        history.navigate(DmRoute())
+                        history.navigate(DmRoute(AppModule.nostrRepository.lastDmPeer.value))
                         closeDrawer()
                     }
                     if (dmUnread > 0) {
@@ -874,7 +874,7 @@ private fun FrameContent(
                     onOpenRelay = { onNavigate(RelayRoute(it)) },
                     onCreateGroup = onCreateGroup,
                     onJoinGroup = onJoinGroup,
-                    onOpenDms = { onNavigate(DmRoute()) },
+                    onOpenDms = { onNavigate(DmRoute(AppModule.nostrRepository.lastDmPeer.value)) },
                     onOpenNotifications = onOpenNotifications,
                     onOpenDrawer = onOpenDrawer,
                 )

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -171,6 +172,15 @@ fun DmConversationList(
     val userMetadata by dmVm.userMetadata.collectAsState()
     val unreadByPeer by dmVm.unreadByPeer.collectAsState()
     val conversations = if (tab == 0) follows else others
+
+    // Keyed on the peer and on the follow list, so it lands on Others when the open conversation
+    // is a request (including when kind:3 arrives after the list composes) and then leaves the
+    // choice to whoever taps the tabs.
+    val following by dmVm.following.collectAsState()
+    val activeIsRequest = dmVm.isRequestPeer(activePubkey, following)
+    LaunchedEffect(activePubkey, activeIsRequest) {
+        if (activeIsRequest) tab = 1
+    }
 
     fun nameOf(pubkey: String): String {
         val meta = userMetadata[pubkey]

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/AppFrame.kt
@@ -558,7 +558,7 @@ val AppFrame =
                             button {
                                 className = ClassName(if (route is DmRoute && !notificationsOpen) "rail-btn active" else "rail-btn")
                                 title = "Direct messages"
-                                onClick = { pushRoute(DmRoute()) }
+                                onClick = { pushRoute(DmRoute(repo.lastDmPeer.value)) }
                                 icon(Ic.Mail)
                             }
                             if (dmUnread > 0) {
@@ -928,7 +928,7 @@ val AppFrame =
                             onOpenGroup = { pushRoute(GroupRoute(it.relayUrl, it.meta.id)) }
                             onCreateGroup = { setAddGroupStep("create") }
                             onJoinGroup = { setAddGroupStep("join") }
-                            onOpenDms = { pushRoute(DmRoute()) }
+                            onOpenDms = { pushRoute(DmRoute(repo.lastDmPeer.value)) }
                             onOpenNotifications = { pushRoute(NotificationsRoute) }
                         }
                 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/DmSidebar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/DmSidebar.kt
@@ -15,6 +15,7 @@ import react.Props
 import react.dom.html.ReactHTML.button
 import react.dom.html.ReactHTML.div
 import react.dom.html.ReactHTML.span
+import react.useEffect
 import react.useState
 import web.cssom.ClassName
 
@@ -121,6 +122,14 @@ val DmConversationList =
         val userMetadata = useStateFlow(dmVm.userMetadata)
         val unreadByPeer = useStateFlow(dmVm.unreadByPeer)
         val conversations = if (tab == 0) follows else others
+
+        // Keyed on the peer and on the follow list, so it lands on Others when the open
+        // conversation is a request (including when kind:3 arrives after the list renders) and
+        // then leaves the choice to whoever taps the tabs.
+        val activeIsRequest = dmVm.isRequestPeer(props.activePubkey, useStateFlow(dmVm.following))
+        useEffect(props.activePubkey, activeIsRequest) {
+            if (activeIsRequest) setTab(1)
+        }
 
         fun nameOf(pubkey: String): String {
             val meta = userMetadata[pubkey]


### PR DESCRIPTION
The DM entry always pushed `DmRoute()` (the conversation list), so leaving a thread to read a group and coming back cost two clicks: the icon, then the peer. It now reopens whatever conversation was being read, on both the rail and the home page entry, on Compose and web alike. The list also opens on the Others tab when the open conversation is a message request, since a thread hidden behind Follows reads as an empty inbox.

The remembered peer is session state on `DmManager`: it dies with the account (`clear()`) and is dropped when the peer is muted, so the nav can never reopen a conversation the lists hide. Nothing is persisted, so a cold start still lands on the list rather than inside someone's private thread. The rails read the value at click time instead of observing it, which keeps a conversation switch from re-rendering the whole frame. `openConversation` was already the single mount-time call on both UIs, so recording the peer needed no new call site.

| Change | Where |
|---|---|
| `lastPeer` + `rememberLastPeer`, cleared on account switch and on mute | `DmManager.kt` |
| `lastDmPeer` / `rememberDmPeer` on the repo facade | `NostrRepositoryApi.kt`, `NostrRepository.kt` |
| `openConversation` records the peer; `following` + `isRequestPeer` for the tab rule | `DmViewModel.kt` |
| Rail and home entry navigate to `DmRoute(lastDmPeer)` | web + Compose `AppFrame.kt` |
| Conversation list lands on Others for a request peer | web + Compose `DmSidebar.kt` |

Tests: the peer survives until `clear()`, a muted peer resolves to null, opening a conversation records it, and the requests-inbox rule. `compileKotlinJvm`, `compileKotlinJs`, `:composeApp:jvmTest` and `spotlessCheck` all pass.

Closes #279

- 2a4abbf4 feat(dm): return to the open conversation from the DM nav entry