### PR TITLE
feat(group): "Private on my list" at group creation

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -4521,9 +4521,11 @@ class NostrRepository(
         isHidden: Boolean,
         picture: String?,
         customGroupId: String?,
+        listPrivately: Boolean,
     ): Result<String> = createGroupInternal(
         name, about, relayUrl, isPrivate, isClosed, isRestricted, isHidden, picture, customGroupId,
         parentGroupId = null,
+        listPrivately = listPrivately,
     )
 
     override suspend fun createSubgroup(
@@ -4537,11 +4539,13 @@ class NostrRepository(
         isHidden: Boolean,
         picture: String?,
         customGroupId: String?,
+        listPrivately: Boolean,
     ): Result<String> = createGroupInternal(
         name, about, relayUrl, isPrivate, isClosed, isRestricted, isHidden, picture, customGroupId,
         // The parent link rides the creation kind:9002: a follow-up parent-only 9002 is
         // rejected by relays as a moderation action with no metadata tags.
         parentGroupId = parentGroupId,
+        listPrivately = listPrivately,
     )
 
     private suspend fun createGroupInternal(
@@ -4555,6 +4559,7 @@ class NostrRepository(
         picture: String?,
         customGroupId: String?,
         parentGroupId: String?,
+        listPrivately: Boolean,
     ): Result<String> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
@@ -4580,6 +4585,14 @@ class NostrRepository(
             currentRelayUrl = connectionManager.currentRelayUrl.value,
             signEvent = { sessionManager.signEvent(it) },
             publishJoinedGroups = { publishJoinedGroupsList() },
+            // The relay confirms (and may replace) the group id inside createGroup, so the
+            // private flag can only be set there, right before the list publish — a group
+            // flagged private afterwards would already have gone out in the clear once.
+            markListedPrivately = if (listPrivately) {
+                { relay, groupId -> outboxManager.setGroupPrivate(relay, groupId, true) }
+            } else {
+                null
+            },
         )
         if (result is Result.Success) {
             scope.launch { ensureJoinedRelaysConnected(connectionManager.currentRelayUrl.value) }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepositoryApi.kt
@@ -536,6 +536,11 @@ interface NostrRepositoryApi {
     )
 
     // --- Group operations ---
+    /**
+     * Create a group. [listPrivately] puts it straight into the encrypted section of the
+     * kind:10009, so the membership is never advertised in the clear, not even by the
+     * creation-time list publish.
+     */
     suspend fun createGroup(
         name: String,
         about: String?,
@@ -546,6 +551,7 @@ interface NostrRepositoryApi {
         isHidden: Boolean = false,
         picture: String? = null,
         customGroupId: String? = null,
+        listPrivately: Boolean = false,
     ): Result<String>
 
     /**
@@ -563,6 +569,7 @@ interface NostrRepositoryApi {
         isHidden: Boolean = false,
         picture: String? = null,
         customGroupId: String? = null,
+        listPrivately: Boolean = false,
     ): Result<String>
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -1844,6 +1844,8 @@ class GroupManager(
         currentRelayUrl: String,
         signEvent: suspend (Event) -> Event,
         publishJoinedGroups: suspend () -> Unit,
+        /** Non-null flags the confirmed group id for the encrypted kind:10009 section. */
+        markListedPrivately: ((relayUrl: String, groupId: String) -> Unit)? = null,
     ): Result<String> {
         val currentClient = connectionManager.getFocusedClient()
             ?: return Result.Error(AppError.Network.Disconnected(currentRelayUrl))
@@ -1928,6 +1930,9 @@ class GroupManager(
             // #p sweep and registers a pending "invite" for our own group; settle it so
             // the creator never sees the accept/decline prompt.
             discardPendingInvite(confirmedGroupId)
+            // Before the list publish: flagged afterwards, the id would already have gone out
+            // in the clear once, and relays keep that version.
+            markListedPrivately?.invoke(normalizedCreateRelay, confirmedGroupId)
             publishJoinedGroups()
             currentClient.requestGroupMessages(confirmedGroupId)
             // Pull the kind:39000 produced by the edit-metadata above so name and parent land

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -1910,12 +1910,26 @@ class GroupManager(
                     content = "",
                 ),
             )
-            currentClient.send(
-                buildJsonArray {
-                    add("EVENT")
-                    add(signedMeta.toJsonObject())
-                }.toString(),
-            )
+            val metaJson = buildJsonArray {
+                add("EVENT")
+                add(signedMeta.toJsonObject())
+            }.toString()
+            val metaId = signedMeta.id ?: suggestedId
+            // The group's name rides this 9002, and relays can reject it when the creator's
+            // admin grant from the 9007 hasn't materialized yet — a fire-and-forget send turns
+            // that race into a silently nameless group. Await the OK; one delayed retry covers
+            // the grant race (same event id, so the resend is idempotent).
+            var metaResult = currentClient.sendAndAwaitOk(metaJson, metaId, timeoutMs = 7_000)
+            if (metaResult !is org.nostr.nostrord.network.PublishResult.Success) {
+                delay(1_000)
+                metaResult = currentClient.sendAndAwaitOk(metaJson, metaId, timeoutMs = 7_000)
+            }
+            if (metaResult !is org.nostr.nostrord.network.PublishResult.Success) {
+                // The group itself exists on the relay; failing the create would strand it.
+                org.nostr.nostrord.di.AppModule.postSystemMessage(
+                    "Group created, but the relay did not accept its name. Edit the group to set it.",
+                )
+            }
 
             // Normalized key + merged with the persisted slot, for the same reasons as
             // joinGroup: a raw URL variant forks a parallel relay entry, and a partial

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupAccessCopy.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/screens/group/GroupAccessCopy.kt
@@ -26,6 +26,14 @@ object GroupAccessCopy {
     const val HIDDEN_DESC = "Hidden from non-members, not discoverable"
 
     /**
+     * Not a NIP-29 flag: keeps the new group in the NIP-44-encrypted section of the user's
+     * kind:10009, so the membership is never advertised in the clear (same setting as the
+     * group-info toggle, offered at creation time so it never goes out public even once).
+     */
+    const val LIST_PRIVATELY_LABEL = "Private on my list"
+    const val LIST_PRIVATELY_DESC = "Kept encrypted in your group list so others can't see you joined"
+
+    /**
      * NIP-29 `livekit`. Not an access flag: it adds a relay-hosted audio/video room any member
      * can join. Only offered when the relay advertises support at `/.well-known/nip29/livekit`.
      */

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/FakeNostrRepository.kt
@@ -447,6 +447,7 @@ class FakeNostrRepository : NostrRepositoryApi {
         isHidden: Boolean,
         picture: String?,
         customGroupId: String?,
+        listPrivately: Boolean,
     ): Result<String> = Result.Success(customGroupId ?: "fake-group-id")
 
     override suspend fun createSubgroup(
@@ -460,6 +461,7 @@ class FakeNostrRepository : NostrRepositoryApi {
         isHidden: Boolean,
         picture: String?,
         customGroupId: String?,
+        listPrivately: Boolean,
     ): Result<String> = Result.Success(customGroupId ?: "fake-subgroup-id")
 
     override suspend fun joinGroup(

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateGroupModal.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/components/CreateGroupModal.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Shield
 import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -74,6 +75,7 @@ fun CreateGroupModal(
     var isClosed by remember { mutableStateOf(false) }
     var isRestricted by remember { mutableStateOf(false) }
     var isHidden by remember { mutableStateOf(false) }
+    var listPrivately by remember { mutableStateOf(false) }
     var isCreating by remember { mutableStateOf(false) }
     var creatingJob by remember { mutableStateOf<Job?>(null) }
     var errorMessage by remember { mutableStateOf<String?>(null) }
@@ -400,6 +402,24 @@ fun CreateGroupModal(
                         onCheckedChange = { isHidden = it },
                     )
 
+                    Spacer(modifier = Modifier.height(Spacing.xxl))
+
+                    // Local-list setting, not a relay flag: encrypted NIP-51 entry from the start.
+                    Text(
+                        text = "YOUR LIST",
+                        style = NostrordTypography.SectionHeader,
+                        color = NostrordColors.TextMuted,
+                    )
+                    Spacer(modifier = Modifier.height(Spacing.sm))
+
+                    AccessToggleRow(
+                        icon = Icons.Default.Shield,
+                        label = GroupAccessCopy.LIST_PRIVATELY_LABEL,
+                        description = GroupAccessCopy.LIST_PRIVATELY_DESC,
+                        checked = listPrivately,
+                        onCheckedChange = { listPrivately = it },
+                    )
+
                     // Error message
                     if (errorMessage != null) {
                         Spacer(modifier = Modifier.height(Spacing.md))
@@ -493,6 +513,7 @@ fun CreateGroupModal(
                                                         isHidden = isHidden,
                                                         picture = picture.trim().ifBlank { null },
                                                         customGroupId = customGroupId.trim().ifBlank { null },
+                                                        listPrivately = listPrivately,
                                                     )
                                                 } else {
                                                     AppModule.nostrRepository.createGroup(
@@ -505,6 +526,7 @@ fun CreateGroupModal(
                                                         isHidden = isHidden,
                                                         picture = picture.trim().ifBlank { null },
                                                         customGroupId = customGroupId.trim().ifBlank { null },
+                                                        listPrivately = listPrivately,
                                                     )
                                                 }
                                             isCreating = false

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/modals/CreateGroupModal.kt
@@ -90,6 +90,7 @@ val CreateGroupModal =
         val (isClosed, setIsClosed) = useState { false }
         val (isRestricted, setIsRestricted) = useState { false }
         val (isHidden, setIsHidden) = useState { false }
+        val (listPrivately, setListPrivately) = useState { false }
         val (busy, setBusy) = useState { false }
         val (error, setError) = useState<String?> { null }
 
@@ -128,6 +129,7 @@ val CreateGroupModal =
                             isHidden = isHidden,
                             picture = picture.trim().ifBlank { null },
                             customGroupId = groupId.trim().ifBlank { null },
+                            listPrivately = listPrivately,
                         )
                     } else {
                         repo.createGroup(
@@ -140,6 +142,7 @@ val CreateGroupModal =
                             isHidden = isHidden,
                             picture = picture.trim().ifBlank { null },
                             customGroupId = groupId.trim().ifBlank { null },
+                            listPrivately = listPrivately,
                         )
                     }
                 setBusy(false)
@@ -323,6 +326,18 @@ val CreateGroupModal =
                     description = GroupAccessCopy.HIDDEN_DESC,
                     checked = isHidden,
                     onToggle = { setIsHidden(!isHidden) },
+                )
+                // Local-list setting, not a relay flag: encrypted NIP-51 entry from the start.
+                div {
+                    className = ClassName("access-section-title")
+                    +"YOUR LIST"
+                }
+                accessToggle(
+                    ic = Ic.Shield,
+                    label = GroupAccessCopy.LIST_PRIVATELY_LABEL,
+                    description = GroupAccessCopy.LIST_PRIVATELY_DESC,
+                    checked = listPrivately,
+                    onToggle = { setListPrivately(!listPrivately) },
                 )
 
                 if (error != null) {


### PR DESCRIPTION
A group could only be moved into the encrypted section of the kind:10009 after it existed, so a group meant to stay private went out in the clear at least once and relays keep that version. The create modal now offers the choice up front, in its own YOUR LIST section below ACCESS SETTINGS: it is a list setting, not a NIP-29 access flag like the four above it, and the section name matches the group-info modal.

The relay confirms (and may replace) the group id inside `GroupManager.createGroup`, so the repo cannot pre-flag the way `joinGroup` does. The flag rides a `markListedPrivately` lambda invoked with the confirmed id right before `publishJoinedGroups()`. There is no revert on publish failure: leaning private is the safe direction.

Second commit is a separate fix found on the same path. The creation kind:9002 carries the group name and was fire-and-forget, while `editGroup` already awaited its OK. Relays reject that 9002 when the creator's admin grant from the 9007 has not materialized yet, which silently produced nameless groups.

| Change | Effect |
|---|---|
| `listPrivately` on `createGroup` / `createSubgroup` | new group lands straight in the encrypted kind:10009 section |
| `markListedPrivately` lambda in `GroupManager` | flag applied to the relay-confirmed id, before the list publish |
| YOUR LIST section in both create modals | list setting separated from the NIP-29 access flags |
| `sendAndAwaitOk` + one 1s retry on the creation 9002 | no more silently nameless groups; on final failure the create still succeeds with a system message |

- 8f1cd7b3 feat(group): offer "Private on my list" when creating a group
- 9f3cd988 fix(group): await the OK on the creation kind:9002

compileKotlinJvm, compileKotlinJs and jvmTest green. Device validation of the 9002 retry pending (the reject is intermittent).