### PR TITLE
fix(dm): file attachments upload and render across clients

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -69,8 +69,9 @@ import org.nostr.nostrord.network.managers.UnreadManager
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.upload.decodeImageDimensions
-import org.nostr.nostrord.network.upload.uploadMedia
+import org.nostr.nostrord.network.upload.uploadEncryptedBlob
 import org.nostr.nostrord.nostr.Crypto
+import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
 import org.nostr.nostrord.nostr.Nip11RelayInfo
@@ -2226,23 +2227,17 @@ class NostrRepository(
     }
 
     /**
-     * Send an image or other file as a NIP-17 kind:15 message: encrypt it, upload the ciphertext,
-     * and put the url plus the decryption material in the rumor. The media server only ever holds
-     * bytes it cannot read, unlike a plain url in a text message, which anyone who learns it can
-     * fetch. [width] and [height] let the reader reserve the right slot before the bytes land.
+     * Encrypt and upload a DM attachment, returning what the composer keeps until Enter. The
+     * media server only ever holds ciphertext: key and nonce travel inside the sealed kind:15.
+     * [width] and [height] let the reader reserve the right slot before the bytes land.
      */
-    override suspend fun sendDmFile(
-        recipientPubkey: String,
+    override suspend fun uploadDmFile(
         bytes: ByteArray,
         filename: String,
         mimeType: String,
         width: Int?,
         height: Int?,
-    ): Result<Unit> {
-        val signer =
-            ActiveAccountManager.session.value?.signer
-                ?: return Result.Error(AppError.Auth.NotAuthenticated)
-        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+    ): Result<DmOutgoingFile> {
         if (bytes.isEmpty()) return Result.Error(AppError.Unknown("The file is empty"))
         // A private key is 32 bytes off the platform CSPRNG, which is exactly what the cipher
         // wants; drawing from it keeps randomness on one primitive instead of a fifth expect/actual.
@@ -2251,37 +2246,75 @@ class NostrRepository(
         val encrypted =
             AesGcm.encrypt(key, nonce, bytes)
                 ?: return Result.Error(AppError.Unknown("Could not encrypt the file"))
-        val uploaded = uploadMedia(encrypted, "$filename.bin", "application/octet-stream")
+        val uploaded = uploadEncryptedBlob(encrypted, filename)
         val upload = uploaded.getOrNull() ?: return Result.Error(uploaded.errorOrNull() ?: AppError.Unknown("Upload failed"))
-        awaitPeerDmRelays(recipientPubkey)
         // Without a `dim` the reader cannot reserve the image's box and the thread jumps when the
-        // bytes land. The server cannot supply one here (it only sees ciphertext), so decode it.
+        // bytes land. The server cannot supply one (it only sees ciphertext), so decode it here.
         val (dimWidth, dimHeight) =
             if (width != null && height != null) {
                 width to height
             } else {
                 decodeImageDimensions(bytes, mimeType) ?: (null to null)
             }
+        return Result.Success(
+            DmOutgoingFile(
+                url = upload.url,
+                mimeType = mimeType,
+                keyHex = key.toHexString(),
+                nonceHex = nonce.toHexString(),
+                originalHashHex = Crypto.sha256(bytes).toHexString(),
+                size = bytes.size.toLong(),
+                width = dimWidth?.takeIf { it > 0 },
+                height = dimHeight?.takeIf { it > 0 },
+            ),
+        )
+    }
+
+    /**
+     * Send an uploaded attachment as a NIP-17 kind:15: the url is the content and the tags carry
+     * the key, the nonce and `ox`, the shape other NIP-17 clients read. Each file is its own rumor;
+     * any text goes in a separate kind:14.
+     */
+    override suspend fun sendDmUploadedFile(
+        recipientPubkey: String,
+        file: DmOutgoingFile,
+    ): Result<Unit> {
+        val signer =
+            ActiveAccountManager.session.value?.signer
+                ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        val myPub = sessionManager.getPublicKey() ?: return Result.Error(AppError.Auth.NotAuthenticated)
+        awaitPeerDmRelays(recipientPubkey)
         val tags =
             buildList {
-                add(listOf("file-type", mimeType))
+                add(listOf(Nip17File.TAG_FILE_TYPE, file.mimeType))
                 add(listOf("encryption-algorithm", Nip17File.ALGORITHM_AES_GCM))
-                add(listOf(Nip17File.TAG_DECRYPTION_KEY, key.toHexString()))
-                add(listOf("decryption-nonce", nonce.toHexString()))
+                add(listOf(Nip17File.TAG_DECRYPTION_KEY, file.keyHex))
+                add(listOf("decryption-nonce", file.nonceHex))
                 // Hash of the plaintext: what the reader checks the decrypted bytes against.
-                add(listOf("ox", Crypto.sha256(bytes).toHexString()))
-                add(listOf("x", Crypto.sha256(encrypted).toHexString()))
-                add(listOf("size", bytes.size.toString()))
-                if (dimWidth != null && dimHeight != null && dimWidth > 0 && dimHeight > 0) {
-                    add(listOf("dim", "${dimWidth}x$dimHeight"))
-                }
+                add(listOf("ox", file.originalHashHex))
+                add(listOf("size", file.size.toString()))
+                val w = file.width
+                val h = file.height
+                if (w != null && h != null) add(listOf("dim", "${w}x$h"))
             }
         return publishDmRumor(
-            Nip17.buildRumor(myPub, recipientPubkey, upload.url, extraTags = tags, kind = Nip17.KIND_FILE),
+            Nip17.buildRumor(myPub, recipientPubkey, file.url, extraTags = tags, kind = Nip17.KIND_FILE),
             recipientPubkey,
             myPub,
             signer,
         )
+    }
+
+    override suspend fun sendDmFile(
+        recipientPubkey: String,
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        width: Int?,
+        height: Int?,
+    ): Result<Unit> = when (val uploaded = uploadDmFile(bytes, filename, mimeType, width, height)) {
+        is Result.Error -> Result.Error(uploaded.error)
+        is Result.Success -> sendDmUploadedFile(recipientPubkey, uploaded.data)
     }
 
     /**
@@ -3174,11 +3207,11 @@ class NostrRepository(
 
     private fun org.nostr.nostrord.storage.cache.CachedMsg.toDmMessage(myPubkey: String): DmMessage {
         // Rows written before file messages had their own cache kind all claim kind:14, so the
-        // decryption tag is what identifies an attachment; without this an existing one hydrates
+        // file-type tag is what identifies an attachment; without this an existing one hydrates
         // as text and renders its blob url. Matched on the raw json: hydration runs over the whole
         // history at startup, and parsing every row's tags to answer this costs more than it saves.
         val rumorKind =
-            if (kind == DM_FILE_CACHE_KIND || tagsJson.contains("\"${Nip17File.TAG_DECRYPTION_KEY}\"")) {
+            if (kind == DM_FILE_CACHE_KIND || tagsJson.contains("\"${Nip17File.TAG_FILE_TYPE}\"")) {
                 Nip17.KIND_FILE
             } else {
                 Nip17.KIND_CHAT

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -71,6 +71,7 @@ import org.nostr.nostrord.network.outbox.Nip65Relay
 import org.nostr.nostrord.network.upload.decodeImageDimensions
 import org.nostr.nostrord.network.upload.uploadEncryptedBlob
 import org.nostr.nostrord.nostr.Crypto
+import org.nostr.nostrord.nostr.DmMessageOrder
 import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.KeyPair
@@ -2218,8 +2219,9 @@ class NostrRepository(
         // A reply is an `e` tag on the rumor, with no relay hint: the rumor's id is computed
         // before any relay lookup, and the reply never leaves the conversation anyway.
         val replyTags = replyToId?.let { listOf(listOf("e", it)) } ?: emptyList()
+        val (createdAt, ms) = DmMessageOrder.next()
         return publishDmRumor(
-            Nip17.buildRumor(myPub, recipientPubkey, content, extraTags = replyTags),
+            Nip17.buildRumor(myPub, recipientPubkey, content, createdAt, DmMessageOrder.withOrderTag(replyTags, ms)),
             recipientPubkey,
             myPub,
             signer,
@@ -2297,8 +2299,9 @@ class NostrRepository(
                 val h = file.height
                 if (w != null && h != null) add(listOf("dim", "${w}x$h"))
             }
+        val (createdAt, ms) = DmMessageOrder.next()
         return publishDmRumor(
-            Nip17.buildRumor(myPub, recipientPubkey, file.url, extraTags = tags, kind = Nip17.KIND_FILE),
+            Nip17.buildRumor(myPub, recipientPubkey, file.url, createdAt, DmMessageOrder.withOrderTag(tags, ms), kind = Nip17.KIND_FILE),
             recipientPubkey,
             myPub,
             signer,
@@ -3222,6 +3225,7 @@ class NostrRepository(
             senderPubkey = pubkey,
             content = content,
             createdAt = createdAt,
+            orderKey = DmMessageOrder.orderKey(createdAt, tagsJson),
             mine = pubkey == myPubkey,
             kind = rumorKind,
             // Assembled as text around the tags exactly as they were stored, rather than parsed

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -15,6 +15,7 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
+import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17File
 import org.nostr.nostrord.nostr.Nip46Client
@@ -214,10 +215,7 @@ interface NostrRepositoryApi {
     /** Send status of our own DM messages, keyed by rumor id (Sending until a relay OKs). */
     val dmMessageStatus: StateFlow<Map<String, GroupManager.MessageStatus>>
 
-    /**
-     * Send a file as an encrypted kind:15 message: the bytes are encrypted before upload, so the
-     * media server holds ciphertext and only the recipient can read the file.
-     */
+    /** [uploadDmFile] followed by [sendDmUploadedFile], for a caller with nothing else to send. */
     suspend fun sendDmFile(
         recipientPubkey: String,
         bytes: ByteArray,
@@ -225,6 +223,21 @@ interface NostrRepositoryApi {
         mimeType: String,
         width: Int? = null,
         height: Int? = null,
+    ): Result<Unit>
+
+    /** Encrypt and upload a DM attachment; the result waits in the composer until Enter. */
+    suspend fun uploadDmFile(
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        width: Int? = null,
+        height: Int? = null,
+    ): Result<DmOutgoingFile>
+
+    /** Send an uploaded attachment as its own kind:15 (url as content, key/nonce/ox as tags). */
+    suspend fun sendDmUploadedFile(
+        recipientPubkey: String,
+        file: DmOutgoingFile,
     ): Result<Unit>
 
     /** React to a DM message with [emoji] (NIP-25 rumor); [emojiUrl] for a custom emoji. */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmFileManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmFileManager.kt
@@ -65,7 +65,7 @@ class DmFileManager(
      */
     fun load(rumorId: String, file: Nip17File) {
         if (_states.value[rumorId] is FileState.Ready || rumorId in inFlight.value) return
-        if (!file.isDecryptable) {
+        if (!file.isReadable) {
             _states.update { it + (rumorId to FileState.Failed("Unsupported encryption")) }
             return
         }
@@ -99,6 +99,14 @@ class DmFileManager(
                 http.get { url(file.url) }.readRawBytes()
             }
         if (encrypted.isEmpty()) return FileState.Failed("The file is no longer on the server")
+        if (file.isPlain) {
+            // Plain upload: `x` is the hash of the served bytes, nothing to decrypt.
+            val expected = file.encryptedHashHex ?: file.originalHashHex
+            if (expected != null && Crypto.sha256(encrypted).toHexString() != expected.lowercase()) {
+                return FileState.Failed("This file was altered on the server")
+            }
+            return FileState.Ready(encrypted, file.mimeType)
+        }
         val key = file.decryptionKeyHex?.decodeHexOrNull() ?: return FileState.Failed("Missing decryption key")
         val nonce = file.decryptionNonceHex?.decodeHexOrNull() ?: return FileState.Failed("Missing decryption nonce")
         val plaintext =

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import org.nostr.nostrord.auth.NostrSigner
+import org.nostr.nostrord.nostr.DmMessageOrder
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.nostr.Nip17
 import org.nostr.nostrord.nostr.Nip17File
@@ -26,6 +27,8 @@ data class DmMessage(
     val content: String,
     val createdAt: Long,
     val mine: Boolean,
+    /** Sort key with the rumor's `ms` tag folded in; see [org.nostr.nostrord.nostr.DmMessageOrder]. */
+    val orderKey: Long = createdAt * 1000,
     /** Full decrypted rumor as NIP-01 JSON (unsigned). Null on messages cached
      *  before this field existed; DmMessage.eventJson() reconstructs a fallback. */
     val rumorJson: String? = null,
@@ -341,6 +344,7 @@ class DmManager(
                 senderPubkey = sender,
                 content = rumor.content,
                 createdAt = rumor.createdAt,
+                orderKey = DmMessageOrder.orderKey(rumor),
                 mine = sender == myPubkey,
                 rumorJson = rumor.toJsonString(),
                 kind = rumor.kind,
@@ -376,6 +380,7 @@ class DmManager(
                 senderPubkey = rumor.pubkey,
                 content = rumor.content,
                 createdAt = rumor.createdAt,
+                orderKey = DmMessageOrder.orderKey(rumor),
                 mine = rumor.pubkey == myPubkey,
                 rumorJson = rumor.toJsonString(),
                 kind = rumor.kind,
@@ -397,6 +402,7 @@ class DmManager(
                 senderPubkey = myPubkey,
                 content = rumor.content,
                 createdAt = rumor.createdAt,
+                orderKey = DmMessageOrder.orderKey(rumor),
                 mine = true,
                 rumorJson = rumor.toJsonString(),
                 kind = rumor.kind,
@@ -424,6 +430,7 @@ class DmManager(
                 senderPubkey = sender,
                 content = rumor.content,
                 createdAt = rumor.createdAt,
+                orderKey = DmMessageOrder.orderKey(rumor),
                 mine = sender == myPubkey,
                 rumorJson = rumor.toJsonString(),
                 kind = Nip17.KIND_REACTION,
@@ -443,6 +450,7 @@ class DmManager(
                 senderPubkey = myPubkey,
                 content = rumor.content,
                 createdAt = rumor.createdAt,
+                orderKey = DmMessageOrder.orderKey(rumor),
                 mine = true,
                 rumorJson = rumor.toJsonString(),
                 kind = Nip17.KIND_REACTION,
@@ -491,7 +499,7 @@ class DmManager(
     private fun addMessage(peer: String, message: DmMessage) {
         peerByRumor.update { it + (message.id to peer) }
         _messagesByPeer.update { current ->
-            val merged = (current[peer].orEmpty() + message).sortedBy { it.createdAt }
+            val merged = (current[peer].orEmpty() + message).sortedBy { it.orderKey }
             current + (peer to merged)
         }
     }
@@ -610,7 +618,7 @@ class DmManager(
                 messages
                     .groupBy { it.peerPubkey }
                     .mapValues { (_, msgs) ->
-                        msgs.sortedBy { it.createdAt }.map { m ->
+                        msgs.sortedBy { it.orderKey }.map { m ->
                             relaysByRumor.value[m.id]?.sorted()?.let { m.copy(relays = it) } ?: m
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/MediaServer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/MediaServer.kt
@@ -39,6 +39,13 @@ val RECOMMENDED_BLOSSOM_SERVERS: List<String> =
 val DEFAULT_BLOSSOM_SERVERS: List<String> = RECOMMENDED_BLOSSOM_SERVERS.take(3)
 
 /**
+ * Where an encrypted DM attachment goes when the user's own media service refuses it: media
+ * hosts such as nostr.build only take images, video and audio, and the ciphertext is none of
+ * those. A host other NIP-17 clients already use for the same purpose.
+ */
+const val ENCRYPTED_DM_FALLBACK_BLOSSOM: String = "https://blossom.jumble.social"
+
+/**
  * Normalize a user-typed server address to a comparable origin: adds `https://` when the
  * scheme is missing, drops the path/trailing slash, lowercases the host. Returns null when
  * the input can't be a server URL, so the caller can reject it with one check.

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/MediaUploader.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/upload/MediaUploader.kt
@@ -91,6 +91,35 @@ suspend fun uploadMedia(
 }
 
 /**
+ * Upload the ciphertext of a DM attachment. It keeps the original [filename] and goes out as
+ * `application/octet-stream` through the configured service first, like any other upload; a
+ * host that refuses it (nostr.build takes media only) is answered by [ENCRYPTED_DM_FALLBACK_BLOSSOM],
+ * which stores arbitrary blobs.
+ */
+suspend fun uploadEncryptedBlob(
+    bytes: ByteArray,
+    filename: String,
+): Result<UploadResult> {
+    val mime = "application/octet-stream"
+    val first = uploadMedia(bytes, filename, mime)
+    if (first is Result.Success) return first
+    val settings = AppModule.mediaServerSettings
+    val fallback =
+        MediaUploader.upload(
+            service = MediaUploadService.Blossom,
+            blossomServers = listOf(ENCRYPTED_DM_FALLBACK_BLOSSOM),
+            bytes = bytes,
+            filename = filename,
+            mimeType = mime,
+            buildNip98AuthHeader = AppModule.nostrRepository::buildNip98AuthHeader,
+            buildBlossomAuthHeader = AppModule.nostrRepository::buildBlossomAuthHeader,
+        )
+    if (fallback is Result.Success) return fallback
+    // Configured service's refusal is the one the user can act on (Settings → Media).
+    return if (settings.service.value is MediaUploadService.Nip96) first else fallback
+}
+
+/**
  * Mime type for an upload, derived from the filename extension. Blob refs
  * ("nostrord-blob|<mime>|…") carry their own mime because the bytes are already cached.
  */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/DmMessageOrder.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/DmMessageOrder.kt
@@ -1,0 +1,36 @@
+package org.nostr.nostrord.nostr
+
+import org.nostr.nostrord.utils.epochMillis
+
+/**
+ * Sub-second ordering for private rumors. `created_at` has one-second resolution, so an image
+ * and the text sent right after it tie and sort by accident; the millisecond rides in an `ms`
+ * tag inside the sealed rumor (a convention other NIP-17 clients share) and sends from one
+ * session are stamped strictly increasing without pushing any rumor a whole second ahead.
+ */
+object DmMessageOrder {
+    const val TAG = "ms"
+
+    private var lastMs = 0L
+
+    /** created_at plus the millisecond to put in the [TAG] tag. Monotonic within the session. */
+    fun next(nowMs: Long = epochMillis()): Pair<Long, Int> {
+        lastMs = maxOf(nowMs, lastMs + 1)
+        return (lastMs / 1000) to (lastMs % 1000).toInt()
+    }
+
+    /** [tags] with a fresh [TAG], replacing any stale copy. */
+    fun withOrderTag(tags: List<List<String>>, millisecond: Int): List<List<String>> = tags.filter { it.firstOrNull() != TAG } + listOf(listOf(TAG, millisecond.toString()))
+
+    /** Millisecond sort key: created_at * 1000 + ms. A missing or invalid tag counts as 0. */
+    fun orderKey(createdAt: Long, tags: List<List<String>>): Long = createdAt * 1000 + (tags.firstOrNull { it.firstOrNull() == TAG }?.getOrNull(1)?.let(::validMs) ?: 0)
+
+    fun orderKey(rumor: Event): Long = orderKey(rumor.createdAt, rumor.tags)
+
+    /** Same key off the cached tags json, without parsing the whole array. */
+    fun orderKey(createdAt: Long, tagsJson: String): Long = createdAt * 1000 + (CACHED_TAG.find(tagsJson)?.groupValues?.get(1)?.let(::validMs) ?: 0)
+
+    private fun validMs(raw: String): Int? = raw.toIntOrNull()?.takeIf { it in 0..999 }
+
+    private val CACHED_TAG = Regex("""\["ms","(\d{1,3})"\]""")
+}

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17File.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip17File.kt
@@ -1,9 +1,10 @@
 package org.nostr.nostrord.nostr
 
 /**
- * A NIP-17 kind:15 file message: the rumor's content is the URL of an AES-GCM encrypted blob on a
- * media server, and its tags carry everything needed to read it back. Nothing about the file is
- * public - the server holds ciphertext only, and the key never leaves the sealed rumor.
+ * A NIP-17 kind:15 file message: the rumor's content is the URL of a file on a media server and
+ * its tags carry what is needed to read it back. Two shapes exist in the wild: an AES-GCM blob
+ * whose key rides in the tags, and a plain upload with no key, which is what
+ * this client sends (same upload path as group media, only the rumor is sealed).
  *
  * Tag names follow what NIP-17 specifies and what other clients (Jumble, 0xchat) actually publish:
  * `file-type` for the mime type, `encryption-algorithm`, `decryption-key`, `decryption-nonce`,
@@ -33,17 +34,26 @@ data class Nip17File(
     /** The dim hint, when the sender published one, for reserving the bubble's slot. */
     val dimensions: Pair<Int, Int>? get() = if (width != null && height != null) width to height else null
 
-    /** False when a tag is missing or names an algorithm we cannot read, so the UI offers the raw link instead. */
+    /** No encryption tags at all: the url serves the file as-is. */
+    val isPlain: Boolean
+        get() = algorithm == null && decryptionKeyHex == null && decryptionNonceHex == null
+
+    /** True for an AES-GCM blob with both key and nonce present. */
     val isDecryptable: Boolean
         get() = decryptionKeyHex != null &&
             decryptionNonceHex != null &&
             (algorithm == null || algorithm == ALGORITHM_AES_GCM)
 
+    /** False when a tag is missing or names an algorithm we cannot read, so the UI offers the raw link instead. */
+    val isReadable: Boolean get() = isPlain || isDecryptable
+
     companion object {
         const val ALGORITHM_AES_GCM = "aes-gcm"
 
-        /** Tag holding the AES key; its presence is what marks a rumor as a file message. */
         const val TAG_DECRYPTION_KEY = "decryption-key"
+
+        /** Mime tag; present on every file rumor, encrypted or not. */
+        const val TAG_FILE_TYPE = "file-type"
 
         /** Parse a kind:15 rumor. Null for any other kind, or when the content is not a url. */
         fun fromRumor(rumor: Event): Nip17File? {
@@ -54,7 +64,7 @@ data class Nip17File(
             return Nip17File(
                 url = url,
                 // `m` is the NIP-94 spelling; some clients send that instead of `file-type`.
-                mimeType = rumor.tagValue("file-type") ?: rumor.tagValue("m"),
+                mimeType = rumor.tagValue(TAG_FILE_TYPE) ?: rumor.tagValue("m"),
                 algorithm = rumor.tagValue("encryption-algorithm")?.lowercase(),
                 decryptionKeyHex = rumor.tagValue(TAG_DECRYPTION_KEY),
                 decryptionNonceHex = rumor.tagValue("decryption-nonce"),
@@ -69,3 +79,20 @@ data class Nip17File(
         private fun Event.tagValue(name: String): String? = getTag(name)?.getOrNull(1)?.takeIf { it.isNotBlank() }
     }
 }
+
+/**
+ * A file the composer already encrypted and uploaded, waiting for Enter to go out as a kind:15.
+ * Carries exactly what the rumor's tags need: readers decrypt only when key, nonce
+ * and `ox` are all present.
+ */
+data class DmOutgoingFile(
+    val url: String,
+    val mimeType: String,
+    val keyHex: String,
+    val nonceHex: String,
+    /** SHA-256 of the plaintext, hex. */
+    val originalHashHex: String,
+    val size: Long,
+    val width: Int?,
+    val height: Int?,
+)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmChatItems.kt
@@ -59,7 +59,7 @@ sealed class DmChatItem {
 }
 
 fun buildDmChatItems(messages: List<DmMessage>): List<DmChatItem> {
-    val sorted = messages.sortedBy { it.createdAt }
+    val sorted = messages.sortedBy { it.orderKey }
     val items = mutableListOf<DmChatItem>()
     sorted.forEachIndexed { i, m ->
         val prev = sorted.getOrNull(i - 1)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import org.nostr.nostrord.network.NostrRepositoryApi
 import org.nostr.nostrord.network.managers.DmConversation
 import org.nostr.nostrord.network.managers.DmMessage
+import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.ui.screens.withMinDuration
 import org.nostr.nostrord.utils.Result
 
@@ -47,25 +48,6 @@ class DmViewModel(
 
     /** Reactions keyed by the message they target, then by emoji. */
     val reactions = repo.dmReactions
-
-    /**
-     * Send [bytes] as an encrypted kind:15 attachment. Unlike pasting a url into the text, the
-     * file is unreadable to anyone who has not been sent the key.
-     */
-    fun sendFile(
-        recipientPubkey: String,
-        bytes: ByteArray,
-        filename: String,
-        mimeType: String,
-        width: Int? = null,
-        height: Int? = null,
-        onFailure: (String) -> Unit = {},
-    ) {
-        viewModelScope.launch {
-            val result = repo.sendDmFile(recipientPubkey, bytes, filename, mimeType, width, height)
-            if (result is Result.Error) onFailure(result.error.message)
-        }
-    }
 
     /** React to [messageId] in the conversation with [peerPubkey]. */
     fun react(peerPubkey: String, messageId: String, emoji: String, emojiUrl: String? = null) {
@@ -179,17 +161,32 @@ class DmViewModel(
 
     fun getPublicKey(): String? = repo.getPublicKey()
 
+    /**
+     * Send the composer's draft. Every url in [uploads] that is still in [content] goes out as
+     * its own kind:15 (how NIP-17 clients send images), and whatever text is left as one
+     * kind:14, so a reader that renders kind:15 as media sees the picture and not a link.
+     */
     fun send(
         recipientPubkey: String,
         content: String,
         replyToId: String? = null,
+        uploads: List<DmOutgoingFile> = emptyList(),
         onSuccess: () -> Unit = {},
         onFailure: () -> Unit = {},
     ) {
-        val text = content.trim()
-        if (text.isEmpty()) return
+        val (files, text) = splitUploads(content, uploads)
+        if (text.isEmpty() && files.isEmpty()) return
         viewModelScope.launch {
-            val result = withMinDuration { repo.sendDm(recipientPubkey, text, replyToId) }
+            val result =
+                withMinDuration {
+                    var r: Result<Unit> = Result.Success(Unit)
+                    for (file in files) {
+                        r = repo.sendDmUploadedFile(recipientPubkey, file)
+                        if (r is Result.Error) break
+                    }
+                    if (r is Result.Success && text.isNotEmpty()) r = repo.sendDm(recipientPubkey, text, replyToId)
+                    r
+                }
             when (result) {
                 is Result.Error -> onFailure()
                 is Result.Success -> onSuccess()
@@ -202,6 +199,29 @@ class DmViewModel(
 
     /** Drop a refused message from the conversation (the Dismiss action). */
     fun dismiss(rumorId: String) = repo.dismissDm(rumorId)
+
+    /** Encrypt and upload a picked file; the composer keeps the result until Enter. */
+    suspend fun uploadFile(
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+    ): Result<DmOutgoingFile> = repo.uploadDmFile(bytes, filename, mimeType)
+
+    /** The uploads whose url is still in [content], in content order, and the text without them. */
+    internal fun splitUploads(
+        content: String,
+        uploads: List<DmOutgoingFile>,
+    ): Pair<List<DmOutgoingFile>, String> {
+        val byUrl = uploads.associateBy { it.url }
+        val files = mutableListOf<DmOutgoingFile>()
+        val words =
+            content.split(' ', '\n').filter { word ->
+                val upload = byUrl[word]
+                if (upload != null && files.none { it.url == word }) files += upload
+                upload == null
+            }
+        return files to words.joinToString(" ").trim()
+    }
 
     /** Clear the unread badge for a conversation when it is open on screen. */
     fun markRead(peerPubkey: String) {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -18,6 +18,7 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.managers.PendingGroupInvite
 import org.nostr.nostrord.network.managers.ZapManager
 import org.nostr.nostrord.network.outbox.Nip65Relay
+import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.nostr.Nip11RelayInfo
 import org.nostr.nostrord.nostr.Nip17File
 import org.nostr.nostrord.nostr.Nip46Client
@@ -178,6 +179,36 @@ class FakeNostrRepository : NostrRepositoryApi {
         height: Int?,
     ): Result<Unit> {
         sentDmFiles += Triple(recipientPubkey, mimeType, bytes.size)
+        return Result.Success(Unit)
+    }
+
+    override suspend fun uploadDmFile(
+        bytes: ByteArray,
+        filename: String,
+        mimeType: String,
+        width: Int?,
+        height: Int?,
+    ): Result<DmOutgoingFile> = Result.Success(
+        DmOutgoingFile(
+            url = "https://fake/$filename",
+            mimeType = mimeType,
+            keyHex = "a".repeat(64),
+            nonceHex = "b".repeat(24),
+            originalHashHex = "c".repeat(64),
+            size = bytes.size.toLong(),
+            width = width,
+            height = height,
+        ),
+    )
+
+    /** Uploads sent through [sendDmUploadedFile], as (recipient, url). */
+    val sentDmUploads = mutableListOf<Pair<String, String>>()
+
+    override suspend fun sendDmUploadedFile(
+        recipientPubkey: String,
+        file: DmOutgoingFile,
+    ): Result<Unit> {
+        sentDmUploads += recipientPubkey to file.url
         return Result.Success(Unit)
     }
 

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmFileMessageTest.kt
@@ -109,6 +109,23 @@ class DmFileMessageTest {
         val file = Nip17File.fromRumor(rumor)
         assertNotNull(file)
         assertTrue(!file.isDecryptable)
+        assertTrue(!file.isReadable)
+    }
+
+    @Test
+    fun `a plain upload with no key is readable as-is`() {
+        val rumor =
+            fileRumor(
+                signer().pubkey,
+                signer().pubkey,
+                tags = listOf(listOf("file-type", "image/png"), listOf("x", "d".repeat(64)), listOf("size", "10")),
+            )
+        val file = Nip17File.fromRumor(rumor)
+        assertNotNull(file)
+        assertTrue(file.isPlain)
+        assertTrue(!file.isDecryptable)
+        assertTrue(file.isReadable)
+        assertEquals("d".repeat(64), file.encryptedHashHex)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/DmMessageOrderTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/DmMessageOrderTest.kt
@@ -1,0 +1,35 @@
+package org.nostr.nostrord.nostr
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DmMessageOrderTest {
+    @Test
+    fun `stamps within one second stay strictly increasing`() {
+        val a = DmMessageOrder.next(1_000_500)
+        val b = DmMessageOrder.next(1_000_500)
+        val c = DmMessageOrder.next(1_000_400)
+        assertEquals(1_000L to 500, a)
+        assertEquals(1_000L to 501, b)
+        assertEquals(1_000L to 502, c)
+    }
+
+    @Test
+    fun `the ms tag breaks a created_at tie and a missing or bad tag counts as zero`() {
+        val image = DmMessageOrder.orderKey(10, listOf(listOf("ms", "120")))
+        val text = DmMessageOrder.orderKey(10, listOf(listOf("ms", "121")))
+        val legacy = DmMessageOrder.orderKey(10, emptyList())
+        val bad = DmMessageOrder.orderKey(10, listOf(listOf("ms", "5000")))
+        assertTrue(image < text)
+        assertEquals(10_000, legacy)
+        assertEquals(legacy, bad)
+        assertEquals(text, DmMessageOrder.orderKey(10, """[["p","x"],["ms","121"]]"""))
+    }
+
+    @Test
+    fun `withOrderTag replaces a stale copy`() {
+        val tags = DmMessageOrder.withOrderTag(listOf(listOf("ms", "1"), listOf("e", "id")), 42)
+        assertEquals(listOf(listOf("e", "id"), listOf("ms", "42")), tags)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/DmViewModelTest.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.nostr.nostrord.network.FakeNostrRepository
 import org.nostr.nostrord.network.managers.DmConversation
+import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.ui.screens.dm.DmViewModel
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -30,6 +31,8 @@ class DmViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
     }
+
+    private fun outgoing(url: String) = DmOutgoingFile(url, "image/png", "a".repeat(64), "b".repeat(24), "c".repeat(64), 10, null, null)
 
     private fun convo(peer: String, unread: Int = 0) = DmConversation(peerPubkey = peer, lastMessage = "hi", lastAt = 1, unread = unread)
 
@@ -131,5 +134,36 @@ class DmViewModelTest {
 
         assertEquals(false, vm.isRequestPeer("alice", vm.following.value, vm.followsLoaded.value))
         assertEquals(true, vm.isRequestPeer("bob", vm.following.value, vm.followsLoaded.value))
+    }
+
+    @Test
+    fun `each uploaded url goes out as its own file message and the text as one chat message`() = runTest {
+        val repo = FakeNostrRepository()
+        val sent = mutableListOf<String>()
+        repo.sendDmAction = { _, content ->
+            sent += content
+            org.nostr.nostrord.utils.Result.Success(Unit)
+        }
+        val vm = DmViewModel(repo)
+        val a = outgoing("https://x/a.png")
+        val b = outgoing("https://x/b.png")
+
+        vm.send("peer", "look https://x/a.png at these https://x/b.png", uploads = listOf(a, b))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("peer" to a.url, "peer" to b.url), repo.sentDmUploads)
+        assertEquals(listOf("look at these"), sent)
+    }
+
+    @Test
+    fun `an upload removed from the draft is not sent`() = runTest {
+        val repo = FakeNostrRepository()
+        val vm = DmViewModel(repo)
+        val a = outgoing("https://x/a.png")
+
+        vm.send("peer", "https://x/a.png", uploads = listOf(a, outgoing("https://x/gone.png")))
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(listOf("peer" to a.url), repo.sentDmUploads)
     }
 }

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
@@ -115,8 +115,8 @@ fun MessageComposer(
     groupMentions: Map<String, GroupInfo> = emptyMap(),
     onGroupMentionsChange: (Map<String, GroupInfo>) -> Unit = {},
     // Set by callers that own the upload themselves (DMs encrypt the bytes first). Picked and
-    // pasted files are handed over raw instead of being uploaded and appended as a url.
-    onFilePicked: ((ByteArray, String) -> Unit)? = null,
+    // pasted files are handed over raw; the spinner stays up until the handler returns.
+    onFilePicked: (suspend (ByteArray, String) -> Unit)? = null,
     // Message being replied to. Non-null shows its quote above the input with a way out.
     replyAuthorName: String? = null,
     replySnippet: String? = null,
@@ -191,12 +191,11 @@ fun MessageComposer(
             pasteError = "This file is too large. The maximum upload size is 20 MB."
             return
         }
-        if (onFilePicked != null) {
-            isUploadingPaste = false
-            onFilePicked(bytes, filename)
-            return
-        }
         try {
+            if (onFilePicked != null) {
+                onFilePicked(bytes, filename)
+                return
+            }
             val mime = mimeTypeForFilename(filename)
             when (val result = uploadMedia(bytes, filename, mime)) {
                 is Result.Success -> appendUploadedUrl(result.data.url)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/upload/MessageUploadButton.kt
@@ -31,7 +31,7 @@ import org.nostr.nostrord.utils.Result
  *
  * [onFilePicked] takes the picked bytes instead, leaving the upload to the caller. DMs use it:
  * their attachments are encrypted before they reach a media server, so the plain upload here
- * would defeat the point.
+ * would defeat the point. The spinner stays up until the handler returns.
  */
 @Composable
 fun MessageUploadButton(
@@ -40,7 +40,7 @@ fun MessageUploadButton(
     // Upload owned by the caller (paste / drag-and-drop) that doesn't go through
     // this button's picker. When true, the spinner shows here on the attach icon.
     externalBusy: Boolean = false,
-    onFilePicked: ((ByteArray, String) -> Unit)? = null,
+    onFilePicked: (suspend (ByteArray, String) -> Unit)? = null,
 ) {
     val scope = rememberCoroutineScope()
     var isUploading by remember { mutableStateOf(false) }
@@ -59,13 +59,12 @@ fun MessageUploadButton(
                 uploadError = it
             },
         ) { bytes, filename ->
-            if (onFilePicked != null) {
-                isUploading = false
-                onFilePicked(bytes, filename)
-                return@rememberMediaPickerLauncher
-            }
             scope.launch {
                 try {
+                    if (onFilePicked != null) {
+                        onFilePicked(bytes, filename)
+                        return@launch
+                    }
                     val mime = mimeTypeForFilename(filename)
                     val result =
                         uploadMedia(bytes, filename, mime)

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextAlign
@@ -62,6 +63,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.network.managers.previewText
 import org.nostr.nostrord.network.upload.mimeTypeForFilename
+import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.ui.components.ConfirmDialog
 import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.chat.DateSeparator
@@ -91,6 +93,7 @@ import org.nostr.nostrord.ui.screens.profile.ProfilePageViewModel
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.Spacing
+import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.utils.rememberClipboardWriter
 
@@ -180,7 +183,6 @@ fun DmPageScreen(
         val myPubkey = remember { dmVm.getPublicKey() }
         // Message the emoji picker was opened for; null while it is closed.
         var reactingTo by remember { mutableStateOf<String?>(null) }
-        var uploadError by remember { mutableStateOf<String?>(null) }
         // Message being replied to; the composer shows its quote until it is sent or cancelled.
         var replyingTo by remember { mutableStateOf<String?>(null) }
         // Picking Reply puts the caret in the composer, ready to type (chat/web parity). Bumped per
@@ -266,6 +268,9 @@ fun DmPageScreen(
         // The message the composer is answering, if it is still in the thread.
         val replyParent = messages.firstOrNull { it.id == replyingTo }
 
+        // Uploads whose url sits in the draft; each goes out as its own kind:15 on send.
+        var pendingUploads by remember(pubkey) { mutableStateOf<List<DmOutgoingFile>>(emptyList()) }
+        var uploadError by remember { mutableStateOf<String?>(null) }
         val send = {
             val body = textFieldValue.text.trim()
             if (body.isNotBlank() && !isSending) {
@@ -274,13 +279,16 @@ fun DmPageScreen(
                 // takes, and a draft still sitting there reads as "not sent".
                 val sentValue = textFieldValue
                 val sentReply = replyParent?.id
+                val sentUploads = pendingUploads
                 isSending = true
                 textFieldValue = TextFieldValue("")
                 replyingTo = null
+                pendingUploads = emptyList()
                 dmVm.send(
                     pubkey,
                     body,
                     replyToId = sentReply,
+                    uploads = sentUploads,
                     onSuccess = { isSending = false },
                     onFailure = {
                         isSending = false
@@ -288,6 +296,7 @@ fun DmPageScreen(
                         if (textFieldValue.text.isBlank()) {
                             textFieldValue = sentValue
                             replyingTo = sentReply
+                            pendingUploads = sentUploads
                         }
                     },
                 )
@@ -678,22 +687,25 @@ fun DmPageScreen(
             replySnippet = replyParent?.previewText(),
             onCancelReply = { replyingTo = null },
             focusRequester = composerFocus,
-            // A DM attachment is encrypted before it reaches a media server, so the picked bytes
-            // go out as a kind:15 message instead of being uploaded and pasted as a url.
+            // A picked or pasted file is encrypted and uploaded here, and its url appended to the
+            // draft like any other upload; on send each url becomes its own kind:15.
             onFilePicked = { bytes, filename ->
-                dmVm.sendFile(
-                    recipientPubkey = pubkey,
-                    bytes = bytes,
-                    filename = filename,
-                    mimeType = mimeTypeForFilename(filename),
-                    onFailure = { uploadError = it },
-                )
+                when (val r = dmVm.uploadFile(bytes, filename, mimeTypeForFilename(filename))) {
+                    is Result.Success -> {
+                        val current = textFieldValue.text
+                        val sep = if (current.isNotEmpty() && !current.endsWith(" ") && !current.endsWith("\n")) " " else ""
+                        val newText = current + sep + r.data.url
+                        textFieldValue = TextFieldValue(newText, TextRange(newText.length))
+                        if (pendingUploads.none { it.url == r.data.url }) pendingUploads = pendingUploads + r.data
+                    }
+                    is Result.Error -> uploadError = r.error.message
+                }
             },
         )
 
         uploadError?.let { error ->
             ConfirmDialog(
-                title = "Could not send the file",
+                title = "Upload Failed",
                 message = error,
                 confirmLabel = "OK",
                 cancelLabel = null,

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/components/UploadButton.kt
@@ -75,6 +75,7 @@ external interface UploadButtonProps : Props {
     /**
      * Takes the validated bytes instead of uploading them. DMs use it: their attachments are
      * encrypted before they reach a media server, so the plain upload here would defeat the point.
+     * The caller owns the spinner through [busy] for as long as its upload runs.
      */
     var onPicked: ((PickedFile) -> Unit)?
 }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -7,6 +7,7 @@ import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.DmMessage
 import org.nostr.nostrord.network.managers.previewText
+import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.extractDmGroupInvite
 import org.nostr.nostrord.ui.navigation.DmRoute
@@ -214,6 +215,8 @@ val DmPage =
         }
         val (text, setText) = useState { "" }
         val (sending, setSending) = useState { false }
+        // Uploads whose url sits in the draft; each goes out as its own kind:15 on send.
+        val (pendingUploads, setPendingUploads) = useState<List<DmOutgoingFile>> { emptyList() }
         val send = {
             if (text.isNotBlank() && !sending) {
                 // Clear in the same gesture that sent: the publish round-trip lasts as long as
@@ -221,18 +224,22 @@ val DmPage =
                 // build/sign failure pushes it back, and only if no new message was started.
                 val sentText = text
                 val sentReply = replyingTo
+                val sentUploads = pendingUploads
                 setSending(true)
                 setText("")
                 setReplyingTo(null)
+                setPendingUploads(emptyList())
                 dmVm.send(
                     pubkey,
                     sentText,
                     replyToId = sentReply,
+                    uploads = sentUploads,
                     onSuccess = { setSending(false) },
                     onFailure = {
                         setSending(false)
                         setText { cur -> if (cur.isBlank()) sentText else cur }
                         setReplyingTo { cur -> cur ?: sentReply }
+                        setPendingUploads { cur -> if (cur.isEmpty()) sentUploads else cur }
                     },
                 )
             }
@@ -294,20 +301,22 @@ val DmPage =
 
         fun isMediaMime(type: String?): Boolean = type != null && (type.startsWith("image/") || type.startsWith("video/") || type.startsWith("audio/"))
 
-        // Send a picked / pasted / dropped file as an encrypted kind:15 message. It is not appended
-        // to the draft as a url the way the group composer does: a DM attachment is encrypted
-        // before upload, so the server holds bytes nobody else can read.
-        fun sendMediaFile(picked: PickedFile) {
+        // Encrypt + upload a picked / pasted / dropped file and append its url to the draft
+        // (chat parity): nothing goes out until Enter, when each url becomes a kind:15 and the
+        // text a kind:14. The spinner sits on the attach icon for as long as the upload runs.
+        fun appendUploaded(file: DmOutgoingFile) {
+            setText { prev -> if (prev.isBlank()) file.url else "$prev ${file.url}" }
+            setPendingUploads { cur -> if (cur.any { it.url == file.url }) cur else cur + file }
+        }
+
+        fun uploadPicked(picked: PickedFile) {
             setUploadCount { it + 1 }
             launchApp {
                 try {
-                    dmVm.sendFile(
-                        recipientPubkey = pubkey,
-                        bytes = picked.bytes,
-                        filename = picked.name,
-                        mimeType = picked.mimeType,
-                        onFailure = { setUploadError(it) },
-                    )
+                    when (val r = dmVm.uploadFile(picked.bytes, picked.name, picked.mimeType)) {
+                        is Result.Success -> appendUploaded(r.data)
+                        is Result.Error -> setUploadError(r.error.message)
+                    }
                 } finally {
                     setUploadCount { it - 1 }
                 }
@@ -319,7 +328,7 @@ val DmPage =
             launchApp {
                 try {
                     when (val r = readPickedFile(file)) {
-                        is Result.Success -> sendMediaFile(r.data)
+                        is Result.Success -> uploadPicked(r.data)
                         is Result.Error -> setUploadError(r.error.message)
                     }
                 } finally {
@@ -794,7 +803,7 @@ val DmPage =
                         onBusyChange = { b -> setUploadCount { if (b) it + 1 else it - 1 } }
                         onPickerClosed = { composerInputRef.current?.focus() }
                         onUploaded = {}
-                        onPicked = { picked -> sendMediaFile(picked) }
+                        onPicked = { picked -> uploadPicked(picked) }
                         onError = { setUploadError(it) }
                     }
                     textarea {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3665,9 +3665,14 @@ body {
 }
 
 .dm-composer-btn {
-    display: flex;
+    /* Same 32px box as the group .composer-btn: centers the icon (and the upload spinner)
+       against the one-line textarea, and keeps it on the bottom row when the text grows. */
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     flex-shrink: 0;
-    padding: 0 0 var(--space-xs);
+    height: 32px;
+    padding: 0;
     border: 0;
     background: transparent;
     color: var(--color-text-secondary);


### PR DESCRIPTION
No DM attachment ever went out: the ciphertext was pushed as a .bin through the media service, which nostr.build and the Blossom hosts refuse with HTTP 400, and the error dialog replaced the upload spinner. A picked, pasted or dropped file is now encrypted and uploaded at once (original filename, application/octet-stream, configured service first, then a Blossom host that stores arbitrary blobs), its url lands in the draft like chat and threads, and on Enter each url goes out as its own kind:15 with the decryption tags other NIP-17 clients read, plus the remaining text as a kind:14. An `ms` tag keeps the image and its text in send order when both land in the same second, and the DM composer icons sit centered on the input row.

| Area | Change |
|---|---|
| Upload | Encrypt at pick time, upload through the configured service with a Blossom fallback for ciphertext; spinner stays up on both UIs |
| Composer | Url waits in the draft; Enter sends one kind:15 per file, then the text as kind:14 |
| Reader | Accepts kind:15 with or without encryption tags |
| Order | Session-monotonic `ms` tag on outgoing rumors, conversations sorted by created_at*1000+ms |
| Web CSS | `.dm-composer-btn` uses the 32px centered box of the chat composer |

- 4ee07bc3 fix(dm): attachments upload, wait in the composer and go out as kind:15
- 7258c79e fix(web): center the DM composer icons on the input row
- 69ec246e fix(dm): keep an image and its text in send order with an ms tag