### PR TITLE
Typed @name mentions, plus the profile card and inline chips they render as

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -54,6 +54,8 @@ import org.nostr.nostrord.network.managers.DmPairingManager
 import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.network.managers.LegacySealVerifier
 import org.nostr.nostrord.network.managers.LiveCursorStore
+import org.nostr.nostrord.network.managers.MentionCandidate
+import org.nostr.nostrord.network.managers.MentionTags
 import org.nostr.nostrord.network.managers.MetadataManager
 import org.nostr.nostrord.network.managers.OutboxManager
 import org.nostr.nostrord.network.managers.PendingDmWrap
@@ -4814,6 +4816,20 @@ class NostrRepository(
         groupManager.fetchGroupMessageById(groupId, messageId)
     }
 
+    /**
+     * [mentions] plus the `@name`s typed out in [content] without picking a suggestion, matched
+     * against the group's members so a hand-typed mention still resolves to `nostr:npub` + a `p`
+     * tag. Members are the same pool the composer popup offers.
+     */
+    private fun withTypedMentions(groupId: String, content: String, mentions: Map<String, String>): Map<String, String> {
+        val metadata = metadataManager.userMetadata.value
+        val candidates = groupManager.getMembersForGroup(groupId).map { pubkey ->
+            val meta = metadata[pubkey]
+            MentionCandidate(pubkey, listOfNotNull(meta?.displayName, meta?.name))
+        }
+        return mentions + MentionTags.resolveTyped(content, mentions, candidates)
+    }
+
     override suspend fun sendMessage(groupId: String, content: String, channel: String?, mentions: Map<String, String>, replyToMessageId: String?, extraTags: List<List<String>>): Result<Unit> {
         val pubKey = sessionManager.getPublicKey()
             ?: return Result.Error(AppError.Auth.NotAuthenticated)
@@ -4822,7 +4838,7 @@ class NostrRepository(
             content = content,
             pubKey = pubKey,
             channel = channel,
-            mentions = mentions,
+            mentions = withTypedMentions(groupId, content, mentions),
             replyToMessageId = replyToMessageId,
             extraTags = extraTags,
             signEvent = { sessionManager.signEvent(it) },
@@ -4852,7 +4868,7 @@ class NostrRepository(
             title = title,
             content = content,
             pubKey = pubKey,
-            mentions = mentions,
+            mentions = withTypedMentions(groupId, content, mentions),
             signEvent = { sessionManager.signEvent(it) },
         )
     }
@@ -4872,7 +4888,7 @@ class NostrRepository(
             parent = parent,
             content = content,
             pubKey = pubKey,
-            mentions = mentions,
+            mentions = withTypedMentions(groupId, content, mentions),
             signEvent = { sessionManager.signEvent(it) },
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MentionTags.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MentionTags.kt
@@ -1,6 +1,16 @@
 package org.nostr.nostrord.network.managers
 
 import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.utils.normalizeForSearch
+
+/**
+ * A person a typed `@token` can resolve to: their pubkey and the names they are known by
+ * (display name, name). Built from the group's member list at send time.
+ */
+internal data class MentionCandidate(
+    val pubkey: String,
+    val labels: List<String>,
+)
 
 /**
  * Resolution of composer `@displayName` mentions into event content + NIP-01 `p` tags. Shared by
@@ -11,9 +21,13 @@ import org.nostr.nostrord.nostr.Nip19
  * knows which relay hosts the mentioned group.
  */
 internal object MentionTags {
+    // Trailing characters that end a sentence rather than a name, dropped off a typed token.
+    private const val TOKEN_TRAILERS = ".,;:!?)]}>\"'`*_~…"
+
     /**
      * [content] with each `@displayName` replaced by its `nostr:npub...`, plus the `p` tags for the
-     * mentioned pubkeys. Pubkeys already tagged by [existingTags] are skipped: a duplicate `p`
+     * mentioned pubkeys. Matching is token-aligned (longest name first), so `@ana` never eats the
+     * head of `@anastasia`. Pubkeys already tagged by [existingTags] are skipped: a duplicate `p`
      * carries nothing and inflates the indexable-tag count some NIP-29 relays reject.
      */
     fun apply(
@@ -22,13 +36,81 @@ internal object MentionTags {
         existingTags: List<List<String>> = emptyList(),
     ): Pair<String, List<List<String>>> {
         if (mentions.isEmpty()) return content to emptyList()
+        val names = mentions.keys.sortedByDescending { it.length }
         val tagged = existingTags.filter { it.size >= 2 && it[0] == "p" }.mapTo(mutableSetOf()) { it[1] }
         val tags = mutableListOf<List<String>>()
-        var text = content
-        mentions.forEach { (displayName, pubkeyHex) ->
-            text = text.replace("@$displayName", "nostr:${Nip19.encodeNpub(pubkeyHex)}")
+        val text = StringBuilder(content.length)
+        var i = 0
+        while (i < content.length) {
+            val name = if (isTokenStart(content, i)) names.firstOrNull { endsToken(content, i + 1, it) } else null
+            if (name == null) {
+                text.append(content[i])
+                i++
+                continue
+            }
+            val pubkeyHex = mentions.getValue(name)
+            text.append("nostr:").append(Nip19.encodeNpub(pubkeyHex))
             if (tagged.add(pubkeyHex)) tags.add(listOf("p", pubkeyHex))
+            i += 1 + name.length
         }
-        return text to tags
+        return text.toString() to tags
+    }
+
+    /**
+     * The `@token`s in [content] that were typed out instead of picked from the autocomplete,
+     * mapped to the pubkey they name, so a hand-typed mention notifies like a picked one. A token
+     * resolves only on an exact name match (spaces optional) or a literal `npub`; an ambiguous name
+     * shared by two members stays plain text rather than mentioning the wrong person.
+     */
+    fun resolveTyped(
+        content: String,
+        mentions: Map<String, String>,
+        candidates: List<MentionCandidate>,
+    ): Map<String, String> {
+        val byLabel = mutableMapOf<String, MutableSet<String>>()
+        candidates.forEach { candidate ->
+            candidate.labels.filter { it.isNotBlank() }.forEach { label ->
+                val normalized = label.normalizeForSearch()
+                byLabel.getOrPut(normalized) { mutableSetOf() }.add(candidate.pubkey)
+                // A multi-word name can't be typed as one token (the trigger dies at the space),
+                // so "Alice Cooper" is also reachable as "@alicecooper".
+                val compact = normalized.filterNot { it.isWhitespace() }
+                if (compact != normalized && compact.isNotEmpty()) {
+                    byLabel.getOrPut(compact) { mutableSetOf() }.add(candidate.pubkey)
+                }
+            }
+        }
+        val resolved = mutableMapOf<String, String>()
+        var i = 0
+        while (i < content.length) {
+            if (!isTokenStart(content, i)) {
+                i++
+                continue
+            }
+            // A picked name can hold spaces, so its first word reads as a token of its own here.
+            val picked = mentions.keys.firstOrNull { endsToken(content, i + 1, it) }
+            if (picked != null) {
+                i += 1 + picked.length
+                continue
+            }
+            val raw = content.substring(i + 1).takeWhile { !it.isWhitespace() }
+            val token = raw.trimEnd { it in TOKEN_TRAILERS }
+            i += 1 + raw.length
+            if (token.isEmpty() || token in resolved) continue
+            val pubkey = npubPubkey(token) ?: byLabel[token.normalizeForSearch()]?.singleOrNull()
+            if (pubkey != null) resolved[token] = pubkey
+        }
+        return resolved
+    }
+
+    /** [name] sits at [from] and ends the word there, so `@ana` does not eat the head of `@anastasia`. */
+    private fun endsToken(content: String, from: Int, name: String): Boolean = content.startsWith(name, from) && content.getOrNull(from + name.length)?.isLetterOrDigit() != true
+
+    /** An `@` that starts a word: mid-word (an email, a handle in a URL) is not a mention. */
+    private fun isTokenStart(content: String, index: Int): Boolean = content[index] == '@' && content.getOrNull(index - 1)?.isLetterOrDigit() != true
+
+    private fun npubPubkey(token: String): String? {
+        if (!token.startsWith("npub1", ignoreCase = true)) return null
+        return (Nip19.decode(token.lowercase()) as? Nip19.Entity.Npub)?.pubkey
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/StandaloneRef.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/text/StandaloneRef.kt
@@ -1,0 +1,17 @@
+package org.nostr.nostrord.ui.text
+
+/**
+ * Whether a `nostr:` reference is the only thing on its line. Alone on a line it renders as a rich
+ * block (profile card, group card, quote); mixed with text it stays a compact inline chip. The rule
+ * is per line and not per message, so an invite ("You've been added to X" + the naddr underneath)
+ * still gets the card.
+ */
+object StandaloneRef {
+    fun isStandalone(content: String, token: String): Boolean {
+        val bech32 = token.removePrefix("nostr:")
+        return content.lineSequence().any { line ->
+            val trimmed = line.trim()
+            trimmed == bech32 || trimmed == "nostr:$bech32"
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/MentionTagsTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/MentionTagsTest.kt
@@ -1,0 +1,75 @@
+package org.nostr.nostrord.network.managers
+
+import org.nostr.nostrord.nostr.Nip19
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MentionTagsTest {
+    private val alice = "1".repeat(64)
+    private val bob = "2".repeat(64)
+    private val anastasia = "3".repeat(64)
+
+    private val candidates = listOf(
+        MentionCandidate(alice, listOf("Alice Cooper", "alice")),
+        MentionCandidate(bob, listOf("Bob")),
+        MentionCandidate(anastasia, listOf("anastasia")),
+    )
+
+    @Test
+    fun typedNameResolvesWithoutPickingASuggestion() {
+        val resolved = MentionTags.resolveTyped("hey @Bob, look", emptyMap(), candidates)
+        assertEquals(mapOf("Bob" to bob), resolved)
+    }
+
+    @Test
+    fun typedNameIsCaseInsensitiveAndIgnoresSpacesInTheName() {
+        assertEquals(mapOf("bob" to bob), MentionTags.resolveTyped("@bob", emptyMap(), candidates))
+        assertEquals(mapOf("alicecooper" to alice), MentionTags.resolveTyped("@alicecooper hi", emptyMap(), candidates))
+    }
+
+    @Test
+    fun typedNpubResolves() {
+        val npub = Nip19.encodeNpub(bob)
+        assertEquals(mapOf(npub to bob), MentionTags.resolveTyped("ping @$npub", emptyMap(), candidates))
+    }
+
+    @Test
+    fun ambiguousNameStaysPlainText() {
+        val twins = listOf(MentionCandidate(alice, listOf("Sam")), MentionCandidate(bob, listOf("sam")))
+        assertTrue(MentionTags.resolveTyped("@Sam here", emptyMap(), twins).isEmpty())
+    }
+
+    @Test
+    fun pickedMentionsAndNonMembersAreLeftAlone() {
+        val picked = mapOf("Alice Cooper" to alice)
+        val resolved = MentionTags.resolveTyped("@Alice Cooper and @stranger", picked, candidates)
+        assertTrue(resolved.isEmpty())
+    }
+
+    @Test
+    fun midWordAtSignIsNotAMention() {
+        assertTrue(MentionTags.resolveTyped("mail me at me@bob.com", emptyMap(), candidates).isEmpty())
+    }
+
+    @Test
+    fun applyReplacesWholeTokensOnly() {
+        val mentions = mapOf("alice" to alice, "anastasia" to anastasia)
+        val (content, tags) = MentionTags.apply("@anastasia met @alice", mentions)
+        assertEquals("nostr:${Nip19.encodeNpub(anastasia)} met nostr:${Nip19.encodeNpub(alice)}", content)
+        assertEquals(listOf(listOf("p", anastasia), listOf("p", alice)), tags.sortedBy { content.indexOf(it[1]) })
+    }
+
+    @Test
+    fun applyTagsOnlyTheNamesLeftInTheText() {
+        val (content, tags) = MentionTags.apply("just @alice now", mapOf("alice" to alice, "Bob" to bob))
+        assertEquals("just nostr:${Nip19.encodeNpub(alice)} now", content)
+        assertEquals(listOf(listOf("p", alice)), tags)
+    }
+
+    @Test
+    fun applySkipsPubkeysAlreadyTagged() {
+        val (_, tags) = MentionTags.apply("@alice", mapOf("alice" to alice), listOf(listOf("p", alice)))
+        assertTrue(tags.isEmpty())
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/StandaloneRefTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/text/StandaloneRefTest.kt
@@ -1,0 +1,35 @@
+package org.nostr.nostrord.ui.text
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class StandaloneRefTest {
+    private val npub = "npub1f27g79lrpey73wtqa2pprn7vv3yveyytws08lxqe7pn0yuj8ppyqyk9swu"
+
+    @Test
+    fun aloneInTheMessageIsStandalone() {
+        assertTrue(StandaloneRef.isStandalone("nostr:$npub", "nostr:$npub"))
+    }
+
+    @Test
+    fun aloneOnItsOwnLineIsStandalone() {
+        assertTrue(StandaloneRef.isStandalone("You've been added to X\nnostr:$npub", "nostr:$npub"))
+    }
+
+    @Test
+    fun mixedWithTextOnTheLineIsNot() {
+        assertFalse(StandaloneRef.isStandalone("hey nostr:$npub how are you", "nostr:$npub"))
+    }
+
+    @Test
+    fun bareBech32MatchesThePrefixedToken() {
+        assertTrue(StandaloneRef.isStandalone(npub, "nostr:$npub"))
+        assertTrue(StandaloneRef.isStandalone("nostr:$npub", npub))
+    }
+
+    @Test
+    fun anotherReferenceOnItsOwnLineDoesNotCount() {
+        assertFalse(StandaloneRef.isStandalone("hey nostr:$npub\nnostr:npub1other", "nostr:$npub"))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.InlineTextContent
 import androidx.compose.foundation.text.appendInlineContent
@@ -68,6 +69,7 @@ import org.nostr.nostrord.isLinuxDesktop
 import org.nostr.nostrord.network.CachedEvent
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip84
+import org.nostr.nostrord.ui.components.avatars.OptimizedSmallAvatar
 import org.nostr.nostrord.ui.components.avatars.OptimizedUserAvatar
 import org.nostr.nostrord.ui.components.media.AudioPlayerContent
 import org.nostr.nostrord.ui.components.media.PlatformVideoPlayer
@@ -80,6 +82,7 @@ import org.nostr.nostrord.ui.navigation.GroupView
 import org.nostr.nostrord.ui.navigation.LocalFrameNavigator
 import org.nostr.nostrord.ui.screens.group.components.GroupHeaderIcon
 import org.nostr.nostrord.ui.text.BlockEmbedText
+import org.nostr.nostrord.ui.text.StandaloneRef
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordShapes
 import org.nostr.nostrord.ui.theme.NostrordTypography
@@ -182,24 +185,35 @@ private fun AnnotatedString.Builder.appendWithEmojiFont(
     }
 }
 
-private fun isBlockPart(part: ContentPart): Boolean = when (part) {
+private fun isBlockPart(part: ContentPart, content: String? = null): Boolean = when (part) {
     is ImagePart -> true
     is CodeBlockPart -> true
     is BlockquotePart -> true
     is VideoPart -> true
     is AudioPart -> true
-    is RelayPart -> true
+    // A NIP-29 group address is the full card only when the message IS the link; mixed with text
+    // it flows as a chip. A bare relay url stays its own block.
+    is RelayPart -> !part.url.contains('\'') || content == null || content.trim() == part.url
     is CashuPart -> true
     is CashuRequestPart -> true
     is MentionPart -> {
-        // Quoted events (nevent, note, naddr) are block elements
-        when (part.reference.entity) {
-            is Nip19.Entity.Nevent, is Nip19.Entity.Note, is Nip19.Entity.Naddr -> true
+        // Quoted events are always blocks. A profile or group reference gets its card only when it
+        // stands alone on its line; inline with text it is a chip (web parity).
+        when (val entity = part.reference.entity) {
+            is Nip19.Entity.Nevent, is Nip19.Entity.Note -> true
+            is Nip19.Entity.Naddr ->
+                entity.kind != GROUP_METADATA_KIND || isStandaloneRef(part, content)
+            is Nip19.Entity.Npub, is Nip19.Entity.Nprofile -> isStandaloneRef(part, content)
             else -> false
         }
     }
     else -> false
 }
+
+/** kind:39000 — the NIP-29 group metadata a naddr points at. */
+private const val GROUP_METADATA_KIND = 39000
+
+private fun isStandaloneRef(part: MentionPart, content: String?): Boolean = content != null && StandaloneRef.isStandalone(content, part.reference.bech32)
 
 /**
  * Absorb the newline the author typed on either side of a block embed: the block already breaks
@@ -207,14 +221,14 @@ private fun isBlockPart(part: ContentPart): Boolean = when (part) {
  * media (rules in [BlockEmbedText]). Text parts left empty are dropped so they add no line of
  * their own.
  */
-private fun trimAroundBlocks(parts: List<ContentPart>): List<ContentPart> = parts
+private fun trimAroundBlocks(parts: List<ContentPart>, content: String? = null): List<ContentPart> = parts
     .mapIndexed { index, part ->
         if (part !is TextPart) {
             part
         } else {
             var text = part.content
-            if (parts.getOrNull(index - 1)?.let { isBlockPart(it) } == true) text = BlockEmbedText.trimAfter(text)
-            if (parts.getOrNull(index + 1)?.let { isBlockPart(it) } == true) text = BlockEmbedText.trimBefore(text)
+            if (parts.getOrNull(index - 1)?.let { isBlockPart(it, content) } == true) text = BlockEmbedText.trimAfter(text)
+            if (parts.getOrNull(index + 1)?.let { isBlockPart(it, content) } == true) text = BlockEmbedText.trimBefore(text)
             if (text == part.content) part else part.copy(content = text)
         }
     }.filter { it !is TextPart || it.content.isNotEmpty() }
@@ -283,12 +297,12 @@ fun MessageContent(
 
     // Group parts into inline sequences and block elements
     val groups =
-        remember(parts) {
+        remember(parts, content) {
             val result = mutableListOf<List<ContentPart>>()
             var currentInlineGroup = mutableListOf<ContentPart>()
 
-            trimAroundBlocks(parts).forEach { part ->
-                if (isBlockPart(part)) {
+            trimAroundBlocks(parts, content).forEach { part ->
+                if (isBlockPart(part, content)) {
                     // Flush current inline group if not empty
                     if (currentInlineGroup.isNotEmpty()) {
                         result.add(currentInlineGroup.toList())
@@ -333,7 +347,7 @@ fun MessageContent(
                 val firstPart = group.firstOrNull()
 
                 // Check if this is a block element group (single block element)
-                if (group.size == 1 && isBlockPart(firstPart!!)) {
+                if (group.size == 1 && isBlockPart(firstPart!!, content)) {
                     when (firstPart) {
                         is ImagePart -> {
                             // 4dp above and nothing below: the web's `.msg-image { margin-top: 4px }`,
@@ -461,22 +475,13 @@ fun MessageContent(
                             Spacer(modifier = Modifier.height(8.dp))
                             val apostrophe = firstPart.url.indexOf('\'')
                             if (apostrophe > 0) {
-                                // NIP-29 group address relay'groupId: the full card only when the
-                                // message IS the link; mixed with text it renders as the compact
-                                // chip (web parity).
-                                if (content.trim() == firstPart.url) {
-                                    GroupLinkCard(
-                                        groupId = firstPart.url.substring(apostrophe + 1),
-                                        relayUrl = firstPart.url.substring(0, apostrophe),
-                                        onNavigateToGroup = onNavigateToGroup,
-                                    )
-                                } else {
-                                    GroupMentionChip(
-                                        groupId = firstPart.url.substring(apostrophe + 1),
-                                        relayUrl = firstPart.url.substring(0, apostrophe),
-                                        onNavigateToGroup = onNavigateToGroup,
-                                    )
-                                }
+                                // NIP-29 group address relay'groupId: a block only when the message
+                                // IS the link, so it always reads as the full card here.
+                                GroupLinkCard(
+                                    groupId = firstPart.url.substring(apostrophe + 1),
+                                    relayUrl = firstPart.url.substring(0, apostrophe),
+                                    onNavigateToGroup = onNavigateToGroup,
+                                )
                             } else {
                                 RelayContent(
                                     url = firstPart.url,
@@ -519,6 +524,7 @@ fun MessageContent(
                         userMetadata = userMetadata,
                         onMentionClick = onMentionClick,
                         onHashtagClick = onHashtagClick,
+                        onNavigateToGroup = onNavigateToGroup,
                         textColor = textColor,
                     )
                 }
@@ -555,20 +561,23 @@ private fun InlineContentGroup(
     modifier: Modifier = Modifier,
     onMentionClick: (String) -> Unit = {},
     onHashtagClick: (String) -> Unit = {},
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit = { _, _, _, _ -> },
     textColor: Color = NostrordColors.TextContent,
 ) {
-    // Check if this group contains any custom emojis
+    val chips = rememberInlineChips(parts, userMetadata, onMentionClick, onNavigateToGroup)
     val hasCustomEmojis =
         remember(parts) {
             parts.any { it is CustomEmojiPart }
         }
 
-    if (hasCustomEmojis) {
-        // Messages with emojis: disable selection to prevent crash, but show images
+    // Inline images (emoji, chip avatars) go through the placeholder renderer, which must run
+    // without selection: InlineTextContent inside a SelectionContainer crashes on Skiko.
+    if (hasCustomEmojis || chips.isNotEmpty()) {
         DisableSelection {
-            InlineContentWithEmojis(
+            InlineContentWithImages(
                 parts = parts,
                 userMetadata = userMetadata,
+                chips = chips,
                 modifier = modifier,
                 onMentionClick = onMentionClick,
                 onHashtagClick = onHashtagClick,
@@ -576,7 +585,7 @@ private fun InlineContentGroup(
             )
         }
     } else {
-        // Messages without emojis: full selection support
+        // Plain runs keep full selection support
         InlineContentTextOnly(
             parts = parts,
             userMetadata = userMetadata,
@@ -588,14 +597,213 @@ private fun InlineContentGroup(
     }
 }
 
+/** A user or group reference that flows inline as an avatar + name chip (web `.msg-mention-chip`). */
+private data class InlineChip(
+    /** Inline-content id and link tag; unique per reference. */
+    val key: String,
+    val imageUrl: String?,
+    val identifier: String,
+    val name: String,
+    /** Text for renderers that paint no avatar, where a bare name would not read as a mention. */
+    val plainName: String,
+    val isGroup: Boolean,
+    val onClick: () -> Unit,
+)
+
+/** The group a reference points at: `naddr` (kind:39000) and the `relay'groupId` link form. */
+private fun groupRefOf(part: ContentPart): Pair<String, String?>? = when (part) {
+    is MentionPart -> (part.reference.entity as? Nip19.Entity.Naddr)
+        ?.takeIf { it.kind == GROUP_METADATA_KIND }
+        ?.let { it.identifier to it.relays.firstOrNull() }
+    is RelayPart -> part.url.indexOf('\'').takeIf { it > 0 }
+        ?.let { part.url.substring(it + 1) to part.url.substring(0, it) }
+    else -> null
+}
+
+/** The chips for [parts], keyed by the token they were parsed from (bech32, or the relay link). */
+@Composable
+private fun rememberInlineChips(
+    parts: List<ContentPart>,
+    userMetadata: Map<String, org.nostr.nostrord.network.UserMetadata>,
+    onMentionClick: (String) -> Unit,
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
+): Map<String, InlineChip> {
+    val userChips =
+        remember(parts, userMetadata) {
+            parts.filterIsInstance<MentionPart>().mapNotNull { part ->
+                val pubkey =
+                    when (val entity = part.reference.entity) {
+                        is Nip19.Entity.Npub -> entity.pubkey
+                        is Nip19.Entity.Nprofile -> entity.pubkey
+                        else -> null
+                    } ?: return@mapNotNull null
+                val meta = userMetadata[pubkey]
+                val name = meta?.displayName?.takeIf { it.isNotBlank() }
+                    ?: meta?.name?.takeIf { it.isNotBlank() }
+                    ?: shortNpub(pubkey)
+                part.reference.bech32 to
+                    InlineChip(
+                        key = "chip:${part.reference.bech32}",
+                        imageUrl = meta?.picture,
+                        identifier = pubkey,
+                        name = name,
+                        plainName = "@$name",
+                        isGroup = false,
+                        onClick = { onMentionClick(pubkey) },
+                    )
+            }.toMap()
+        }
+
+    // The group flows are collected only for a run that names a group: every message row with a
+    // mention would otherwise recompose on each group-list update.
+    val hasGroupRef = remember(parts) { parts.any { groupRefOf(it) != null } }
+    if (!hasGroupRef) return userChips
+    return userChips + rememberGroupChips(parts, onNavigateToGroup)
+}
+
+/** The group chips for [parts], resolved against the relay each reference points at. */
+@Composable
+private fun rememberGroupChips(
+    parts: List<ContentPart>,
+    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
+): Map<String, InlineChip> {
+    val repo = AppModule.nostrRepository
+    val groups by repo.groups.collectAsState()
+    val groupsByRelay by repo.groupsByRelay.collectAsState()
+
+    // A group named by a reference is usually one the reader has not joined, so its kind:39000
+    // has to be fetched before the chip can show a name and an avatar.
+    LaunchedEffect(parts) {
+        parts.mapNotNull { groupRefOf(it) }.distinct().forEach { (groupId, relayUrl) ->
+            if (relayUrl != null && resolveGroupRef(groupsByRelay, groupId, relayUrl, fallback = groups)?.name == null) {
+                repo.fetchGroupPreview(groupId, relayUrl)
+            }
+        }
+    }
+
+    return remember(parts, groups, groupsByRelay) {
+        parts.mapNotNull { part ->
+            val (groupId, relayUrl) = groupRefOf(part) ?: return@mapNotNull null
+            val meta = resolveGroupRef(groupsByRelay, groupId, relayUrl, fallback = groups)
+            val name = meta?.name?.takeIf { it.isNotBlank() } ?: groupId
+            val token = if (part is MentionPart) part.reference.bech32 else (part as RelayPart).url
+            token to
+                InlineChip(
+                    key = "chip:$token",
+                    imageUrl = meta?.picture,
+                    identifier = groupId,
+                    name = name,
+                    plainName = name,
+                    isGroup = true,
+                    onClick = { onNavigateToGroup(groupId, meta?.name, relayUrl, null) },
+                )
+        }.toMap()
+    }
+}
+
+/** The inline-content entry that paints a chip's avatar, sized to sit on the text baseline. */
+private fun chipInlineContent(chip: InlineChip): InlineTextContent = InlineTextContent(
+    placeholder =
+    Placeholder(
+        // 4sp wider than the avatar: the trailing gap before the name (web chip `gap: 4px`).
+        width = 20.sp,
+        height = 16.sp,
+        placeholderVerticalAlign = PlaceholderVerticalAlign.Center,
+    ),
+) {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.CenterStart) {
+        OptimizedSmallAvatar(
+            imageUrl = chip.imageUrl,
+            identifier = chip.identifier,
+            displayName = chip.name,
+            size = 16.dp,
+            shape = if (chip.isGroup) RoundedCornerShape(4.dp) else CircleShape,
+            isGroup = chip.isGroup,
+        )
+    }
+}
+
+/** Avatar + tinted name, the inline form of a user or group reference. */
+private fun AnnotatedString.Builder.appendChip(chip: InlineChip, inlineAvatars: Boolean) {
+    withLink(
+        LinkAnnotation.Clickable(
+            tag = chip.key,
+            // One chip style for people and groups (web `.msg-mention-chip`): mention text on a
+            // brand tint. The avatar shape is what tells the two apart.
+            styles =
+            TextLinkStyles(
+                style =
+                SpanStyle(
+                    color = NostrordColors.MentionText,
+                    fontWeight = FontWeight.Medium,
+                    background = NostrordColors.Primary.copy(alpha = 0.18f),
+                ),
+            ),
+            linkInteractionListener = { chip.onClick() },
+        ),
+    ) {
+        if (inlineAvatars) {
+            appendInlineContent(chip.key, " ")
+            append(chip.name)
+        } else {
+            append(chip.plainName)
+        }
+    }
+}
+
 /**
- * Renders inline content WITH custom emoji images.
+ * One reference run in the annotated string: the chip when the reference resolves to a person or
+ * a group, else the tinted link a quoted event keeps.
+ */
+private fun AnnotatedString.Builder.appendReference(
+    part: MentionPart,
+    chip: InlineChip?,
+    inlineAvatars: Boolean,
+    userMetadata: Map<String, org.nostr.nostrord.network.UserMetadata>,
+    onMentionClick: (String) -> Unit,
+) {
+    if (chip != null) {
+        appendChip(chip, inlineAvatars)
+        return
+    }
+    val displayText = getMentionDisplayText(part, userMetadata)
+    val style =
+        TextLinkStyles(
+            style =
+            SpanStyle(
+                color = NostrordColors.MentionText,
+                fontWeight = FontWeight.Medium,
+                background = NostrordColors.MentionText.copy(alpha = 0.15f),
+            ),
+        )
+    val pubkey =
+        when (val entity = part.reference.entity) {
+            is Nip19.Entity.Npub -> entity.pubkey
+            is Nip19.Entity.Nprofile -> entity.pubkey
+            else -> null
+        }
+    if (pubkey != null) {
+        withLink(
+            LinkAnnotation.Clickable(tag = "mention_$pubkey", styles = style, linkInteractionListener = { onMentionClick(pubkey) }),
+        ) {
+            append(displayText)
+        }
+    } else {
+        withLink(LinkAnnotation.Url(url = part.reference.uri, styles = style)) {
+            append(displayText)
+        }
+    }
+}
+
+/**
+ * Renders inline content WITH images (custom emoji, chip avatars).
  * Must be wrapped in DisableSelection to prevent crashes.
  */
 @Composable
-private fun InlineContentWithEmojis(
+private fun InlineContentWithImages(
     parts: List<ContentPart>,
     userMetadata: Map<String, org.nostr.nostrord.network.UserMetadata>,
+    chips: Map<String, InlineChip>,
     modifier: Modifier = Modifier,
     onMentionClick: (String) -> Unit = {},
     onHashtagClick: (String) -> Unit = {},
@@ -626,7 +834,7 @@ private fun InlineContentWithEmojis(
     // unique emoji, reused for every occurrence.  This avoids creating N separate
     // SafeEmojiImage composables when the same emoji appears N times.
     val inlineContentMap =
-        remember(parts) {
+        remember(parts, chips) {
             parts
                 .filterIsInstance<CustomEmojiPart>()
                 .distinctBy { it.shortcode }
@@ -645,7 +853,7 @@ private fun InlineContentWithEmojis(
                                 imageUrl = emoji.imageUrl,
                             )
                         }
-                }
+                } + chips.values.associate { chip -> chip.key to chipInlineContent(chip) }
         }
 
     // Build the annotated string — each emoji references its shortcode key
@@ -653,12 +861,13 @@ private fun InlineContentWithEmojis(
     // Spoilers start hidden; tapping one toggles its index here (Discord-style).
     var revealedSpoilers by remember(parts) { mutableStateOf(emptySet<Int>()) }
     val annotatedString =
-        remember(parts, userMetadata, emojiFontFamily, revealedSpoilers) {
+        remember(parts, userMetadata, chips, emojiFontFamily, revealedSpoilers) {
             var spoilerIndex = 0
             buildAnnotatedString {
                 parts.forEach { part ->
                     when (part) {
                         is TextPart -> appendWithEmojiFont(part.content, emojiFontFamily)
+                        is RelayPart -> chips[part.url]?.let { appendChip(it, inlineAvatars = true) } ?: append(part.url)
                         is LinkPart -> {
                             withLink(
                                 LinkAnnotation.Url(
@@ -672,58 +881,7 @@ private fun InlineContentWithEmojis(
                                 append(part.url)
                             }
                         }
-                        is MentionPart -> {
-                            val displayText = getMentionDisplayText(part, userMetadata)
-                            val entity = part.reference.entity
-                            // For user mentions (npub/nprofile), use clickable to open profile modal
-                            // For other mentions (nevent, note), use URL to open in external handler
-                            val pubkey =
-                                when (entity) {
-                                    is Nip19.Entity.Npub -> entity.pubkey
-                                    is Nip19.Entity.Nprofile -> entity.pubkey
-                                    else -> null
-                                }
-                            if (pubkey != null) {
-                                withLink(
-                                    LinkAnnotation.Clickable(
-                                        tag = "mention_$pubkey",
-                                        styles =
-                                        TextLinkStyles(
-                                            style =
-                                            SpanStyle(
-                                                color = NostrordColors.MentionText,
-                                                fontWeight = FontWeight.Medium,
-                                                // Tinted pill behind the @name approximates the web mention chip.
-                                                // (No inline avatar: InlineTextContent images crash on Skiko.)
-                                                background = NostrordColors.MentionText.copy(alpha = 0.15f),
-                                            ),
-                                        ),
-                                        linkInteractionListener = { onMentionClick(pubkey) },
-                                    ),
-                                ) {
-                                    append(displayText)
-                                }
-                            } else {
-                                withLink(
-                                    LinkAnnotation.Url(
-                                        url = part.reference.uri,
-                                        styles =
-                                        TextLinkStyles(
-                                            style =
-                                            SpanStyle(
-                                                color = NostrordColors.MentionText,
-                                                fontWeight = FontWeight.Medium,
-                                                // Tinted pill behind the @name approximates the web mention chip.
-                                                // (No inline avatar: InlineTextContent images crash on Skiko.)
-                                                background = NostrordColors.MentionText.copy(alpha = 0.15f),
-                                            ),
-                                        ),
-                                    ),
-                                ) {
-                                    append(displayText)
-                                }
-                            }
-                        }
+                        is MentionPart -> appendReference(part, chips[part.reference.bech32], inlineAvatars = true, userMetadata = userMetadata, onMentionClick = onMentionClick)
                         is CustomEmojiPart -> {
                             appendInlineContent(
                                 part.shortcode,
@@ -862,58 +1020,7 @@ private fun InlineContentTextOnly(
                                 append(part.url)
                             }
                         }
-                        is MentionPart -> {
-                            val displayText = getMentionDisplayText(part, userMetadata)
-                            val entity = part.reference.entity
-                            // For user mentions (npub/nprofile), use clickable to open profile modal
-                            // For other mentions (nevent, note), use URL to open in external handler
-                            val pubkey =
-                                when (entity) {
-                                    is Nip19.Entity.Npub -> entity.pubkey
-                                    is Nip19.Entity.Nprofile -> entity.pubkey
-                                    else -> null
-                                }
-                            if (pubkey != null) {
-                                withLink(
-                                    LinkAnnotation.Clickable(
-                                        tag = "mention_$pubkey",
-                                        styles =
-                                        TextLinkStyles(
-                                            style =
-                                            SpanStyle(
-                                                color = NostrordColors.MentionText,
-                                                fontWeight = FontWeight.Medium,
-                                                // Tinted pill behind the @name approximates the web mention chip.
-                                                // (No inline avatar: InlineTextContent images crash on Skiko.)
-                                                background = NostrordColors.MentionText.copy(alpha = 0.15f),
-                                            ),
-                                        ),
-                                        linkInteractionListener = { onMentionClick(pubkey) },
-                                    ),
-                                ) {
-                                    append(displayText)
-                                }
-                            } else {
-                                withLink(
-                                    LinkAnnotation.Url(
-                                        url = part.reference.uri,
-                                        styles =
-                                        TextLinkStyles(
-                                            style =
-                                            SpanStyle(
-                                                color = NostrordColors.MentionText,
-                                                fontWeight = FontWeight.Medium,
-                                                // Tinted pill behind the @name approximates the web mention chip.
-                                                // (No inline avatar: InlineTextContent images crash on Skiko.)
-                                                background = NostrordColors.MentionText.copy(alpha = 0.15f),
-                                            ),
-                                        ),
-                                    ),
-                                ) {
-                                    append(displayText)
-                                }
-                            }
-                        }
+                        is MentionPart -> appendReference(part, chip = null, inlineAvatars = false, userMetadata = userMetadata, onMentionClick = onMentionClick)
                         // Text formatting
                         is BoldPart -> {
                             withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
@@ -1348,8 +1455,10 @@ private fun QuotedEventBlock(
                 onMentionClick = onMentionClick,
             )
         }
+        is Nip19.Entity.Npub -> UserLinkCard(pubkey = entity.pubkey, onMentionClick = onMentionClick, modifier = modifier)
+        is Nip19.Entity.Nprofile -> UserLinkCard(pubkey = entity.pubkey, onMentionClick = onMentionClick, modifier = modifier)
         is Nip19.Entity.Naddr -> {
-            if (entity.kind == 39000) {
+            if (entity.kind == GROUP_METADATA_KIND) {
                 GroupLinkCard(
                     groupId = entity.identifier,
                     relayUrl = entity.relays.firstOrNull(),
@@ -1423,8 +1532,10 @@ private fun ThreadQuoteCard(
         Column(
             modifier =
             modifier
-                .fillMaxWidth()
+                // Cap first: fillMaxWidth expands to the capped constraint, not the row width
+                // (the web cards are a block box with `max-width: 380px`).
                 .widthIn(max = 380.dp)
+                .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
                 .background(NostrordColors.Surface)
                 .then(
@@ -2546,57 +2657,7 @@ private fun QuotedInlineContentGroup(
                                 append(part.url)
                             }
                         }
-                        is MentionPart -> {
-                            val displayText = getMentionDisplayText(part, userMetadata)
-                            // User mentions (npub/nprofile) open the profile; event/group refs have
-                            // no profile, so they keep the URL handler.
-                            val mentionPubkey =
-                                when (val mentionEntity = part.reference.entity) {
-                                    is Nip19.Entity.Npub -> mentionEntity.pubkey
-                                    is Nip19.Entity.Nprofile -> mentionEntity.pubkey
-                                    else -> null
-                                }
-                            if (mentionPubkey != null) {
-                                withLink(
-                                    LinkAnnotation.Clickable(
-                                        tag = "mention_$mentionPubkey",
-                                        styles =
-                                        TextLinkStyles(
-                                            style =
-                                            SpanStyle(
-                                                color = NostrordColors.MentionText,
-                                                fontWeight = FontWeight.Medium,
-                                                // Tinted pill behind the @name approximates the web mention chip.
-                                                // (No inline avatar: InlineTextContent images crash on Skiko.)
-                                                background = NostrordColors.MentionText.copy(alpha = 0.15f),
-                                            ),
-                                        ),
-                                        linkInteractionListener = { onMentionClick(mentionPubkey) },
-                                    ),
-                                ) {
-                                    append(displayText)
-                                }
-                            } else {
-                                withLink(
-                                    LinkAnnotation.Url(
-                                        url = part.reference.uri,
-                                        styles =
-                                        TextLinkStyles(
-                                            style =
-                                            SpanStyle(
-                                                color = NostrordColors.MentionText,
-                                                fontWeight = FontWeight.Medium,
-                                                // Tinted pill behind the @name approximates the web mention chip.
-                                                // (No inline avatar: InlineTextContent images crash on Skiko.)
-                                                background = NostrordColors.MentionText.copy(alpha = 0.15f),
-                                            ),
-                                        ),
-                                    ),
-                                ) {
-                                    append(displayText)
-                                }
-                            }
-                        }
+                        is MentionPart -> appendReference(part, chip = null, inlineAvatars = false, userMetadata = userMetadata, onMentionClick = onMentionClick)
                         is CustomEmojiPart -> {
                             appendInlineContent(
                                 "quoted_emoji_${emojiIndex++}_${part.shortcode}",
@@ -2898,9 +2959,10 @@ private fun GroupLinkCard(
         Row(
             modifier =
             modifier
-                .fillMaxWidth()
-                // Match the web group-link-card cap (.group-link-card max-width: 380px).
+                // Match the web group-link-card box (.group-link-card max-width: 380px): the
+                // cap comes first so fillMaxWidth expands to it.
                 .widthIn(max = 380.dp)
+                .fillMaxWidth()
                 .clip(RoundedCornerShape(12.dp))
                 .background(NostrordColors.Surface)
                 .clickable { onNavigateToGroup(groupId, groupMeta?.name, relayUrl, null) }
@@ -2945,62 +3007,6 @@ private fun GroupLinkCard(
                     )
                 }
             }
-        }
-    }
-}
-
-/**
- * Compact chip for a group reference mixed with running text (group avatar + name); the full
- * [GroupLinkCard] is reserved for a message that is only the group link. Mirrors the web
- * `.msg-mention-chip` rendering of inline group refs.
- */
-@Composable
-private fun GroupMentionChip(
-    groupId: String,
-    relayUrl: String?,
-    onNavigateToGroup: (groupId: String, groupName: String?, relayUrl: String?, messageId: String?) -> Unit,
-) {
-    val repo = AppModule.nostrRepository
-    val groups by repo.groups.collectAsState()
-    val groupsByRelay by repo.groupsByRelay.collectAsState()
-    // Same relay-scoped resolution as the full card: the chip's avatar must come from the
-    // relay the naddr points at.
-    val groupMeta = resolveGroupRef(groupsByRelay, groupId, relayUrl, fallback = groups)
-
-    LaunchedEffect(groupId, relayUrl) {
-        if (relayUrl != null && groupMeta?.name == null) {
-            repo.fetchGroupPreview(groupId, relayUrl)
-        }
-    }
-
-    val displayName = groupMeta?.name?.takeIf { it.isNotBlank() } ?: groupId
-    DisableSelection {
-        Row(
-            modifier =
-            Modifier
-                .clip(RoundedCornerShape(6.dp))
-                .background(NostrordColors.PrimarySubtle)
-                .clickable { onNavigateToGroup(groupId, groupMeta?.name, relayUrl, null) }
-                .pointerHoverIcon(PointerIcon.Hand)
-                .padding(horizontal = 6.dp, vertical = 2.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(4.dp),
-        ) {
-            GroupHeaderIcon(
-                pictureUrl = groupMeta?.picture,
-                groupId = groupId,
-                displayName = displayName,
-                size = 16.dp,
-                cornerRadius = 4.dp,
-            )
-            Text(
-                text = displayName,
-                color = NostrordColors.Primary,
-                fontSize = 13.sp,
-                fontWeight = FontWeight.Medium,
-                maxLines = 1,
-                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-            )
         }
     }
 }
@@ -3219,6 +3225,32 @@ private fun AddressableEvent(
 }
 
 /**
+ * A user reference standing alone on its line: the same [ProfileCard] a kind:0 naddr gets, the
+ * native counterpart of the web `.user-link-card`.
+ */
+@Composable
+private fun UserLinkCard(
+    pubkey: String,
+    onMentionClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val userMetadata by AppModule.nostrRepository.userMetadata.collectAsState()
+
+    LaunchedEffect(pubkey) {
+        if (!userMetadata.containsKey(pubkey)) {
+            AppModule.nostrRepository.requestUserMetadata(setOf(pubkey))
+        }
+    }
+
+    ProfileCard(
+        metadata = userMetadata[pubkey],
+        pubkey = pubkey,
+        onClick = { onMentionClick(pubkey) },
+        modifier = modifier,
+    )
+}
+
+/**
  * Profile card for kind 0 (user metadata) naddr
  */
 @Composable
@@ -3231,21 +3263,24 @@ private fun ProfileCard(
     Row(
         modifier =
         modifier
+            // Same box as the web `.user-link-card`: capped at 380px, filling it.
+            .widthIn(max = 380.dp)
             .fillMaxWidth()
             .clip(RoundedCornerShape(NostrordShapes.radiusMedium))
             .background(NostrordColors.Surface)
             .clickable(onClick = onClick)
-            .padding(Spacing.md),
+            .padding(Spacing.sm),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         // Avatar
         OptimizedUserAvatar(
             imageUrl = metadata?.picture,
             pubkey = pubkey,
             displayName = metadata?.displayName ?: metadata?.name ?: "Unknown",
-            size = 64.dp,
+            size = 36.dp,
         )
 
-        Spacer(modifier = Modifier.width(Spacing.md))
+        Spacer(modifier = Modifier.width(Spacing.sm))
 
         // Profile info
         Column(modifier = Modifier.weight(1f)) {
@@ -3256,21 +3291,14 @@ private fun ProfileCard(
                 fontWeight = FontWeight.Bold,
             )
 
+            // Name + nip05 only: an about paragraph turns a reference into a wall of text.
             if (metadata?.nip05 != null) {
                 Text(
                     text = metadata.nip05,
                     color = NostrordColors.TextSecondary,
                     style = NostrordTypography.Caption,
-                )
-            }
-
-            if (metadata?.about != null) {
-                Spacer(modifier = Modifier.height(Spacing.xs))
-                Text(
-                    text = metadata.about,
-                    color = NostrordColors.TextContent,
-                    style = NostrordTypography.Caption,
-                    maxLines = 3,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -40,6 +40,7 @@ import org.nostr.nostrord.ui.scroll.JumpPillTarget
 import org.nostr.nostrord.ui.text.BlockEmbedText
 import org.nostr.nostrord.ui.text.MarkdownEmphasis
 import org.nostr.nostrord.ui.text.MarkdownMedia
+import org.nostr.nostrord.ui.text.StandaloneRef
 import org.nostr.nostrord.utils.ChatSearch
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.epochSeconds
@@ -3669,24 +3670,13 @@ private fun ChildrenBuilder.renderEntities(
             val apostrophe = token.indexOf('\'')
             groupRef(token.substring(apostrophe + 1), "wss://" + token.substring(0, apostrophe), asCard = content.trim() == token, onGroupRef)
         } else {
-            // A mention standing alone (on its own line) keeps the rich form (group card,
-            // @name); inline with other text it becomes a compact avatar+name chip, matching
-            // the prototype. Per-line, not whole-message, so an invite DM ("You've been
-            // added to X" + the naddr on the next line) still renders the group card.
-            val standalone = content.split('\n').any { it.trim() == token }
+            // A reference standing alone on its line gets the rich card (profile, group);
+            // inline with other text it becomes a compact avatar+name chip, matching the
+            // prototype.
+            val standalone = StandaloneRef.isStandalone(content, token)
             when (val entity = Nip19.decode(token.removePrefix("nostr:"))) {
-                is Nip19.Entity.Npub ->
-                    if (standalone) {
-                        mentionSpan(entity.pubkey, userMetadata, onUser)
-                    } else {
-                        userMentionChip(entity.pubkey, userMetadata, onUser)
-                    }
-                is Nip19.Entity.Nprofile ->
-                    if (standalone) {
-                        mentionSpan(entity.pubkey, userMetadata, onUser)
-                    } else {
-                        userMentionChip(entity.pubkey, userMetadata, onUser)
-                    }
+                is Nip19.Entity.Npub -> userRef(entity.pubkey, userMetadata, standalone, onUser)
+                is Nip19.Entity.Nprofile -> userRef(entity.pubkey, userMetadata, standalone, onUser)
                 is Nip19.Entity.Nevent ->
                     QuotedEvent {
                         eventId = entity.eventId
@@ -3766,10 +3756,11 @@ private fun isBlockEmbedToken(token: String, content: String): Boolean {
     // text it is an inline chip.
     if (token.contains('\'')) return content.trim() == token
     if (token.startsWith("wss://") || token.startsWith("ws://")) return false
-    val standalone = content.split('\n').any { it.trim() == token }
+    val standalone = StandaloneRef.isStandalone(content, token)
     return when (val entity = Nip19.decode(token.removePrefix("nostr:"))) {
         is Nip19.Entity.Nevent, is Nip19.Entity.Note -> true
         is Nip19.Entity.Naddr -> entity.kind == 39000 && standalone
+        is Nip19.Entity.Npub, is Nip19.Entity.Nprofile -> standalone
         else -> false
     }
 }
@@ -3803,13 +3794,68 @@ private fun ChildrenBuilder.renderFormattedText(text: String, emojiMap: Map<Stri
     if (last < text.length) renderTextWithEmojis(text.substring(last), emojiMap)
 }
 
-private fun ChildrenBuilder.mentionSpan(pubkey: String, userMetadata: Map<String, UserMetadata>, onUser: (String) -> Unit) {
-    span {
-        className = ClassName("msg-mention")
-        onClick = { onUser(pubkey) }
-        +"@${displayName(pubkey, userMetadata[pubkey])}"
+/** A user reference in message text: the full profile card when it stands alone, else the chip. */
+private fun ChildrenBuilder.userRef(
+    pubkey: String,
+    userMetadata: Map<String, UserMetadata>,
+    asCard: Boolean,
+    onUser: (String) -> Unit,
+) {
+    if (asCard) {
+        UserLinkCard {
+            this.pubkey = pubkey
+            meta = userMetadata[pubkey]
+            this.onUser = onUser
+        }
+    } else {
+        userMentionChip(pubkey, userMetadata, onUser)
     }
 }
+
+private external interface UserLinkCardProps : Props {
+    var pubkey: String
+    var meta: UserMetadata?
+    var onUser: (String) -> Unit
+}
+
+/**
+ * Standalone `npub` / `nprofile` reference: avatar + name + nip05 + about, the user counterpart of
+ * [GroupLinkCard] and of native `ProfileCard`. Tapping it opens the profile.
+ */
+private val UserLinkCard =
+    FC<UserLinkCardProps> { props ->
+        val name = displayName(props.pubkey, props.meta)
+
+        useEffect(props.pubkey, props.meta == null) {
+            if (props.meta == null) {
+                launchApp { AppModule.nostrRepository.requestUserMetadata(setOf(props.pubkey)) }
+            }
+        }
+
+        div {
+            className = ClassName("user-link-card")
+            onClick = { props.onUser(props.pubkey) }
+            WebAvatar {
+                url = props.meta?.picture
+                seed = props.pubkey
+                this.name = name
+                cls = "user-link-avatar"
+            }
+            div {
+                className = ClassName("user-link-meta")
+                div {
+                    className = ClassName("user-link-name")
+                    +name
+                }
+                props.meta?.nip05?.takeIf { it.isNotBlank() }?.let {
+                    div {
+                        className = ClassName("user-link-nip05")
+                        +it
+                    }
+                }
+            }
+        }
+    }
 
 /** Inline user mention chip (prototype): circular avatar + display name, tinted and tappable. */
 private fun ChildrenBuilder.userMentionChip(pubkey: String, userMetadata: Map<String, UserMetadata>, onUser: (String) -> Unit) {

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -7086,6 +7086,49 @@ body {
     text-overflow: ellipsis;
 }
 
+/* Standalone npub/nprofile reference: profile card, the user twin of .group-link-card. */
+.user-link-card {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 380px;
+    margin: 4px 0;
+    padding: 8px;
+    background: var(--color-surface);
+    border-radius: 12px;
+    cursor: pointer;
+}
+.user-link-card:hover {
+    background: var(--color-surface-variant);
+}
+.user-link-avatar {
+    width: 36px;
+    height: 36px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    font-size: 16px;
+    font-weight: 700;
+}
+.user-link-meta {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+.user-link-name {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--color-text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.user-link-nip05 {
+    font-size: 12px;
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 /* "Test sound" link in notification settings */
 .settings-test-sound {
     margin-top: 8px;


### PR DESCRIPTION
Typing `@name` without picking the autocomplete suggestion used to send plain text: the mentions map was only ever filled by a popup pick. Resolution now happens once at send time in `NostrRepository.withTypedMentions`, so chat, thread root and thread reply all notify the same way and neither composer changed signature.

The other half is how a mention reads once sent. A nostr reference alone on its line renders as a rich card, mixed with text as a compact avatar+name chip. That rule moved into commonMain (`StandaloneRef`) and both UIs read it, so an `npub` finally gets the treatment a group `naddr` already had. On the web a standalone mention becomes the new `.user-link-card` instead of a bare `@name`. On Compose user mentions gained the real inline chip (avatar through `InlineTextContent`, tinted name) and a group reference mixed with text stops breaking the line into a full card.

| | before | after |
|---|---|---|
| hand-typed `@name` | plain text, no `p` tag | `nostr:npub` + `p` tag, resolved against the group members |
| standalone `npub` (web) | `@name` in mention color | profile card: avatar, name, nip05 |
| standalone `npub` (Compose) | `@name` in mention color | the same card, reusing `ProfileCard` |
| inline user mention (Compose) | tinted text, no avatar | avatar + name chip, like the web |
| inline group ref (Compose) | full card on its own line | inline chip in the running text |
| chip style | amber on amber (user), violet on violet (group) | one style both sides: mention text on a brand tint |

`MentionTags.resolveTyped` matches a token against member display/name (case- and space-insensitive, so `@alicecooper` hits "Alice Cooper") or a literal npub; a name two members share resolves to nothing rather than mentioning the wrong person. The Compose chip renders inside `DisableSelection`, the trade the custom-emoji path already makes, because `InlineTextContent` inside a `SelectionContainer` crashes on Skiko. The block-level `GroupMentionChip` composable the inline chip supersedes is deleted, and the card width cap that ran after `fillMaxWidth` (so it never applied) is fixed for the profile, group and thread-quote cards.

- c2b12fb4 feat(mentions): resolve a hand-typed @name without picking a suggestion
- e6ba0d22 feat(mentions): profile card for a standalone mention, inline chips on native