### PR TITLE
fix(dm): focus the composer when picking Reply

### DIFF
--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
@@ -181,6 +182,13 @@ fun DmPageScreen(
         var uploadError by remember { mutableStateOf<String?>(null) }
         // Message being replied to; the composer shows its quote until it is sent or cancelled.
         var replyingTo by remember { mutableStateOf<String?>(null) }
+        // Picking Reply puts the caret in the composer, ready to type (chat/web parity). Bumped per
+        // pick so replying twice to the same message re-focuses.
+        val composerFocus = remember { FocusRequester() }
+        var replyFocusNonce by remember { mutableStateOf(0) }
+        LaunchedEffect(replyingTo, replyFocusNonce) {
+            if (replyingTo != null) runCatching { composerFocus.requestFocus() }
+        }
         // Resolve where this peer reads before the first message is written, not after their reply.
         LaunchedEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -495,7 +503,10 @@ fun DmPageScreen(
                                         onCopyText = { copyToClipboard(m.content) },
                                         onReact = { dmVm.react(pubkey, m.id, it) },
                                         onOpenReactionPicker = { reactingTo = m.id },
-                                        onReply = { replyingTo = m.id },
+                                        onReply = {
+                                            replyingTo = m.id
+                                            replyFocusNonce++
+                                        },
                                     )
                                     // Web parity (.dm-bubble max-width 75%): the spacer eats the other
                                     // 25% on the bubble's growth side; the Box owns the 75% slot and
@@ -644,6 +655,7 @@ fun DmPageScreen(
             replyAuthorName = replyParent?.let { replyAuthorName(it, userMetadata, name, myPubkey) },
             replySnippet = replyParent?.previewText(),
             onCancelReply = { replyingTo = null },
+            focusRequester = composerFocus,
             // A DM attachment is encrypted before it reaches a media server, so the picked bytes
             // go out as a kind:15 message instead of being uploaded and pasted as a url.
             onFilePicked = { bytes, filename ->

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -22,6 +22,7 @@ import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.formatDateTime
 import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.web.DmConversationList
+import org.nostr.nostrord.web.bridge.VirtualKeyboard
 import org.nostr.nostrord.web.bridge.launchApp
 import org.nostr.nostrord.web.bridge.useStateFlow
 import org.nostr.nostrord.web.bridge.useViewModel
@@ -132,6 +133,8 @@ val DmPage =
         val myPubkey = dmVm.getPublicKey()
         // Message being replied to; the composer keeps its chip until the reply is sent.
         val (replyingTo, setReplyingTo) = useState<String?> { null }
+        // Bumped per Reply pick so replying twice to the same message re-focuses the composer.
+        val (replyNonce, setReplyNonce) = useState { 0 }
         // Resolve where this peer reads before the first message is written, not after their reply.
         useEffect(pubkey) { dmVm.openConversation(pubkey) }
         // Mark the conversation read while it is open (and as new messages stream in).
@@ -330,6 +333,19 @@ val DmPage =
             }
             ta.focus()
             document.asDynamic().execCommand("insertText", false, s)
+        }
+
+        // Picking Reply puts the caret in the composer, ready to type (chat parity). focus() is a
+        // no-op when the textarea is already focused with the keyboard dismissed (Android back
+        // button), so blur first and let the refocus re-summon the IME. Never blur while the
+        // keyboard is up: a refocus outside a user gesture is not guaranteed to bring it back.
+        useEffect(replyingTo, replyNonce) {
+            if (replyingTo == null) return@useEffect
+            val ta = composerInputRef.current ?: return@useEffect
+            if (!VirtualKeyboard.isOpen && document.asDynamic().activeElement === ta.asDynamic()) {
+                ta.blur()
+            }
+            ta.focus()
         }
 
         div {
@@ -651,6 +667,7 @@ val DmPage =
                         }
                         ctxItem(Ic.Reply, "Reply") {
                             setReplyingTo(menuMsg.id)
+                            setReplyNonce { it + 1 }
                             setMenuFor(null)
                         }
                         ctxItem(Ic.Visibility, "View source") {


### PR DESCRIPTION
Picking Reply on a DM message showed the quote chip but left the composer unfocused, so typing required a second click/tap. Group chat and threads already focus on reply; the DM page was missing the same wiring on both platforms.

Native gets the ThreadsScreen pattern (FocusRequester into the shared MessageComposer + LaunchedEffect keyed on the replied message and a per-pick nonce, so replying twice to the same message re-focuses). Web gets the ChatScreen pattern (useEffect keyed the same way, with the keyboard-safe blur-then-focus that re-summons the IME only when the virtual keyboard is closed).

Commits:
- 70e03ac1 fix(dm): focus the composer when picking Reply