### PR TITLE
fix(chat): agree on same-second order and keep the header under the divider

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/ChatMessageOrder.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/ChatMessageOrder.kt
@@ -1,0 +1,12 @@
+package org.nostr.nostrord.network
+
+/**
+ * Display order for chat messages: created_at, then event id.
+ *
+ * created_at alone leaves same-second messages tied, and a stable sort keeps whatever arrival
+ * order each client happened to have — the sender inserts its own message optimistically at the
+ * tail while the peer receives it interleaved, so the two transcripts disagree and never
+ * converge. The event id is the only field every client agrees on, so it breaks ties identically
+ * everywhere.
+ */
+fun List<NostrGroupClient.NostrMessage>.sortedForDisplay(): List<NostrGroupClient.NostrMessage> = sortedWith(compareBy({ it.createdAt }, { it.id }))

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/EventOrderingBuffer.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/EventOrderingBuffer.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.sortedForDisplay
 
 /**
  * Buffers incoming chat messages per group, then flushes them sorted by
@@ -86,7 +87,7 @@ class EventOrderingBuffer(
                                     b.toList()
                                 }
                             if (batch.isNotEmpty()) {
-                                onFlush(groupId, batch.sortedBy { it.createdAt })
+                                onFlush(groupId, batch.sortedForDisplay())
                             }
                         }
                 }
@@ -113,7 +114,7 @@ class EventOrderingBuffer(
                 }
             snapshot.forEach { (groupId, messages) ->
                 if (messages.isNotEmpty()) {
-                    onFlush(groupId, messages.sortedBy { it.createdAt })
+                    onFlush(groupId, messages.sortedForDisplay())
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -36,6 +36,7 @@ import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.RoleDefinition
 import org.nostr.nostrord.network.groupMetadataListSerializer
 import org.nostr.nostrord.network.outbox.EventDeduplicator
+import org.nostr.nostrord.network.sortedForDisplay
 import org.nostr.nostrord.nostr.Event
 import org.nostr.nostrord.storage.SecureStorage
 import org.nostr.nostrord.storage.addLeftGroupForRelay
@@ -3219,7 +3220,7 @@ class GroupManager(
             val current = currentMap[groupId] ?: emptyList()
             val index = messageIdIndex.getOrPut(groupId) { current.mapTo(mutableSetOf()) { it.id } }
             if (!index.add(message.id)) return@update currentMap
-            currentMap + (groupId to (current + message).sortedBy { it.createdAt })
+            currentMap + (groupId to (current + message).sortedForDisplay())
         }
         touchGroupRecency(groupId)
     }
@@ -3405,7 +3406,7 @@ class GroupManager(
             val list = current[groupId] ?: emptyList()
             if (list.any { it.id == message.id }) return@update current
             inserted = true
-            current + (groupId to (list + message).sortedBy { it.createdAt })
+            current + (groupId to (list + message).sortedForDisplay())
         }
         // Notify only on a real insert of a relay-delivered event: a disk hydration is not news,
         // and an un-echoed optimistic send is our own.
@@ -4215,7 +4216,7 @@ class GroupManager(
             val fresh = restored.filter { index.add(it.id) }
             if (fresh.isEmpty()) return@update current
             added = true
-            current + (groupId to (existing + fresh).sortedBy { it.createdAt })
+            current + (groupId to (existing + fresh).sortedForDisplay())
         }
         return added
     }
@@ -5051,11 +5052,12 @@ class GroupManager(
             // message, just append the sorted batch (the common live-message case).
             // Avoids re-sorting the full list on every flush.
             val lastExistingTs = current.lastOrNull()?.createdAt ?: 0L
-            val allNewer = newMessages.all { it.createdAt >= lastExistingTs }
+            // Strict: a same-second message can sort before an existing one on the id tie-break.
+            val allNewer = newMessages.all { it.createdAt > lastExistingTs }
             val merged = if (allNewer) {
-                current + newMessages.sortedBy { it.createdAt }
+                current + newMessages.sortedForDisplay()
             } else {
-                (current + newMessages).sortedBy { it.createdAt }
+                (current + newMessages).sortedForDisplay()
             }
             currentMap + (groupId to merged)
         }
@@ -5185,7 +5187,7 @@ class GroupManager(
             val index = messageIdIndex.getOrPut(groupId) { existing.mapTo(mutableSetOf()) { it.id } }
             val fresh = restored.filter { index.add(it.id) }
             if (fresh.isEmpty()) return@update current
-            current + (groupId to (existing + fresh).sortedBy { it.createdAt })
+            current + (groupId to (existing + fresh).sortedForDisplay())
         }
         touchGroupRecency(groupId)
     }
@@ -5728,7 +5730,7 @@ class GroupManager(
                     existing.forEach { index.add(it.id) }
                     val newMsgs = messages.filter { index.add(it.id) }
                     if (newMsgs.isEmpty() && existing.isNotEmpty()) return@update current
-                    val merged = (existing + newMsgs).sortedBy { it.createdAt }
+                    val merged = (existing + newMsgs).sortedForDisplay()
                     current + (groupId to merged)
                 }
                 touchGroupRecency(groupId)

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/ChatMessageOrderTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/ChatMessageOrderTest.kt
@@ -1,0 +1,32 @@
+package org.nostr.nostrord.network
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChatMessageOrderTest {
+    private fun msg(id: String, createdAt: Long) = NostrGroupClient.NostrMessage(
+        id = id,
+        pubkey = "pub",
+        content = id,
+        createdAt = createdAt,
+        kind = 9,
+    )
+
+    @Test
+    fun sameSecondMessagesOrderTheSameOnEveryClient() {
+        val mine = msg("bbb", 1000)
+        val theirs = msg("aaa", 1000)
+        // Each client inserts its own send at the tail and the peer's on arrival.
+        val sender = listOf(theirs, mine).sortedForDisplay()
+        val peer = listOf(mine, theirs).sortedForDisplay()
+        assertEquals(listOf("aaa", "bbb"), sender.map { it.id })
+        assertEquals(sender.map { it.id }, peer.map { it.id })
+    }
+
+    @Test
+    fun createdAtStillWins() {
+        val older = msg("zzz", 999)
+        val newer = msg("aaa", 1000)
+        assertEquals(listOf("zzz", "aaa"), listOf(newer, older).sortedForDisplay().map { it.id })
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItemDividerGroupingTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItemDividerGroupingTest.kt
@@ -1,0 +1,51 @@
+package org.nostr.nostrord.ui.screens.group.model
+
+import org.nostr.nostrord.network.NostrGroupClient.NostrMessage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The "New Messages" divider must break message grouping: a continuation row rendered under it
+ * carries no avatar and no author name, so it reads as belonging to whoever posted above.
+ */
+class ChatItemDividerGroupingTest {
+    private fun msg(id: String, pubkey: String, createdAt: Long) = NostrMessage(
+        id = id,
+        pubkey = pubkey,
+        content = id,
+        createdAt = createdAt,
+        kind = 9,
+    )
+
+    @Test
+    fun firstMessageAfterDividerStartsANewGroup() {
+        val items = buildChatItems(
+            messages = listOf(
+                msg("a", "bob", 1_000),
+                // Same author, inside the 5-minute grouping window, but unread.
+                msg("b", "bob", 1_060),
+            ),
+            lastReadTimestamp = 1_030,
+            currentUserPubkey = "me",
+        )
+        val dividerAt = items.indexOfFirst { it is ChatItem.NewMessagesDivider }
+        assertTrue(dividerAt >= 0, "divider missing")
+        val afterDivider = items[dividerAt + 1] as ChatItem.Message
+        assertEquals("b", afterDivider.message.id)
+        assertTrue(afterDivider.isFirstInGroup, "message under the divider lost its author header")
+    }
+
+    @Test
+    fun groupingSurvivesWithoutADivider() {
+        val items = buildChatItems(
+            messages = listOf(msg("a", "bob", 1_000), msg("b", "bob", 1_060)),
+            lastReadTimestamp = null,
+            currentUserPubkey = "me",
+        )
+        val messages = items.filterIsInstance<ChatItem.Message>()
+        assertEquals(2, messages.size)
+        assertTrue(messages[0].isFirstInGroup)
+        assertTrue(!messages[1].isFirstInGroup, "consecutive same-author messages must stay grouped")
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
@@ -147,6 +147,10 @@ fun buildChatItems(
             flushPendingSystemEvent()
             items.add(ChatItem.NewMessagesDivider)
             newMessagesDividerInserted = true
+            // Reset grouping after the divider: a continuation row under it would lose its
+            // author header and read as coming from whoever posted above the divider.
+            lastMessagePubkey = null
+            lastMessageTime = null
         }
 
         when (message.kind) {

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/group/model/ChatItem.kt
@@ -2,6 +2,7 @@ package org.nostr.nostrord.ui.screens.group.model
 
 import androidx.compose.runtime.Immutable
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.sortedForDisplay
 import org.nostr.nostrord.ui.screens.group.clampSystemEventsToLoadedWindow
 import org.nostr.nostrord.utils.getDateLabel
 
@@ -97,7 +98,7 @@ fun buildChatItems(
     var lastMessageTime: Long? = null
     var newMessagesDividerInserted = false
 
-    val sortedAll = messages.sortedBy { it.createdAt }
+    val sortedAll = messages.sortedForDisplay()
     // Bound the rendered timeline to the loaded message window (shared with the web list):
     // hide moderation events older than the oldest loaded kind:9 message so a streamed older
     // join/leave never inserts mid-list and shifts the reading position (opens above old events).

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatItems.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatItems.kt
@@ -1,6 +1,7 @@
 package org.nostr.nostrord.web.screens
 
 import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.network.sortedForDisplay
 import org.nostr.nostrord.ui.screens.group.clampSystemEventsToLoadedWindow
 import org.nostr.nostrord.utils.getDateLabel
 import kotlin.math.abs
@@ -50,7 +51,7 @@ fun buildWebChatItems(
     currentUserPubkey: String? = null,
 ): List<WebChatItem> {
     val items = mutableListOf<WebChatItem>()
-    val sortedAll = messages.sortedBy { it.createdAt }
+    val sortedAll = messages.sortedForDisplay()
 
     // Bound the rendered timeline to the loaded message window (shared with the native list).
     val sorted = clampSystemEventsToLoadedWindow(sortedAll)

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatItems.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatItems.kt
@@ -122,6 +122,10 @@ fun buildWebChatItems(
             flush()
             items.add(WebChatItem.NewMessagesDivider)
             dividerInserted = true
+            // Reset grouping after the divider: a continuation row under it would lose its
+            // author header and read as coming from whoever posted above the divider.
+            lastMessagePubkey = null
+            lastMessageTime = null
         }
 
         when (message.kind) {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -16,6 +16,7 @@ import org.nostr.nostrord.network.UserMetadata
 import org.nostr.nostrord.network.managers.ConnectionManager
 import org.nostr.nostrord.network.managers.GroupLoadingState
 import org.nostr.nostrord.network.managers.GroupManager
+import org.nostr.nostrord.network.sortedForDisplay
 import org.nostr.nostrord.network.toEventJson
 import org.nostr.nostrord.network.upload.UploadResult
 import org.nostr.nostrord.nostr.Nip19
@@ -1029,7 +1030,7 @@ val ChatScreen =
         // Memoized so the O(n log n) sort + index only re-run when THIS group's messages change,
         // not on every re-render (reactions, zaps, metadata and members each emit separately and
         // would otherwise re-sort the whole list 15+ times during a group switch).
-        val messages = useMemo(rawMessages) { rawMessages.sortedBy { it.createdAt } }
+        val messages = useMemo(rawMessages) { rawMessages.sortedForDisplay() }
         val messagesById = useMemo(messages) { messages.associateBy { it.id } }
         // Copied nevents and links embed the relay this group is open on. Scanning for "some relay
         // serving this id" would hand out the other relay's same-id group, and the link would open


### PR DESCRIPTION
Two people typing in the same second ended up with permanently different transcripts: each client showed its own messages last. Every chat list ordered by `created_at` alone, and `sortedBy` is stable, so ties kept whatever arrival order that client happened to have — the sender inserts its own send optimistically at the tail, the peer receives it interleaved, and nothing ever reconciles them. Ordering now runs through a shared `sortedForDisplay()` that breaks ties by event id, the only field every client agrees on. The append shortcut in the buffered path had to become strict (`>` instead of `>=`), since a same-second message can now sort before one already in the list.

The second commit fixes what the screenshots also showed: the "New Messages" divider did not reset the grouping state, so a message continuing the same author's run rendered under it as a compact row with no avatar, no name and no timestamp, reading as if it came from whoever posted above the divider. Both timeline builders now reset grouping after inserting it, exactly as the date separator already does.

| Change | Effect |
|---|---|
| `sortedForDisplay()` in commonMain, applied at all 9 chat sort sites plus both timeline builders and the web memo | every client resolves same-second ties identically |
| strict `>` in the append shortcut (`GroupManager`) | a same-second arrival can no longer skip the merge sort |
| grouping reset after the divider (`ChatItem.kt`, `ChatItems.kt`) | the first message under "New Messages" keeps its author header |

- 8f91ba16 fix(chat): break same-second ties by event id so clients agree
- 984256c1 fix(chat): keep the author header on the message under the divider

4 new tests in commonTest (ordering agreement, created_at still wins, header under the divider, grouping otherwise intact). compileKotlinJvm, compileKotlinJs and jvmTest green. Visual check on two clients still worth doing before merge.