### PR TITLE
fix(links): generate nevent, never note1

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip19.kt
@@ -156,7 +156,8 @@ object Nip19 {
     fun encodeNsec(privkeyHex: String): String = Bech32.encode("nsec", privkeyHex.hexToByteArray())
 
     /**
-     * Encode an event ID to note
+     * Encode an event ID to note. Decode-side fixtures only: links and references we generate
+     * use [encodeNevent], since a bare note carries neither author nor relay hint.
      */
     fun encodeNote(eventIdHex: String): String = Bech32.encode("note", eventIdHex.hexToByteArray())
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip27.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/nostr/Nip27.kt
@@ -109,7 +109,13 @@ object Nip27 {
     fun createNpubUri(pubkeyHex: String): String = "nostr:${Nip19.encodeNpub(pubkeyHex)}"
 
     /**
-     * Create a nostr: URI for an event
+     * Create a nostr: URI for an event. Always nevent: a bare note carries neither author nor
+     * relay, so NIP-29 events encoded that way are unfetchable elsewhere.
      */
-    fun createNoteUri(eventIdHex: String): String = "nostr:${Nip19.encodeNote(eventIdHex)}"
+    fun createEventUri(
+        eventIdHex: String,
+        relays: List<String> = emptyList(),
+        authorHex: String? = null,
+        kind: Int? = null,
+    ): String = "nostr:${Nip19.encodeNevent(eventIdHex, relays, authorHex, kind)}"
 }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip27UriTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/nostr/Nip27UriTest.kt
@@ -1,0 +1,31 @@
+package org.nostr.nostrord.nostr
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/** Event URIs we generate must be nevent, never a bare note (issue #290). */
+class Nip27UriTest {
+
+    private val eventIdHex = "b9f5441e45ca39179320e0031cfb18e34078f374526e496f1c1b0d53d26b7e7e"
+    private val authorHex = "3bf0c63fcb93463407af97a5e5ee64fa883d107ef9e558472c4eb9aaaefa459d"
+
+    @Test
+    fun `createEventUri encodes nevent with author, relay and kind`() {
+        val uri = Nip27.createEventUri(eventIdHex, listOf("wss://relay.example"), authorHex, 9)
+        assertTrue(uri.startsWith("nostr:nevent1"), uri)
+
+        val decoded = Nip19.decode(uri.removePrefix("nostr:"))
+        assertIs<Nip19.Entity.Nevent>(decoded)
+        assertEquals(eventIdHex, decoded.eventId)
+        assertEquals(authorHex, decoded.author)
+        assertEquals(9, decoded.kind)
+        assertEquals(listOf("wss://relay.example"), decoded.relays)
+    }
+
+    @Test
+    fun `createEventUri stays nevent without hints`() {
+        assertTrue(Nip27.createEventUri(eventIdHex).startsWith("nostr:nevent1"))
+    }
+}

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageContent.kt
@@ -2255,7 +2255,17 @@ private fun QuotedEvent(
                             Modifier
                                 .size(16.dp)
                                 .clickable {
-                                    val url = "https://jumble.social/notes/${Nip19.encodeNote(event.id)}"
+                                    // nevent, never note: the bare id strands the event on a
+                                    // NIP-29 relay the other client doesn't know about, and
+                                    // carries no author to fall back on.
+                                    val nevent =
+                                        Nip19.encodeNevent(
+                                            event.id,
+                                            relays = relayHints.ifEmpty { listOfNotNull(currentRelayUrl) },
+                                            authorHex = event.pubkey,
+                                            kind = event.kind,
+                                        )
+                                    val url = "https://jumble.social/notes/$nevent"
                                     if (isLinuxDesktop) {
                                         copyToClipboard(url)
                                         AppModule.postSystemMessage("Link copied")

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/ChatScreen.kt
@@ -4151,7 +4151,17 @@ private val QuotedEvent =
                     }
                     a {
                         className = ClassName("quoted-event-open")
-                        href = "https://jumble.social/notes/${Nip19.encodeNote(props.eventId)}"
+                        // nevent, never note: the bare id strands the event on a NIP-29 relay
+                        // the other client doesn't know about, and carries no author to fall
+                        // back on.
+                        href =
+                            "https://jumble.social/notes/" +
+                            Nip19.encodeNevent(
+                                props.eventId,
+                                relays = props.relays.ifEmpty { listOf(props.relayUrl) },
+                                authorHex = pubkey,
+                                kind = local?.kind ?: cachedEv?.kind ?: props.kind,
+                            )
                         asDynamic().target = "_blank"
                         rel = "noopener noreferrer"
                         title = "Open in another client"


### PR DESCRIPTION
The quoted-event "open on the web" button encoded a bare `note1`. That carries neither author nor relay hint, and NIP-29 events live only on their group relay, so the receiving client had nowhere to fetch them from and rendered a dead link. Both surfaces now encode `nevent` with the author, the kind and the relay the quote was read on (the nevent`s own hints when it had them, otherwise the relay the group is open on).

`Nip27.createNoteUri` had no callers and never had any since it was added; it becomes `createEventUri`, nevent-based, so the next caller cannot reintroduce the bare form. `Nip19.encodeNote` stays for decode-side test fixtures and is documented as such. Parsing of incoming `note1` is untouched.

| Surface | Before | After |
|---|---|---|
| Quoted-event card, Compose | `jumble.social/notes/<note1>` | `jumble.social/notes/<nevent1>` + author + kind + relay |
| Quoted-event card, web | same | same |
| `Nip27.createNoteUri` | dead, `nostr:note1...` | `createEventUri`, `nostr:nevent1...` |

Closes #290

- d373b769 fix(links): generate nevent, never note1