### PR TITLE
fix(notifications): stop the cold-start backlog from notifying

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -40,6 +40,7 @@ import org.nostr.nostrord.notifications.NotificationPermission
 import org.nostr.nostrord.notifications.NotificationRequest
 import org.nostr.nostrord.notifications.NotificationService
 import org.nostr.nostrord.notifications.NotificationType
+import org.nostr.nostrord.notifications.RealtimeCutoff
 import org.nostr.nostrord.notifications.playNotificationSound
 import org.nostr.nostrord.settings.AppearanceSettings
 import org.nostr.nostrord.settings.DmSettings
@@ -371,15 +372,12 @@ object AppModule {
 
     val notificationHistoryStore: NotificationHistoryStore by lazy { NotificationHistoryStore() }
 
-    // Unix-seconds timestamp of the most recent account activation. Events
-    // with `createdAt < switchInstantSeconds` are catch-up: they predate the
-    // user's current session of this account, so they enter the in-app feed
-    // but do NOT play sound or fire OS popups. Set on every activation in
-    // [applyActiveAccountChange].
-    @kotlin.concurrent.Volatile
-    private var switchInstantSeconds: Long = 0L
+    // Events predating the current session's activation are catch-up: they
+    // enter the in-app feed but do NOT play sound or fire OS popups. Armed on
+    // every session activation, disarmed on logout.
+    private val realtimeCutoff = RealtimeCutoff()
 
-    private fun isRealtime(eventCreatedAt: Long): Boolean = eventCreatedAt >= switchInstantSeconds
+    private fun isRealtime(eventCreatedAt: Long): Boolean = realtimeCutoff.isRealtime(eventCreatedAt)
 
     val unreadManager: UnreadManager by lazy {
         UnreadManager(
@@ -697,6 +695,10 @@ object AppModule {
         if (ActiveAccountManager.session.value?.accountId?.value == account.id) return
         val session = accountSessionFactory.build(account, authManager) ?: return
         ActiveAccountManager.activate(session)
+        // Cold start restores a session without ever passing through
+        // applyActiveAccountChange, so the cutoff has to be armed here too or
+        // the whole relay backlog would arrive as realtime.
+        realtimeCutoff.arm(epochSeconds())
     }
 
     /**
@@ -711,9 +713,9 @@ object AppModule {
      */
     suspend fun applyActiveAccountChange(account: Account?) {
         // Record the activation instant before any state is cleared. Events
-        // with createdAt < this value are treated as catch-up (feed only,
-        // no sound/popup). Set to 0 on logout so realtime gating is moot.
-        switchInstantSeconds = if (account != null) epochSeconds() else 0L
+        // older than it are catch-up (feed only, no sound/popup). Logout
+        // disarms so a logged-out app announces nothing.
+        if (account != null) realtimeCutoff.arm(epochSeconds()) else realtimeCutoff.disarm()
         // Cancel any OS popups still in flight from the previous account so a
         // notification scheduled for A doesn't surface after B is active.
         try {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -277,8 +277,8 @@ object AppModule {
     /**
      * Notify an externally granted membership. Only the kind:9000 path carries an actor;
      * 39002-inferred invites (the user opened the group link and is looking at it) stay
-     * silent. Catch-up adds (offline at put time) enter the feed but skip sound/popup via
-     * [isRealtime], like every other notification type.
+     * silent. Catch-up adds (offline at put time) enter the feed already read and skip
+     * sound/popup via [isRealtime], like every other notification type.
      */
     // Feed-entry age cap for external adds, matching the put-user watch's own 7-day
     // catch-up lookback. The no-since 39002 membership sweep has no such bound: on a
@@ -311,6 +311,7 @@ object AppModule {
         // user already decided): a notification for it would be noise.
         if (add.groupId !in groupManager.pendingGroupInvites.value) return
         val groupName = groupDisplayName(add.relayUrl, add.groupId)
+        val realtime = isRealtime(add.createdAtSeconds)
         notificationHistoryStore.add(
             NotificationEntry(
                 id = add.eventId ?: "gadd_${add.groupId}",
@@ -322,12 +323,12 @@ object AppModule {
                 preview = "",
                 groupName = groupName,
                 relayName = relayDisplayName(add.relayUrl),
+                read = !realtime,
             ),
         )
         if (displayLabelFor(actor, prefixAt = false) == null) {
             appScope.launch { nostrRepository.requestUserMetadata(setOf(actor)) }
         }
-        val realtime = isRealtime(add.createdAtSeconds)
         if (realtime && notificationSettings.soundEnabled.value) {
             playNotificationSound()
         }
@@ -372,9 +373,10 @@ object AppModule {
 
     val notificationHistoryStore: NotificationHistoryStore by lazy { NotificationHistoryStore() }
 
-    // Events predating the current session's activation are catch-up: they
-    // enter the in-app feed but do NOT play sound or fire OS popups. Armed on
-    // every session activation, disarmed on logout.
+    // Events predating the current session's activation are catch-up: they land
+    // in the in-app feed already read, and play no sound and fire no OS popup.
+    // The history stays browsable without the badge counting what happened while
+    // the user was away. Armed on every session activation, disarmed on logout.
     private val realtimeCutoff = RealtimeCutoff()
 
     private fun isRealtime(eventCreatedAt: Long): Boolean = realtimeCutoff.isRealtime(eventCreatedAt)
@@ -407,6 +409,7 @@ object AppModule {
                     val preview = notificationPreview(message.content)
                     val groupName = groupDisplayName(relayUrl, groupId)
                     val relayName = relayDisplayName(relayUrl)
+                    val realtime = isRealtime(message.createdAt)
                     notificationHistoryStore.add(
                         NotificationEntry(
                             id = message.id,
@@ -419,9 +422,9 @@ object AppModule {
                             messageId = message.id,
                             groupName = groupName,
                             relayName = relayName,
+                            read = !realtime,
                         ),
                     )
-                    val realtime = isRealtime(message.createdAt)
                     // Sound — gated by the user-facing toggle in Settings → Notifications,
                     // and suppressed for catch-up events (older than the current activation)
                     // so a switch-in doesn't trigger a burst of sounds.
@@ -454,6 +457,7 @@ object AppModule {
                 val preview = notificationPreview(message.content)
                 val groupName = groupDisplayName(relayUrl, groupId)
                 val relayName = relayDisplayName(relayUrl)
+                val realtime = isRealtime(message.createdAt)
                 notificationHistoryStore.add(
                     NotificationEntry(
                         id = message.id,
@@ -466,9 +470,9 @@ object AppModule {
                         messageId = message.id,
                         groupName = groupName,
                         relayName = relayName,
+                        read = !realtime,
                     ),
                 )
-                val realtime = isRealtime(message.createdAt)
                 if (realtime && notificationSettings.soundEnabled.value) {
                     playNotificationSound()
                 }
@@ -497,6 +501,7 @@ object AppModule {
                 // The E tag is the thread root; without it the entry would open the chat, where a
                 // kind:1111 does not exist. Falls back to the reply itself so the pane still opens.
                 val rootId = reply.tags.firstOrNull { it.size >= 2 && it[0] == "E" }?.get(1) ?: reply.id
+                val realtime = isRealtime(reply.createdAt)
                 notificationHistoryStore.add(
                     NotificationEntry(
                         id = reply.id,
@@ -510,9 +515,9 @@ object AppModule {
                         threadRootId = rootId,
                         groupName = groupName,
                         relayName = relayName,
+                        read = !realtime,
                     ),
                 )
-                val realtime = isRealtime(reply.createdAt)
                 if (realtime && notificationSettings.soundEnabled.value) {
                     playNotificationSound()
                 }
@@ -538,6 +543,7 @@ object AppModule {
                 val preview = notificationPreview(message.content)
                 val groupName = groupDisplayName(relayUrl, groupId)
                 val relayName = relayDisplayName(relayUrl)
+                val realtime = isRealtime(message.createdAt)
                 notificationHistoryStore.add(
                     NotificationEntry(
                         id = message.id,
@@ -550,9 +556,9 @@ object AppModule {
                         messageId = message.id,
                         groupName = groupName,
                         relayName = relayName,
+                        read = !realtime,
                     ),
                 )
-                val realtime = isRealtime(message.createdAt)
                 if (realtime && notificationSettings.soundEnabled.value) {
                     playNotificationSound()
                 }
@@ -580,6 +586,7 @@ object AppModule {
                     val emoji = reaction.emoji.ifBlank { "+" }
                     val groupName = groupDisplayName(relayUrl, groupId)
                     val relayName = relayDisplayName(relayUrl)
+                    val realtime = isRealtime(reaction.createdAt)
                     notificationHistoryStore.add(
                         NotificationEntry(
                             id = reaction.id,
@@ -599,9 +606,9 @@ object AppModule {
                             emoji = emoji,
                             groupName = groupName,
                             relayName = relayName,
+                            read = !realtime,
                         ),
                     )
-                    val realtime = isRealtime(reaction.createdAt)
                     if (realtime && notificationSettings.soundEnabled.value) {
                         playNotificationSound()
                     }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -271,6 +271,11 @@ object AppModule {
             appScope.launch {
                 gm.externalAddPending.collect { add -> onExternalGroupAdd(add) }
             }
+            // Prune notifications whose event is gone. A deleted thread root orphans the
+            // entries for every reply under it: they point at a thread that cannot open.
+            appScope.launch {
+                gm.deletedEventIds.collect { ids -> notificationHistoryStore.removeForEvents(ids) }
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/GroupManager.kt
@@ -3383,6 +3383,9 @@ class GroupManager(
             current + (groupId to list.filterNot { it.id in stale })
         }
         if (removed.isEmpty()) return
+        // Deleted on another device: the kind:5/9005 is never replayed here, so this EOSE
+        // comparison is the only signal the notification feed gets.
+        _deletedEventIds.tryEmit(removed)
         val account = currentPubkey ?: return
         scope.launch {
             try {
@@ -4364,6 +4367,14 @@ class GroupManager(
     private val _externalAddPending = MutableSharedFlow<ExternalGroupAdd>(extraBufferCapacity = 64)
     val externalAddPending: SharedFlow<ExternalGroupAdd> = _externalAddPending.asSharedFlow()
 
+    /**
+     * Ids of events that no longer exist: a kind:5/9005 removed them, or a relay's answer dropped
+     * them at EOSE. AppModule prunes the notification feed from this, so an entry never outlives
+     * the event it points at. Buffered for a reconcile burst; tryEmit drops what doesn't fit.
+     */
+    private val _deletedEventIds = MutableSharedFlow<Set<String>>(extraBufferCapacity = 64)
+    val deletedEventIds: SharedFlow<Set<String>> = _deletedEventIds.asSharedFlow()
+
     init {
         // This init block sits AFTER _pendingGroupInvites' declaration on purpose: init
         // blocks run in declaration order, and the collector reads the field from another
@@ -5236,6 +5247,8 @@ class GroupManager(
             .toSet()
 
         if (eventIdsToDelete.isEmpty()) return
+
+        _deletedEventIds.tryEmit(eventIdsToDelete)
 
         // Remove deleted messages from the list
         _messages.update { currentMap ->

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/UnreadManager.kt
@@ -310,7 +310,7 @@ class UnreadManager(
      * No lastRead/high-water anchor either, unlike chat: those track chat reading, so a group
      * whose chat was just opened would silently swallow every thread reply that follows within
      * the same second. Re-announcing is handled where it belongs - the feed dedupes by event id,
-     * and AppModule gates sound and popup on the event being realtime.
+     * and AppModule gates sound, popup and the unread flag on the event being realtime.
      */
     fun onThreadEventReceived(
         groupId: String,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStore.kt
@@ -152,6 +152,28 @@ class NotificationHistoryStore {
     }
 
     /**
+     * Drop entries about events that no longer exist: [eventIds] were deleted, or a relay's answer
+     * no longer serves them. An entry matches on its own event, its chat message, or its thread
+     * root - a deleted kind:11 orphans every kind:1111 reply notification under it, and those
+     * would otherwise sit in the feed forever pointing at a thread that cannot open.
+     *
+     * The announced ids stay: a deleted event must not be announced again if the relay replays it.
+     */
+    fun removeForEvents(eventIds: Set<String>) {
+        if (eventIds.isEmpty()) return
+        var changed = false
+        _entries.update { current ->
+            val filtered = current.filterNot {
+                it.id in eventIds || it.messageId in eventIds || it.threadRootId in eventIds
+            }
+            if (filtered.size == current.size) return@update current
+            changed = true
+            filtered
+        }
+        if (changed) persist()
+    }
+
+    /**
      * Drop every entry from the in-memory feed and erase the persisted blob. The announced ids
      * stay: emptying the feed is not a request to be told about those events again.
      */

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/RealtimeCutoff.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/notifications/RealtimeCutoff.kt
@@ -1,0 +1,30 @@
+package org.nostr.nostrord.notifications
+
+/**
+ * Separates realtime events from catch-up backlog for notification purposes.
+ *
+ * Armed at the instant a session becomes active. An event whose `createdAt`
+ * predates that instant happened while the user was away: it belongs in the
+ * in-app feed but must not play a sound or fire an OS popup.
+ *
+ * Disarmed means "no active session" and nothing is realtime. That is the
+ * initial state, so a subscription that starts streaming before the cutoff is
+ * armed stays quiet instead of announcing an entire relay backlog.
+ */
+class RealtimeCutoff {
+    @kotlin.concurrent.Volatile
+    private var armedAtSeconds: Long? = null
+
+    fun arm(nowSeconds: Long) {
+        armedAtSeconds = nowSeconds
+    }
+
+    fun disarm() {
+        armedAtSeconds = null
+    }
+
+    fun isRealtime(eventCreatedAt: Long): Boolean {
+        val armedAt = armedAtSeconds ?: return false
+        return eventCreatedAt >= armedAt
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStoreTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/NotificationHistoryStoreTest.kt
@@ -53,6 +53,35 @@ class NotificationHistoryStoreTest {
     }
 
     @Test
+    fun `deleting a thread root drops the notifications for its replies`() {
+        val store = store()
+        store.add(entry("reply1"))
+        store.add(entry("reply2"))
+        store.add(entry("other", rootId = "root2"))
+
+        store.removeForEvents(setOf("root1"))
+
+        assertEquals(listOf("other"), store.entries.value.map { it.id })
+    }
+
+    @Test
+    fun `deleting an event drops its own notification`() {
+        val store = store()
+        store.add(entry("e1"))
+        store.removeForEvents(setOf("e1"))
+        assertTrue(store.entries.value.isEmpty())
+    }
+
+    @Test
+    fun `a removed event re-served does not come back`() {
+        val store = store()
+        store.add(entry("e1"))
+        store.removeForEvents(setOf("e1"))
+        store.add(entry("e1"))
+        assertTrue(store.entries.value.isEmpty())
+    }
+
+    @Test
     fun `clearing the feed does not re-open the gate`() {
         val store = store()
         store.add(entry("e1"))

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/RealtimeCutoffTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/notifications/RealtimeCutoffTest.kt
@@ -1,0 +1,40 @@
+package org.nostr.nostrord.notifications
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RealtimeCutoffTest {
+    @Test
+    fun disarmedTreatsNothingAsRealtime() {
+        val cutoff = RealtimeCutoff()
+        assertFalse(cutoff.isRealtime(0L))
+        assertFalse(cutoff.isRealtime(Long.MAX_VALUE))
+    }
+
+    @Test
+    fun armedSplitsOnTheActivationInstant() {
+        val cutoff = RealtimeCutoff()
+        cutoff.arm(1_000L)
+        assertFalse(cutoff.isRealtime(999L))
+        assertTrue(cutoff.isRealtime(1_000L))
+        assertTrue(cutoff.isRealtime(1_001L))
+    }
+
+    @Test
+    fun disarmAfterArmSilencesAgain() {
+        val cutoff = RealtimeCutoff()
+        cutoff.arm(1_000L)
+        cutoff.disarm()
+        assertFalse(cutoff.isRealtime(2_000L))
+    }
+
+    @Test
+    fun rearmMovesTheCutoffForward() {
+        val cutoff = RealtimeCutoff()
+        cutoff.arm(1_000L)
+        cutoff.arm(2_000L)
+        assertFalse(cutoff.isRealtime(1_500L))
+        assertTrue(cutoff.isRealtime(2_000L))
+    }
+}


### PR DESCRIPTION
Opening a group on a cold start played the chime once per event and filled the feed with unread thread replies from 23 and 55 days ago. Three separate causes, one per commit.

The gate that separates live events from catch-up backlog, `AppModule.isRealtime`, compared against `switchInstantSeconds`, and that field was assigned only in `applyActiveAccountChange` — account switch, logout and removal. A cold start with an account already logged in left it at `0L`, so every event the relay served passed `createdAt >= 0` as realtime. It is now a `RealtimeCutoff` armed in `activateSessionForActiveAccount()`, which runs in both branches of `finishLoginInit`. The arm in `applyActiveAccountChange` stays: `AccountManager.switchAccount` calls `ActiveAccountManager.activate` directly and never passes through the activation helper, so the two points are not redundant.

Catch-up entries were still counted by the badge. They now enter the feed already read, so the history stays browsable without 22 phantom unreads.

The last one is a separate bug the sound fix does not touch: `handleDeletion` removed a deleted event from the message list, the thread stores, the reactions and the disk cache, but never from the notification feed, so a kind:1111 entry outlived its thread and pointed at a root that cannot open.

| Commit | Change |
|---|---|
| `21313df0` | `RealtimeCutoff` extracted and armed on session activation; disarmed (not zeroed) when there is no session, so a subscription that streams before activation stays quiet |
| `60895344` | `read = !realtime` at entry creation, in the six paths that build a `NotificationEntry` |
| `0caf3d0b` | `GroupManager` publishes the ids it drops; `AppModule` prunes the feed from them, matching on the entry's own event, its message, or its thread root |

Two mechanics worth knowing for review. A thread deleted on another device never replays its `kind:5` here, so the live deletion handler is not enough — `reconcileThreadsAtEose`, which already distinguishes "the relay no longer serves this" from "we never asked", is the second source. And the announced-ids set is deliberately left alone on removal: a deleted event must not be re-announced if a relay replays it.

Not addressed: entries whose thread root was never cached on this device have nothing to reconcile against, so they stay in the feed until "Mark all as read". Clearing those would need a click-time check (root does not resolve after EOSE), which is a different change. Sound cadence is also untouched — there is no coalescing, so N live events still play N chimes.