### PR TITLE
fix(dm): resolve a group nevent quoted in a DM

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/di/AppModule.kt
@@ -361,6 +361,7 @@ object AppModule {
             scope = appScope,
             cacheStore = cacheStore,
             accountProvider = { sessionManager.getPublicKey() },
+            joinedGroupsForRelay = { relay -> groupManager.joinedGroupsByRelay.value[relay.normalizeRelayUrl()].orEmpty() },
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrGroupClient.kt
@@ -214,6 +214,13 @@ suspend fun NostrGroupClient.sendAndAwaitOkOrError(eventJson: String, eventId: S
 /** [NostrGroupClient.diagRole] for the sockets the NIP-46 client owns. */
 const val SIGNER_DIAG_ROLE = "signer"
 
+/**
+ * True for the one-shot by-id fetches that feed the quote cache: [NostrGroupClient.requestEventById]
+ * (`e_`), its `#h`-scoped twin [NostrGroupClient.requestGroupMessageById] (`eh_`), and the legacy
+ * `event_` prefix. `eh_` does not start with `e_`, so every dispatch site has to test all three.
+ */
+fun isQuoteFetchSubId(subId: String): Boolean = subId.startsWith("e_") || subId.startsWith("eh_") || subId.startsWith("event_")
+
 class NostrGroupClient(
     private val relayUrl: String = "wss://groups.fiatjaf.com",
     diagRole: String? = null,

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/NostrRepository.kt
@@ -6722,8 +6722,8 @@ class NostrRepository(
                 val event = arr[2].jsonObject
                 val kind = event["kind"]?.jsonPrimitive?.int
 
-                // Handle event subscriptions (event_* or e_*) for quotes
-                if (subId.startsWith("event_") || subId.startsWith("e_")) {
+                // Handle event subscriptions (event_*, e_* or the #h-scoped eh_*) for quotes
+                if (isQuoteFetchSubId(subId)) {
                     metadataManager.parseAndCacheEvent(event, client.getRelayUrl())?.let { cachedEvent ->
                         if (!metadataManager.hasMetadata(cachedEvent.pubkey)) {
                             scope.launch {
@@ -6868,12 +6868,11 @@ class NostrRepository(
             subId.startsWith("metadata_") ||
             subId.startsWith("msg_") ||
             subId.startsWith("gapfill_") ||
-            subId.startsWith("e_") ||
+            isQuoteFetchSubId(subId) ||
             subId.startsWith("a_") ||
             subId.startsWith("reactions_") ||
             subId.startsWith("zaps_") ||
             subId.startsWith("threadfocus_") ||
-            subId.startsWith("event_") ||
             // requestSelfPutUser's actor-enrichment fetch (distinct from the live mux_padd_ watch).
             subId.startsWith("padd_one_")
         ) {
@@ -6905,8 +6904,8 @@ class NostrRepository(
                 val event = arr[2].jsonObject
                 val kind = event["kind"]?.jsonPrimitive?.int
 
-                // Handle event subscriptions (event_* or e_*)
-                if (subId.startsWith("event_") || subId.startsWith("e_")) {
+                // Handle event subscriptions (event_*, e_* or the #h-scoped eh_*)
+                if (isQuoteFetchSubId(subId)) {
                     metadataManager.parseAndCacheEvent(event, client.getRelayUrl())?.let { cachedEvent ->
                         if (!metadataManager.hasMetadata(cachedEvent.pubkey)) {
                             scope.launch {

--- a/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/nostr/nostrord/network/managers/MetadataManager.kt
@@ -37,6 +37,9 @@ private const val EVENT_FETCH_AUTH_TIMEOUT_MS = 8_000L
 /** How long a by-id fetch blocks an identical one. Must stay under the UI's give-up window. */
 private const val EVENT_FETCH_RETRY_AFTER_MS = 4_000L
 
+/** Cap on the `#h`-scoped lookups a by-id fetch fans out when the reference carries no group. */
+private const val MAX_UNSCOPED_GROUP_LOOKUPS = 12
+
 class MetadataManager(
     private val connectionManager: ConnectionManager,
     private val outboxManager: OutboxManager,
@@ -44,6 +47,9 @@ class MetadataManager(
     private val cacheStore: CacheStore = InMemoryCacheStore(),
     // Active account (pubkey hex) for scoping the event cache; null/blank skips persistence.
     private val accountProvider: () -> String? = { null },
+    /** Groups joined on a relay. Scopes a by-id lookup with `#h` when the reference itself carries
+     *  no group, which is every quote pasted into a DM. */
+    private val joinedGroupsForRelay: (String) -> Set<String> = { emptySet() },
 ) {
     /** Set by NostrRepository so batchFetch can reconnect bootstrap relays when all are offline. */
     var messageHandler: ((String, NostrGroupClient) -> Unit)? = null
@@ -418,7 +424,17 @@ class MetadataManager(
             // The #h lookup is additive, and a separate subscription rather than a second filter
             // on the same REQ: a strict NIP-29 relay CLOSEs a REQ whose filter omits `#h`, which
             // would take the group lookup down with it.
-            if (groupId != null) requestGroupMessageById(groupId, eventId)
+            //
+            // With no group of its own the reference falls back to the groups joined on this
+            // relay: a nevent quoted in a DM carries only id + relay hint, and a strict NIP-29
+            // relay answers its ids-only REQ with nothing.
+            val scopes =
+                if (groupId != null) {
+                    listOf(groupId)
+                } else {
+                    joinedGroupsForRelay(getRelayUrl()).take(MAX_UNSCOPED_GROUP_LOOKUPS)
+                }
+            scopes.forEach { requestGroupMessageById(it, eventId) }
         }
         // Skip if already cached or already in-flight
         if (_cachedEvents.value.containsKey(eventId)) return
@@ -494,7 +510,23 @@ class MetadataManager(
                     try {
                         val existing = connectionManager.getClientForRelay(hint)
                         if (existing == null || !existing.isConnected()) {
-                            connectionManager.getOrConnectRelay(hint, messageHandler)?.reqEvent()
+                            val dialed = connectionManager.getOrConnectRelay(hint, messageHandler)
+                            dialed?.reqEvent()
+                            // A relay dialed just now answers this REQ before its NIP-42 completes,
+                            // so a gated group event (the common case for a hint) comes back empty.
+                            // Same second chance the pooled clients above get once AUTH lands.
+                            if (dialed != null && dialed.requiresAuth() && !dialed.hasAuthSucceeded()) {
+                                scope.launch {
+                                    if (dialed.awaitAuthOrTimeout(EVENT_FETCH_AUTH_TIMEOUT_MS) &&
+                                        !_cachedEvents.value.containsKey(eventId)
+                                    ) {
+                                        try {
+                                            dialed.reqEvent()
+                                        } catch (_: Exception) {
+                                        }
+                                    }
+                                }
+                            }
                         }
                     } catch (_: Exception) {
                     }

--- a/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/QuoteFetchSubIdTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/nostr/nostrord/network/QuoteFetchSubIdTest.kt
@@ -1,0 +1,22 @@
+package org.nostr.nostrord.network
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class QuoteFetchSubIdTest {
+    @Test
+    fun `the h-scoped by-id fetch is recognised as a quote fetch`() {
+        // "eh_" does not start with "e_": a prefix test that only covers "e_" drops every reply to
+        // requestGroupMessageById, which is the only lookup a strict NIP-29 relay answers.
+        assertTrue(isQuoteFetchSubId("eh_1787680017123"))
+        assertTrue(isQuoteFetchSubId("e_1787680017123"))
+        assertTrue(isQuoteFetchSubId("event_abc"))
+    }
+
+    @Test
+    fun `other subscriptions are left to their own handlers`() {
+        listOf("mux_chat_1", "gapfill_1", "a_1", "addr_1", "reactions_1", "threadfocus_1", "padd_one_1")
+            .forEach { assertFalse(isQuoteFetchSubId(it), "$it must not be treated as a quote fetch") }
+    }
+}


### PR DESCRIPTION
A NIP-29 relay answers a group message's ids-only REQ with nothing, so resolving a quoted nevent needs the `#h` filter. Outside a group chat that filter never worked: `requestGroupMessageById` mints `eh_` subIds while every dispatch site tested `e_` / `event_`, and `"eh_"` starts with neither, so the one reply that could resolve the quote was dropped on the floor (and its subscription never closed after EOSE). A DM has no group to scope with either, so only the ids-only REQ went out. Both sides are fixed, and the reference card in a DM now renders the forwarded message instead of "Event removed or unavailable" - validated on a private group.

| file | change |
|---|---|
| `NostrGroupClient.kt` | `isQuoteFetchSubId` - one place that knows `e_` / `eh_` / `event_` |
| `NostrRepository.kt` | both EVENT dispatches and the post-EOSE CLOSE go through it |
| `MetadataManager.kt` | with no group on the reference, the by-id lookup scopes `#h` to the groups joined on that relay (capped at 12); a relay dialed from the nevent hint gets the post-AUTH retry the pooled clients already had |
| `AppModule.kt` | injects `joinedGroupsForRelay` from `groupManager` |
| `QuoteFetchSubIdTest.kt` | pins the prefix set, `eh_` included |

- 81f5c85e fix(dm): resolve a group nevent quoted in a DM