### PR TITLE
fix(dm): messages that reach the account's other devices, and a composer that keeps focus

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -309,6 +309,11 @@ class NostrRepository(
     // can't leak the publish job; delivery is best-effort and swallows failures anyway.
     private val PUBLISH_RELAY_TIMEOUT_MS = 8_000L
 
+    // How long a wrap refused with "auth-required" waits for the NIP-42 signature before it is sent
+    // again. Generous because a bunker or a signer app makes that a round-trip, not a formality, and
+    // the wait runs in the send queue's own scope: nothing on screen is blocked by it.
+    private val PUBLISH_AUTH_SIGN_BUDGET_MS = 20_000L
+
     // Budget for the relays to answer with this account's own kind:10044 before enabling acts on
     // local state. Short: it is paid on every Settings open and on a first enable.
     private val OWN_ANNOUNCEMENT_WAIT_MS = 2_500L
@@ -2923,6 +2928,26 @@ class NostrRepository(
         }
     }
 
+    /**
+     * Publish one gift wrap to a relay, once through AUTH if the relay asks for it.
+     *
+     * A DM inbox relay that gates writes (auth.nostr1.com, and any strfry with `auth_required`)
+     * answers the first EVENT with OK-false "auth-required" and issues its NIP-42 challenge in the
+     * same breath. The wrap only lands if it is sent AGAIN once the challenge is answered, so the
+     * publish waits out the signature here. Leaving it to the send queue's backoff instead loses:
+     * every later attempt reopens the same race, so the message sits on the Sending clock while the
+     * socket next to it is already authenticated.
+     */
+    private suspend fun sendWrapAwaitingAuth(client: NostrGroupClient, frame: String, wrapId: String): PublishResult {
+        val first = client.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
+        val reason = (first as? PublishResult.Rejected)?.reason ?: return first
+        if (classifyRejection(reason) != RelayRejection.Transient || !reason.trim().lowercase().startsWith("auth-required")) return first
+        // A challenge the relay already sent resolves this immediately; the budget is spent only on
+        // the signature itself.
+        if (!client.awaitAuthSigned(PUBLISH_AUTH_SIGN_BUDGET_MS)) return first
+        return client.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
+    }
+
     // Publish a pre-serialized gift wrap event and wait for a relay OK, so a DM has a real delivered
     // signal (not fire-and-forget). Accepted the moment any relay OKs it, carrying the relays that
     // took it so the message can name where it landed. Rejected only when every target answered
@@ -2942,14 +2967,15 @@ class NostrRepository(
                 targets.map { url ->
                     async {
                         try {
-                            val result =
+                            // Only the connect is bounded here: sendWrapAwaitingAuth carries its own
+                            // budget, and a relay that gates writes needs more than a connect's worth
+                            // of it.
+                            val client =
                                 withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
-                                    val client =
-                                        connectionManager.getClientForRelay(url)
-                                            ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
-                                    client?.sendAndAwaitOk(frame, wrapId, PUBLISH_RELAY_TIMEOUT_MS)
+                                    connectionManager.getClientForRelay(url)
+                                        ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
                                 }
-                            url to result
+                            url to client?.let { sendWrapAwaitingAuth(it, frame, wrapId) }
                         } catch (e: CancellationException) {
                             throw e
                         } catch (_: Throwable) {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -2407,9 +2407,9 @@ class NostrRepository(
                 }
             val rumorId = rumor.id ?: return Result.Error(AppError.Unknown("Failed to build the message"))
             // Enqueue both wraps (recipient + self-copy) in the persisted send queue, then publish.
-            // The message shows as Sending and flips to Delivered on the first relay OK (or when the
-            // self-copy echoes back). The queue survives an app restart and never gives up, so a
-            // wrap that never reached a relay keeps retrying instead of being stranded local-only.
+            // The message shows as Sending and flips to Delivered when a relay OKs the recipient's
+            // wrap. The queue survives an app restart and never gives up, so a wrap that never
+            // reached a relay keeps retrying instead of being stranded local-only.
             //
             // Queue first, bubble second: both writes are durable, and this order means a crash
             // between them costs the bubble (which the self-copy repaints) rather than the retry.
@@ -2991,7 +2991,6 @@ class NostrRepository(
         DmSendQueue(
             scope = scope,
             publish = { relays, wrapJson, wrapId -> publishWrapJsonAwaitOk(relays, wrapJson, wrapId) },
-            isDelivered = { rumorId -> dmManager.messageStatus.value[rumorId] is GroupManager.MessageStatus.Delivered },
             onDelivered = { rumorId, relays ->
                 dmManager.markDelivered(rumorId)
                 dmManager.recordSentTo(rumorId, relays)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -2949,53 +2950,64 @@ class NostrRepository(
     }
 
     // Publish a pre-serialized gift wrap event and wait for a relay OK, so a DM has a real delivered
-    // signal (not fire-and-forget). Accepted the moment any relay OKs it, carrying the relays that
-    // took it so the message can name where it landed. Rejected only when every target answered
-    // OK-false for a reason retrying cannot fix: one unreachable relay keeps the whole send
-    // retryable, since it might be the one that would have taken it.
-    private suspend fun publishWrapJsonAwaitOk(relays: List<String>, wrapJson: String, wrapId: String): DmPublishOutcome {
+    // signal (not fire-and-forget). Accepted the moment the FIRST relay OKs it, naming that relay;
+    // the other targets keep going and report through [onLateAccept] as they land, so the bubble
+    // resolves at the speed of the fastest relay while "seen on" and the second tick still fill in
+    // from the slow ones. Rejected only when every target answered OK-false for a reason retrying
+    // cannot fix: one unreachable relay keeps the whole send retryable, since it might be the one
+    // that would have taken it.
+    private suspend fun publishWrapJsonAwaitOk(
+        relays: List<String>,
+        wrapJson: String,
+        wrapId: String,
+        onLateAccept: (List<String>) -> Unit = {},
+    ): DmPublishOutcome {
         if (wrapId.isBlank()) return DmPublishOutcome.Retry
         val frame = """["EVENT",$wrapJson]"""
         val targets = relays.distinct()
         if (targets.isEmpty()) return DmPublishOutcome.Retry
-        // Concurrent for the same reason as publishEventToRelays: a relay that never answers OK
-        // costs the full timeout, and serially those stack into a send that looks hung. Every
-        // target is tried rather than stopping at the first acceptance, because the peer reads
-        // from whichever of their DM relays they happen to be on.
-        val results =
-            coroutineScope {
-                targets.map { url ->
-                    async {
-                        try {
-                            // Only the connect is bounded here: sendWrapAwaitingAuth carries its own
-                            // budget, and a relay that gates writes needs more than a connect's worth
-                            // of it.
-                            val client =
-                                withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
-                                    connectionManager.getClientForRelay(url)
-                                        ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
-                                }
-                            url to client?.let { sendWrapAwaitingAuth(it, frame, wrapId) }
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (_: Throwable) {
-                            url to null
-                        }
+        // Every target is tried, concurrently, because the peer reads from whichever of their DM
+        // relays they happen to be on. The attempts run on the repository scope, not the caller's:
+        // an early return below must not cancel the relays still working, and the buffered channel
+        // lets each of them finish and report even if nobody is listening any more.
+        val settled = Channel<Pair<String, PublishResult?>>(targets.size)
+        targets.forEach { url ->
+            scope.launch {
+                val result =
+                    try {
+                        // Only the connect is bounded here: sendWrapAwaitingAuth carries its own
+                        // budget, and a relay that gates writes needs more than a connect's worth
+                        // of it.
+                        val client =
+                            withTimeoutOrNull(PUBLISH_RELAY_TIMEOUT_MS) {
+                                connectionManager.getClientForRelay(url)
+                                    ?: connectionManager.getOrConnectRelay(url) { m, c -> enqueueToRelayPipeline(m, c) }
+                            }
+                        client?.let { sendWrapAwaitingAuth(it, frame, wrapId) }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (_: Throwable) {
+                        null
                     }
-                }.awaitAll()
+                settled.send(url to result)
             }
-        // "duplicate" counts as acceptance: the relay is telling us it already holds this wrap,
-        // which is exactly what the retry wanted. Anything else keeps its OK-false meaning.
-        val acceptedBy =
-            results.mapNotNull { (url, result) ->
-                when (result) {
-                    is PublishResult.Success -> url
-                    is PublishResult.Rejected ->
-                        url.takeIf { classifyRejection(result.reason) == RelayRejection.AlreadyStored }
-                    else -> null
+        }
+        val results = mutableListOf<Pair<String, PublishResult?>>()
+        repeat(targets.size) {
+            val entry = settled.receive()
+            results += entry
+            if (!wrapAccepted(entry.second)) return@repeat
+            val pending = targets.size - results.size
+            if (pending > 0) {
+                scope.launch {
+                    repeat(pending) {
+                        val (url, result) = settled.receive()
+                        if (wrapAccepted(result)) onLateAccept(listOf(url))
+                    }
                 }
             }
-        if (acceptedBy.isNotEmpty()) return DmPublishOutcome.Accepted(acceptedBy)
+            return DmPublishOutcome.Accepted(listOf(entry.first))
+        }
         // A stated rejection is worth more than a timeout, which only says nobody answered, so a
         // send is final only when every target refused it outright.
         val refusals =
@@ -3009,6 +3021,14 @@ class NostrRepository(
         return DmPublishOutcome.Rejected("${relayHost(url)} refused it: $why")
     }
 
+    // "duplicate" counts as acceptance: the relay is telling us it already holds this wrap, which
+    // is exactly what the retry wanted. Anything else keeps its OK-false meaning.
+    private fun wrapAccepted(result: PublishResult?): Boolean = when (result) {
+        is PublishResult.Success -> true
+        is PublishResult.Rejected -> classifyRejection(result.reason) == RelayRejection.AlreadyStored
+        else -> false
+    }
+
     private fun relayHost(url: String): String = url.removePrefix("wss://").removePrefix("ws://").trimEnd('/')
 
     // Persisted DM send queue: undelivered wraps by account, mirrored to SecureStorage. Retries
@@ -3016,7 +3036,7 @@ class NostrRepository(
     private val dmSendQueue by lazy {
         DmSendQueue(
             scope = scope,
-            publish = { relays, wrapJson, wrapId -> publishWrapJsonAwaitOk(relays, wrapJson, wrapId) },
+            publish = { relays, wrapJson, wrapId, onLateAccept -> publishWrapJsonAwaitOk(relays, wrapJson, wrapId, onLateAccept) },
             onDelivered = { rumorId, relays ->
                 dmManager.markDelivered(rumorId)
                 dmManager.recordSentTo(rumorId, relays)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmManager.kt
@@ -331,9 +331,9 @@ class DmManager(
 
         if (!markRumorSeen(rumorId)) {
             // Same rumor from another relay or the self-wrap echo of an optimistic send: nothing
-            // new to show, but the wrap round-tripped a relay, so an own message is now Delivered,
-            // and its relay still counts for "seen on".
-            markDelivered(rumorId)
+            // new to show, but its relay still counts for "seen on". Not Delivered, though: the
+            // echo is our own copy coming back from our own relays, which says nothing about the
+            // peer's wrap. Delivered is the send queue's call, on the recipient wrap's OK.
             linkWrapToRumor(giftWrap.id, rumorId, peer)
             return true
         }

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmSendQueue.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmSendQueue.kt
@@ -2,6 +2,9 @@ package org.nostr.nostrord.network.managers
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
@@ -47,8 +50,14 @@ sealed interface DmPublishOutcome {
  */
 class DmSendQueue(
     private val scope: CoroutineScope,
-    /** Publishes a wrap to its relay set. */
-    private val publish: suspend (relays: List<String>, wrapJson: String, wrapId: String) -> DmPublishOutcome,
+    /** Publishes a wrap to its relay set. Returns on the first relay that takes it; relays that
+     *  take it later are reported through the callback, after the entry is already gone. */
+    private val publish: suspend (
+        relays: List<String>,
+        wrapJson: String,
+        wrapId: String,
+        onLateAccept: (List<String>) -> Unit,
+    ) -> DmPublishOutcome,
     /** Fires when the recipient's wrap is accepted, with the relays that took it, so the on-screen
      *  message resolves to Delivered and can name where it landed. The self-copy never fires it:
      *  landing on our own relays says nothing about the peer. */
@@ -173,10 +182,11 @@ class DmSendQueue(
         while (true) {
             val active = entries.value.filter { it.parkedReason == null }
             if (active.isEmpty()) return
-            for (entry in active) {
-                if (now() < nextAttemptAt(entry)) continue
-                attempt(entry)
-            }
+            // Every due entry at once: the two wraps of a message are independent, and the
+            // self-copy waiting behind the recipient's wrap is exactly the delay the other devices
+            // would feel.
+            val due = active.filter { now() >= nextAttemptAt(it) }
+            coroutineScope { due.map { async { attempt(it) } }.awaitAll() }
             val remaining = entries.value.filter { it.parkedReason == null }
             if (remaining.isEmpty()) return
             val wait = remaining.minOf { nextAttemptAt(it) } - now()
@@ -185,7 +195,10 @@ class DmSendQueue(
     }
 
     private suspend fun attempt(entry: PendingDmWrap) {
-        when (val outcome = publish(entry.relays, entry.wrapJson, entry.wrapId)) {
+        // Relays that take the wrap after the first one keep feeding "seen on"; markDelivered
+        // is idempotent, so repeating onDelivered is the whole point rather than a hazard.
+        val onLateAccept: (List<String>) -> Unit = { if (!entry.toSelf) onDelivered(entry.rumorId, it) }
+        when (val outcome = publish(entry.relays, entry.wrapJson, entry.wrapId, onLateAccept)) {
             is DmPublishOutcome.Accepted -> {
                 if (!entry.toSelf) onDelivered(entry.rumorId, outcome.relays)
                 remove(entry.wrapId)

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmSendQueue.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/DmSendQueue.kt
@@ -38,15 +38,20 @@ sealed interface DmPublishOutcome {
  * refused it for a reason that will not change, so it is parked (kept, but no longer swept) and
  * reported through [onRejected] for the UI to offer Retry / Dismiss. A rejected self-copy is
  * dropped quietly, since it says nothing about whether the peer got the message.
+ *
+ * The two wraps of one message are independent entries. The recipient's decides Delivered; the
+ * self-copy is what the account's other devices read the message from, so it goes out on its own
+ * terms and never on the recipient wrap's fate: nothing about one wrap having landed makes the
+ * other one unnecessary. A wrap a relay already holds costs nothing to send again ("duplicate"
+ * counts as accepted), so no shortcut is needed for that either.
  */
 class DmSendQueue(
     private val scope: CoroutineScope,
     /** Publishes a wrap to its relay set. */
     private val publish: suspend (relays: List<String>, wrapJson: String, wrapId: String) -> DmPublishOutcome,
-    /** True when the rumor already counts as delivered, e.g. its self-copy echoed back. */
-    private val isDelivered: (rumorId: String) -> Boolean,
-    /** Fires when a wrap is accepted, with the relays that took it, so the on-screen message
-     *  resolves to Delivered and can name where it landed. */
+    /** Fires when the recipient's wrap is accepted, with the relays that took it, so the on-screen
+     *  message resolves to Delivered and can name where it landed. The self-copy never fires it:
+     *  landing on our own relays says nothing about the peer. */
     private val onDelivered: (rumorId: String, relays: List<String>) -> Unit,
     /** Fires when the recipient's wrap is refused for good, so the bubble can offer Retry / Dismiss. */
     private val onRejected: (rumorId: String, reason: String) -> Unit,
@@ -102,9 +107,12 @@ class DmSendQueue(
             entries.value = queued.takeLast(MAX_QUEUE_SIZE)
         }
         if (queued.isEmpty()) return
-        queued.forEach { entry ->
+        // Only the recipient's wrap speaks for the bubble. A self-copy still queued next to a
+        // delivered message would otherwise put that message back on Sending, with nothing left
+        // to take it off again.
+        queued.filterNot { it.toSelf }.forEach { entry ->
             val parked = entry.parkedReason
-            if (parked != null && !entry.toSelf) onRejected(entry.rumorId, parked) else onQueued(entry.rumorId)
+            if (parked != null) onRejected(entry.rumorId, parked) else onQueued(entry.rumorId)
         }
         restartSweep()
     }
@@ -177,13 +185,9 @@ class DmSendQueue(
     }
 
     private suspend fun attempt(entry: PendingDmWrap) {
-        if (isDelivered(entry.rumorId)) {
-            remove(entry.wrapId)
-            return
-        }
         when (val outcome = publish(entry.relays, entry.wrapJson, entry.wrapId)) {
             is DmPublishOutcome.Accepted -> {
-                onDelivered(entry.rumorId, outcome.relays)
+                if (!entry.toSelf) onDelivered(entry.rumorId, outcome.relays)
                 remove(entry.wrapId)
             }
             is DmPublishOutcome.Rejected -> {

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmManagerTest.kt
@@ -222,17 +222,18 @@ class DmManagerTest {
     }
 
     @Test
-    fun `own message is Sending then Delivered on the self-echo`() = runTest {
+    fun `own message stays Sending on the self-echo`() = runTest {
         val dm = DmManager(backgroundScope)
         val alice = signer()
         val rumor = Nip17.buildRumor(alice.pubkey, "bb".repeat(32), "hi")
         dm.addOptimistic(rumor, "bb".repeat(32), alice.pubkey)
         assertEquals(GroupManager.MessageStatus.Sending, dm.messageStatus.value[rumor.id])
 
-        // The self-copy echoes back through the inbox (deduped) -> Delivered.
+        // The self-copy echoing back through the inbox is our own relays returning our own copy:
+        // deduped, and not a word about the peer's wrap, so the status does not move.
         val selfWrap = Nip17.wrap(rumor, alice.pubkey, alice)
         dm.ingestGiftWrap(selfWrap, alice.pubkey, alice)
-        assertEquals(GroupManager.MessageStatus.Delivered, dm.messageStatus.value[rumor.id])
+        assertEquals(GroupManager.MessageStatus.Sending, dm.messageStatus.value[rumor.id])
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmSendQueueTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmSendQueueTest.kt
@@ -25,7 +25,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ ->
+                publish = { _, _, _, _ ->
                     attempts++
                     if (attempts >= 20) DmPublishOutcome.Accepted(listOf("wss://dm.example")) else DmPublishOutcome.Retry
                 },
@@ -50,7 +50,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ -> DmPublishOutcome.Retry },
+                publish = { _, _, _, _ -> DmPublishOutcome.Retry },
                 onDelivered = { _, _ -> },
                 onRejected = { _, _ -> },
                 onQueued = {},
@@ -75,7 +75,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ ->
+                publish = { _, _, _, _ ->
                     attempts++
                     DmPublishOutcome.Accepted(listOf("wss://dm.example"))
                 },
@@ -103,7 +103,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ ->
+                publish = { _, _, _, _ ->
                     attempts++
                     if (online) DmPublishOutcome.Accepted(listOf("wss://dm.example")) else DmPublishOutcome.Retry
                 },
@@ -134,7 +134,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, wrapId ->
+                publish = { _, _, wrapId, _ ->
                     published += wrapId
                     DmPublishOutcome.Accepted(listOf("wss://relay"))
                 },
@@ -155,12 +155,40 @@ class DmSendQueueTest {
     }
 
     @Test
+    fun aRelayThatTakesTheWrapLateStillReportsThroughOnDelivered() = runTest {
+        val delivered = mutableListOf<Pair<String, List<String>>>()
+        var lateAccept: ((List<String>) -> Unit)? = null
+        val queue =
+            DmSendQueue(
+                scope = backgroundScope,
+                publish = { _, _, wrapId, onLateAccept ->
+                    if (wrapId == "wrap1") lateAccept = onLateAccept
+                    DmPublishOutcome.Accepted(listOf("wss://fast"))
+                },
+                onDelivered = { rumorId, relays -> delivered += rumorId to relays },
+                onRejected = { _, _ -> },
+                onQueued = {},
+                persist = { _, _ -> },
+                now = { testScheduler.currentTime },
+            )
+
+        queue.enqueue("me", listOf(wrap("rumor1", "wrap1"), wrap("rumor1", "wrap-self", toSelf = true)))
+        advanceTimeBy(10_000L)
+        assertEquals(0, queue.size)
+        assertEquals(listOf("rumor1" to listOf("wss://fast")), delivered)
+
+        // The slow relay answers after the entry is gone: still counts for "seen on".
+        lateAccept!!(listOf("wss://slow"))
+        assertEquals(listOf("rumor1" to listOf("wss://fast"), "rumor1" to listOf("wss://slow")), delivered)
+    }
+
+    @Test
     fun anAcceptedSelfCopyDoesNotMarkTheMessageDelivered() = runTest {
         val delivered = mutableListOf<String>()
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, wrapId ->
+                publish = { _, _, wrapId, _ ->
                     if (wrapId == "wrap-self") DmPublishOutcome.Accepted(listOf("wss://relay")) else DmPublishOutcome.Retry
                 },
                 onDelivered = { rumorId, _ -> delivered += rumorId },
@@ -185,7 +213,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ ->
+                publish = { _, _, _, _ ->
                     attempts++
                     DmPublishOutcome.Rejected("blocked: pubkey not allowed")
                 },
@@ -211,7 +239,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ -> DmPublishOutcome.Rejected("invalid: too large") },
+                publish = { _, _, _, _ -> DmPublishOutcome.Rejected("invalid: too large") },
                 onDelivered = { _, _ -> },
                 onRejected = { rumorId, _ -> rejected += rumorId },
                 onQueued = {},
@@ -234,7 +262,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ ->
+                publish = { _, _, _, _ ->
                     if (refuse) DmPublishOutcome.Rejected("blocked: pubkey not allowed") else DmPublishOutcome.Accepted(listOf("wss://dm.example"))
                 },
                 onDelivered = { rumorId, _ -> delivered += rumorId },
@@ -262,7 +290,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ -> DmPublishOutcome.Retry },
+                publish = { _, _, _, _ -> DmPublishOutcome.Retry },
                 onDelivered = { _, _ -> },
                 onRejected = { _, _ -> },
                 onQueued = {},
@@ -287,7 +315,7 @@ class DmSendQueueTest {
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ -> DmPublishOutcome.Retry },
+                publish = { _, _, _, _ -> DmPublishOutcome.Retry },
                 onDelivered = { _, _ -> },
                 onRejected = { rumorId, _ -> rejected += rumorId },
                 onQueued = { queued += it },

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmSendQueueTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/managers/DmSendQueueTest.kt
@@ -29,7 +29,6 @@ class DmSendQueueTest {
                     attempts++
                     if (attempts >= 20) DmPublishOutcome.Accepted(listOf("wss://dm.example")) else DmPublishOutcome.Retry
                 },
-                isDelivered = { false },
                 onDelivered = { rumorId, _ -> delivered += rumorId },
                 onRejected = { _, _ -> },
                 onQueued = {},
@@ -52,7 +51,6 @@ class DmSendQueueTest {
             DmSendQueue(
                 scope = backgroundScope,
                 publish = { _, _, _ -> DmPublishOutcome.Retry },
-                isDelivered = { false },
                 onDelivered = { _, _ -> },
                 onRejected = { _, _ -> },
                 onQueued = {},
@@ -81,7 +79,6 @@ class DmSendQueueTest {
                     attempts++
                     DmPublishOutcome.Accepted(listOf("wss://dm.example"))
                 },
-                isDelivered = { false },
                 onDelivered = { _, _ -> },
                 onRejected = { _, _ -> },
                 onQueued = { sending += it },
@@ -89,11 +86,13 @@ class DmSendQueueTest {
                 now = { testScheduler.currentTime },
             )
 
-        queue.resume("me", listOf(wrap("rumor1", "wrap1"), wrap("rumor1", "wrap2")))
+        queue.resume("me", listOf(wrap("rumor1", "wrap1"), wrap("rumor2", "wrap2"), wrap("rumor2", "wrap2-self", toSelf = true)))
         advanceTimeBy(10_000L)
 
-        assertEquals(listOf("rumor1", "rumor1"), sending)
-        assertEquals(2, attempts)
+        // A restored self-copy is sent but never reported: it must not put a message whose
+        // recipient wrap already landed back on Sending.
+        assertEquals(listOf("rumor1", "rumor2"), sending)
+        assertEquals(3, attempts)
         assertEquals(0, queue.size)
     }
 
@@ -108,7 +107,6 @@ class DmSendQueueTest {
                     attempts++
                     if (online) DmPublishOutcome.Accepted(listOf("wss://dm.example")) else DmPublishOutcome.Retry
                 },
-                isDelivered = { false },
                 onDelivered = { _, _ -> },
                 onRejected = { _, _ -> },
                 onQueued = {},
@@ -130,28 +128,54 @@ class DmSendQueueTest {
     }
 
     @Test
-    fun aWrapDeliveredByItsSelfCopyEchoLeavesTheQueueWithoutPublishing() = runTest {
-        var attempts = 0
+    fun theSelfCopyStillGoesOutAfterTheRecipientWrapIsAccepted() = runTest {
+        val published = mutableListOf<String>()
+        val delivered = mutableListOf<String>()
         val queue =
             DmSendQueue(
                 scope = backgroundScope,
-                publish = { _, _, _ ->
-                    attempts++
-                    DmPublishOutcome.Retry
+                publish = { _, _, wrapId ->
+                    published += wrapId
+                    DmPublishOutcome.Accepted(listOf("wss://relay"))
                 },
-                isDelivered = { true },
-                onDelivered = { _, _ -> },
+                onDelivered = { rumorId, _ -> delivered += rumorId },
                 onRejected = { _, _ -> },
                 onQueued = {},
                 persist = { _, _ -> },
                 now = { testScheduler.currentTime },
             )
 
-        queue.enqueue("me", listOf(wrap("rumor1", "wrap1")))
+        queue.enqueue("me", listOf(wrap("rumor1", "wrap1"), wrap("rumor1", "wrap-self", toSelf = true)))
         advanceTimeBy(10_000L)
 
-        assertEquals(0, attempts)
+        assertEquals(listOf("wrap1", "wrap-self"), published)
+        // Delivered once, on the recipient's wrap; the self-copy landing is not delivery.
+        assertEquals(listOf("rumor1"), delivered)
         assertEquals(0, queue.size)
+    }
+
+    @Test
+    fun anAcceptedSelfCopyDoesNotMarkTheMessageDelivered() = runTest {
+        val delivered = mutableListOf<String>()
+        val queue =
+            DmSendQueue(
+                scope = backgroundScope,
+                publish = { _, _, wrapId ->
+                    if (wrapId == "wrap-self") DmPublishOutcome.Accepted(listOf("wss://relay")) else DmPublishOutcome.Retry
+                },
+                onDelivered = { rumorId, _ -> delivered += rumorId },
+                onRejected = { _, _ -> },
+                onQueued = {},
+                persist = { _, _ -> },
+                now = { testScheduler.currentTime },
+            )
+
+        queue.enqueue("me", listOf(wrap("rumor1", "wrap1"), wrap("rumor1", "wrap-self", toSelf = true)))
+        advanceTimeBy(10_000L)
+
+        assertEquals(emptyList(), delivered)
+        // The recipient wrap is still in flight; only the self-copy left the queue.
+        assertEquals(1, queue.size)
     }
 
     @Test
@@ -165,7 +189,6 @@ class DmSendQueueTest {
                     attempts++
                     DmPublishOutcome.Rejected("blocked: pubkey not allowed")
                 },
-                isDelivered = { false },
                 onDelivered = { _, _ -> },
                 onRejected = { rumorId, reason -> rejected += rumorId to reason },
                 onQueued = {},
@@ -189,7 +212,6 @@ class DmSendQueueTest {
             DmSendQueue(
                 scope = backgroundScope,
                 publish = { _, _, _ -> DmPublishOutcome.Rejected("invalid: too large") },
-                isDelivered = { false },
                 onDelivered = { _, _ -> },
                 onRejected = { rumorId, _ -> rejected += rumorId },
                 onQueued = {},
@@ -215,7 +237,6 @@ class DmSendQueueTest {
                 publish = { _, _, _ ->
                     if (refuse) DmPublishOutcome.Rejected("blocked: pubkey not allowed") else DmPublishOutcome.Accepted(listOf("wss://dm.example"))
                 },
-                isDelivered = { false },
                 onDelivered = { rumorId, _ -> delivered += rumorId },
                 onRejected = { _, _ -> },
                 onQueued = { queued += it },
@@ -242,7 +263,6 @@ class DmSendQueueTest {
             DmSendQueue(
                 scope = backgroundScope,
                 publish = { _, _, _ -> DmPublishOutcome.Retry },
-                isDelivered = { false },
                 onDelivered = { _, _ -> },
                 onRejected = { _, _ -> },
                 onQueued = {},
@@ -268,7 +288,6 @@ class DmSendQueueTest {
             DmSendQueue(
                 scope = backgroundScope,
                 publish = { _, _, _ -> DmPublishOutcome.Retry },
-                isDelivered = { false },
                 onDelivered = { _, _ -> },
                 onRejected = { rumorId, _ -> rejected += rumorId },
                 onQueued = { queued += it },

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/components/chat/MessageComposer.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import kotlinx.coroutines.launch
+import org.nostr.nostrord.autoFocusTextInput
 import org.nostr.nostrord.getPlatform
 import org.nostr.nostrord.network.upload.FileTooLargeException
 import org.nostr.nostrord.network.upload.MAX_UPLOAD_BYTES
@@ -178,6 +179,14 @@ fun MessageComposer(
 
     val canSend = value.text.isNotBlank() && !isSending && !isUploadingPaste
 
+    // Sending is not the end of the writing session: hand the caret straight back so the next
+    // message can be typed without clicking the field again (group MessageInput does the same).
+    // Gated on autoFocusTextInput, since on mobile a refocus would force the keyboard back up.
+    fun submit() {
+        onSend()
+        if (autoFocusTextInput) runCatching { focusRequester?.requestFocus() }
+    }
+
     fun appendUploadedUrl(url: String) {
         val current = value.text
         val sep = if (current.isNotEmpty() && !current.endsWith(" ") && !current.endsWith("\n")) " " else ""
@@ -282,14 +291,14 @@ fun MessageComposer(
                 if (sendLabel != null) {
                     AppButton(
                         text = sendLabel,
-                        onClick = onSend,
+                        onClick = { submit() },
                         enabled = canSend,
                         loading = isSending,
                         size = AppButtonSize.Small,
                     )
                 } else {
                     IconButton(
-                        onClick = onSend,
+                        onClick = { submit() },
                         enabled = canSend,
                         modifier = Modifier.size(width = 26.dp, height = 32.dp),
                     ) {
@@ -379,7 +388,7 @@ fun MessageComposer(
                                         ctrlOrMeta = event.isCtrlPressed || event.isMetaPressed,
                                         shift = event.isShiftPressed,
                                     )
-                                    if (submits && canSend) onSend()
+                                    if (submits && canSend) submit()
                                     submits
                                 }
                                 event.type == KeyEventType.KeyDown && event.key == Key.Enter && event.isShiftPressed -> {
@@ -390,7 +399,7 @@ fun MessageComposer(
                                     true
                                 }
                                 event.type == KeyEventType.KeyDown && event.key == Key.Enter && !event.isShiftPressed -> {
-                                    if (canSend) onSend()
+                                    if (canSend) submit()
                                     true
                                 }
                                 else -> false

--- a/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
+++ b/composeApp/src/uiComposeMain/kotlin/org/nostr/nostrord/ui/screens/dm/DmPageScreen.kt
@@ -1,4 +1,7 @@
 package org.nostr.nostrord.ui.screens.dm
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -49,6 +52,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.positionInParent
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.TextFieldValue
@@ -57,6 +62,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.nostr.nostrord.di.AppModule
 import org.nostr.nostrord.network.UserMetadata
@@ -96,6 +102,10 @@ import org.nostr.nostrord.ui.theme.Spacing
 import org.nostr.nostrord.utils.Result
 import org.nostr.nostrord.utils.formatTime
 import org.nostr.nostrord.utils.rememberClipboardWriter
+
+// Breathing room above a message jumped to from a reply quote, so it does not sit glued to the
+// top edge of the feed.
+private const val JUMP_TOP_GAP_PX = 24f
 
 /**
  * Direct-message conversation page (NIP-17). Renders the decrypted thread and a composer that
@@ -474,6 +484,26 @@ fun DmPageScreen(
                         }
                     }
                     val chatItems = remember(messages) { buildDmChatItems(messages) }
+                    // Tapping a reply quote lands on the message it answers. The feed is a plain
+                    // scrolling Column, so every row reports its content offset here and the jump
+                    // scrolls straight to it. A plain map, not snapshot state: it is written on
+                    // every layout pass and only ever read inside a click handler.
+                    val messageOffsets = remember(pubkey) { mutableMapOf<String, Float>() }
+                    var highlightedId by remember(pubkey) { mutableStateOf<String?>(null) }
+                    val jumpToMessage: (String) -> Unit = { id ->
+                        messageOffsets[id]?.let { y ->
+                            scrollScope.launch {
+                                // The reader asked to be up in the history: nothing arriving below
+                                // may drag them back down.
+                                pinnedToBottom.value = false
+                                highlightedId = id
+                                messagesScroll.animateScrollTo((y - JUMP_TOP_GAP_PX).toInt().coerceAtLeast(0))
+                                delay(2500)
+                                if (highlightedId == id) highlightedId = null
+                            }
+                        }
+                        Unit
+                    }
                     var menuForId by remember { mutableStateOf<String?>(null) }
                     var menuAnchorPx by remember { mutableStateOf<Offset?>(null) }
                     var sourceForId by remember { mutableStateOf<String?>(null) }
@@ -490,12 +520,21 @@ fun DmPageScreen(
                             is DmChatItem.DateSeparator -> DateSeparator(item.label)
                             is DmChatItem.Message -> {
                                 val m = item.message
+                                // Flash after a reply-quote jump: snaps on, fades out, same cue as
+                                // the group feed's MessageItem.
+                                val highlighted = highlightedId == m.id
+                                val highlightColor by animateColorAsState(
+                                    targetValue = if (highlighted) NostrordColors.Primary.copy(alpha = 0.18f) else Color.Transparent,
+                                    animationSpec = if (highlighted) snap() else tween(durationMillis = 1200),
+                                )
                                 // WhatsApp/Telegram-style: a small clock inside every bubble,
                                 // bottom-right under the text.
                                 Row(
                                     modifier =
                                     Modifier
                                         .fillMaxWidth()
+                                        .onGloballyPositioned { messageOffsets[m.id] = it.positionInParent().y }
+                                        .background(highlightColor, NostrordShapes.shapeSmall)
                                         .padding(top = if (item.firstInGroup) Spacing.sm else Spacing.xxs)
                                         // Tap (mobile) / right-click (desktop) opens the context menu
                                         // at the pointer, same interaction as group chat rows.
@@ -544,6 +583,16 @@ fun DmPageScreen(
                                                         ReplyQuote(
                                                             authorName = replyAuthorName(parent, userMetadata, name, myPubkey),
                                                             snippet = parent?.previewText() ?: "Message not loaded",
+                                                            // Tappable only while the answered message is loaded; a
+                                                            // no-op click would still swallow the long-press that
+                                                            // opens the row menu, so the quote offers it back.
+                                                            onClick = parent?.let { p -> { jumpToMessage(p.id) } },
+                                                            onLongClick = parent?.let {
+                                                                {
+                                                                    menuAnchorPx = null
+                                                                    menuForId = m.id
+                                                                }
+                                                            },
                                                             modifier = Modifier.padding(bottom = Spacing.xxs),
                                                         )
                                                     }

--- a/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
+++ b/composeApp/src/webMain/kotlin/org/nostr/nostrord/web/screens/DmPage.kt
@@ -10,6 +10,7 @@ import org.nostr.nostrord.network.managers.previewText
 import org.nostr.nostrord.nostr.DmOutgoingFile
 import org.nostr.nostrord.ui.components.emoji.QuickReactions
 import org.nostr.nostrord.ui.extractDmGroupInvite
+import org.nostr.nostrord.ui.keyboard.VirtualKeyboardPolicy
 import org.nostr.nostrord.ui.navigation.DmRoute
 import org.nostr.nostrord.ui.navigation.GroupRoute
 import org.nostr.nostrord.ui.navigation.UserRoute
@@ -57,6 +58,7 @@ import react.useLayoutEffect
 import react.useRef
 import react.useState
 import web.cssom.ClassName
+import web.dom.ElementId
 import web.html.HTMLDivElement
 import web.html.HTMLTextAreaElement
 import kotlin.math.abs
@@ -137,6 +139,8 @@ val DmPage =
         val (replyingTo, setReplyingTo) = useState<String?> { null }
         // Bumped per Reply pick so replying twice to the same message re-focuses the composer.
         val (replyNonce, setReplyNonce) = useState { 0 }
+        // The message a reply quote jumped to, flashing until the animation is done.
+        val (highlightId, setHighlightId) = useState<String?> { null }
         // Second tick: the wrap reached every inbox relay this peer publishes.
         val fullyDelivered = useStateFlow(dmVm.fullyDelivered)
         // Resolve where this peer reads before the first message is written, not after their reply.
@@ -337,6 +341,17 @@ val DmPage =
             }
         }
 
+        // Tapping a reply quote lands on the message it answers and flashes it. Nothing else moves
+        // the feed for the reader, so the jump also unpins it: media loading in must not yank the
+        // view back to the bottom while they read up here.
+        fun jumpToMessage(id: String) {
+            val row = document.getElementById("dm-msg-$id") ?: return
+            pinnedToBottom.current = false
+            row.asDynamic().scrollIntoView(js("({ block: 'center', behavior: 'smooth' })"))
+            setHighlightId(id)
+            window.setTimeout({ setHighlightId(null) }, 2_600)
+        }
+
         fun insertAtCursor(s: String) {
             val ta = composerInputRef.current
             if (ta == null) {
@@ -487,12 +502,15 @@ val DmPage =
                                 val m = item.message
                                 div {
                                     key = m.id
+                                    // The reply-quote jump targets this row by id and flashes it.
+                                    id = ElementId("dm-msg-${m.id}")
                                     className =
                                         ClassName(
                                             buildString {
                                                 append("dm-msg")
                                                 if (m.mine) append(" mine")
                                                 if (!item.firstInGroup) append(" grouped")
+                                                if (m.id == highlightId) append(" highlight")
                                             },
                                         )
                                     // First right-click opens our menu at the cursor; with it open the
@@ -561,7 +579,10 @@ val DmPage =
                                             m.replyToId?.let { parentId ->
                                                 val parent = messages.firstOrNull { it.id == parentId }
                                                 div {
-                                                    className = ClassName("msg-reply")
+                                                    // Tappable only while the answered message is
+                                                    // loaded; otherwise there is nowhere to jump.
+                                                    className = ClassName(if (parent != null) "msg-reply tappable" else "msg-reply")
+                                                    if (parent != null) onClick = { jumpToMessage(parent.id) }
                                                     div { className = ClassName("msg-reply-bar") }
                                                     div {
                                                         className = ClassName("msg-reply-content")
@@ -767,10 +788,13 @@ val DmPage =
 
             div {
                 className = ClassName("dm-composer-wrap")
-                // Reply chip above the input, same markup as the group composer's.
+                // Reply chip above the input, same markup as the group composer's. Both children
+                // carry a stable key: without one React reconciles this list by index and rebuilds
+                // the textarea when the chip goes away on send, which drops the caret.
                 replyingTo?.let { targetId ->
                     val parent = messages.firstOrNull { it.id == targetId }
                     div {
+                        key = "composer-reply"
                         className = ClassName("composer-reply")
                         icon(Ic.Reply)
                         span {
@@ -795,6 +819,7 @@ val DmPage =
                     }
                 }
                 div {
+                    key = "dm-composer"
                     className = ClassName("dm-composer")
                     UploadButton {
                         cls = "dm-composer-btn"
@@ -854,7 +879,15 @@ val DmPage =
                         className = ClassName("dm-composer-btn send")
                         title = "Send"
                         disabled = (text.isBlank() && uploadCount == 0) || uploadCount > 0 || sending
-                        onMouseDown = { e -> e.preventDefault() }
+                        // Keyboard-neutral tap: keep textarea focus (so the keyboard stays up)
+                        // only when it is already up; rules in VirtualKeyboardPolicy.
+                        onMouseDown = { e ->
+                            val keep = VirtualKeyboardPolicy.keepComposerFocusOnTap(
+                                keyboardOpen = VirtualKeyboard.isOpen,
+                                touchDevice = window.navigator.maxTouchPoints > 0,
+                            )
+                            if (keep) e.preventDefault()
+                        }
                         onClick = { send() }
                         if (sending) span { className = ClassName("btn-spinner") } else icon(Ic.Send)
                     }

--- a/composeApp/src/webMain/resources/styles.css
+++ b/composeApp/src/webMain/resources/styles.css
@@ -3443,6 +3443,19 @@ body {
     justify-content: flex-end;
 }
 
+/* Reply-quote jump target: the whole row flashes as one band (native tints the row, not the
+   bubble), same keyframes as the group feed's .msg.highlight. */
+.dm-msg.highlight {
+    border-radius: var(--radius-sm);
+    animation: msg-flash 2.4s ease-out;
+}
+
+/* A quote whose answered message is not loaded has nowhere to jump, so it does not offer a tap
+   (.msg-reply carries cursor: pointer for the group feed, where the quote is always tappable). */
+.dm-msg .msg-reply:not(.tappable) {
+    cursor: default;
+}
+
 /* Bubble plus its "Not delivered" row stack vertically. The column carries the 75% cap so the
    bubble still measures against the thread width, not against itself. */
 .dm-msg-col {


### PR DESCRIPTION
Sending a DM from one device never showed it on the account's other devices, and the send itself sat on the Sending clock far longer than the relays needed.

Both gift wraps of a message carry the same rumor id, and `DmSendQueue` skipped any wrap whose rumor already counted as delivered. The recipient's wrap is swept first, so accepting it dropped the self-copy from the queue before it was ever published: the copy the other devices read from did not exist on any relay. Delivered is now the recipient wrap's OK alone, and each wrap runs to its own; neither an accepted self-copy nor its echo through the inbox moves the status, since our own relays taking our own copy says nothing about the peer.

The rest is delivery latency and reply UX:

| change | why |
| --- | --- |
| Re-send a wrap once the relay's NIP-42 AUTH lands | A DM inbox relay that gates writes (`auth.nostr1.com`) answers the first EVENT with OK-false `auth-required` and challenges in the same breath, so the wrap only lands if it is sent again. That reply was left to the queue's backoff, where every later attempt reopened the same race. |
| Resolve the send on the first relay OK | The bubble waited for every target, including one in HTTP 503 all morning. The remaining relays keep going and report through `onLateAccept`, so "seen on" and the second tick still fill in from the slow ones. |
| Sweep every due entry concurrently | The two wraps are independent now, and the self-copy queued behind the recipient's wrap is exactly the delay the other devices feel. |
| Tappable reply quotes | Tapping the quote scrolls to the message it answers and flashes it, on both UIs; inert while that message is not loaded. |
| A composer that keeps focus | Compose hands the caret back after a send, gated on `autoFocusTextInput` so mobile keyboards are not forced up. On the web the reply chip and composer row carry stable keys, so the textarea survives the chip disappearing on send, and the send button uses `VirtualKeyboardPolicy` instead of preventDefault'ing unconditionally. |

Not addressed: a wrap no relay ever accepts still sits on a mute Sending clock, with no per-relay reason surfaced after N attempts. Neither is the device that lacks the account's NIP-4e key told why its own messages are missing, which reads as message loss.