### PR TITLE
fix(chat): eat the leading parent pointer of NIP-C7 replies

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/chat/ReplyReference.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/ui/chat/ReplyReference.kt
@@ -1,0 +1,84 @@
+package org.nostr.nostrord.ui.chat
+
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.nostr.Nip19
+
+private val NOSTR_EVENT_REGEX = Regex("""nostr:(nevent1[a-zA-Z0-9]+|note1[a-zA-Z0-9]+|naddr1[a-zA-Z0-9]+)""")
+
+/** Same pointer, anchored to the start of the body. */
+private val LEADING_POINTER = Regex("""^\s*nostr:(nevent1[a-zA-Z0-9]+|note1[a-zA-Z0-9]+|naddr1[a-zA-Z0-9]+)""")
+
+/** Event id (hex) or `kind:pubkey:identifier` coordinate a bech32 entity points at. */
+private fun referenceOf(bech32: String): String? = when (val entity = Nip19.decode(bech32)) {
+    is Nip19.Entity.Note -> entity.eventId
+    is Nip19.Entity.Nevent -> entity.eventId
+    is Nip19.Entity.Naddr -> "${entity.kind}:${entity.pubkey}:${entity.identifier}"
+    else -> null
+}
+
+/** Event ids / coordinates embedded in [content] via nostr:nevent, nostr:note or nostr:naddr. */
+fun extractEmbeddedEventIds(content: String): Set<String> = NOSTR_EVENT_REGEX
+    .findAll(content)
+    .mapNotNull { referenceOf(it.groupValues[1]) }
+    .toSet()
+
+/**
+ * Body of [content] once an opening `nostr:` pointer to [parentId] is eaten.
+ *
+ * A NIP-C7 reply repeats its parent as a pointer ahead of the text (`nostr:nevent1…\n\ntext` next to
+ * the "q" tag), which the reply quote already shows. Null when there is nothing to eat: the body
+ * opens with something else, the pointer aims elsewhere, or the pointer is the whole body, which is
+ * a share and would render blank.
+ */
+fun bodyWithoutLeadingPointer(content: String, parentId: String): String? {
+    val match = LEADING_POINTER.find(content) ?: return null
+    if (referenceOf(match.groupValues[1]) != parentId) return null
+    return content.substring(match.range.last + 1).trimStart().ifBlank { null }
+}
+
+/**
+ * Parent event id of a reply, or null when there is no reply tag or the reference already renders as
+ * an inline quote card.
+ *
+ * Tag order: "q" (NIP-C7), the NIP-10 `["e", id, relay, "reply"]` marker, then a plain "e". An naddr
+ * coordinate stays inline: a reply quote can't render an addressable event.
+ */
+fun getReplyParentId(message: NostrGroupClient.NostrMessage): String? {
+    if (message.kind != 9) return null
+
+    val embeddedEventIds = extractEmbeddedEventIds(message.content)
+
+    // A pointer anywhere but the head of the body is a deliberate inline quote: its card already
+    // carries the reference, so no reply quote goes on top of it.
+    fun rendersAsInlineQuote(reference: String) = reference in embeddedEventIds && bodyWithoutLeadingPointer(message.content, reference) == null
+
+    val qTag = message.tags.find { it.size >= 2 && it[0] == "q" && it[1].isNotBlank() }
+    if (qTag != null) {
+        val reference = qTag[1]
+        if (rendersAsInlineQuote(reference)) return null
+        if (reference.length == 64 && reference.all { it.isLetterOrDigit() }) return reference
+        if (reference.contains(":")) return null
+    }
+
+    val replyMarkerTag = message.tags.find { it.size >= 4 && it[0] == "e" && it[3] == "reply" }
+    if (replyMarkerTag != null) {
+        val eventId = replyMarkerTag[1]
+        if (rendersAsInlineQuote(eventId)) return null
+        if (eventId.length == 64) return eventId
+    }
+
+    val eTag = message.tags.find { it.size >= 2 && it[0] == "e" && it[1].length == 64 }
+    if (eTag != null) {
+        val eventId = eTag[1]
+        if (rendersAsInlineQuote(eventId)) return null
+        return eventId
+    }
+
+    return null
+}
+
+/** [content] as the chat renders it: an opening pointer to [parentId] is eaten. */
+fun messageBody(content: String, parentId: String?): String = parentId?.let { bodyWithoutLeadingPointer(content, it) } ?: content
+
+/** [message] body as the chat renders it. For previews, where the parent id isn't at hand. */
+fun messageBody(message: NostrGroupClient.NostrMessage): String = messageBody(message.content, getReplyParentId(message))

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/chat/ReplyReferenceTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/ui/chat/ReplyReferenceTest.kt
@@ -1,0 +1,92 @@
+package org.nostr.nostrord.ui.chat
+
+import org.nostr.nostrord.network.NostrGroupClient
+import org.nostr.nostrord.nostr.Nip19
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ReplyReferenceTest {
+    private val parentId = "a".repeat(63) + "b"
+    private val otherId = "c".repeat(63) + "d"
+    private val nevent = Nip19.encodeNevent(parentId, listOf("wss://relay.example"))
+    private val note = Nip19.encodeNote(parentId)
+
+    private fun message(content: String, tags: List<List<String>>) = NostrGroupClient.NostrMessage(
+        id = "e".repeat(64),
+        pubkey = "f".repeat(64),
+        content = content,
+        createdAt = 0L,
+        kind = 9,
+        tags = tags,
+    )
+
+    private fun reply(content: String) = message(content, listOf(listOf("q", parentId, "wss://relay.example", "f".repeat(64))))
+
+    @Test
+    fun eatsPointerThatOpensTheBody() {
+        // The shape Flotilla writes: pointer, blank line, text.
+        val m = reply("nostr:$nevent\n\nyes")
+        assertEquals(parentId, getReplyParentId(m))
+        assertEquals("yes", messageBody(m))
+    }
+
+    @Test
+    fun eatsPointerSeparatedByASingleNewlineOrSpace() {
+        assertEquals("yes", messageBody(reply("nostr:$nevent\nyes")))
+        assertEquals("yes", messageBody(reply("nostr:$nevent yes")))
+    }
+
+    @Test
+    fun eatsANotePointerToo() {
+        assertEquals("yes", messageBody(reply("nostr:$note\n\nyes")))
+    }
+
+    @Test
+    fun keepsAPointerFurtherIntoTheBody() {
+        // A quote mid-sentence is deliberate: it renders as its own card, and stacking a reply
+        // header on top of it would say the same thing twice.
+        val m = reply("as I said in nostr:$nevent, no")
+        assertNull(getReplyParentId(m))
+        assertEquals("as I said in nostr:$nevent, no", messageBody(m))
+    }
+
+    @Test
+    fun keepsAPointerThatIsTheWholeBody() {
+        // A bare pointer is a share of the event, not a reply: eating it leaves nothing to render.
+        val m = reply("nostr:$nevent")
+        assertNull(getReplyParentId(m))
+        assertEquals("nostr:$nevent", messageBody(m))
+    }
+
+    @Test
+    fun keepsAPointerAimedAtAnotherEvent() {
+        val m = reply("nostr:${Nip19.encodeNote(otherId)}\n\nyes")
+        assertEquals(parentId, getReplyParentId(m))
+        assertEquals("nostr:${Nip19.encodeNote(otherId)}\n\nyes", messageBody(m))
+    }
+
+    @Test
+    fun eatsThePointerOfANip10ReplyMarker() {
+        val m = message("nostr:$nevent\n\nyes", listOf(listOf("e", parentId, "wss://relay.example", "reply")))
+        assertEquals(parentId, getReplyParentId(m))
+        assertEquals("yes", messageBody(m))
+    }
+
+    @Test
+    fun leavesAPlainMessageAlone() {
+        val m = message("hello", emptyList())
+        assertNull(getReplyParentId(m))
+        assertEquals("hello", messageBody(m))
+    }
+
+    @Test
+    fun naddrPointerStaysInline() {
+        // A reply header cannot render an addressable event, so the coordinate keeps its card.
+        val naddr = Nip19.encodeNaddr("chat", "wss://relay.example", 39000, "f".repeat(64))
+        val coord = "39000:${"f".repeat(64)}:chat"
+        val m = message("nostr:$naddr\n\nyes", listOf(listOf("q", coord)))
+        assertNull(getReplyParentId(m))
+        assertEquals("nostr:$naddr\n\nyes", messageBody(m))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageItem.kt
@@ -55,6 +55,8 @@ import org.nostr.nostrord.network.managers.GroupManager
 import org.nostr.nostrord.nostr.Nip19
 import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.nostr.Nip57
+import org.nostr.nostrord.ui.chat.getReplyParentId
+import org.nostr.nostrord.ui.chat.messageBody
 import org.nostr.nostrord.ui.components.ReportUserModal
 import org.nostr.nostrord.ui.components.avatars.ProfileAvatar
 import org.nostr.nostrord.ui.components.zap.ZapBadge
@@ -145,7 +147,10 @@ fun MessageItem(
         }
 
     // Check if this message is a reply and find the parent message
-    val replyParentId = remember(message.tags) { getReplyParentId(message) }
+    val replyParentId = remember(message.tags, message.content) { getReplyParentId(message) }
+
+    // A NIP-C7 reply opens its body with a pointer to the parent the reply quote already shows.
+    val body = remember(message.content, replyParentId) { messageBody(message.content, replyParentId) }
 
     // Collect cached events from repository for parent message lookup
     val cachedEvents by AppModule.nostrRepository.cachedEvents.collectAsState()
@@ -456,7 +461,7 @@ fun MessageItem(
                     Row(verticalAlignment = Alignment.Bottom) {
                         Box(modifier = Modifier.weight(1f, fill = false)) {
                             MessageContent(
-                                content = message.content,
+                                content = body,
                                 tags = message.tags,
                                 onMentionClick = currentOnUsernameClick,
                                 onHashtagClick = { hashtag ->

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/ReplyPreview.kt
@@ -27,109 +27,11 @@ import androidx.compose.ui.unit.dp
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.NostrGroupClient
 import org.nostr.nostrord.network.UserMetadata
-import org.nostr.nostrord.nostr.Nip19
+import org.nostr.nostrord.ui.chat.messageBody
 import org.nostr.nostrord.ui.theme.NostrordColors
 import org.nostr.nostrord.ui.theme.NostrordTypography
 import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.utils.shortNpub
-
-// Regex to match nostr:nevent, nostr:note, or nostr:naddr references
-private val NOSTR_EVENT_REGEX = Regex("""nostr:(nevent1[a-zA-Z0-9]+|note1[a-zA-Z0-9]+|naddr1[a-zA-Z0-9]+)""")
-
-/**
- * Extract event IDs/coordinates embedded in content via nostr:nevent, nostr:note, or nostr:naddr.
- * Used to avoid showing duplicate reply preview when event is already quoted inline.
- *
- * Returns both hex event IDs and naddr coordinates (kind:pubkey:identifier format).
- */
-fun extractEmbeddedEventIds(content: String): Set<String> = NOSTR_EVENT_REGEX
-    .findAll(content)
-    .mapNotNull { match ->
-        val bech32 = match.groupValues[1]
-        when (val entity = Nip19.decode(bech32)) {
-            is Nip19.Entity.Nevent -> entity.eventId
-            is Nip19.Entity.Note -> entity.eventId
-            is Nip19.Entity.Naddr -> "${entity.kind}:${entity.pubkey}:${entity.identifier}"
-            else -> null
-        }
-    }.toSet()
-
-/**
- * Extract the parent event ID from a message's tags for REPLY threading.
- *
- * For NIP-29 group messages (kind 9), replies are detected via:
- * 1. "q" tag with hex event ID or naddr coordinate (quoted reply)
- * 2. "e" tag with "reply" marker (legacy format)
- * 3. Plain "e" tag (fallback)
- *
- * If the reply target is already embedded in content (via nostr:nevent/naddr),
- * returns null to avoid duplicate display.
- *
- * Returns the parent event ID/coordinate or null if not a reply (or already embedded).
- */
-fun getReplyParentId(message: NostrGroupClient.NostrMessage): String? {
-    // Only kind 9 messages can have replies in group context
-    if (message.kind != 9) {
-        return null
-    }
-
-    // Extract event IDs/coordinates already embedded in content
-    val embeddedEventIds = extractEmbeddedEventIds(message.content)
-
-    // 1. Check for "q" tag (quoted reply)
-    // Can be either 64-char hex event ID or naddr coordinate (kind:pubkey:identifier)
-    val qTag =
-        message.tags.find { tag ->
-            tag.size >= 2 && tag[0] == "q" && tag[1].isNotBlank()
-        }
-    if (qTag != null) {
-        val reference = qTag[1]
-        // Skip if already embedded in content (will be shown as inline quote)
-        if (reference in embeddedEventIds) {
-            return null
-        }
-        // Only return if it's a valid hex event ID (64 chars)
-        // naddr coordinates are handled inline via content rendering
-        if (reference.length == 64 && reference.all { it.isLetterOrDigit() }) {
-            return reference
-        }
-        // For naddr-style coordinates in q tag, skip if content has matching naddr
-        // These are rendered inline, not as reply headers
-        if (reference.contains(":")) {
-            return null
-        }
-    }
-
-    // 2. Check for "e" tag with "reply" marker (legacy format)
-    val replyMarkerTag =
-        message.tags.find { tag ->
-            tag.size >= 4 && tag[0] == "e" && tag[3] == "reply"
-        }
-    if (replyMarkerTag != null) {
-        val eventId = replyMarkerTag[1]
-        if (eventId in embeddedEventIds) {
-            return null
-        }
-        if (eventId.length == 64) {
-            return eventId
-        }
-    }
-
-    // 3. Check for plain "e" tag (fallback)
-    val eTag =
-        message.tags.find { tag ->
-            tag.size >= 2 && tag[0] == "e" && tag[1].length == 64
-        }
-    if (eTag != null) {
-        val eventId = eTag[1]
-        if (eventId in embeddedEventIds) {
-            return null
-        }
-        return eventId
-    }
-
-    return null
-}
 
 /**
  * Compact reply preview shown above a message that is replying to another message.
@@ -183,9 +85,10 @@ fun ReplyPreview(
     }
 
     // Process mentions in content to show @name instead of nostr:npub...
+    // messageBody keeps a parent that is itself a NIP-C7 reply from opening the snippet with a pointer.
     val processedContent =
         remember(parentMessage.content) {
-            processMentionsInContent(parentMessage.content, resolveMetadata)
+            processMentionsInContent(messageBody(parentMessage), resolveMetadata)
                 .replace('\n', ' ')
         }
 

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -24,6 +24,8 @@ import org.nostr.nostrord.nostr.Nip27
 import org.nostr.nostrord.nostr.Nip57
 import org.nostr.nostrord.nostr.Nip68
 import org.nostr.nostrord.nostr.Nip84
+import org.nostr.nostrord.ui.chat.getReplyParentId
+import org.nostr.nostrord.ui.chat.messageBody
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.keyboard.VirtualKeyboardPolicy
 import org.nostr.nostrord.ui.mentions.MentionAutocomplete
@@ -150,21 +152,6 @@ external interface ChatScreenProps : Props {
 
     /** Opens the groups-sidebar drawer (mobile only — the chat header hamburger). */
     var onOpenDrawer: () -> Unit
-}
-
-/**
- * Parent message id of a reply (kind 9 only). Nostrord tags replies with "q"; other clients
- * may use the NIP-10 reply marker ["e", id, relay?, "reply"], which native also honors
- * (getReplyParentId). The plain unmarked "e" fallback is intentionally not used here — it is
- * ambiguous (root vs mention vs inline quote) without the content embed-check native does.
- */
-private fun parentMessageOf(message: org.nostr.nostrord.network.NostrGroupClient.NostrMessage): String? {
-    if (message.kind != 9) return null
-    fun isHexId(s: String) = s.length == 64 && s.all { it.isLetterOrDigit() }
-    message.tags.firstOrNull { it.size >= 2 && it[0] == "q" && isHexId(it[1]) }?.let { return it[1] }
-    return message.tags
-        .firstOrNull { it.size >= 4 && it[0] == "e" && it[3] == "reply" && isHexId(it[1]) }
-        ?.get(1)
 }
 
 /** Plain-text preview of a parent message for a reply chip/banner: mentions resolved,
@@ -2131,12 +2118,13 @@ val ChatScreen =
 
                                         is WebChatItem.Message -> {
                                             val message = item.message
-                                            val parent = parentMessageOf(message)?.let { messagesById[it] }
+                                            val parentId = getReplyParentId(message)
+                                            val parent = parentId?.let { messagesById[it] }
                                             val replyPreview =
                                                 parent?.let {
                                                     ReplyPreviewData(
                                                         author = displayName(it.pubkey, userMetadata[it.pubkey]),
-                                                        content = replyPreviewText(it.content, userMetadata, 120),
+                                                        content = replyPreviewText(messageBody(it), userMetadata, 120),
                                                         tags = it.tags,
                                                     )
                                                 }
@@ -2154,7 +2142,8 @@ val ChatScreen =
                                                 name = displayName(message.pubkey, userMetadata[message.pubkey])
                                                 avatarUrl = userMetadata[message.pubkey]?.picture
                                                 time = formatTime(message.createdAt)
-                                                content = message.content
+                                                // A NIP-C7 reply opens its body with a pointer to the parent the reply quote shows.
+                                                content = messageBody(message.content, parentId)
                                                 this.tags = message.tags
                                                 this.firstInGroup = item.firstInGroup
                                                 isAuthorAdmin = message.pubkey in admins
@@ -2296,7 +2285,7 @@ val ChatScreen =
                             replyingToId?.let { id -> messagesById[id]?.let { p -> displayName(p.pubkey, userMetadata[p.pubkey]) } }
                         this.replyParentContent =
                             replyingToId?.let { id ->
-                                messagesById[id]?.let { p -> replyPreviewText(p.content, userMetadata, 80) }
+                                messagesById[id]?.let { p -> replyPreviewText(messageBody(p), userMetadata, 80) }
                             }
                         this.onCancelReply = { setReplyingToId(null) }
                         this.onSent = {

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -158,6 +158,16 @@ external interface ChatScreenProps : Props {
  *  newlines flattened, trimmed, and capped at [max] chars. */
 private fun replyPreviewText(content: String, userMetadata: Map<String, UserMetadata>, max: Int): String = processMentions(content, userMetadata).replace('\n', ' ').trim().take(max)
 
+/** Cached event as a message, so the reply quote reads a parent outside the loaded window the same way. */
+private fun org.nostr.nostrord.network.CachedEvent.asMessage() = NostrGroupClient.NostrMessage(
+    id = id,
+    pubkey = pubkey,
+    content = content,
+    createdAt = createdAt,
+    kind = kind,
+    tags = tags,
+)
+
 /** Reply-preview payload: author name, plain-text body, and the parent event's tags for emoji resolution. */
 data class ReplyPreviewData(
     val author: String,
@@ -1168,15 +1178,27 @@ val ChatScreen =
         // @names and nevent/note quotes resolved to the referenced note's text (in-memory only).
         // It is the expensive step, so it memoizes on messages + metadata + cache (only while
         // search is open); the cheap per-keystroke match below then reuses it via the extractor.
-        val searchCachedEvents = useStateFlow(vm.cachedEvents)
-        val searchTextById = useMemo(messagesByGroup[group.id], userMetadata, searchCachedEvents, searchActive) {
+        val cachedEvents = useStateFlow(vm.cachedEvents)
+
+        // Parents of replies that are outside the loaded window: fetch them so their quotes fill in.
+        val missingReplyParents = useMemo(messages, cachedEvents) {
+            messages.mapNotNull { getReplyParentId(it) }
+                .filter { it !in messagesById && it !in cachedEvents }
+                .toSet()
+        }
+        useEffect(missingReplyParents) {
+            if (missingReplyParents.isNotEmpty()) {
+                launchApp { missingReplyParents.forEach { repo.requestEventById(it, listOf(hostRelay), null, group.id) } }
+            }
+        }
+        val searchTextById = useMemo(messagesByGroup[group.id], userMetadata, cachedEvents, searchActive) {
             if (!searchActive) {
                 emptyMap()
             } else {
                 ChatSearch.buildSearchTextById(
                     messages,
                     resolveMention = { pubkey -> userMetadata[pubkey]?.let { it.displayName ?: it.name }?.takeIf(String::isNotBlank) },
-                    resolveCachedQuote = { id -> searchCachedEvents[id]?.content },
+                    resolveCachedQuote = { id -> cachedEvents[id]?.content },
                 )
             }
         }
@@ -2119,14 +2141,20 @@ val ChatScreen =
                                         is WebChatItem.Message -> {
                                             val message = item.message
                                             val parentId = getReplyParentId(message)
-                                            val parent = parentId?.let { messagesById[it] }
+                                            val parent = parentId?.let { messagesById[it] ?: cachedEvents[it]?.asMessage() }
+                                            // The quote renders even before the parent arrives, so a reply to a
+                                            // message outside the loaded window still reads as a reply.
                                             val replyPreview =
-                                                parent?.let {
-                                                    ReplyPreviewData(
-                                                        author = displayName(it.pubkey, userMetadata[it.pubkey]),
-                                                        content = replyPreviewText(messageBody(it), userMetadata, 120),
-                                                        tags = it.tags,
-                                                    )
+                                                parentId?.let {
+                                                    if (parent == null) {
+                                                        ReplyPreviewData("", "Replying to a message...", emptyList())
+                                                    } else {
+                                                        ReplyPreviewData(
+                                                            author = displayName(parent.pubkey, userMetadata[parent.pubkey]),
+                                                            content = replyPreviewText(messageBody(parent), userMetadata, 120),
+                                                            tags = parent.tags,
+                                                        )
+                                                    }
                                                 }
                                             val authorMeta = userMetadata[message.pubkey]
                                             val zapInfo = zapsByMsg[message.id]
@@ -3080,9 +3108,11 @@ private val MessageRow =
                         div { className = ClassName("msg-reply-bar") }
                         div {
                             className = ClassName("msg-reply-content")
-                            div {
-                                className = ClassName("msg-reply-author")
-                                +reply.author
+                            if (reply.author.isNotEmpty()) {
+                                div {
+                                    className = ClassName("msg-reply-author")
+                                    +reply.author
+                                }
                             }
                             div {
                                 className = ClassName("msg-reply-text")


### PR DESCRIPTION
A NIP-C7 reply repeats its parent as `nostr:nevent1…` at the head of the content, next to the `q` tag. Nostrord rendered that pointer as a full quote card: on native with no reply indicator at all, on web alongside the reply quote, so the parent showed twice. This drops the pointer when it opens the body and points at the reply parent, and the row renders through the normal reply quote.

| content | before (native) | before (web) | after |
|---|---|---|---|
| pointer at the head | card, no reply quote | card + reply quote | reply quote |
| pointer mid body | card | card + reply quote | card |
| pointer is the whole body | card | card + reply quote | card |

The last two rows are unchanged by design: a pointer mid body is a deliberate inline quote, and a pointer that is the whole body is a share, which would render blank if eaten.

The rule moved to `commonMain/ui/chat/ReplyReference.kt` so both UIs decide identically. Web's duplicate `parentMessageOf` is gone.

Second commit is a related web gap found while testing: the web built the reply quote only from the loaded message window, so a reply to an older message showed no reply indication at all. It now falls back to the event cache, paints a placeholder meanwhile, and requests the missing parents, as native already did.

Validated on desktop and web against real events on `wss://groups.0xchat.com`. `commonTest/ui/chat/ReplyReferenceTest.kt` covers the four cases plus naddr, NIP-10 markers, and a pointer aimed at another event.

Closes #265

- fc619ae3 fix(chat): eat the leading parent pointer of NIP-C7 replies
- b205f44b fix(web): show the reply quote before the parent arrives