### PR TITLE
fix(dm): pick the right Follows/Others tab on reload

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -96,11 +96,16 @@ class DmViewModel(
     /** NIP-02 follow list, for deciding which inbox tab holds a conversation. */
     val following: StateFlow<Set<String>> = repo.following
 
+    /** True once the kind:3 contact list resolved; before that [following] is emptily wrong. */
+    val followsLoaded: StateFlow<Boolean> = repo.contactListLoaded
+
     /**
      * The conversation with [peerPubkey] sits in the Others inbox (message requests), so the list
      * must show that tab: an open thread hidden behind the Follows tab reads as an empty inbox.
+     * Until the contact list loads every peer looks unfollowed, so no one is a request yet:
+     * deciding early would flip a followed peer's reload onto the Others tab.
      */
-    fun isRequestPeer(peerPubkey: String?, follows: Set<String>): Boolean = peerPubkey != null && peerPubkey !in follows
+    fun isRequestPeer(peerPubkey: String?, follows: Set<String>, followsLoaded: Boolean): Boolean = followsLoaded && peerPubkey != null && peerPubkey !in follows
 
     /** Unread total across the Others inbox, for the requests-tab badge. */
     val othersUnread: StateFlow<Int> =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -102,10 +102,15 @@ class DmViewModel(
     /**
      * The conversation with [peerPubkey] sits in the Others inbox (message requests), so the list
      * must show that tab: an open thread hidden behind the Follows tab reads as an empty inbox.
-     * Until the contact list loads every peer looks unfollowed, so no one is a request yet:
-     * deciding early would flip a followed peer's reload onto the Others tab.
+     * The split is only decidable once the follow set is usable: the live kind:3 resolved, or the
+     * persisted cache seeded a non-empty set on cold boot. Deciding on an empty unloaded set would
+     * flip a followed peer's reload onto the Others tab; refusing to decide on a seeded set would
+     * leave a request peer's reload stuck on Follows until a relay echoes the kind:3.
      */
-    fun isRequestPeer(peerPubkey: String?, follows: Set<String>, followsLoaded: Boolean): Boolean = followsLoaded && peerPubkey != null && peerPubkey !in follows
+    fun isRequestPeer(peerPubkey: String?, follows: Set<String>, followsLoaded: Boolean): Boolean {
+        val followsKnown = followsLoaded || follows.isNotEmpty()
+        return followsKnown && peerPubkey != null && peerPubkey !in follows
+    }
 
     /** Unread total across the Others inbox, for the requests-tab badge. */
     val othersUnread: StateFlow<Int> =

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
@@ -98,10 +98,26 @@ class DmViewModelTest {
     fun `an unfollowed peer belongs to the requests inbox`() = runTest {
         val fake = FakeNostrRepository()
         fake._following.value = setOf("alice")
+        fake._contactListLoaded.value = true
         val vm = DmViewModel(fake)
 
-        assertEquals(false, vm.isRequestPeer("alice", vm.following.value))
-        assertEquals(true, vm.isRequestPeer("bob", vm.following.value))
-        assertEquals(false, vm.isRequestPeer(null, vm.following.value))
+        assertEquals(false, vm.isRequestPeer("alice", vm.following.value, vm.followsLoaded.value))
+        assertEquals(true, vm.isRequestPeer("bob", vm.following.value, vm.followsLoaded.value))
+        assertEquals(false, vm.isRequestPeer(null, vm.following.value, vm.followsLoaded.value))
+    }
+
+    @Test
+    fun `no peer is a request before the contact list loads`() = runTest {
+        val fake = FakeNostrRepository()
+        fake._contactListLoaded.value = false
+        val vm = DmViewModel(fake)
+
+        // A reload lands here with follows still empty; deciding now would flip a
+        // followed peer's open conversation onto the Others tab.
+        assertEquals(false, vm.isRequestPeer("bob", vm.following.value, vm.followsLoaded.value))
+
+        fake._following.value = setOf("alice")
+        fake._contactListLoaded.value = true
+        assertEquals(true, vm.isRequestPeer("bob", vm.following.value, vm.followsLoaded.value))
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
@@ -120,4 +120,16 @@ class DmViewModelTest {
         fake._contactListLoaded.value = true
         assertEquals(true, vm.isRequestPeer("bob", vm.following.value, vm.followsLoaded.value))
     }
+
+    @Test
+    fun `a cache-seeded follow set classifies peers before the live kind3 lands`() = runTest {
+        val fake = FakeNostrRepository()
+        // Cold boot: the follow set is seeded from disk, the relay kind:3 has not arrived yet.
+        fake._contactListLoaded.value = false
+        fake._following.value = setOf("alice")
+        val vm = DmViewModel(fake)
+
+        assertEquals(false, vm.isRequestPeer("alice", vm.following.value, vm.followsLoaded.value))
+        assertEquals(true, vm.isRequestPeer("bob", vm.following.value, vm.followsLoaded.value))
+    }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/layout/DmSidebar.kt
@@ -177,7 +177,8 @@ fun DmConversationList(
     // is a request (including when kind:3 arrives after the list composes) and then leaves the
     // choice to whoever taps the tabs.
     val following by dmVm.following.collectAsState()
-    val activeIsRequest = dmVm.isRequestPeer(activePubkey, following)
+    val followsLoaded by dmVm.followsLoaded.collectAsState()
+    val activeIsRequest = dmVm.isRequestPeer(activePubkey, following, followsLoaded)
     LaunchedEffect(activePubkey, activeIsRequest) {
         if (activeIsRequest) tab = 1
     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/DmSidebar.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/DmSidebar.kt
@@ -126,7 +126,7 @@ val DmConversationList =
         // Keyed on the peer and on the follow list, so it lands on Others when the open
         // conversation is a request (including when kind:3 arrives after the list renders) and
         // then leaves the choice to whoever taps the tabs.
-        val activeIsRequest = dmVm.isRequestPeer(props.activePubkey, useStateFlow(dmVm.following))
+        val activeIsRequest = dmVm.isRequestPeer(props.activePubkey, useStateFlow(dmVm.following), useStateFlow(dmVm.followsLoaded))
         useEffect(props.activePubkey, activeIsRequest) {
             if (activeIsRequest) setTab(1)
         }


### PR DESCRIPTION
Reloading with an open DM misplaced the sidebar's tab selection in both directions. For a followed peer, the tab landed on Others: the sidebar renders before the kind:3 arrives, so the empty follow set made every peer look like a request, and the one-way auto-select never came back. For a request peer, the opposite: contactListLoaded only flips when a relay echoes the kind:3, so gating on it alone left the tab stuck on Follows even though cold boot seeds the follow set from disk long before that.

isRequestPeer now decides only once the follow set is usable: the live kind:3 resolved, or the persisted cache seeded a non-empty set. Pure function in DmViewModel, consumed unchanged by both sidebars (Compose and web).

| Reload scenario | Result |
| --- | --- |
| Followed peer, before any load | no decision, stays on Follows |
| Followed peer, cache seeded | Follows |
| Request peer, cache seeded | Others immediately |
| Request peer, no cache, kind:3 arrives later | flips to Others when it lands |
| User who follows nobody, kind:3 loaded | Others |

Commits:
- 512e20c4 fix(dm): don't auto-select the Others tab before the contact list loads
- b6965052 fix(dm): classify request peers from the cache-seeded follow set on cold boot