### PR TITLE
fix: clear the composer in the gesture that sends

### DIFF
--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -258,17 +258,27 @@ fun DmPageScreen(
         val send = {
             val body = textFieldValue.text.trim()
             if (body.isNotBlank() && !isSending) {
+                // Snapshot for restore-on-failure (GroupScreen does the same). The field clears
+                // in the gesture that sent: the publish round-trip runs for as long as the signer
+                // takes, and a draft still sitting there reads as "not sent".
+                val sentValue = textFieldValue
+                val sentReply = replyParent?.id
                 isSending = true
+                textFieldValue = TextFieldValue("")
+                replyingTo = null
                 dmVm.send(
                     pubkey,
                     body,
-                    replyToId = replyParent?.id,
-                    onSuccess = {
-                        textFieldValue = TextFieldValue("")
-                        replyingTo = null
+                    replyToId = sentReply,
+                    onSuccess = { isSending = false },
+                    onFailure = {
                         isSending = false
+                        // Push it back for a retry, unless a new message was started.
+                        if (textFieldValue.text.isBlank()) {
+                            textFieldValue = sentValue
+                            replyingTo = sentReply
+                        }
                     },
-                    onFailure = { isSending = false },
                 )
             }
         }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/ThreadsScreen.kt
@@ -454,19 +454,33 @@ fun ThreadsScreen(
                         onValueChange = { reply = it },
                         onSend = {
                             if (reply.text.isNotBlank() && !sending) {
+                                // Snapshot for restore-on-failure (GroupScreen does the same). The
+                                // field clears in the gesture that sent, so a slow signer round-trip
+                                // never leaves the reply sitting there looking unsent.
+                                val sentReply = reply
+                                val sentMentions = replyMentions
+                                val sentGroupMentions = replyGroupMentions
+                                val sentParent = replyingTo
                                 sending = true
+                                reply = TextFieldValue("")
+                                replyMentions = emptyMap()
+                                replyGroupMentions = emptyMap()
+                                replyingTo = null
                                 vm.sendReply(
-                                    resolveGroupMentions(reply.text.trim(), replyGroupMentions),
-                                    parent = replyingTo,
-                                    mentions = replyMentions,
-                                    onSuccess = {
-                                        reply = TextFieldValue("")
-                                        replyMentions = emptyMap()
-                                        replyGroupMentions = emptyMap()
-                                        replyingTo = null
+                                    resolveGroupMentions(sentReply.text.trim(), sentGroupMentions),
+                                    parent = sentParent,
+                                    mentions = sentMentions,
+                                    onSuccess = { sending = false },
+                                    onFailure = {
                                         sending = false
+                                        // Push it back for a retry, unless a new reply was started.
+                                        if (reply.text.isBlank()) {
+                                            reply = sentReply
+                                            replyMentions = sentMentions
+                                            replyGroupMentions = sentGroupMentions
+                                            replyingTo = sentParent
+                                        }
                                     },
-                                    onFailure = { sending = false },
                                 )
                             }
                         },

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/MessageInput.kt
@@ -285,19 +285,10 @@ fun MessageInput(
     }
 
     fun handleTextFieldValueChange(newValue: TextFieldValue) {
-        // Lock typing while a send is in flight. We do this here instead of via
-        // readOnly so the Android IME session is not torn down and recreated,
-        // which closes and reopens the soft keyboard (flicker) on every send.
-        // Simply dropping the change is not enough: the Android IME keeps a
-        // composing region and replays the buffered keystrokes once the lock
-        // lifts (e.g. "adas" + typed "das" -> "adasdas"). Re-assert the current
-        // value with the composition cleared so nothing can accumulate.
-        if (isSending) {
-            if (textFieldValue.composition != null) {
-                textFieldValue = textFieldValue.copy(composition = null)
-            }
-            return
-        }
+        // Typing stays live while a send is in flight: the round-trip lasts as long as the
+        // signer takes, and a field that swallows keystrokes for that window reads as a frozen
+        // app. Only the send itself waits (see [submit] and the send button). A restore from a
+        // failed send is skipped once the next message is started (see the messageInput channel).
         // Drop the glyph the Ctrl+/ chord injected (see swallowChordGlyph).
         if (swallowChordGlyph) {
             swallowChordGlyph = false

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -297,10 +297,8 @@ private val ChatComposer =
         val groupName = props.groupName
 
         val (draft, setDraft) = useState { "" }
-        // Tracks an in-flight sendMessage so we (a) don't double-send if the user
-        // mashes Enter, and (b) keep the draft visible until the signer + relay
-        // come back — clearing optimistically erased the message when a NIP-07
-        // cancel or relay reject killed the publish.
+        // Tracks an in-flight sendMessage so a mashed Enter can't double-send while
+        // the signer + relay are still out.
         val (sending, setSending) = useState { false }
         // Active media uploads in flight (paste / drag-and-drop). The send button
         // shows a spinner instead of the Send icon while > 0.
@@ -396,25 +394,40 @@ private val ChatComposer =
             val replyId = props.replyingToId
             // NIP-68 imeta for any media uploaded into this draft (native parity).
             val imetaTags = pendingUploads.map { it.toImetaTag() }
+            // Snapshot for restore-on-failure (native GroupScreen does the same). The field
+            // clears now, in the same gesture that sent: the publish round-trip runs for as
+            // long as the signer takes, and a draft still sitting there reads as "not sent"
+            // and swallows whatever is typed meanwhile when the late clear lands.
+            val sentDraft = draft
+            val sentMentions = mentions
+            val sentGroupMentions = groupMentions
+            val sentUploads = pendingUploads
             setSending(true)
+            setDraft("")
+            setMentions(emptyMap())
+            setGroupMentions(emptyMap())
+            setPendingUploads(emptyList())
+            // Keep the mobile keyboard up and the cursor in the field for the next message.
+            composerInputRef.current?.focus()
             vm.sendMessage(
                 content = text,
                 channel = null,
-                mentions = mentions,
+                mentions = sentMentions,
                 replyToId = replyId,
                 extraTags = imetaTags,
                 onSuccess = {
                     setSending(false)
-                    // Clear only after publish succeeded so a cancel/reject keeps the draft.
-                    setDraft("")
-                    setMentions(emptyMap())
-                    setGroupMentions(emptyMap())
-                    setPendingUploads(emptyList())
-                    // Keep the mobile keyboard up and the cursor in the field for the next message.
-                    composerInputRef.current?.focus()
                     props.onSent()
                 },
-                onFailure = { setSending(false) },
+                onFailure = {
+                    setSending(false)
+                    // Push the message back so it can be retried, unless the user already
+                    // started a new one.
+                    setDraft { cur -> if (cur.isBlank()) sentDraft else cur }
+                    setMentions { cur -> if (cur.isEmpty()) sentMentions else cur }
+                    setGroupMentions { cur -> if (cur.isEmpty()) sentGroupMentions else cur }
+                    setPendingUploads { cur -> if (cur.isEmpty()) sentUploads else cur }
+                },
             )
         }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -210,17 +210,24 @@ val DmPage =
         val (sending, setSending) = useState { false }
         val send = {
             if (text.isNotBlank() && !sending) {
+                // Clear in the same gesture that sent: the publish round-trip lasts as long as
+                // the signer takes, and a draft still sitting there reads as "not sent". Only a
+                // build/sign failure pushes it back, and only if no new message was started.
+                val sentText = text
+                val sentReply = replyingTo
                 setSending(true)
+                setText("")
+                setReplyingTo(null)
                 dmVm.send(
                     pubkey,
-                    text,
-                    replyToId = replyingTo,
-                    onSuccess = {
-                        setText("")
-                        setReplyingTo(null)
+                    sentText,
+                    replyToId = sentReply,
+                    onSuccess = { setSending(false) },
+                    onFailure = {
                         setSending(false)
+                        setText { cur -> if (cur.isBlank()) sentText else cur }
+                        setReplyingTo { cur -> cur ?: sentReply }
                     },
-                    onFailure = { setSending(false) },
                 )
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ThreadsScreen.kt
@@ -201,19 +201,30 @@ private val ThreadComposer =
             // @user mentions are resolved by the repo from the mentions map (+ p tag).
             var text = reply
             groupMentions.forEach { (name, ref) -> text = text.replace("%$name", ref) }
+            // Snapshot for restore-on-failure: the field clears in the same gesture that sent,
+            // so a slow signer round-trip never leaves the reply sitting there looking unsent.
+            val sentReply = reply
+            val sentMentions = mentions
+            val sentGroupMentions = groupMentions
             setSending(true)
+            setReply("")
+            setMentions(emptyMap())
+            setGroupMentions(emptyMap())
             vm.sendReply(
                 text,
                 parent = props.replyingTo,
-                mentions = mentions,
+                mentions = sentMentions,
                 onSuccess = {
-                    setReply("")
-                    setMentions(emptyMap())
-                    setGroupMentions(emptyMap())
                     setSending(false)
                     props.onSent()
                 },
-                onFailure = { setSending(false) },
+                onFailure = {
+                    setSending(false)
+                    // Push the reply back for a retry, unless a new one was started.
+                    setReply { cur -> if (cur.isBlank()) sentReply else cur }
+                    setMentions { cur -> if (cur.isEmpty()) sentMentions else cur }
+                    setGroupMentions { cur -> if (cur.isEmpty()) sentGroupMentions else cur }
+                },
             )
         }
 


### PR DESCRIPTION
Sending a message left the text sitting in the composer for the length of the publish round-trip, so the send looked like it had not taken; anything typed in the meantime was then wiped when the late clear finally landed. The web composers cleared the draft inside `sendMessage`'s `onSuccess`, which only arrives after the signer and the relay come back. `GroupScreen` on native already cleared on send and restored on failure, but the DM page and the thread reply box did not, and the group's own `MessageInput` went further and dropped every keystroke while a send was in flight.

All five composers now clear in the same gesture that sends and push the message back only on a build/sign failure, and only when the field is still empty so a new message is never overwritten. Typing stays live throughout; only the send waits, with the button already showing a spinner and staying disabled.

| Surface | Before | After |
|---|---|---|
| web chat / DM / thread reply | cleared in `onSuccess` | clears on send, restores on failure |
| native DM (`DmPageScreen`) | cleared in `onSuccess` | clears on send, restores on failure |
| native thread reply (`ThreadsScreen`) | cleared in `onSuccess` | clears on send, restores on failure |
| native chat (`MessageInput`) | typing locked while `isSending` | typing live, send still blocked |

The typing lock cost at least the 400ms `MIN_SEND_SPINNER` floor on every message and the full signer latency with Amber or a bunker.

- 823d4d97 fix(web): clear the composer in the gesture that sends
- bc548ce0 fix(native): clear the DM and thread composers in the gesture that sends
- 3bd2e955 fix(native): keep typing live while a send is in flight

`compileKotlinJvm` and `compileKotlinJs` pass. Device validation pending, in particular the failure path: cancel the NIP-07 / Amber / bunker prompt and confirm the text comes back.